### PR TITLE
PORTALS-2580 - refactor for synapse-oauth-signin + misc fixes

### DIFF
--- a/apps/portals/craco.config.js
+++ b/apps/portals/craco.config.js
@@ -2,19 +2,26 @@ const { ProvidePlugin } = require('webpack')
 
 module.exports = {
   webpack: {
-    configure: {
-      resolve: {
-        fallback: {
-          path: require.resolve('path-browserify'),
-          timers: require.resolve('timers-browserify'),
-          fs: require.resolve('memfs'),
-          https: require.resolve('https-browserify'),
-          stream: require.resolve('stream-browserify'),
-          http: require.resolve('stream-http'),
-          events: require.resolve('events'),
-        },
-      },
-      ignoreWarnings: [/Failed to parse source map/],
+    configure: (webpackConfig) => {
+      const scopePluginIndex = webpackConfig.resolve.plugins.findIndex(
+        ({ constructor }) =>
+          constructor && constructor.name === 'ModuleScopePlugin',
+      )
+
+      webpackConfig.resolve.plugins.splice(scopePluginIndex, 1)
+
+      webpackConfig.resolve.fallback = {
+        ...webpackConfig.resolve.fallback,
+        path: require.resolve('path-browserify'),
+        timers: require.resolve('timers-browserify'),
+        fs: require.resolve('memfs'),
+        https: require.resolve('https-browserify'),
+        stream: require.resolve('stream-browserify'),
+        http: require.resolve('stream-http'),
+        events: require.resolve('events'),
+      }
+      webpackConfig.ignoreWarnings = [/Failed to parse source map/]
+      return webpackConfig
     },
     plugins: {
       add: [
@@ -28,6 +35,7 @@ module.exports = {
   eslint: {
     enable: false,
   },
+
   // babel: {
   //   presets: ['@babel/preset-react'],
   //   plugins: [

--- a/apps/portals/src/AppInitializer.tsx
+++ b/apps/portals/src/AppInitializer.tsx
@@ -1,4 +1,6 @@
-import RedirectDialog, {redirectInstructionsMap} from 'portal-components/RedirectDialog'
+import RedirectDialog, {
+  redirectInstructionsMap,
+} from 'portal-components/RedirectDialog'
 import React, {
   SetStateAction,
   useCallback,
@@ -16,6 +18,7 @@ import { TwoFactorAuthErrorResponse } from 'synapse-react-client/dist/utils/syna
 import useAnalytics from 'useAnalytics'
 import docTitleConfig from './config/docTitleConfig.json'
 import palette from './config/paletteConfig'
+import { redirectAfterSSO } from './utils'
 
 export type SignInProps = {
   userProfile: UserProfile | undefined
@@ -120,9 +123,7 @@ function AppInitializer(props: { children?: React.ReactNode }) {
   const [showLoginDialog, setShowLoginDialog] = useState(false)
   const [twoFaErrorResponse, setTwoFaErrorResponse] =
     useState<TwoFactorAuthErrorResponse>()
-  const [redirectUrl, setRedirectUrl] = useState<
-    string | undefined
-  >(undefined)
+  const [redirectUrl, setRedirectUrl] = useState<string | undefined>(undefined)
   const [isFramed, setIsFramed] = useState(false)
 
   const { token, userProfile, getSession, hasCalledGetSession, resetSession } =
@@ -165,7 +166,10 @@ function AppInitializer(props: { children?: React.ReactNode }) {
           anchorElement.text === DOWNLOAD_FILES_MENU_TEXT
         if (anchorElement.href) {
           const { hostname } = new URL(anchorElement.href)
-          if (hostname.toLowerCase() === 'www.synapse.org' || redirectInstructionsMap[anchorElement.href]) {
+          if (
+            hostname.toLowerCase() === 'www.synapse.org' ||
+            redirectInstructionsMap[anchorElement.href]
+          ) {
             // && anchorElement.target !== '_blank') {  // should we skip the dialog if opening in a new window?
             ev.preventDefault()
             if (!redirectUrl) {
@@ -233,6 +237,7 @@ function AppInitializer(props: { children?: React.ReactNode }) {
   }, [])
 
   useDetectSSOCode({
+    onSignInComplete: redirectAfterSSO,
     onTwoFactorAuthRequired: (twoFactorAuthError) => {
       setTwoFaErrorResponse(twoFactorAuthError)
       setShowLoginDialog(true)

--- a/apps/portals/src/Navbar.tsx
+++ b/apps/portals/src/Navbar.tsx
@@ -10,7 +10,7 @@ import { ConfigRoute, GenericRoute } from 'types/portal-config'
 import Button from 'react-bootstrap/esm/Button'
 import { preparePostSSORedirect, redirectAfterSSO } from './utils'
 import { Dialog, DialogContent, IconButton } from '@mui/material'
-import IconSvg from 'synapse-react-client/build/src/lib/containers/IconSvg'
+import IconSvg from 'synapse-react-client/dist/containers/IconSvg'
 
 type SynapseSettingLink = {
   text: string

--- a/apps/portals/src/Navbar.tsx
+++ b/apps/portals/src/Navbar.tsx
@@ -2,13 +2,15 @@ import * as React from 'react'
 import routesConfig from './config/routesConfig'
 import logoHeaderConfig from './config/logoHeaderConfig'
 import Dropdown from 'react-bootstrap/Dropdown'
-import Modal from 'react-bootstrap/Modal'
 import { SynapseComponents } from 'synapse-react-client'
 import { SignInProps } from './AppInitializer'
 import NavLink from 'portal-components/NavLink'
 import NavUserLink from './portal-components/NavUserLink'
 import { ConfigRoute, GenericRoute } from 'types/portal-config'
 import Button from 'react-bootstrap/esm/Button'
+import { preparePostSSORedirect, redirectAfterSSO } from './utils'
+import { Dialog, DialogContent, IconButton } from '@mui/material'
+import IconSvg from 'synapse-react-client/build/src/lib/containers/IconSvg'
 
 type SynapseSettingLink = {
   text: string
@@ -212,38 +214,38 @@ class Navbar extends React.Component<any, State> {
                   >
                     SIGN&nbsp;IN
                   </Button>
-                  <Modal
-                    animation={false}
-                    backdrop="static"
-                    keyboard={false}
-                    onHide={() => {
+                  <Dialog
+                    onClose={() => {
                       handleCloseLoginDialog()
                     }}
-                    className="login-modal"
-                    show={showLoginDialog}
+                    open={showLoginDialog}
                   >
-                    <Modal.Header closeButton />
-                    <SynapseComponents.Login
-                      twoFactorAuthenticationRequired={twoFaErrorResponse}
-                      onBeginOAuthSignIn={() => {
-                        // save current route (so that we can go back here after SSO)
-                        localStorage.setItem(
-                          'after-sso-login-url',
-                          window.location.href,
-                        )
+                    <IconButton
+                      aria-label={'Close'}
+                      onClick={() => {
+                        handleCloseLoginDialog()
                       }}
-                      sessionCallback={async () => {
-                        await getSession()
-                        const originalUrl = localStorage.getItem(
-                          'after-sso-login-url',
-                        )
-                        localStorage.removeItem('after-sso-login-url')
-                        if (originalUrl) {
-                          window.location.replace(originalUrl)
-                        }
-                      }}
-                    />
-                  </Modal>
+                      sx={{ marginLeft: 'auto' }}
+                    >
+                      <IconSvg
+                        icon={'close'}
+                        wrap={false}
+                        sx={{ color: 'grey.700' }}
+                      />
+                    </IconButton>
+                    <DialogContent>
+                      <SynapseComponents.Login
+                        twoFactorAuthenticationRequired={twoFaErrorResponse}
+                        onBeginOAuthSignIn={() => {
+                          preparePostSSORedirect()
+                        }}
+                        sessionCallback={async () => {
+                          await getSession()
+                          redirectAfterSSO()
+                        }}
+                      />
+                    </DialogContent>
+                  </Dialog>
                 </div>
               )}
 

--- a/apps/portals/src/_Navbar.scss
+++ b/apps/portals/src/_Navbar.scss
@@ -1,20 +1,6 @@
 // Import the theme css
 @use './style/variables' as Portal;
 
-.login-modal {
-  .modal-dialog {
-    display: flex;
-    width: 360px;
-  }
-  .modal-content {
-    padding: 5px !important;
-  }
-  .modal-header {
-    padding: 5px 16px 0 !important;
-    border-bottom: 0 none;
-  }
-}
-
 .crawler-link {
   position: absolute;
   top: -500px;

--- a/apps/portals/src/utils.ts
+++ b/apps/portals/src/utils.ts
@@ -12,3 +12,24 @@ export const DESKTOP_VIEWPORT_MIN_WIDTH_MEDIA_QUERY = `(min-width: ${DESKTOP_VIE
 
 export const useShowDesktop = () =>
   useMedia(DESKTOP_VIEWPORT_MIN_WIDTH_MEDIA_QUERY)
+
+const POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY = 'after-sso-login-url'
+
+export function preparePostSSORedirect() {
+  // save current route (so that we can go back here after SSO)
+  localStorage.setItem(
+    POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY,
+    window.location.href,
+  )
+}
+
+export function redirectAfterSSO() {
+  // go back to original route after successful SSO login
+  const originalUrl = localStorage.getItem(
+    POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY,
+  )
+  localStorage.removeItem(POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY)
+  if (originalUrl) {
+    window.location.replace(originalUrl)
+  }
+}

--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -58,7 +58,7 @@
     "markdown-it-synapse-heading": "^1.0.1",
     "markdown-it-synapse-math": "^3.0.4",
     "markdown-it-synapse-table": "^1.0.6",
-    "mui-one-time-password-input": "^1.0.4",
+    "mui-one-time-password-input": "^1.1.0",
     "plotly.js-basic-dist": "^2.11.1",
     "pluralize": "^8.0.0",
     "qrcode": "^1.5.1",

--- a/packages/synapse-react-client/src/lib/containers/auth/TOTPForm.tsx
+++ b/packages/synapse-react-client/src/lib/containers/auth/TOTPForm.tsx
@@ -17,6 +17,7 @@ export default function TOTPForm(props: TOTPFormProps) {
   return (
     <Box>
       <MuiOtpInput
+        autoFocus
         length={TOTP_LENGTH}
         value={verificationCode}
         onChange={setVerificationCode}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2479,7 +2479,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@emotion/babel-plugin': 11.10.5
       '@emotion/cache': 11.10.5
       '@emotion/serialize': 1.1.1
@@ -2568,7 +2568,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@emotion/babel-plugin': 11.10.5
       '@emotion/is-prop-valid': 1.2.0
       '@emotion/react': 11.10.5_3stiutgnnbnfnf3uowm5cip22i
@@ -3760,7 +3760,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@mui/material': 5.11.7_rqh7qj4464ntrqrt6banhaqg4q
       '@types/react': 18.0.27
       react: 18.2.0
@@ -3836,7 +3836,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@emotion/react': 11.10.5_3stiutgnnbnfnf3uowm5cip22i
       '@emotion/styled': 11.10.5_jrh5enlbqfbnumycmktdqgd6se
       '@mui/base': 5.0.0-alpha.116_5ndqzdd6t4rivxsukjv3i3ak2q
@@ -3921,7 +3921,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@emotion/hash': 0.9.0
       '@mui/private-theming': 5.11.7_3stiutgnnbnfnf3uowm5cip22i
       '@mui/types': 7.2.3_@types+react@18.0.27
@@ -4409,7 +4409,7 @@ packages:
       react: ^16.0.0 || ^17.0.0
       react-dom: ^16.0.0 || ^17.0.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       classnames: 2.3.2
       memoize-one: 5.2.1
       prop-types: 15.8.1
@@ -5810,7 +5810,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@types/aria-query': 5.0.1
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -5865,7 +5865,7 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@testing-library/dom': 8.20.0
       '@types/react-dom': 18.0.10
       react: 18.2.0
@@ -10210,7 +10210,7 @@ packages:
     peerDependencies:
       eslint: ^6.8.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@testing-library/dom': 8.20.0
       eslint: 8.33.0
       requireindex: 1.2.0
@@ -16215,7 +16215,7 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@restart/context': 2.1.4_react@18.2.0
       '@restart/hooks': 0.4.8_react@18.2.0
       '@types/invariant': 2.2.35
@@ -16557,7 +16557,7 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       broadcast-channel: 3.7.0
       match-sorter: 6.3.1
       react: 18.2.0
@@ -16593,7 +16593,7 @@ packages:
     peerDependencies:
       react: '>=15'
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -16903,7 +16903,7 @@ packages:
       react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
       react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       memoize-one: 5.2.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,7 +325,7 @@ importers:
       memfs: ^3.4.7
       msw: ^1.0.0
       msw-storybook-addon: ^1.7.0
-      mui-one-time-password-input: ^1.0.4
+      mui-one-time-password-input: ^1.1.0
       path-browserify: ^1.0.1
       plotly.js-basic-dist: ^2.11.1
       pluralize: ^8.0.0
@@ -428,7 +428,7 @@ importers:
       markdown-it-synapse-heading: 1.0.1
       markdown-it-synapse-math: 3.0.5
       markdown-it-synapse-table: 1.0.6
-      mui-one-time-password-input: 1.0.4_siun3uzv6nitm2nntynjepm5jy
+      mui-one-time-password-input: 1.1.0_siun3uzv6nitm2nntynjepm5jy
       plotly.js-basic-dist: 2.18.0
       pluralize: 8.0.0
       qrcode: 1.5.1
@@ -3111,7 +3111,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -3123,7 +3123,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       jest-message-util: 28.1.3
       jest-util: 28.1.3
@@ -3135,7 +3135,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       jest-message-util: 29.4.3
       jest-util: 29.4.3
@@ -3147,7 +3147,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       jest-message-util: 29.4.3
       jest-util: 29.4.3
@@ -3168,7 +3168,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -3213,14 +3213,14 @@ packages:
       '@jest/test-result': 29.4.3
       '@jest/transform': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.7.1
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.4.3
-      jest-config: 29.4.3_@types+node@16.18.11
+      jest-config: 29.4.3_@types+node@14.18.36
       jest-haste-map: 29.4.3
       jest-message-util: 29.4.3
       jest-regex-util: 29.4.3
@@ -3247,7 +3247,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       jest-mock: 27.5.1
     dev: true
 
@@ -3257,7 +3257,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       jest-mock: 29.4.3
     dev: true
 
@@ -3284,7 +3284,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -3296,7 +3296,7 @@ packages:
     dependencies:
       '@jest/types': 29.4.3
       '@sinonjs/fake-timers': 10.0.2
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       jest-message-util: 29.4.3
       jest-mock: 29.4.3
       jest-util: 29.4.3
@@ -3337,7 +3337,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -3376,7 +3376,7 @@ packages:
       '@jest/transform': 29.4.3
       '@jest/types': 29.4.3
       '@jridgewell/trace-mapping': 0.3.17
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -3544,7 +3544,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       '@types/yargs': 16.0.5
       chalk: 4.1.2
     dev: true
@@ -3556,7 +3556,7 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       '@types/yargs': 17.0.22
       chalk: 4.1.2
     dev: true
@@ -3568,7 +3568,7 @@ packages:
       '@jest/schemas': 29.4.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       '@types/yargs': 17.0.22
       chalk: 4.1.2
     dev: true
@@ -3580,7 +3580,7 @@ packages:
       '@jest/schemas': 29.4.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       '@types/yargs': 17.0.22
       chalk: 4.1.2
     dev: true
@@ -4171,7 +4171,7 @@ packages:
       node-gyp-build: 4.6.0
     dev: true
 
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.10_unmakpayn7vcxadrrsbqlrpehy:
+  /@pmmmwh/react-refresh-webpack-plugin/0.5.10_eamahzwwmqth5cpkxuccgzmpoa:
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -4207,8 +4207,8 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.1.1
       source-map: 0.7.4
-      webpack: 5.75.0
-      webpack-dev-server: 4.11.1_webpack@5.75.0
+      webpack: 5.76.1
+      webpack-dev-server: 4.11.1_webpack@5.76.1
     dev: true
 
   /@popperjs/core/2.11.6:
@@ -4958,12 +4958,12 @@ packages:
       telejson: 7.0.4
     dev: true
 
-  /@storybook/channel-postmessage/7.0.0-rc.0:
-    resolution: {integrity: sha512-dTpTapmoVbe3kYuU8aqT6cYW3u7XtUR88YgHxVf6iU+BJ9vjgQXEvDS5DJQ2xL3uAYxNU38betVXLzk+ToWytg==}
+  /@storybook/channel-postmessage/7.0.0-rc.3:
+    resolution: {integrity: sha512-1uptuCjA4vAvvoxNoIJPTIpSARzJnLU7eahRhTPwELBnCH0ObqvgInge0cvbYsaTRDNV90oBbEKlxLf1Zb1BhQ==}
     dependencies:
-      '@storybook/channels': 7.0.0-rc.0
-      '@storybook/client-logger': 7.0.0-rc.0
-      '@storybook/core-events': 7.0.0-rc.0
+      '@storybook/channels': 7.0.0-rc.3
+      '@storybook/client-logger': 7.0.0-rc.3
+      '@storybook/core-events': 7.0.0-rc.3
       '@storybook/global': 5.0.0
       qs: 6.11.0
       telejson: 7.0.4
@@ -4990,8 +4990,8 @@ packages:
     resolution: {integrity: sha512-3Wr0jXpwIKppOHaputPLpZBwYYN7gQzqM0MYTQmw1e+lzblhdZkFAI0KaHrMWIEi70NLbsR48ZEVwyZVwrLMRw==}
     dev: true
 
-  /@storybook/channels/7.0.0-rc.0:
-    resolution: {integrity: sha512-iYKkcJ413rQ1QoHEAebamm6v/GpI9hwjmvee323noHqG4yu3MKVlZW6vjS8gJW/5ehbadjvoPK+KGXKxwH/v4Q==}
+  /@storybook/channels/7.0.0-rc.3:
+    resolution: {integrity: sha512-jaODIck+um16Fn2k1vwHK9RNk2J8hLVyzLSkoGM40TsMF5nichwI3rA6225pLk015itJbhCAi/RhaMFBI+ZtsA==}
     dev: true
 
   /@storybook/cli/7.0.0-beta.38:
@@ -5053,8 +5053,8 @@ packages:
       '@storybook/global': 5.0.0
     dev: true
 
-  /@storybook/client-logger/7.0.0-rc.0:
-    resolution: {integrity: sha512-xkZItcHGvzek7IYEJdREGJWAkZV0/fg/P78x/CaOYIQzCXN9PgCYusaHXRqybv6YECafzFrglCBCFjiTejNvCg==}
+  /@storybook/client-logger/7.0.0-rc.3:
+    resolution: {integrity: sha512-cC7lq+S4n5fFooDCyefgTAOfipadiZskNuzsQF7drE9nQLZ8GflLdmTKK//5NQUHKPzF7r+4Q5DAK4I3nqIkxA==}
     dependencies:
       '@storybook/global': 5.0.0
     dev: true
@@ -5148,8 +5148,8 @@ packages:
     resolution: {integrity: sha512-VzC+ssutXDheDeoDnnImVdyzzKxO4THANlM2hV8aekcRMzQe5MFSOy4kNu4bu7aA4okkz10f3Pj/TwEbgwkH0A==}
     dev: true
 
-  /@storybook/core-events/7.0.0-rc.0:
-    resolution: {integrity: sha512-jFAbT/dSEcB1OHAtSJU5uuyL+x9AoGPMVMTEkzu5E1ClsneJNJRvV16PswliH8NXjS/hcJR0yPEnVv7VytWfHw==}
+  /@storybook/core-events/7.0.0-rc.3:
+    resolution: {integrity: sha512-EBihNmxxiIJbPt6OhCTXFPl2T/9OXNVKtsy8hchBNEzp+UJGyeHx+t9K6tRvbcmt5TG/y7C7ZsYx9U28JTwNkg==}
     dev: true
 
   /@storybook/core-server/7.0.0-beta.38:
@@ -5278,14 +5278,14 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/instrumenter/7.0.0-rc.0:
-    resolution: {integrity: sha512-SedZ1D2+yToI70pRwK1J/CmYmMgoSJmU5KLwf/1PvFGBASCDnvD0YzKjViYwXeMQXlGzdo6WuQHkYKN0dCfwUg==}
+  /@storybook/instrumenter/7.0.0-rc.3:
+    resolution: {integrity: sha512-LgFLh7v4wHgalThho8BjHd0xq2Tz8EACIbKOJO/qkSvpupfE6FDROrCYGJpQHsTKWAVdZZwVIMd6A+OnPHOLyg==}
     dependencies:
-      '@storybook/channels': 7.0.0-rc.0
-      '@storybook/client-logger': 7.0.0-rc.0
-      '@storybook/core-events': 7.0.0-rc.0
+      '@storybook/channels': 7.0.0-rc.3
+      '@storybook/client-logger': 7.0.0-rc.3
+      '@storybook/core-events': 7.0.0-rc.3
       '@storybook/global': 5.0.0
-      '@storybook/preview-api': 7.0.0-rc.0
+      '@storybook/preview-api': 7.0.0-rc.3
     dev: true
 
   /@storybook/manager-api/7.0.0-beta.38_biqbaboplfbrettd7655fr4n2y:
@@ -5359,16 +5359,16 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/preview-api/7.0.0-rc.0:
-    resolution: {integrity: sha512-IJgSrwExqjSYVKMpe9nIhHpEpfBdHITdktjbQxNvwf2cZ5cA61rBF12rSgvjiYTXXzXI8TkSihTqf8ywFOXZJQ==}
+  /@storybook/preview-api/7.0.0-rc.3:
+    resolution: {integrity: sha512-iIifbFRmrFIlLzApTZyCWmI3JNt2IxfM8Dm4rNlMJBifjtgHfpxA+DsQI8mW8UGM64a8N1wF7azkN6cnRz6v2w==}
     dependencies:
-      '@storybook/channel-postmessage': 7.0.0-rc.0
-      '@storybook/channels': 7.0.0-rc.0
-      '@storybook/client-logger': 7.0.0-rc.0
-      '@storybook/core-events': 7.0.0-rc.0
+      '@storybook/channel-postmessage': 7.0.0-rc.3
+      '@storybook/channels': 7.0.0-rc.3
+      '@storybook/client-logger': 7.0.0-rc.3
+      '@storybook/core-events': 7.0.0-rc.3
       '@storybook/csf': 0.0.2-next.10
       '@storybook/global': 5.0.0
-      '@storybook/types': 7.0.0-rc.0
+      '@storybook/types': 7.0.0-rc.3
       '@types/qs': 6.9.7
       dequal: 2.0.3
       lodash: 4.17.21
@@ -5505,8 +5505,8 @@ packages:
   /@storybook/testing-library/0.0.14-next.1:
     resolution: {integrity: sha512-1CAl40IKIhcPaCC4pYCG0b9IiYNymktfV/jTrX7ctquRY3akaN7f4A1SippVHosksft0M+rQTFE0ccfWW581fw==}
     dependencies:
-      '@storybook/client-logger': 7.0.0-rc.0
-      '@storybook/instrumenter': 7.0.0-rc.0
+      '@storybook/client-logger': 7.0.0-rc.3
+      '@storybook/instrumenter': 7.0.0-rc.3
       '@testing-library/dom': 8.20.0
       '@testing-library/user-event': 13.5.0_yxlyej73nftwmh2fiao7paxmlm
       ts-dedent: 2.2.0
@@ -5553,10 +5553,10 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/types/7.0.0-rc.0:
-    resolution: {integrity: sha512-xdxhvYbmuYeAYdFk6AUolMIUxsMLVhh9V//rjvRHT6v+ziK4JpJkb5igVRXNG21B8bo713wWaizb3ddc15KcOg==}
+  /@storybook/types/7.0.0-rc.3:
+    resolution: {integrity: sha512-2xxgs4zL1QZUdut+Zt5sQdgNCUP0n/y5CRbvEpDwkcuE4KWbfJYixJNumioZ6UwK17ZE9gf4ZxVgttvexmW8eg==}
     dependencies:
-      '@storybook/channels': 7.0.0-rc.0
+      '@storybook/channels': 7.0.0-rc.3
       '@types/babel__core': 7.20.0
       '@types/express': 4.17.16
       file-system-cache: 2.0.2
@@ -5966,13 +5966,13 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/bonjour/3.5.10:
     resolution: {integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/brainhubeu__react-carousel/1.15.0:
@@ -5985,13 +5985,13 @@ packages:
     resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==}
     dependencies:
       '@types/express-serve-static-core': 4.17.33
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/cookie/0.3.3:
@@ -6240,7 +6240,7 @@ packages:
   /@types/express-serve-static-core/4.17.33:
     resolution: {integrity: sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: true
@@ -6266,7 +6266,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/google.maps/3.50.5:
@@ -6280,7 +6280,7 @@ packages:
   /@types/graceful-fs/4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/history/4.7.11:
@@ -6301,7 +6301,7 @@ packages:
   /@types/http-proxy/1.17.9:
     resolution: {integrity: sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/invariant/2.2.35:
@@ -6365,7 +6365,7 @@ packages:
   /@types/jsdom/20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       '@types/tough-cookie': 4.0.2
       parse5: 7.1.2
     dev: true
@@ -6437,7 +6437,7 @@ packages:
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       form-data: 3.0.1
     dev: true
 
@@ -6606,7 +6606,7 @@ packages:
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/retry/0.12.0:
@@ -6630,13 +6630,13 @@ packages:
     resolution: {integrity: sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/set-cookie-parser/2.4.2:
     resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/shortid/0.0.29:
@@ -6650,7 +6650,7 @@ packages:
   /@types/sockjs/0.3.33:
     resolution: {integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/spark-md5/3.0.2:
@@ -6698,7 +6698,7 @@ packages:
   /@types/ws/8.5.4:
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /@types/xml2js/0.4.11:
@@ -7651,7 +7651,7 @@ packages:
       schema-utils: 2.7.1
     dev: true
 
-  /babel-loader/8.3.0_la66t7xldg4uecmyawueag5wkm:
+  /babel-loader/8.3.0_vbwv3zr3kwaf4v2iytwakh6feu:
     resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -7663,7 +7663,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /babel-plugin-istanbul/6.1.1:
@@ -8753,7 +8753,7 @@ packages:
       hyphenate-style-name: 1.0.4
     dev: false
 
-  /css-loader/6.7.3_webpack@5.75.0:
+  /css-loader/6.7.3_webpack@5.76.1:
     resolution: {integrity: sha512-qhOH1KlBMnZP8FzRO6YCH9UHXQhVMcEGLyNdb7Hv2cpcmJbW0YrddO+tG1ab5nT41KpHIYGsbeHqxB9xPu1pKQ==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -8767,10 +8767,10 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.4.21
       postcss-value-parser: 4.2.0
       semver: 7.3.8
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
-  /css-minimizer-webpack-plugin/3.4.1_webpack@5.75.0:
+  /css-minimizer-webpack-plugin/3.4.1_webpack@5.76.1:
     resolution: {integrity: sha512-1u6D71zeIfgngN2XNRJefc/hY7Ybsxd74Jm4qngIXyUEk7fss3VUzuHxLAq/R8NAba4QU9OUSaMZlbpRc7bM4Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -8795,7 +8795,7 @@ packages:
       schema-utils: 4.0.0
       serialize-javascript: 6.0.1
       source-map: 0.6.1
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /css-prefers-color-scheme/6.0.3_postcss@8.4.21:
@@ -10404,7 +10404,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint-webpack-plugin/3.2.0_nkwuvqep7k7zzhloz3wxbhr4hq:
+  /eslint-webpack-plugin/3.2.0_jb6p7kdr6szvmkzg5qu6snnoue:
     resolution: {integrity: sha512-avrKcGncpPbPSUHX6B3stNGzkKFto3eL+DKM4+VyMrVnhPc3vRczVlCq3uhuFOdRvDHTVXuzwk1ZKUrqDQHQ9w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -10417,7 +10417,7 @@ packages:
       micromatch: 4.0.5
       normalize-path: 3.0.0
       schema-utils: 4.0.0
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /eslint/8.33.0:
@@ -10805,7 +10805,7 @@ packages:
       flat-cache: 3.0.4
     dev: true
 
-  /file-loader/6.2.0_webpack@5.75.0:
+  /file-loader/6.2.0_webpack@5.76.1:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -10813,7 +10813,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /file-system-cache/2.0.2:
@@ -10973,7 +10973,7 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.2_5nsnk2aswgmt3bqwilhpeaeih4:
+  /fork-ts-checker-webpack-plugin/6.5.2_xd7ncxsma4hqdb7auvbs7iobfm:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -11002,7 +11002,7 @@ packages:
       semver: 7.3.8
       tapable: 1.1.3
       typescript: 4.9.5
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /form-data/3.0.1:
@@ -11581,7 +11581,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /html-webpack-plugin/5.5.0_webpack@5.75.0:
+  /html-webpack-plugin/5.5.0_webpack@5.76.1:
     resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -11592,7 +11592,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /htmlparser2/6.1.0:
@@ -12361,7 +12361,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -12389,7 +12389,7 @@ packages:
       '@jest/expect': 29.4.3
       '@jest/test-result': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -12545,45 +12545,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-config/29.4.3_@types+node@16.18.11:
-    resolution: {integrity: sha512-eCIpqhGnIjdUCXGtLhz4gdDoxKSWXKjzNcc5r+0S1GKOp2fwOipx5mRcwa9GB/ArsxJ1jlj2lmlD9bZAsBxaWQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.20.12
-      '@jest/test-sequencer': 29.4.3
-      '@jest/types': 29.4.3
-      '@types/node': 16.18.11
-      babel-jest: 29.4.3_@babel+core@7.20.12
-      chalk: 4.1.2
-      ci-info: 3.7.1
-      deepmerge: 4.3.0
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-circus: 29.4.3
-      jest-environment-node: 29.4.3
-      jest-get-type: 29.4.3
-      jest-regex-util: 29.4.3
-      jest-resolve: 29.4.3
-      jest-runner: 29.4.3
-      jest-util: 29.4.3
-      jest-validate: 29.4.3
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.4.3
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /jest-diff/27.5.1:
     resolution: {integrity: sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -12688,7 +12649,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -12700,7 +12661,7 @@ packages:
       '@jest/environment': 29.4.3
       '@jest/fake-timers': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       jest-mock: 29.4.3
       jest-util: 29.4.3
     dev: true
@@ -12727,7 +12688,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.6
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -12747,7 +12708,7 @@ packages:
     dependencies:
       '@jest/types': 29.4.3
       '@types/graceful-fs': 4.1.6
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -12792,7 +12753,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -12899,7 +12860,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
     dev: true
 
   /jest-mock/29.4.3:
@@ -12907,7 +12868,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       jest-util: 29.4.3
     dev: true
 
@@ -13011,7 +12972,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.10
@@ -13043,7 +13004,7 @@ packages:
       '@jest/test-result': 29.4.3
       '@jest/transform': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.10
@@ -13104,7 +13065,7 @@ packages:
       '@jest/test-result': 29.4.3
       '@jest/transform': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -13127,7 +13088,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       graceful-fs: 4.2.10
     dev: true
 
@@ -13198,7 +13159,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       ci-info: 3.7.1
       graceful-fs: 4.2.10
@@ -13210,7 +13171,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       ci-info: 3.7.1
       graceful-fs: 4.2.10
@@ -13222,7 +13183,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       chalk: 4.1.2
       ci-info: 3.7.1
       graceful-fs: 4.2.10
@@ -13275,7 +13236,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -13288,7 +13249,7 @@ packages:
     dependencies:
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -13302,7 +13263,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -13322,7 +13283,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -13331,7 +13292,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -13340,7 +13301,7 @@ packages:
     resolution: {integrity: sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -13349,7 +13310,7 @@ packages:
     resolution: {integrity: sha512-GLHN/GTAAMEy5BFdvpUfzr9Dr80zQqBrh0fz1mtRMe05hqP45+HfQltu7oTBfduD0UeZs09d+maFtFYAXFWvAA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 14.18.36
       jest-util: 29.4.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -14318,14 +14279,14 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /mini-css-extract-plugin/2.7.2_webpack@5.75.0:
+  /mini-css-extract-plugin/2.7.2_webpack@5.76.1:
     resolution: {integrity: sha512-EdlUizq13o0Pd+uCp+WO/JpkLvHRVGt97RqfeGhXqAcorYo1ypJSpkV+WDT0vY/kmh/p7wRdJNJtuyK540PXDw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.0.0
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /minimalistic-assert/1.0.1:
@@ -14462,8 +14423,8 @@ packages:
       - supports-color
     dev: true
 
-  /mui-one-time-password-input/1.0.4_siun3uzv6nitm2nntynjepm5jy:
-    resolution: {integrity: sha512-fq6vNtTvMsijFCicW76EfanDOyKyjTkz7om+590y7ridWg1zXroWwCObtFwHIkCRNmgNRAlcyykzvpM8ccEOhQ==}
+  /mui-one-time-password-input/1.1.0_siun3uzv6nitm2nntynjepm5jy:
+    resolution: {integrity: sha512-PUAsTHZk9HNewrpqo2z+xlQqnI36ltzYvvVFFe2HLsRk42TNM3W0GM6oZXpCrhNLBE4rCcujU6PhICqyzDlsXw==}
     peerDependencies:
       '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
@@ -15520,7 +15481,7 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /postcss-loader/6.2.1_6jdsrmfenkuhhw3gx4zvjlznce:
+  /postcss-loader/6.2.1_mquw4qchulb5tpkmg3p2j6qala:
     resolution: {integrity: sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -15531,7 +15492,7 @@ packages:
       klona: 2.0.6
       postcss: 8.4.21
       semver: 7.3.8
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /postcss-logical/5.0.4_postcss@8.4.21:
@@ -16318,7 +16279,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  /react-dev-utils/12.0.1_5nsnk2aswgmt3bqwilhpeaeih4:
+  /react-dev-utils/12.0.1_xd7ncxsma4hqdb7auvbs7iobfm:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -16337,7 +16298,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_5nsnk2aswgmt3bqwilhpeaeih4
+      fork-ts-checker-webpack-plugin: 6.5.2_xd7ncxsma4hqdb7auvbs7iobfm
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -16353,7 +16314,7 @@ packages:
       strip-ansi: 6.0.1
       text-table: 0.2.0
       typescript: 4.9.5
-      webpack: 5.75.0
+      webpack: 5.76.1
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -16671,54 +16632,54 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.20.12
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_unmakpayn7vcxadrrsbqlrpehy
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_eamahzwwmqth5cpkxuccgzmpoa
       '@svgr/webpack': 5.5.0
       babel-jest: 27.5.1_@babel+core@7.20.12
-      babel-loader: 8.3.0_la66t7xldg4uecmyawueag5wkm
+      babel-loader: 8.3.0_vbwv3zr3kwaf4v2iytwakh6feu
       babel-plugin-named-asset-import: 0.3.8_@babel+core@7.20.12
       babel-preset-react-app: 10.0.1
       bfj: 7.0.2
       browserslist: 4.21.5
       camelcase: 6.3.0
       case-sensitive-paths-webpack-plugin: 2.4.0
-      css-loader: 6.7.3_webpack@5.75.0
-      css-minimizer-webpack-plugin: 3.4.1_webpack@5.75.0
+      css-loader: 6.7.3_webpack@5.76.1
+      css-minimizer-webpack-plugin: 3.4.1_webpack@5.76.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
       eslint: 8.33.0
       eslint-config-react-app: 7.0.1_6iwopyuv7xg3y3j23xjlstyxr4
-      eslint-webpack-plugin: 3.2.0_nkwuvqep7k7zzhloz3wxbhr4hq
-      file-loader: 6.2.0_webpack@5.75.0
+      eslint-webpack-plugin: 3.2.0_jb6p7kdr6szvmkzg5qu6snnoue
+      file-loader: 6.2.0_webpack@5.76.1
       fs-extra: 10.1.0
-      html-webpack-plugin: 5.5.0_webpack@5.75.0
+      html-webpack-plugin: 5.5.0_webpack@5.76.1
       identity-obj-proxy: 3.0.0
       jest: 27.5.1
       jest-resolve: 27.5.1
       jest-watch-typeahead: 1.1.0_jest@27.5.1
-      mini-css-extract-plugin: 2.7.2_webpack@5.75.0
+      mini-css-extract-plugin: 2.7.2_webpack@5.76.1
       postcss: 8.4.21
       postcss-flexbugs-fixes: 5.0.2_postcss@8.4.21
-      postcss-loader: 6.2.1_6jdsrmfenkuhhw3gx4zvjlznce
+      postcss-loader: 6.2.1_mquw4qchulb5tpkmg3p2j6qala
       postcss-normalize: 10.0.1_jrpp4geoaqu5dz2gragkckznb4
       postcss-preset-env: 7.8.3_postcss@8.4.21
       prompts: 2.4.2
       react: 18.2.0
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1_5nsnk2aswgmt3bqwilhpeaeih4
+      react-dev-utils: 12.0.1_xd7ncxsma4hqdb7auvbs7iobfm
       react-refresh: 0.11.0
       resolve: 1.22.1
       resolve-url-loader: 4.0.0
-      sass-loader: 12.6.0_sass@1.57.1+webpack@5.75.0
+      sass-loader: 12.6.0_sass@1.57.1+webpack@5.76.1
       semver: 7.3.8
-      source-map-loader: 3.0.2_webpack@5.75.0
-      style-loader: 3.3.1_webpack@5.75.0
+      source-map-loader: 3.0.2_webpack@5.76.1
+      style-loader: 3.3.1_webpack@5.76.1
       tailwindcss: 3.2.4
-      terser-webpack-plugin: 5.3.6_webpack@5.75.0
+      terser-webpack-plugin: 5.3.6_webpack@5.76.1
       typescript: 4.9.5
-      webpack: 5.75.0
-      webpack-dev-server: 4.11.1_webpack@5.75.0
-      webpack-manifest-plugin: 4.1.1_webpack@5.75.0
-      workbox-webpack-plugin: 6.5.4_webpack@5.75.0
+      webpack: 5.76.1
+      webpack-dev-server: 4.11.1_webpack@5.76.1
+      webpack-manifest-plugin: 4.1.1_webpack@5.76.1
+      workbox-webpack-plugin: 6.5.4_webpack@5.76.1
     optionalDependencies:
       fsevents: 2.3.2
     transitivePeerDependencies:
@@ -17447,7 +17408,7 @@ packages:
     resolution: {integrity: sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA==}
     dev: true
 
-  /sass-loader/12.6.0_sass@1.57.1+webpack@5.75.0:
+  /sass-loader/12.6.0_sass@1.57.1+webpack@5.76.1:
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -17469,7 +17430,7 @@ packages:
       klona: 2.0.6
       neo-async: 2.6.2
       sass: 1.57.1
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /sass/1.57.1:
@@ -17893,7 +17854,7 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
-  /source-map-loader/3.0.2_webpack@5.75.0:
+  /source-map-loader/3.0.2_webpack@5.76.1:
     resolution: {integrity: sha512-BokxPoLjyl3iOrgkWaakaxqnelAJSS+0V+De0kKIq6lyWrXuiPgYTGp6z3iHmqljKAaLXwZa+ctD8GccRJeVvg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -17902,7 +17863,7 @@ packages:
       abab: 2.0.6
       iconv-lite: 0.6.3
       source-map-js: 1.0.2
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /source-map-resolve/0.5.3:
@@ -18301,13 +18262,13 @@ packages:
       through: 2.3.8
     dev: true
 
-  /style-loader/3.3.1_webpack@5.75.0:
+  /style-loader/3.3.1_webpack@5.76.1:
     resolution: {integrity: sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /stylehacks/5.1.1_postcss@8.4.21:
@@ -18547,7 +18508,7 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: true
 
-  /terser-webpack-plugin/5.3.6_webpack@5.75.0:
+  /terser-webpack-plugin/5.3.6_webpack@5.76.1:
     resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -18568,7 +18529,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.1
       terser: 5.16.2
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
   /terser/5.16.2:
@@ -19391,7 +19352,7 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /webpack-dev-middleware/5.3.3_webpack@5.75.0:
+  /webpack-dev-middleware/5.3.3_webpack@5.76.1:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -19402,10 +19363,10 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.0
-      webpack: 5.75.0
+      webpack: 5.76.1
     dev: true
 
-  /webpack-dev-server/4.11.1_webpack@5.75.0:
+  /webpack-dev-server/4.11.1_webpack@5.76.1:
     resolution: {integrity: sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
@@ -19443,8 +19404,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.75.0
-      webpack-dev-middleware: 5.3.3_webpack@5.75.0
+      webpack: 5.76.1
+      webpack-dev-middleware: 5.3.3_webpack@5.76.1
       ws: 8.12.0
     transitivePeerDependencies:
       - bufferutil
@@ -19453,14 +19414,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /webpack-manifest-plugin/4.1.1_webpack@5.75.0:
+  /webpack-manifest-plugin/4.1.1_webpack@5.76.1:
     resolution: {integrity: sha512-YXUAwxtfKIJIKkhg03MKuiFAD72PlrqCiwdwO4VEXdRO5V0ORCNwaOwAZawPZalCbmH9kBDmXnNeQOw+BIEiow==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       webpack: ^4.44.2 || ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.75.0
+      webpack: 5.76.1
       webpack-sources: 2.3.1
     dev: true
 
@@ -19496,8 +19457,8 @@ packages:
     resolution: {integrity: sha512-5tyDlKLqPfMqjT3Q9TAqf2YqjwmnUleZwzJi1A5qXnlBCdj2AtOJ6wAWdglTIDOPgOiOrXeBeFcsQ8+aGQ6QbA==}
     dev: true
 
-  /webpack/5.75.0:
-    resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}
+  /webpack/5.76.1:
+    resolution: {integrity: sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -19527,7 +19488,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.6_webpack@5.75.0
+      terser-webpack-plugin: 5.3.6_webpack@5.76.1
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -19822,7 +19783,7 @@ packages:
     resolution: {integrity: sha512-vo2RQo7DILVRoH5LjGqw3nphavEjK4Qk+FenXeUsknKn14eCNedHOXWbmnvP4ipKhlE35pvJ4yl4YYf6YsJArA==}
     dev: true
 
-  /workbox-webpack-plugin/6.5.4_webpack@5.75.0:
+  /workbox-webpack-plugin/6.5.4_webpack@5.76.1:
     resolution: {integrity: sha512-LmWm/zoaahe0EGmMTrSLUi+BjyR3cdGEfU3fS6PN1zKFYbqAKuQ+Oy/27e4VSXsyIwAw8+QDfk1XHNGtZu9nQg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -19831,7 +19792,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       pretty-bytes: 5.6.0
       upath: 1.2.0
-      webpack: 5.75.0
+      webpack: 5.76.1
       webpack-sources: 1.4.3
       workbox-build: 6.5.4
     transitivePeerDependencies:


### PR DESCRIPTION
Changes I've made in synapse-oauth-signin are dependent upon the changes to useDetectSSOCode, which is how this work is related to PORTALS-2580

-----

- Refactor useDetectSSOCode so SSO redirect logic can be captured in-app
- Upgrade mui-one-time-password-input to 1.1.0 and use new `autoFocus`
- Fix dialog UI in portals

-----

Current portals login dialog needs more padding: 

<img width="387" alt="image" src="https://user-images.githubusercontent.com/17580037/225354357-c758847c-4795-4540-9573-386bd48428c4.png">

after changes:
<img width="509" alt="image" src="https://user-images.githubusercontent.com/17580037/225356108-3e8c53ff-3aaa-4a9b-9aa2-3b5b6d62fa04.png">
