### PR TITLE
Release synapse-react-client v3.1.28

### DIFF
--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "3.1.27",
+  "version": "3.1.28",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## What's Changed
* PORTALS-2527: support other links that require an intermediate screen by @jay-hodgson in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/57
* SWC-6394 - Add 2FA recovery code generation by @nickgros in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/59
* SWC-6407 - Fix copy by @nickgros in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/61
* SWC-5997 - Allow non-ACT reviewers to view User Submission History by @nickgros in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/60
* SWC-6365 by @jay-hodgson in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/63
* SWC-6393 - Add 2FA panel for settings page by @nickgros in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/62
* PORTALS-2579: update BarPlot (used by ThemesPlot only) to hide text o… by @jay-hodgson in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/65
* SWC-6393 - Tweaks + fixes discovered while porting 2FA to SWC by @nickgros in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/64


**Full Changelog**: https://github.com/Sage-Bionetworks/synapse-web-monorepo/compare/synapse-react-client/v3.1.27...synapse-react-client/v3.1.28