### PR TITLE
PORTALS-2581 - Google SSO + Synapse 2FA in SageAccountWeb

### DIFF
--- a/apps/SageAccountWeb/src/LoginPage.tsx
+++ b/apps/SageAccountWeb/src/LoginPage.tsx
@@ -8,21 +8,21 @@ import {
   StyledInnerContainer,
   StyledOuterContainer,
 } from 'components/StyledComponents'
+import { useTwoFactorAuthSSOContext } from './TwoFactorAuthSSOContext'
+import {
+  preparePostSSORedirect,
+  redirectAfterSSO,
+} from 'synapse-react-client/dist/utils/AppUtils'
 
 export type OwnProps = {
   returnToUrl: string
 }
 export type LoginPageProps = OwnProps & RouteComponentProps
 
-const LoginPage: React.FunctionComponent<LoginPageProps> = ({
-  returnToUrl,
-}: OwnProps) => {
-  const [isSessionEstablished, setIsSessionEstablished] =
-    React.useState<boolean>(false)
-  if (isSessionEstablished) {
-    // using this instead of Redirect since we may need a page refresh
-    window.location.replace(returnToUrl)
-  }
+function LoginPage(props: LoginPageProps) {
+  const { returnToUrl } = props
+  const { twoFactorAuthErrorResponse } = useTwoFactorAuthSSOContext()
+
   return (
     <StyledOuterContainer>
       <StyledInnerContainer>
@@ -32,16 +32,16 @@ const LoginPage: React.FunctionComponent<LoginPageProps> = ({
               <SourceAppLogo />
             </div>
             <StandaloneLoginForm
-              sessionCallback={() => setIsSessionEstablished(true)}
+              sessionCallback={() => {
+                redirectAfterSSO(returnToUrl)
+              }}
               registerAccountUrl={'/register1'}
               resetPasswordUrl={'/resetPassword'}
               onBeginOAuthSignIn={() => {
                 // save current route (so that we can go back here after SSO)
-                localStorage.setItem(
-                  'after-sso-login-url',
-                  window.location.href,
-                )
+                preparePostSSORedirect()
               }}
+              twoFactorAuthenticationRequired={twoFactorAuthErrorResponse}
             />
           </Box>
         </Box>

--- a/apps/SageAccountWeb/src/TwoFactorAuthSSOContext.tsx
+++ b/apps/SageAccountWeb/src/TwoFactorAuthSSOContext.tsx
@@ -1,0 +1,46 @@
+import React, { useContext } from 'react'
+import { TwoFactorAuthErrorResponse } from 'synapse-react-client/dist/utils/synapseTypes/ErrorResponse'
+
+export type TwoFactorAuthSSOContextType = {
+  /* Error object that is required to sign in with two-factor authentication. */
+  twoFactorAuthErrorResponse?: TwoFactorAuthErrorResponse
+}
+
+/*
+ * A twoFactorAuthErrorResponse is required to complete a sign in with 2FA. If signing in with SSO (e.g. Google), then
+ *  the error object would be returned out-of-band and can be passed back into the Login component through context.
+ */
+const TwoFactorAuthSSOContext = React.createContext<
+  TwoFactorAuthSSOContextType | undefined
+>(undefined)
+
+export type TwoFactorAuthSSOContextProviderProps = React.PropsWithChildren<{
+  context: TwoFactorAuthSSOContextType
+}>
+
+export function TwoFactorAuthSSOContextProvider(
+  props: TwoFactorAuthSSOContextProviderProps,
+) {
+  const { context, children } = props
+  return (
+    <TwoFactorAuthSSOContext.Provider value={context}>
+      {children}
+    </TwoFactorAuthSSOContext.Provider>
+  )
+}
+
+export const TwoFactorAuthSSOContextConsumer = TwoFactorAuthSSOContext.Consumer
+
+/*
+ * A twoFactorAuthErrorResponse is required to complete a sign in with 2FA. If signing in with SSO (e.g. Google), then
+ *  the error object would be returned out-of-band and can be passed back into the Login component through this context hook.
+ */
+export function useTwoFactorAuthSSOContext(): TwoFactorAuthSSOContextType {
+  const context = useContext(TwoFactorAuthSSOContext)
+  if (context === undefined) {
+    throw new Error(
+      'useTwoFactorAuthSSOContext must be used within a TwoFactorAuthSSOContextProvider',
+    )
+  }
+  return context
+}

--- a/apps/SageAccountWeb/src/components/ProfileValidation/ORCiDButton.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/ORCiDButton.tsx
@@ -6,27 +6,31 @@ import { displayToast } from 'synapse-react-client/dist/containers/ToastMessage'
 import { ValidationWizardStep } from './ProfileValidation'
 import OrcId from '../../assets/ORCID.svg'
 import EditIcon from '../../assets/RedEditPencil.svg'
+import { POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY } from 'synapse-react-client/dist/utils/AppUtils'
 
 export type ORCiDButtonProps = {
-  redirectAfter?: any
+  redirectAfter?: string
   editButton?: boolean
   sx?: SxProps
 }
 
-export const onBindToORCiD = async (
+export const onBindToORCiD = (
   event: React.SyntheticEvent,
-  setIsLoading: Function,
-  redirectAfter?: any,
+  setIsLoading: (isLoading: boolean) => void,
+  redirectAfter?: string,
 ) => {
   event.preventDefault()
   setIsLoading(true)
   try {
     // after binding, go to ???
     if (redirectAfter) {
-      localStorage.setItem('after-sso-login-url', redirectAfter)
+      localStorage.setItem(
+        POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY,
+        redirectAfter,
+      )
     } else {
       localStorage.setItem(
-        'after-sso-login-url',
+        POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY,
         `${SynapseClient.getRootURL()}authenticated/validate?step=${
           ValidationWizardStep.VERIFY_IDENTITY
         }`,

--- a/apps/SageAccountWeb/src/components/RegisterAccount1.tsx
+++ b/apps/SageAccountWeb/src/components/RegisterAccount1.tsx
@@ -23,6 +23,7 @@ import {
   StyledOuterContainer,
   StyledFormControl,
 } from './StyledComponents'
+import { POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY } from 'synapse-react-client/dist/utils/AppUtils'
 
 export type RegisterAccount1Props = {}
 
@@ -145,7 +146,7 @@ export const RegisterAccount1 = (props: RegisterAccount1Props) => {
         // redirect to Google login, passing the username through via the state param.
         // Send us back to the special oauth2 account creation step2 path (which is ignored by our AppInitializer)
         localStorage.setItem(
-          'after-sso-login-url',
+          POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY,
           `${SynapseClient.getRootURL()}authenticated/signTermsOfUse`,
         )
         const redirectUrl = `${SynapseClient.getRootURL()}?provider=${

--- a/apps/portals/src/AppInitializer.tsx
+++ b/apps/portals/src/AppInitializer.tsx
@@ -18,16 +18,16 @@ import { TwoFactorAuthErrorResponse } from 'synapse-react-client/dist/utils/syna
 import useAnalytics from 'useAnalytics'
 import docTitleConfig from './config/docTitleConfig.json'
 import palette from './config/paletteConfig'
-import { redirectAfterSSO } from './utils'
+import { redirectAfterSSO } from 'synapse-react-client/dist/utils/AppUtils'
 
 export type SignInProps = {
   userProfile: UserProfile | undefined
-  resetSession: Function
+  resetSession: () => Promise<void>
   getSession: () => Promise<void>
   showLoginDialog: boolean
   twoFaErrorResponse: TwoFactorAuthErrorResponse | undefined
-  onSignIn: Function
-  handleCloseLoginDialog: Function
+  onSignIn: () => void
+  handleCloseLoginDialog: () => void
 }
 
 const COOKIE_CONFIG_KEY = 'org.sagebionetworks.security.cookies.portal.config'
@@ -71,7 +71,7 @@ function useSession(
   }, [])
 
   const getSession = useCallback(async () => {
-    let token
+    let token: string | undefined
     try {
       token = await SynapseClient.getAccessTokenFromCookie()
       if (!token) {
@@ -237,7 +237,9 @@ function AppInitializer(props: { children?: React.ReactNode }) {
   }, [])
 
   useDetectSSOCode({
-    onSignInComplete: redirectAfterSSO,
+    onSignInComplete: () => {
+      redirectAfterSSO()
+    },
     onTwoFactorAuthRequired: (twoFactorAuthError) => {
       setTwoFaErrorResponse(twoFactorAuthError)
       setShowLoginDialog(true)

--- a/apps/portals/src/Navbar.tsx
+++ b/apps/portals/src/Navbar.tsx
@@ -8,9 +8,12 @@ import NavLink from 'portal-components/NavLink'
 import NavUserLink from './portal-components/NavUserLink'
 import { ConfigRoute, GenericRoute } from 'types/portal-config'
 import Button from 'react-bootstrap/esm/Button'
-import { preparePostSSORedirect, redirectAfterSSO } from './utils'
 import { Dialog, DialogContent, IconButton } from '@mui/material'
 import IconSvg from 'synapse-react-client/dist/containers/IconSvg'
+import {
+  preparePostSSORedirect,
+  redirectAfterSSO,
+} from 'synapse-react-client/dist/utils/AppUtils'
 
 type SynapseSettingLink = {
   text: string

--- a/apps/portals/src/utils.ts
+++ b/apps/portals/src/utils.ts
@@ -12,24 +12,3 @@ export const DESKTOP_VIEWPORT_MIN_WIDTH_MEDIA_QUERY = `(min-width: ${DESKTOP_VIE
 
 export const useShowDesktop = () =>
   useMedia(DESKTOP_VIEWPORT_MIN_WIDTH_MEDIA_QUERY)
-
-const POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY = 'after-sso-login-url'
-
-export function preparePostSSORedirect() {
-  // save current route (so that we can go back here after SSO)
-  localStorage.setItem(
-    POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY,
-    window.location.href,
-  )
-}
-
-export function redirectAfterSSO() {
-  // go back to original route after successful SSO login
-  const originalUrl = localStorage.getItem(
-    POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY,
-  )
-  localStorage.removeItem(POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY)
-  if (originalUrl) {
-    window.location.replace(originalUrl)
-  }
-}

--- a/apps/synapse-oauth-signin/src/App.test.tsx
+++ b/apps/synapse-oauth-signin/src/App.test.tsx
@@ -8,6 +8,7 @@ import App from './App'
 import userEvent from '@testing-library/user-event'
 import { SynapseClient } from 'synapse-react-client'
 import { LoginResponse } from 'synapse-react-client/dist/utils/synapseTypes/LoginResponse'
+import { POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY } from 'synapse-react-client/dist/utils/AppUtils'
 
 function createParams(prompt?: string) {
   const params = new URLSearchParams()
@@ -239,7 +240,7 @@ describe('App integration tests', () => {
 
     // Note - don't use `renderApp` since it sets the URL and instead we want to simulate the redirect from Google
     localStorage.setItem(
-      'after-sso-login-url',
+      POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY,
       `/?${createParams().toString()}`,
     )
     window.history.replaceState({}, '', `/?${paramsFromProvider.toString()}`)

--- a/apps/synapse-oauth-signin/src/AppInitializer.tsx
+++ b/apps/synapse-oauth-signin/src/AppInitializer.tsx
@@ -13,6 +13,7 @@ import useDetectSSOCode from 'synapse-react-client/dist/utils/hooks/useDetectSSO
 import { TwoFactorAuthErrorResponse } from 'synapse-react-client/dist/utils/synapseTypes/ErrorResponse'
 import { OAuthAppContext } from './OAuthAppContext'
 import themeOptions from './style/theme'
+import { redirectAfterSSO } from 'synapse-react-client/dist/utils/AppUtils'
 
 const queryClient = new QueryClient(defaultQueryClientConfig)
 
@@ -57,11 +58,7 @@ function AppInitializer(
 
   useDetectSSOCode({
     onSignInComplete: () => {
-      const originalUrl = localStorage.getItem('after-sso-login-url')
-      localStorage.removeItem('after-sso-login-url')
-      if (originalUrl) {
-        window.location.replace(originalUrl)
-      }
+      redirectAfterSSO()
     },
     onTwoFactorAuthRequired: twoFactorAuthError => {
       setTwoFactorAuthErrorResponse(twoFactorAuthError)

--- a/apps/synapse-oauth-signin/src/OAuth2Form.tsx
+++ b/apps/synapse-oauth-signin/src/OAuth2Form.tsx
@@ -20,6 +20,10 @@ import FullWidthAlert from 'synapse-react-client/dist/containers/FullWidthAlert'
 import { useOAuthAppContext } from './OAuthAppContext'
 import { OAuthClientError } from './OAuthClientError'
 import { StyledInnerContainer } from './StyledInnerContainer'
+import {
+  preparePostSSORedirect,
+  redirectAfterSSO,
+} from 'synapse-react-client/dist/utils/AppUtils'
 
 export function OAuth2Form() {
   const isMounted = useRef(true)
@@ -417,15 +421,11 @@ export function OAuth2Form() {
           <StandaloneLoginForm
             onBeginOAuthSignIn={() => {
               // save current route (so that we can go back here after SSO)
-              localStorage.setItem('after-sso-login-url', window.location.href)
+              preparePostSSORedirect()
             }}
             sessionCallback={() => {
               getSession().then(() => {
-                const originalUrl = localStorage.getItem('after-sso-login-url')
-                localStorage.removeItem('after-sso-login-url')
-                if (originalUrl) {
-                  window.location.replace(originalUrl)
-                }
+                redirectAfterSSO()
               })
             }}
             twoFactorAuthenticationRequired={twoFactorAuthErrorResponse}

--- a/packages/synapse-react-client/src/lib/utils/AppUtils.ts
+++ b/packages/synapse-react-client/src/lib/utils/AppUtils.ts
@@ -1,0 +1,21 @@
+export const POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY = 'after-sso-login-url'
+
+export function preparePostSSORedirect() {
+  // save current route (so that we can go back here after SSO)
+  localStorage.setItem(
+    POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY,
+    window.location.href,
+  )
+}
+
+export function redirectAfterSSO(fallbackRedirectUrl?: string) {
+  // go back to original route after successful SSO login
+  const originalUrl = localStorage.getItem(
+    POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY,
+  )
+  localStorage.removeItem(POST_SSO_REDIRECT_URL_LOCALSTORAGE_KEY)
+  const redirectUrl = originalUrl ?? fallbackRedirectUrl
+  if (redirectUrl) {
+    window.location.replace(redirectUrl)
+  }
+}


### PR DESCRIPTION
- Add SSO + 2FA handling to SageAccountWeb
- Refactor SSO redirect utils from portals to synapse-react-client
- Use SSO redirect utils in all 3 apps