### PR TITLE
PORTALS-2617: remove background fill color in sage pledge icons

### DIFF
--- a/packages/synapse-react-client/src/lib/style/components/_terms-and-conditions.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_terms-and-conditions.scss
@@ -60,6 +60,7 @@ $signatureLine-width: 420px;
 
         svg {
           height: 60px;
+          fill: transparent;
         }
       }
       .terms-circle {


### PR DESCRIPTION
page | main | feature
:---:|:---:|:---:
signTermsOfUse | ![main_authenticated_signTermsOfUse](https://user-images.githubusercontent.com/26949006/229911314-90fe7086-0fde-43bb-b131-a5ca3e803e57.png) | ![feature_authenticated_signTermsOfUse](https://user-images.githubusercontent.com/26949006/229911290-e7633f1f-136f-4c56-ac57-1f5400f8f1d8.png)
validate | ![main_authenticated_validate](https://user-images.githubusercontent.com/26949006/229911329-baa09cb4-1259-400e-83b7-701597c14af3.png) | ![feature_authenticated_validate](https://user-images.githubusercontent.com/26949006/229911303-a7780485-5cce-42d9-99a9-1750667f921e.png)