### PR TITLE
Release synapse-react-client v3.1.25

### DIFF
--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "3.1.24",
+  "version": "3.1.25",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## What's Changed
* Fix issue where copyfiles glob was not respected in macOS. by @nickgros in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/27
* SWC-6390: BREAKING CHANGE: remove sessionCallback from SynapseClient by @nickgros in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/30
* SWC-6390: Changes to support 2FA Login by @nickgros in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/31
* SWC-6390: add useLogin hook by @nickgros in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/35
* SWC-6390 - basic 2FA login support by @nickgros in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/37
* SWC-6399: Inability to get or clear the session cookie should not cause the web… by @jay-hodgson in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/39
* SWC-6400 - put accessToken in query key by @nickgros in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/41

**Full Changelog**: https://github.com/Sage-Bionetworks/synapse-web-monorepo/compare/synapse-react-client/v3.1.24...synapse-react-client/v3.1.25