### PR TITLE
SWC-6375 - Add `overflow-wrap: break-word` to the expandable table data expanded state

### DIFF
--- a/packages/synapse-react-client/src/lib/style/components/_expandable_table_data.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_expandable_table_data.scss
@@ -10,6 +10,7 @@
   &[aria-expanded='true'] {
     p {
       white-space: normal;
+      overflow-wrap: break-word;
       overflow: hidden;
     }
   }


### PR DESCRIPTION
No spaces in this WWWWWWW... cell

![image](https://user-images.githubusercontent.com/17580037/217927476-340747e3-bebd-4701-978b-46eaa5805593.png)
