### PR TITLE
IT-2660: Update S3 bucket names

### DIFF
--- a/apps/portals/src/configurations/elportal/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/src/configurations/elportal/scripts/exportS3ProductionBucketName.sh
@@ -1,1 +1,1 @@
-export S3_PRODUCTION_BUCK_LOCATION=s3://elportal.synapse.org
+export S3_PRODUCTION_BUCK_LOCATION=s3://prod-eliteportal-synapse-org-websitebucket-f9bag5pqbqc8

--- a/apps/portals/src/configurations/elportal/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/src/configurations/elportal/scripts/exportS3StagingBucketName.sh
@@ -1,1 +1,1 @@
-export S3_STAGING_BUCKET_LOCATION=s3://staging-elportal-NEEDS-UPDATE
+export S3_STAGING_BUCKET_LOCATION=s3://staging-eliteportal-synapse-org-websitebucket-enedr8ccgn9x


### PR DESCRIPTION
This PR sets up the names of the buckets used to deploy https://eliteportal.synapse.org .