### PR TITLE
SWC-6390: BREAKING CHANGE: remove sessionCallback from SynapseClient

### DIFF
--- a/apps/portals/src/Navbar.tsx
+++ b/apps/portals/src/Navbar.tsx
@@ -139,8 +139,12 @@ class Navbar extends React.Component<any, State> {
     )[0]
 
     // if the home route does not contain any titles, then just show a link
-    const homeConfigTitleCount = homeRouteConfig?.synapseConfigArray?.filter(config => config.title !== undefined).length
-    const isHomeDropdown = homeConfigTitleCount ? homeConfigTitleCount > 0 : false
+    const homeConfigTitleCount = homeRouteConfig?.synapseConfigArray?.filter(
+      (config) => config.title !== undefined,
+    ).length
+    const isHomeDropdown = homeConfigTitleCount
+      ? homeConfigTitleCount > 0
+      : false
     return (
       <React.Fragment>
         <nav
@@ -406,9 +410,8 @@ class Navbar extends React.Component<any, State> {
             }
             {
               // if theres less than 7 navbar items show the home page button
-              routesConfig.filter((el) => !el.hideRouteFromNavbar).length <
-                7 && (
-                  isHomeDropdown ? 
+              routesConfig.filter((el) => !el.hideRouteFromNavbar).length < 7 &&
+                (isHomeDropdown ? (
                   <Dropdown className={this.getBorder('')}>
                     <Dropdown.Toggle
                       variant="light"
@@ -436,13 +439,14 @@ class Navbar extends React.Component<any, State> {
                           },
                         )}
                     </Dropdown.Menu>
-                  </Dropdown> :
+                  </Dropdown>
+                ) : (
                   <NavLink
                     className={`nav-button nav-button-container center-content ${isHomeSelectedCssClassName}`}
                     to={'/'}
-                    text='Home'
-                />
-              )
+                    text="Home"
+                  />
+                ))
             }
           </div>
         </nav>

--- a/packages/synapse-react-client/demo/containers/App.tsx
+++ b/packages/synapse-react-client/demo/containers/App.tsx
@@ -100,7 +100,7 @@ export default class App extends React.Component<{}, AppState> {
         You are logged in.&nbsp;
         <button
           onClick={() => {
-            SynapseClient.signOut(this.getSession)
+            SynapseClient.signOut().then(this.getSession)
           }}
         >
           <span aria-hidden="true">Sign out</span>

--- a/packages/synapse-react-client/src/lib/containers/StorybookComponentWrapper.tsx
+++ b/packages/synapse-react-client/src/lib/containers/StorybookComponentWrapper.tsx
@@ -48,7 +48,7 @@ export async function sessionChangeHandler() {
         err,
         'Signing out...',
       )
-      await signOut(() => {})
+      await signOut()
       accessToken = undefined
     }
     // Otherwise rethrow

--- a/packages/synapse-react-client/src/lib/containers/SynapseNavDrawer.tsx
+++ b/packages/synapse-react-client/src/lib/containers/SynapseNavDrawer.tsx
@@ -205,9 +205,7 @@ export const SynapseNavDrawer: React.FunctionComponent<
     if (signoutCallback) {
       signoutCallback()
     } else {
-      await SynapseClient.signOut(() => {
-        console.log('Signed out')
-      })
+      await SynapseClient.signOut()
       window.location.reload()
     }
   }

--- a/packages/synapse-react-client/src/lib/containers/auth/Login.tsx
+++ b/packages/synapse-react-client/src/lib/containers/auth/Login.tsx
@@ -85,7 +85,7 @@ function Login(props: Props) {
       await SynapseClient.setAccessTokenCookie(data.accessToken)
       // Set the new receipt
       localStorage.setItem(authenticationReceiptKey, data.authenticationReceipt)
-      await sessionCallback()
+      sessionCallback()
     } catch (err) {
       console.log('Error on login: ', err.reason)
       setErrorMessage(err.reason)

--- a/packages/synapse-react-client/src/lib/containers/auth/Login.tsx
+++ b/packages/synapse-react-client/src/lib/containers/auth/Login.tsx
@@ -82,12 +82,10 @@ function Login(props: Props) {
         authenticationReceipt,
       )
       // now get access token from cookie has to be called in the portals repo
-      await SynapseClient.setAccessTokenCookie(
-        data.accessToken,
-        sessionCallback,
-      )
+      await SynapseClient.setAccessTokenCookie(data.accessToken)
       // Set the new receipt
       localStorage.setItem(authenticationReceiptKey, data.authenticationReceipt)
+      await sessionCallback()
     } catch (err) {
       console.log('Error on login: ', err.reason)
       setErrorMessage(err.reason)

--- a/packages/synapse-react-client/src/lib/containers/auth/Logout.tsx
+++ b/packages/synapse-react-client/src/lib/containers/auth/Logout.tsx
@@ -13,7 +13,7 @@ export default function Logout(props: LogoutProps) {
       <Button
         variant="default"
         onClick={() => {
-          SynapseClient.signOut(callback)
+          SynapseClient.signOut().then(callback)
         }}
       >
         Log out

--- a/packages/synapse-react-client/stories/LoginPage.stories.ts
+++ b/packages/synapse-react-client/stories/LoginPage.stories.ts
@@ -1,6 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react'
 
 import LoginPage from '../src/lib/containers/auth/LoginPage'
+import { sessionChangeHandler } from '../src/lib/containers/StorybookComponentWrapper'
+import { displayToast } from '../src/lib/containers/ToastMessage'
 
 const meta = {
   title: 'Synapse/LoginPage',
@@ -9,4 +11,16 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Demo: Story = {}
+export const Demo: Story = {
+  args: {
+    sessionCallback: () => {
+      sessionChangeHandler().then(({ profile }) => {
+        displayToast(
+          `You are currently logged in as ${profile.userName}`,
+          'info',
+          { autoCloseInMs: 5000 },
+        )
+      })
+    },
+  },
+}


### PR DESCRIPTION
Remove sessionCallback from SynapseClient functions. If a callback is needed, it can be attached to the promise with `.then`/`await`.