### PR TITLE
Improve test stability

### DIFF
--- a/packages/synapse-react-client/jest.config.js
+++ b/packages/synapse-react-client/jest.config.js
@@ -25,6 +25,8 @@ module.exports = {
       {
         pageTitle: 'synapse-react-client Test Report',
         outputPath: './coverage/test-report.html',
+        includeFailureMsg: true,
+        includeSuiteFailure: true,
       },
     ],
   ],

--- a/packages/synapse-react-client/test/lib/containers/entity/page/title_bar/EntityPageTitleBar.test.tsx
+++ b/packages/synapse-react-client/test/lib/containers/entity/page/title_bar/EntityPageTitleBar.test.tsx
@@ -20,7 +20,6 @@ import * as FavoriteButtonModule from '../../../../../../src/lib/containers/favo
 import * as EntityActionMenuModule from '../../../../../../src/lib/containers/entity/page/action_menu/EntityActionMenu'
 import * as TitleBarPropertiesModule from '../../../../../../src/lib/containers/entity/page/title_bar/TitleBarProperties'
 import * as TitleBarVersionInfoModule from '../../../../../../src/lib/containers/entity/page/title_bar/EntityTitleBarVersionInfo'
-import failOnConsoleError from 'jest-fail-on-console'
 
 const TITLE_BAR_PROPERTIES_TEST_ID = 'title-bar-properties'
 const TITLE_BAR_VERSION_INFO_TEST_ID = 'title-bar-version-info'
@@ -103,7 +102,6 @@ const defaultProps: EntityPageTitleBarProps = {
 }
 
 describe('Entity Page Title Bar', () => {
-  failOnConsoleError()
   beforeAll(() => server.listen())
   afterEach(() => server.restoreHandlers())
   afterAll(() => server.close())


### PR DESCRIPTION
- Remove `failOnConsole` from EntityPageTitleBar test suite that is likely failing due to resources bleeding over from previous test suite.
- Include failure messages in the test report.