### PR TITLE
Fix builds

### DIFF
--- a/apps/portals/run.sh
+++ b/apps/portals/run.sh
@@ -77,7 +77,7 @@ EOL
 
 elif [ "$1" = "push-staging" ]; then
   # sync current with staging
-  pnpm i && pnpm build
+  pnpm i && pnpm nx run portals:build
   node sitemap/generate-sitemap.js $2
   # generate robots.txt
 cat > ./build/robots.txt <<EOL

--- a/packages/synapse-react-client/tsconfig.build.json
+++ b/packages/synapse-react-client/tsconfig.build.json
@@ -1,11 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "src/lib",
     // Set the outDir to dist, where the output will be published to npm
     "outDir": "dist",
     "composite": false,
     "strict": true,
-    "rootDir": "src/lib"
+    "incremental": false
   },
   "include": ["./src/lib/**.ts", "./src/lib/**.tsx"]
 }


### PR DESCRIPTION
- synapse-react-client: Build tsconfig `incremental: true` broke output
- portals: in build machine script, use Nx to guarantee dependencies are built