### PR TITLE
PORTALS-2608: update reset password page design

### DIFF
--- a/apps/SageAccountWeb/src/components/LeftRightPanel.tsx
+++ b/apps/SageAccountWeb/src/components/LeftRightPanel.tsx
@@ -11,11 +11,12 @@ export const LeftRightPanel: React.FC<{
   return (
     <StyledOuterContainer className={className}>
       <StyledInnerContainer>
-        <Box>{leftContent}</Box>
+        <Box className="left-panel">{leftContent}</Box>
         <Box sx={{ position: 'relative' }}>
           <Box
+            className="right-panel"
             sx={{
-              marginTop: theme.spacing(8),
+              marginTop: '95px',
               marginBottom: theme.spacing(4),
               overflow: 'hidden',
               fontWeight: '700',

--- a/apps/SageAccountWeb/src/components/RegisterAccount2.tsx
+++ b/apps/SageAccountWeb/src/components/RegisterAccount2.tsx
@@ -191,9 +191,7 @@ export const RegisterAccount2 = (props: RegisterAccount2Props) => {
         }
         rightContent={
           <div>
-            <Typography variant="headline2" sx={{ marginTop: '50px' }}>
-              Email address verified!
-            </Typography>
+            <Typography variant="headline2">Email address verified!</Typography>
             <Typography variant="headline3" sx={{ marginTop: '20px' }}>
               Now complete your registration.
             </Typography>

--- a/apps/SageAccountWeb/src/components/ResetPassword.tsx
+++ b/apps/SageAccountWeb/src/components/ResetPassword.tsx
@@ -1,4 +1,8 @@
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { Box, Button, IconButton, InputLabel, TextField } from '@mui/material'
+import { StyledFormControl } from 'components/StyledComponents'
 import React, { useEffect, useState } from 'react'
+import { useHistory } from 'react-router-dom'
 import { SynapseClient, Typography } from 'synapse-react-client'
 import { displayToast } from 'synapse-react-client/dist/containers/ToastMessage'
 import {
@@ -6,19 +10,15 @@ import {
   PasswordResetSignedToken,
 } from 'synapse-react-client/dist/utils/synapseTypes/ChangePasswordRequests'
 import { getSearchParam, hexDecodeAndDeserialize } from 'URLUtils'
-import { Button, InputLabel, TextField } from '@mui/material'
-import {
-  StyledFormControl,
-  StyledInnerContainer,
-  StyledOuterContainer,
-} from 'components/StyledComponents'
-import { Container } from 'react-bootstrap'
+import { LeftRightPanel } from './LeftRightPanel'
+import { SourceAppLogo } from './SourceApp'
 
 export type ResetPasswordProps = {
   returnToUrl: string
 }
 
 export const ResetPassword = (props: ResetPasswordProps) => {
+  const history = useHistory()
   const [userName, setUserName] = useState('')
   const [token, setToken] = useState<PasswordResetSignedToken | undefined>()
   const [newPassword, setNewPassword] = useState<string>('')
@@ -80,18 +80,39 @@ export const ResetPassword = (props: ResetPasswordProps) => {
     }
   }
 
+  const formControlSx = {
+    marginTop: '0px',
+    marginBottom: '10px',
+  }
+
+  const buttonSx = {
+    marginTop: '30px',
+  }
+
+  const backButtonSx = {
+    position: 'absolute',
+    padding: '0',
+    width: '24px',
+    margin: '24px',
+    top: '-64px',
+    left: '-64px',
+  }
+
   return (
-    <StyledOuterContainer>
-      <StyledInnerContainer>
-        <Container>
-          {token ? (
+    <>
+      <LeftRightPanel
+        className={'ResetPasswords'}
+        leftContent={
+          token ? (
             <>
+              <SourceAppLogo />
               <form onSubmit={handleChangePasswordWithToken}>
                 <StyledFormControl
                   fullWidth
                   required
                   variant="standard"
                   margin="normal"
+                  sx={formControlSx}
                 >
                   <InputLabel shrink htmlFor="newPassword" required>
                     New password
@@ -110,6 +131,7 @@ export const ResetPassword = (props: ResetPasswordProps) => {
                   required
                   variant="standard"
                   margin="normal"
+                  sx={formControlSx}
                 >
                   <InputLabel shrink htmlFor="confirmPassword" required>
                     Confirm password
@@ -129,30 +151,39 @@ export const ResetPassword = (props: ResetPasswordProps) => {
                   type="submit"
                   fullWidth
                   onSubmit={handleChangePasswordWithToken}
+                  sx={buttonSx}
+                  disabled={!newPassword || !confirmPassword}
                 >
                   Change Password
                 </Button>
               </form>
             </>
           ) : (
-            <>
-              <Typography variant="headline2">Reset your Password</Typography>
-              <Typography variant="body1">
-                Please enter your email address or Synapse user name and we'll
-                send you instructions to reset your password
-              </Typography>
+            <Box sx={{ position: 'relative' }}>
+              <IconButton
+                onClick={() => {
+                  history.goBack()
+                }}
+                sx={backButtonSx}
+              >
+                <ArrowBackIcon />
+              </IconButton>
+              <SourceAppLogo />
               <StyledFormControl
                 fullWidth
                 required
                 variant="standard"
                 margin="normal"
+                sx={formControlSx}
               >
+                <InputLabel shrink htmlFor="username" required>
+                  Email address or username
+                </InputLabel>
                 <TextField
                   fullWidth
                   id="username"
                   name="username"
                   onChange={e => setUserName(e.target.value)}
-                  placeholder="Email address-or-username"
                   value={userName || ''}
                 />
               </StyledFormControl>
@@ -160,13 +191,36 @@ export const ResetPassword = (props: ResetPasswordProps) => {
                 variant="contained"
                 fullWidth
                 onClick={handleResetPassword}
+                sx={buttonSx}
+                type="button"
+                disabled={!userName}
               >
                 Reset my password
               </Button>
-            </>
-          )}
-        </Container>
-      </StyledInnerContainer>
-    </StyledOuterContainer>
+            </Box>
+          )
+        }
+        rightContent={
+          token ? (
+            <div>
+              <Typography variant="headline2">Set a new password</Typography>
+              <Typography variant="smallText1">
+                We recommend using a strong, unique <strong>password</strong> of
+                between 16-32 characters. You can use letters, numbers, and
+                punctuation marks.
+              </Typography>
+            </div>
+          ) : (
+            <div>
+              <Typography variant="headline2">Reset your password</Typography>
+              <Typography variant="body1">
+                Please enter your email address or username and we'll send you
+                instructions to reset your password
+              </Typography>
+            </div>
+          )
+        }
+      ></LeftRightPanel>
+    </>
   )
 }

--- a/apps/SageAccountWeb/src/style/_AccountCreatedPage.scss
+++ b/apps/SageAccountWeb/src/style/_AccountCreatedPage.scss
@@ -1,11 +1,14 @@
 .AccountCreatedPage {
+  .right-panel {
+    margin-top: 16px;
+  }
   button,
   a {
     width: 100%;
     margin: 10px 0px;
     display: block;
   }
-  .sourceAppItem img {
+  .sourceAppItem svg {
     max-height: 50px;
     max-width: 130px;
     height: 37px;


### PR DESCRIPTION
Update reset password component to match design:
  - Style as left-right panel
  - Disable button when required values not entered in form
  - Include back button when requesting password reset

. | main | feature
:----:|:----:|:----:
request reset | ![main_resetpassword_request](https://user-images.githubusercontent.com/26949006/228066944-b6a07825-0609-4e98-9e5c-c851fef9de64.png) | ![feature_resetpassword_request](https://user-images.githubusercontent.com/26949006/228066932-8f2d931d-43cf-48a2-b6eb-a4a9b1d2ec73.png)
change password | ![main_resetpassword_change](https://user-images.githubusercontent.com/26949006/228066941-a20c97de-44a6-44fe-93df-c91ec8a7e7f1.png) | ![feature_resetpassword_change](https://user-images.githubusercontent.com/26949006/228066928-4119e49d-2fd7-495b-b3d6-df7bea1e74f9.png)

Related changes
.  | main | feature
:----:|:----:|:----:
account created - logo sizing, right panel text alignment | ![main_accountcreated](https://user-images.githubusercontent.com/26949006/228067284-7c4e3273-b398-4532-bbad-bd602ddd681d.png) | ![feature_accountcreated](https://user-images.githubusercontent.com/26949006/228067272-904b407a-f939-4e33-8058-aedcf391c185.png)
registeraccount2 - right panel text alignment | ![main_registeraccount2](https://user-images.githubusercontent.com/26949006/228067286-2b8df62e-d161-4178-ae5f-df83dd6b398c.png) | ![feature_registeraccount2](https://user-images.githubusercontent.com/26949006/228067275-6fd4845b-64f8-45a1-83a1-29ee7ce23c5d.png)





