### PR TITLE
PORTALS-2560: polish items for login and registration workflow steps

### DIFF
--- a/apps/SageAccountWeb/src/App.scss
+++ b/apps/SageAccountWeb/src/App.scss
@@ -39,20 +39,17 @@
 }
 
 .SourceAppLogo {
-  img {
-    max-width: 320px;
+  & > .SourceAppImage {
+    height: 65px;
   }
-  svg {
-    height: 100%;
-  }
-  margin-bottom: 50px;
+  margin-bottom: 30px;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .AccountSettingsSourceAppLogo {
-  img {
+  svg {
     height: 24px;
     max-height: 24px;
   }

--- a/apps/SageAccountWeb/src/LoginPage.tsx
+++ b/apps/SageAccountWeb/src/LoginPage.tsx
@@ -54,7 +54,7 @@ const LoginPage: React.FunctionComponent<LoginPageProps> = ({
           <Typography
             className="headline"
             variant="headline2"
-            sx={{ marginTop: '115px' }}
+            sx={{ marginTop: '95px' }}
           >
             Sign in to your account
           </Typography>

--- a/apps/SageAccountWeb/src/components/AccountCreatedPage.tsx
+++ b/apps/SageAccountWeb/src/components/AccountCreatedPage.tsx
@@ -20,9 +20,7 @@ export const AccountCreatedPage = (props: AccountCreatedPageProps) => {
             className={'AccountCreatedPage'}
             leftContent={
               <div>
-                <SourceAppLogo
-                  sx={{ textAlign: 'center', paddingBottom: '50px' }}
-                />
+                <SourceAppLogo sx={{ textAlign: 'center' }} />
                 <Typography variant="headline2">Account created</Typography>
                 <Typography
                   variant="headline3"

--- a/apps/SageAccountWeb/src/components/CurrentAffiliationPage.tsx
+++ b/apps/SageAccountWeb/src/components/CurrentAffiliationPage.tsx
@@ -33,9 +33,7 @@ export const CurrentAffiliationPage = () => {
         className={'CurrentAffiliationPage'}
         leftContent={
           <div>
-            <SourceAppLogo
-              sx={{ textAlign: 'center', paddingBottom: '50px' }}
-            />
+            <SourceAppLogo sx={{ textAlign: 'center' }} />
             <StyledFormControl
               fullWidth
               variant="standard"

--- a/apps/SageAccountWeb/src/components/ProfileValidation/ORCiDButton.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/ORCiDButton.tsx
@@ -4,7 +4,7 @@ import { SynapseClient } from 'synapse-react-client'
 import { PROVIDERS } from 'synapse-react-client/dist/containers/auth/AuthenticationMethodSelection'
 import { displayToast } from 'synapse-react-client/dist/containers/ToastMessage'
 import { ValidationWizardStep } from './ProfileValidation'
-import { ReactComponent as OrcId } from '../../assets/ORCID.svg'
+import OrcId from '../../assets/ORCID.svg'
 import EditIcon from '../../assets/RedEditPencil.svg'
 
 export type ORCiDButtonProps = {
@@ -69,7 +69,7 @@ export const ORCiDButton = (props: ORCiDButtonProps) => {
           sx={props.sx}
           disabled={isLoading}
         >
-          <OrcId />
+          <img src={OrcId} alt="orcid logo" />
           &nbsp; Link your ORCID profile
         </Button>
       )}

--- a/apps/SageAccountWeb/src/components/ProfileValidation/ProfileFieldsEditor.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/ProfileFieldsEditor.tsx
@@ -50,7 +50,12 @@ export const ProfileFieldsEditor = (props: ProfileFieldsEditorProps) => {
           marginBottom: theme.spacing(2),
         }}
       >
-        <StyledFormControl fullWidth variant="standard" margin="normal">
+        <StyledFormControl
+          fullWidth
+          variant="standard"
+          margin="normal"
+          sx={{ marginTop: '0px' }}
+        >
           <InputLabel shrink htmlFor="firstName" required>
             First Name
           </InputLabel>

--- a/apps/SageAccountWeb/src/components/ProfileValidation/ProfileValidation.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/ProfileValidation.tsx
@@ -446,9 +446,7 @@ export const ProfileValidation = (props: ProfileValidationProps) => {
                   <ArrowBackIcon />
                 </IconButton>
               )}
-              <SourceAppLogo
-                sx={{ textAlign: 'center', paddingBottom: '35px' }}
-              />
+              <SourceAppLogo sx={{ textAlign: 'center' }} />
               <BodyControlFactory
                 {...{
                   step: step,

--- a/apps/SageAccountWeb/src/components/RegisterAccount1.tsx
+++ b/apps/SageAccountWeb/src/components/RegisterAccount1.tsx
@@ -58,14 +58,23 @@ export const RegisterAccount1 = (props: RegisterAccount1Props) => {
     }
   }, [appContext.signedToken])
 
+  const formControlSx = {
+    marginTop: '0px',
+    marginBottom: '10px',
+  }
+
   const buttonSx = {
     width: '100%',
     padding: '10px',
     color: 'white',
+    marginTop: '30px',
   }
 
   const chooseButtonSx = {
-    color: '#666',
+    width: '100%',
+    marginBottom: '10px',
+    padding: '10px',
+    color: 'grey.800',
     borderColor: '#EAECEE',
   }
 
@@ -204,6 +213,7 @@ export const RegisterAccount1 = (props: RegisterAccount1Props) => {
                           fullWidth
                           variant="standard"
                           margin="normal"
+                          sx={formControlSx}
                         >
                           <InputLabel shrink htmlFor="emailAddress" required>
                             Email address
@@ -255,6 +265,7 @@ export const RegisterAccount1 = (props: RegisterAccount1Props) => {
                           fullWidth
                           variant="standard"
                           margin="normal"
+                          sx={formControlSx}
                         >
                           <InputLabel shrink htmlFor="username" required>
                             Username
@@ -293,7 +304,7 @@ export const RegisterAccount1 = (props: RegisterAccount1Props) => {
                     "url('https://s3.amazonaws.com/static.synapse.org/images/login-panel-bg.svg') no-repeat right bottom 20px",
                 }}
               >
-                <Typography variant="headline2" sx={{ marginTop: '115px' }}>
+                <Typography variant="headline2" sx={{ marginTop: '95px' }}>
                   Create an Account
                 </Typography>
                 <Typography variant="body2" sx={{ marginBottom: '20px' }}>

--- a/apps/SageAccountWeb/src/components/SageResourcesPage.tsx
+++ b/apps/SageAccountWeb/src/components/SageResourcesPage.tsx
@@ -19,7 +19,13 @@ export const SageResourcesPage = (props: SageResourcesPageProps) => {
     <StyledOuterContainer>
       <Paper
         className="SageResourcesPage"
-        sx={{ margin: '0 auto', width: '900px', backgroundColor: '#FFF' }}
+        sx={{
+          margin: '0 auto',
+          width: '900px',
+          backgroundColor: '#FFF',
+          boxShadow: '0px 2px 6px rgba(53, 58, 63, 0.1)',
+          borderRadius: '5px',
+        }}
       >
         <IconButton
           onClick={() => {

--- a/apps/SageAccountWeb/src/components/StyledComponents.ts
+++ b/apps/SageAccountWeb/src/components/StyledComponents.ts
@@ -1,16 +1,20 @@
 import {
   alpha,
   Box,
+  BoxProps,
   Paper,
+  PaperProps,
   FormControl,
+  FormControlProps,
   formHelperTextClasses,
   inputBaseClasses,
   styled,
   textFieldClasses,
 } from '@mui/material'
 import { latoFont } from 'style/theme'
+import { StyledComponent } from '@mui/styles'
 
-export const StyledOuterContainer = styled(Box, {
+export const StyledOuterContainer: StyledComponent<BoxProps> = styled(Box, {
   label: 'StyledOuterContainer',
 })(({ theme }) => ({
   minHeight: '100vh',
@@ -21,7 +25,7 @@ export const StyledOuterContainer = styled(Box, {
   backgroundSize: 'cover',
 }))
 
-export const StyledInnerContainer = styled(Paper, {
+export const StyledInnerContainer: StyledComponent<PaperProps> = styled(Paper, {
   label: 'StyledInnerContainer',
 })(({ theme }) => ({
   width: '900px',
@@ -52,9 +56,12 @@ export const StyledInnerContainer = styled(Paper, {
             id="someinput"/>
         </StyledFormControl>
 */
-export const StyledFormControl = styled(FormControl, {
-  label: 'StyledFormControl',
-})(({ theme }) => ({
+export const StyledFormControl: StyledComponent<FormControlProps> = styled(
+  FormControl,
+  {
+    label: 'StyledFormControl',
+  },
+)(({ theme }) => ({
   '& label': {
     fontSize: '14px',
     transform: 'none',

--- a/apps/SageAccountWeb/src/style/_Register.scss
+++ b/apps/SageAccountWeb/src/style/_Register.scss
@@ -15,11 +15,6 @@
     .form-group {
       margin-top: 30px;
     }
-    button {
-      width: 100%;
-      margin: 10px 0px;
-      padding: 10px;
-    }
     > * {
       width: 300px;
     }
@@ -27,12 +22,10 @@
   .panel-right-text {
     margin-top: 100px;
   }
-  .panel-right-text {
-    margin-top: 100px;
-  }
   .thankYouContainer {
     background: #fefefe;
-    box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
+    box-shadow: '0px 2px 6px rgba(53, 58, 63, 0.1)';
+    border-radius: '5px';
     padding: 80px;
     width: 500px;
     .thankYouPanel {

--- a/apps/SageAccountWeb/src/style/_SourceApp.scss
+++ b/apps/SageAccountWeb/src/style/_SourceApp.scss
@@ -1,3 +1,5 @@
 .SourceAppImage svg {
   max-width: 300px;
+  height: 100%;
+  width: 100%;
 }


### PR DESCRIPTION
- Use consistent box-shadow and border-radius for content container
- Align left panel buttons and right panel text for different logos
  - Standardize logo height
  - Adjust right panel text padding
- "Tertiary" link should have 20px space from button above it
- Decrease padding between logo and button in left panel to match design
- Size logos in Account Settings page
- Fix ORCID button logo

Examples of changes: 

Change | main | PORTALS-2560
:--------:|:--------:|:--------:
_/_ - logo size | ![main_logo_MTB](https://user-images.githubusercontent.com/26949006/227591064-b5d5ab0e-d38b-44fb-84cf-31693c37b46f.png) ![main_logo_SAGE](https://user-images.githubusercontent.com/26949006/227591695-00195528-df97-486d-b2f9-7214ff022d5d.png) | ![feature_logo_MTB](https://user-images.githubusercontent.com/26949006/227591077-65cdd3df-6d9d-4d11-8e3d-cb915dc780a5.png) ![feature_logo_SAGE](https://user-images.githubusercontent.com/26949006/227591678-93bbd194-3ff2-4f43-ba90-415fdbf70c1a.png)
_/registeraccount1_  - Padding between logo and first button in left panel, adjusting padding in right panel to align text | ![main_2_registeraccount1_email_signup](https://user-images.githubusercontent.com/26949006/227588656-7b985758-1b81-4001-933f-4ccd16cbbb12.png) | ![feature_2_registeraccount1_email_signup](https://user-images.githubusercontent.com/26949006/227588632-7756cf72-ee2b-4f59-859c-8f04400eb1ef.png)
_/authenticated/accountcreated_ - padding between logo and text in left panel | ![main_5_account_created](https://user-images.githubusercontent.com/26949006/227589969-2dce385d-c54a-4316-b050-c0d512770a54.png) | ![feature_5_account_created](https://user-images.githubusercontent.com/26949006/227589956-5c373a6c-49bc-4270-a355-fe28ac53792b.png)
_/sageresources_ - box shadow | ![main_6_sageresources](https://user-images.githubusercontent.com/26949006/227590183-e16e60f0-1f4d-479f-b91f-18bf4e4ecd31.png) | ![feature_6_sageresources](https://user-images.githubusercontent.com/26949006/227590229-eaf0d545-305c-4b49-86fc-0f4529439a0a.png)
_/authenticated/myaccount_ - logo size in header and used by section, logo for ORCID button | ![main_7_sageaccount_header](https://user-images.githubusercontent.com/26949006/227590553-2431b8ea-0b07-4ee4-adb0-2cc8138e6c63.png) ![main_8_sageaccount_used_by](https://user-images.githubusercontent.com/26949006/227590554-60105579-757f-4d20-bb85-a8502ae78d97.png) ![main_9_sageaccount_orcid](https://user-images.githubusercontent.com/26949006/227590555-64b36d8b-2e45-45dd-b473-122468fe4ac0.png) | ![feature_7_sageaccount_header](https://user-images.githubusercontent.com/26949006/227590539-b0c1fcdc-95af-4b63-96a2-ebf975268bca.png) ![feature_8_sageaccount_used_by](https://user-images.githubusercontent.com/26949006/227590541-d8e04cb4-a252-4c99-8df1-8ec5dcdf7836.png) ![feature_9_sageaccount_orcid](https://user-images.githubusercontent.com/26949006/227590542-1795c35b-1cf7-4855-974f-843a4f673029.png)
_/authenticated/validate_ - padding between logo and text in left panel, ORCID button | ![main_11_verification_orcid](https://user-images.githubusercontent.com/26949006/227590964-c3857be1-007b-4019-9e22-8062eda9c166.png) | ![feature_11_verification_orcid](https://user-images.githubusercontent.com/26949006/227590984-76e81a04-82e1-4a80-b8e0-6ccd666d35d4.png)


