### PR TITLE
Re-add accidentally dropped line break

### DIFF
--- a/.github/workflows/deploy-sage-account-web.yml
+++ b/.github/workflows/deploy-sage-account-web.yml
@@ -54,8 +54,9 @@ jobs:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store- - name: install-dependencies
-      - run: pnpm install
+            ${{ runner.os }}-pnpm-store-
+      - name: install-dependencies
+        run: pnpm install
       - name: build
         run: pnpm nx run SageAccountWeb:build
       - name: Assume AWS Role


### PR DESCRIPTION
- move 'install-dependencies' step name back down to its own line