### PR TITLE
Fix issue where copyfiles glob was not respected in macOS.

### DIFF
--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -224,7 +224,7 @@
     "test:coverage": "jest --coverage --runInBand",
     "build": "rimraf dist && pnpm build:js && pnpm build:copy-assets && pnpm build:esbuild",
     "build:js": "tsc --p tsconfig.build.json",
-    "build:copy-assets": "copyfiles -u 2 src/lib/**/*.{css,scss,svg} dist",
+    "build:copy-assets": "copyfiles -u 2 \"src/lib/**/*.{css,scss,svg}\" dist",
     "build:esbuild": "node esbuild.config.mjs",
     "serve:docs": "pnpm storybook",
     "build:docs": "pnpm build:storybook",


### PR DESCRIPTION
In macOS, copyfiles does not properly handle the glob unless the string is surrounded in quotes. The effect was that files deeper than 2 levels were not copied. This issue is not present on Linux, so builds published to NPM via GitHub actions were not affected.

From [copyfiles README](https://github.com/calvinmetcalf/copyfiles#readme):

> if your terminal doesn't support globstars then you can quote them
```
copyfiles -f ./foo/**/*.txt out
```
> does not work by default on a mac
> but
```
copyfiles -f "./foo/**/*.txt" out
```
> does.