### PR TITLE
Update to v73

### DIFF
--- a/apps/portals/src/configurations/nf/resources.ts
+++ b/apps/portals/src/configurations/nf/resources.ts
@@ -4,8 +4,8 @@ export const studiesSql = 'SELECT * FROM syn16787123'
 export const initiativesSql = 'SELECT * FROM syn24189696'
 export const toolsSql = 'SELECT * FROM syn26438037'
 export const peopleSql = 'SELECT * FROM syn23564971'
-export const filesSql = `SELECT name, assay, dataType, diagnosis, tumorType,  species, individualID,  fileFormat, dataSubtype, nf1Genotype as "NF1 Genotype", nf2Genotype as "NF2 Genotype", studyName, fundingAgency, consortium, accessType, accessTeam, Resource_id  FROM syn16858331.62 WHERE resourceType = 'experimentalData'`
-export const metadataFilesSql = `SELECT id, dataType, assay, diagnosis, tumorType, species, individualID, fileFormat, dataSubtype, nf1Genotype, nf2Genotype, fundingAgency, consortium FROM syn16858331.62 where resourceType ='report'`
+export const filesSql = `SELECT name, assay, dataType, diagnosis, tumorType,  species, individualID,  fileFormat, dataSubtype, nf1Genotype as "NF1 Genotype", nf2Genotype as "NF2 Genotype", studyName, fundingAgency, consortium, accessType, accessTeam, Resource_id  FROM syn16858331.73 WHERE resourceType = 'experimentalData'`
+export const metadataFilesSql = `SELECT id, dataType, assay, diagnosis, tumorType, species, individualID, fileFormat, dataSubtype, nf1Genotype, nf2Genotype, fundingAgency, consortium FROM syn16858331.73 where resourceType ='report'`
 export const fundersSql = 'SELECT * FROM syn16858699'
 export const hackathonsSql = 'SELECT * FROM syn25585549'
 export const observationsSql = 'SELECT observationSubmitterName as "submitterName", synapseId as "submitterUserId", observationTime as "time", observationTimeUnits as "timeUnits", observationText as "text", observationType as "tag" FROM syn26470591 '


### PR DESCRIPTION
@cconrad8  - just in case you are curious (perpetual onboarding!), the NF Data Portal points to snapshots of fileviews. This is a safety feature because we have had instances in the past where people push annotations to their data that violate the fileview schema, causing the table to not load. We need to regularly update the version that the portal points to so that new data gets included in the data portal. This PR is an example of updating from v62 to v73. Once this gets merged, staging.nf.synapse.org gets updated. We can then take a look at the portal to ensure all looks good, and then ask Jay or Nick to deploy to production (via a jira ticket like https://sagebionetworks.jira.com/browse/PORTALS-1898).

I don't do this update on a regular schedule, but we should probably start to do that. Maybe bi-weekly? What do you think?