### PR TITLE
PORTALS-2582 - Add 2FA setup to SageAccountWeb

### DIFF
--- a/apps/SageAccountWeb/src/App.tsx
+++ b/apps/SageAccountWeb/src/App.tsx
@@ -26,6 +26,8 @@ import AppInitializer from './AppInitializer'
 import LoginPage from './LoginPage'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import ApplicationSessionManager from 'synapse-react-client/dist/utils/apputils/session/ApplicationSessionManager'
+import TwoFactorAuthEnrollmentPage from './components/TwoFactorAuth/TwoFactorAuthEnrollmentPage'
+import TwoFactorAuthBackupCodesPage from './components/TwoFactorAuth/TwoFactorAuthBackupCodesPage'
 
 const isCodeSearchParam = getSearchParam('code') !== undefined
 const isProviderSearchParam = getSearchParam('provider') !== undefined
@@ -140,6 +142,15 @@ function App() {
                                 exact
                               >
                                 <CertificationQuiz />
+                              </Route>
+                              <Route path={'/authenticated/2fa/enroll'} exact>
+                                <TwoFactorAuthEnrollmentPage />
+                              </Route>
+                              <Route
+                                path={'/authenticated/2fa/generatecodes'}
+                                exact
+                              >
+                                <TwoFactorAuthBackupCodesPage />
                               </Route>
                             </>
                           )}

--- a/apps/SageAccountWeb/src/AppInitializer.tsx
+++ b/apps/SageAccountWeb/src/AppInitializer.tsx
@@ -8,15 +8,17 @@ import { SignedTokenInterface } from 'synapse-react-client/dist/utils/synapseTyp
 import { createTheme, ThemeProvider } from '@mui/material/styles'
 import { useSourceApp } from 'components/SourceApp'
 import { useApplicationSessionContext } from 'synapse-react-client/dist/utils/apputils/session/ApplicationSessionContext'
-import { themeOptions as defaultThemeOptions } from './style/theme'
-import { deepmerge } from '@mui/utils'
+import { sageAccountWebThemeOverrides } from './style/theme'
 import { Theme } from '@mui/material'
+import defaultMuiThemeOptions from 'synapse-react-client/dist/utils/theme/DefaultTheme'
 
 function AppInitializer(props: { children?: React.ReactNode }) {
   const [isFramed, setIsFramed] = useState(false)
   const [appId, setAppId] = useState<string>()
   const [redirectURL, setRedirectURL] = useState<string>()
-  const [theme, setTheme] = useState<Theme>(createTheme(defaultThemeOptions))
+  const [theme, setTheme] = useState<Theme>(
+    createTheme(defaultMuiThemeOptions, sageAccountWebThemeOverrides),
+  )
   const [signedToken, setSignedToken] = useState<
     SignedTokenInterface | undefined
   >()
@@ -50,9 +52,9 @@ function AppInitializer(props: { children?: React.ReactNode }) {
   useEffect(() => {
     if (sourceApp?.palette) {
       setTheme(
-        createTheme(
-          deepmerge(defaultThemeOptions, { palette: sourceApp.palette }),
-        ),
+        createTheme(defaultMuiThemeOptions, sageAccountWebThemeOverrides, {
+          palette: sourceApp.palette,
+        }),
       )
     }
   }, [sourceApp?.appId])

--- a/apps/SageAccountWeb/src/components/AccountCreatedPage.tsx
+++ b/apps/SageAccountWeb/src/components/AccountCreatedPage.tsx
@@ -28,11 +28,11 @@ export const AccountCreatedPage = (props: AccountCreatedPageProps) => {
                 >
                   <strong>Welcome to {sourceApp?.friendlyName}!</strong>
                 </Typography>
-                <Typography variant="body2" sx={{ paddingBottom: '10px' }}>
+                <Typography variant="body1" sx={{ paddingBottom: '10px' }}>
                   You’ve created a Sage Account, which you can use on the{' '}
                   {sourceApp?.friendlyName}.
                 </Typography>
-                <Typography variant="body2" sx={{ paddingBottom: '30px' }}>
+                <Typography variant="body1" sx={{ paddingBottom: '30px' }}>
                   For full access to data and other functionality, we’ll need
                   additional information to verify your identity and certify you
                   to upload data.
@@ -65,7 +65,7 @@ export const AccountCreatedPage = (props: AccountCreatedPageProps) => {
                     Take me to {sourceApp?.friendlyName}
                   </Button>
                 )}
-                <Typography variant="body2" sx={{ paddingBottom: '30px' }}>
+                <Typography variant="body1" sx={{ paddingBottom: '30px' }}>
                   <Link
                     color="primary"
                     component={RouterLink}
@@ -90,7 +90,7 @@ export const AccountCreatedPage = (props: AccountCreatedPageProps) => {
                   Your <strong>Sage Account</strong> can also be used to access
                   all these resources.
                 </Typography>
-                <Typography variant="body2" sx={{ paddingBottom: '10px' }}>
+                <Typography variant="body1" sx={{ paddingBottom: '10px' }}>
                   <Link
                     color="primary"
                     component={RouterLink}

--- a/apps/SageAccountWeb/src/components/AccountSettings.tsx
+++ b/apps/SageAccountWeb/src/components/AccountSettings.tsx
@@ -41,6 +41,7 @@ import { ProfileAvatar } from './ProfileAvatar'
 import { InputLabel } from '@mui/material'
 import { TextField } from '@mui/material'
 import { useSourceAppConfigs } from './SourceApp'
+import TwoFactorAuthSettingsPanel from 'synapse-react-client/dist/containers/auth/TwoFactorAuthSettingsPanel'
 
 const CompletionStatus: React.FC<{ isComplete: boolean | undefined }> = ({
   isComplete,
@@ -87,6 +88,7 @@ export const AccountSettings = () => {
   const timezoneRef = useRef<HTMLDivElement>(null)
   const emailAddressesRef = useRef<HTMLDivElement>(null)
   const trustCredentialRef = useRef<HTMLDivElement>(null)
+  const twoFactorAuthRef = useRef<HTMLDivElement>(null)
   const personalAccessTokenRef = useRef<HTMLDivElement>(null)
   const cookies = new UniversalCookies()
   const [isUTCTime, setUTCTime] = useState<string>(
@@ -206,6 +208,9 @@ export const AccountSettings = () => {
               <ListItemButton onClick={() => handleScroll(trustCredentialRef)}>
                 Trust & Credentials
               </ListItemButton>
+              <ListItemButton onClick={() => handleScroll(twoFactorAuthRef)}>
+                Two-factor Authentication (2FA)
+              </ListItemButton>
               <ListItemButton
                 onClick={() => handleScroll(personalAccessTokenRef)}
               >
@@ -218,11 +223,13 @@ export const AccountSettings = () => {
                 ref={profileInformationRef}
                 className="account-setting-panel main-panel"
               >
-                <h3>Profile Information</h3>
-                <p>
+                <Typography variant={'headline2'}>
+                  Profile Information
+                </Typography>
+                <Typography variant={'body1'}>
                   This information is reused across all{' '}
                   <RouterLink to="/sageresources">Sage products.</RouterLink>
-                </p>
+                </Typography>
                 <ProfileAvatar
                   userProfile={userProfile}
                   onProfileUpdated={() => {
@@ -412,7 +419,9 @@ export const AccountSettings = () => {
                   </StyledFormControl>
                   <div className="primary-button-container">
                     <Button
-                      onClick={updateUserProfile}
+                      onClick={() => {
+                        updateUserProfile()
+                      }}
                       disabled={!changeInForm}
                       variant="contained"
                     >
@@ -425,21 +434,21 @@ export const AccountSettings = () => {
                 ref={emailAddressesRef}
                 className="account-setting-panel main-panel"
               >
-                <h3>Email Addresses</h3>
+                <Typography variant={'headline2'}>Email Addresses</Typography>
                 <ConfigureEmail returnToPath="authenticated/myaccount" />
               </Paper>
               <Paper
                 ref={changePasswordRef}
                 className="account-setting-panel main-panel"
               >
-                <h3>Change Password</h3>
+                <Typography variant={'headline2'}>Change Password</Typography>
                 <ChangePassword />
               </Paper>
               <Paper
                 ref={timezoneRef}
                 className="account-setting-panel main-panel"
               >
-                <h3>Date/Time Format</h3>
+                <Typography variant={'headline2'}>Date/Time Format</Typography>
                 <StyledFormControl
                   fullWidth
                   variant="standard"
@@ -482,23 +491,25 @@ export const AccountSettings = () => {
                 ref={trustCredentialRef}
                 className="account-setting-panel main-panel"
               >
-                <h3>Trust & Credentials</h3>
-                <p>
+                <Typography variant={'headline2'}>
+                  Trust & Credentials
+                </Typography>
+                <Typography variant={'body1'}>
                   This section lists the various ways we support verifying your
                   trust and identity in order to permit access to our products.
                   You may be asked to complete any of the following as part of
                   requesting access within a system.
-                </p>
+                </Typography>
                 <div className="credential-partition">
                   <h4>Terms and Conditions for Use</h4>
                   <CompletionStatus isComplete={termsOfUse} />
-                  <p>
+                  <Typography variant={'body1'} sx={{ my: 1 }}>
                     <i>Required to register</i>
-                  </p>
-                  <p>
+                  </Typography>
+                  <Typography variant={'body1'} sx={{ my: 1 }}>
                     You must affirm your agreement to follow these terms and
                     conditions in order to create an account.{' '}
-                  </p>
+                  </Typography>
                   <div className="primary-button-container">
                     <Button
                       disabled={termsOfUse}
@@ -516,15 +527,15 @@ export const AccountSettings = () => {
                 <div className="credential-partition">
                   <h4>Certification</h4>
                   <CompletionStatus isComplete={isCertified} />
-                  <p>
+                  <Typography variant={'body1'} sx={{ my: 1 }}>
                     <i>Required to upload data.</i>
-                  </p>
-                  <p>
+                  </Typography>
+                  <Typography variant={'body1'} sx={{ my: 1 }}>
                     There are times where human data can only be shared with
                     certain restrictions. In order to upload data on any
                     application, you must pass a quiz on the technical and
                     ethical aspects of sharing data in our system.
-                  </p>
+                  </Typography>
                   <div className="primary-button-container">
                     <Button
                       disabled={isCertified}
@@ -595,13 +606,13 @@ export const AccountSettings = () => {
                       and data.
                     </i>
                   </p>
-                  <p>
+                  <Typography variant={'body1'} sx={{ my: 1 }}>
                     Profile validation requires you to complete your profile,
                     link an ORCID profile, sign and date the Synapse pledge, and
                     upload both the pledge and an identity attestation document,
                     after which your application will be manually reviewed
                     (which may take several days).
-                  </p>
+                  </Typography>
                   <div className="primary-button-container">
                     <Button
                       disabled={!!verified}
@@ -621,16 +632,31 @@ export const AccountSettings = () => {
                 </div>
               </Paper>
               <Paper
+                ref={twoFactorAuthRef}
+                className="account-setting-panel main-panel"
+              >
+                <TwoFactorAuthSettingsPanel
+                  onRegenerateBackupCodes={() => {
+                    history.push('/authenticated/2fa/regeneratecodes')
+                  }}
+                  onBeginTwoFactorEnrollment={() => {
+                    history.push('/authenticated/2fa/enroll')
+                  }}
+                />
+              </Paper>
+              <Paper
                 ref={personalAccessTokenRef}
                 className="account-setting-panel main-panel"
               >
-                <h3>Personal Access Tokens</h3>
-                <p>
+                <Typography variant={'headline2'}>
+                  Personal Access Tokens
+                </Typography>
+                <Typography variant={'body1'} sx={{ my: 1 }}>
                   You can issue personal access tokens to authenticate your
                   scripts with scoped access to your account. It is important
                   that you treat personal access tokens with the same security
                   as your password.
-                </p>
+                </Typography>
                 <div className="primary-button-container">
                   <Link sx={credentialButtonSX}>
                     Manage Personal Access Tokens

--- a/apps/SageAccountWeb/src/components/JoinTeamPage.tsx
+++ b/apps/SageAccountWeb/src/components/JoinTeamPage.tsx
@@ -99,7 +99,7 @@ export const JoinTeamPage = (props: JoinTeamPageProps) => {
               Join a Team
             </Typography>
             <Typography
-              variant="body1"
+              variant="subtitle1"
               sx={{ paddingTop: '10px', paddingBottom: '30px' }}
             >
               <UserOrTeamBadge principalId={membershipInvitation.createdBy} />{' '}
@@ -108,7 +108,7 @@ export const JoinTeamPage = (props: JoinTeamPageProps) => {
               <UserOrTeamBadge principalId={membershipInvitation.teamId} />
             </Typography>
             <Typography
-              variant="body1"
+              variant="subtitle1"
               sx={{ paddingTop: '10px', paddingBottom: '10px' }}
             >
               To join this team, you must register for a Sage account using the
@@ -120,10 +120,10 @@ export const JoinTeamPage = (props: JoinTeamPageProps) => {
                 backgroundColor: 'rgba(241, 243, 245, 0.75)',
               }}
             >
-              <Typography variant="body1" sx={{ fontWeight: 700 }}>
+              <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
                 Use this email address when you register
               </Typography>
-              <Typography variant="body1">
+              <Typography variant="subtitle1">
                 <em>{membershipInvitation.inviteeEmail}</em>
               </Typography>
             </Box>
@@ -147,7 +147,7 @@ export const JoinTeamPage = (props: JoinTeamPageProps) => {
               Joined a Team!
             </Typography>
             <Typography
-              variant="body1"
+              variant="subtitle1"
               sx={{ paddingTop: '10px', paddingBottom: '50px' }}
             >
               <UserOrTeamBadge principalId={joinTeamToken?.memberId} /> is now a

--- a/apps/SageAccountWeb/src/components/ProfileValidation/Attestation.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/Attestation.tsx
@@ -44,10 +44,10 @@ const Attestation: React.FC<AttestationProps> = (props: AttestationProps) => {
     <>
       {isAttachment && (
         <>
-          <Typography variant="body2" sx={{ fontWeight: 700 }}>
+          <Typography variant="body1" sx={{ fontWeight: 700 }}>
             Selected file:
           </Typography>
-          <Typography variant="body2" sx={{ marginBottom: '20px' }}>
+          <Typography variant="body1" sx={{ marginBottom: '20px' }}>
             {attachments[0].fileName}
           </Typography>
         </>

--- a/apps/SageAccountWeb/src/components/ProfileValidation/ProfileValidation.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/ProfileValidation.tsx
@@ -34,7 +34,7 @@ const STEP_CONTENT = [
     body: (
       <>
         <Typography
-          variant="body1"
+          variant="subtitle1"
           sx={theme => ({ fontWeight: 500, marginBottom: theme.spacing(3) })}
         >
           During <strong>identity verification</strong>, our data governance
@@ -79,7 +79,7 @@ const STEP_CONTENT = [
     title: 'Submit recent identity attestation documentation.',
     body: (
       <>
-        <Typography variant="body2" paragraph>
+        <Typography variant="body1" paragraph>
           This document must be current within the past month. Acceptable forms
           of documentation, in English, are any one of the following:{' '}
         </Typography>
@@ -91,7 +91,7 @@ const STEP_CONTENT = [
           }}
         >
           <li>
-            <Typography variant="body2">
+            <Typography variant="body1">
               A letter from a signing official on letterhead attesting to your
               identity (
               <Link
@@ -110,13 +110,13 @@ const STEP_CONTENT = [
             </Typography>
             <Typography
               sx={theme => ({ textAlign: 'center', margin: theme.spacing(1) })}
-              variant="body2"
+              variant="body1"
             >
               OR
             </Typography>
           </li>
           <li>
-            <Typography variant="body2">
+            <Typography variant="body1">
               A notarized letter attesting to your identity (
               <Link
                 color="primary"
@@ -129,17 +129,17 @@ const STEP_CONTENT = [
             </Typography>
             <Typography
               sx={theme => ({ textAlign: 'center', margin: theme.spacing(1) })}
-              variant="body2"
+              variant="body1"
             >
               OR
             </Typography>
           </li>
           <li>
-            <Typography variant="body2" paragraph>
+            <Typography variant="body1" paragraph>
               A copy of your professional license (e.g., a photocopy of your
               medical license).&nbsp;
             </Typography>
-            <Typography variant="body2" paragraph>
+            <Typography variant="body1" paragraph>
               <i>
                 Note that a copy of a work or university identification badge is{' '}
                 <strong>not</strong> an accepted form of identity attestation

--- a/apps/SageAccountWeb/src/components/ProfileValidation/ReturnToAppButton.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/ReturnToAppButton.tsx
@@ -1,9 +1,11 @@
 import {
+  Box,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   IconButton,
+  Stack,
   useTheme,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
@@ -38,46 +40,23 @@ export const ReturnToAppButton: React.FC<{ children?: React.ReactNode }> = ({
   return (
     <>
       {element}
-      <Dialog
-        open={open}
-        fullWidth
-        maxWidth="sm"
-        sx={{ borderRadius: 0 }}
-        PaperProps={{ sx: { borderRadius: 0 } }}
-      >
-        <DialogTitle
-          sx={{
-            margin: theme.spacing(0, 5.5),
-            padding: theme.spacing(4, 0, 2, 0),
-            fontSize: '25px',
-            fontWeight: 700,
-          }}
-        >
-          <IconButton
-            aria-label="close"
-            onClick={onClose}
-            sx={{
-              position: 'absolute',
-              right: '40px',
-              top: '30px',
-              color: '#878E95',
-            }}
-          >
-            <CloseIcon />
-          </IconButton>
-          Cancel verification?
+      <Dialog open={open} fullWidth maxWidth="sm">
+        <DialogTitle>
+          <Stack direction="row" alignItems={'center'} gap={'5px'}>
+            Cancel verification?
+            <Box sx={{ flexGrow: 1 }} />
+            <IconButton aria-label={'Close'} onClick={onClose}>
+              <CloseIcon />
+            </IconButton>
+          </Stack>
         </DialogTitle>
-
-        <DialogContent
-          dividers
-          sx={{ margin: theme.spacing(0, 5.5), padding: theme.spacing(3, 0) }}
-        >
-          <Typography variant="body2" paragraph>
+        <DialogContent dividers>
+          <Typography variant="body1" paragraph>
             If you cancel verification, you'll still be able to use portions of
             the application which are available to registered users, but your
             access will be restricted.
           </Typography>
-          <Typography variant="body2">
+          <Typography variant="body1">
             To resume your verification in the future, access the{' '}
             <NavLink target="_blank" to={'/authenticated/myaccount#trust'}>
               {' '}
@@ -101,7 +80,7 @@ export const ReturnToAppButton: React.FC<{ children?: React.ReactNode }> = ({
             Yes, cancel verification
           </Button>
         </DialogActions>
-      </Dialog>{' '}
+      </Dialog>
     </>
   )
 }

--- a/apps/SageAccountWeb/src/components/ProfileValidation/TermsAndConditionsSignature.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/TermsAndConditionsSignature.tsx
@@ -24,7 +24,7 @@ export const TermsAndConditionsSignature: React.FC<
 > = ({ canSign, onSigned, expectedSignature }) => {
   return (
     <>
-      <Typography variant="body1" sx={tcSignatureTextSx}>
+      <Typography variant="subtitle1" sx={tcSignatureTextSx}>
         After agreeing to the above terms, electronically sign this agreement by
         typing your full name, as it appears below, to acknowledge your
         agreement with the terms stated above. You must sign in order to

--- a/apps/SageAccountWeb/src/components/ProfileValidation/ThankYou.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/ThankYou.tsx
@@ -38,13 +38,13 @@ const ThankYou: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       >
         Here's what to expect next:
       </Typography>
-      <Typography variant="body2" paragraph>
+      <Typography variant="body1" paragraph>
         Our Access and Compliance Team (ACT) will review your application. This
         usually takes about two business days, but it can sometimes take longer.
         You’ll receive an email from us if we have any questions, and when we’ve
         made a decision.
       </Typography>
-      <Typography variant="body2" paragraph>
+      <Typography variant="body1" paragraph>
         You can access unrestricted areas of the website in the mean time.
       </Typography>
       {children}

--- a/apps/SageAccountWeb/src/components/ProfileValidation/UnbindORCiD.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/UnbindORCiD.tsx
@@ -7,14 +7,14 @@ import {
   DialogActions,
   DialogContent,
   Button,
-  useTheme,
+  DialogTitle,
 } from '@mui/material'
 
 export const unbindORCiD = async (
   event: React.SyntheticEvent,
   orcid: string | undefined,
   accessToken: string | undefined,
-  setShow: Function,
+  setShow: (show: boolean) => void,
   redirectAfter: string,
 ) => {
   event.preventDefault()
@@ -34,25 +34,18 @@ export const unbindORCiD = async (
 }
 export type UnbindORCiDDialogProps = {
   show: boolean
-  setShow: Function
+  setShow: (show: boolean) => void
   orcid: string | undefined
   redirectAfter: string
 }
 
 export const UnbindORCiDDialog = (props: UnbindORCiDDialogProps) => {
-  const theme = useTheme()
   const { accessToken } = useSynapseContext()
   return (
-    <Dialog
-      open={props.show}
-      maxWidth="sm"
-      sx={{ borderRadius: 0 }}
-      PaperProps={{ sx: { borderRadius: 0 } }}
-    >
-      <DialogContent
-        sx={{ margin: theme.spacing(0, 5.5), padding: theme.spacing(3, 0) }}
-      >
-        <Typography variant="body2" paragraph>
+    <Dialog open={props.show} maxWidth="sm">
+      <DialogTitle>Unlink ORCID?</DialogTitle>
+      <DialogContent>
+        <Typography variant="body1" paragraph>
           Are you sure you want to unlink this ORCID from your profile?
         </Typography>
       </DialogContent>

--- a/apps/SageAccountWeb/src/components/ProfileValidation/VerifyIdentify.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/VerifyIdentify.tsx
@@ -30,7 +30,7 @@ export const VerifyIdentify = (props: VerifyIdentifyProps) => {
           <>
             <Typography
               style={{ display: 'flex', marginTop: theme.spacing(5) }}
-              variant="body2"
+              variant="body1"
             >
               <CheckIcon style={{ color: '#32A330', marginRight: '8px' }} />
               Profile linked successfully {/*verificationSubmission.orcid*/}

--- a/apps/SageAccountWeb/src/components/RegisterAccount1.tsx
+++ b/apps/SageAccountWeb/src/components/RegisterAccount1.tsx
@@ -290,7 +290,7 @@ export const RegisterAccount1 = (props: RegisterAccount1Props) => {
                 <Typography variant="headline2" sx={{ marginTop: '95px' }}>
                   Create an Account
                 </Typography>
-                <Typography variant="body2" sx={{ marginBottom: '20px' }}>
+                <Typography variant="body1" sx={{ marginBottom: '20px' }}>
                   Your <strong>{sourceAppName}</strong> account is also a{' '}
                   <strong>Sage account</strong>. You can also use it to access
                   many other resources from Sage.

--- a/apps/SageAccountWeb/src/components/ResetPassword.tsx
+++ b/apps/SageAccountWeb/src/components/ResetPassword.tsx
@@ -201,7 +201,7 @@ export const ResetPassword = (props: ResetPasswordProps) => {
           ) : (
             <div>
               <Typography variant="headline2">Reset your password</Typography>
-              <Typography variant="body1">
+              <Typography variant="subtitle1">
                 Please enter your email address or username and we'll send you
                 instructions to reset your password
               </Typography>

--- a/apps/SageAccountWeb/src/components/SageResourcesPage.tsx
+++ b/apps/SageAccountWeb/src/components/SageResourcesPage.tsx
@@ -44,21 +44,21 @@ export const SageResourcesPage = (props: SageResourcesPageProps) => {
           >
             <div className="SageLogo">{sageSourceAppConfig?.logo}</div>
             <Typography
-              variant="body1"
+              variant="subtitle1"
               sx={{ marginTop: '30px', paddingBottom: '30px', fontWeight: 500 }}
             >
               Your Sage Account gets you access to all these tools.
             </Typography>
 
             <Typography
-              variant="body2"
+              variant="body1"
               sx={{ paddingBottom: '30px', fontWeight: 500 }}
             >
               Sage Bionetworks creates resources to help speed the translation
               of science into medicine.
             </Typography>
             <Typography
-              variant="body2"
+              variant="body1"
               sx={{ paddingBottom: '30px', fontWeight: 500 }}
             >
               Your Sage Account can be used across all these different products.
@@ -85,7 +85,7 @@ export const SageResourcesPage = (props: SageResourcesPageProps) => {
                   >
                     <a href={config.appURL}>{config.logo}</a>
                     <Typography
-                      variant="body2"
+                      variant="body1"
                       sx={{ paddingBottom: '30px', fontWeight: 500 }}
                     >
                       <ShowMore summary={config.description} />

--- a/apps/SageAccountWeb/src/components/SourceApp.tsx
+++ b/apps/SageAccountWeb/src/components/SourceApp.tsx
@@ -54,7 +54,7 @@ export const SourceAppLogo: React.FC<{ sx?: SxProps }> = ({ sx }) => {
 export const SourceAppDescription = () => {
   const sourceAppConfig = useSourceApp()
   return sourceAppConfig ? (
-    <Typography className="description" variant="body1">
+    <Typography className="description" variant="subtitle1">
       {sourceAppConfig?.description}
     </Typography>
   ) : (

--- a/apps/SageAccountWeb/src/components/StyledComponents.ts
+++ b/apps/SageAccountWeb/src/components/StyledComponents.ts
@@ -13,17 +13,10 @@ import {
 } from '@mui/material'
 import { latoFont } from 'style/theme'
 import { StyledComponent } from '@mui/styles'
+import { StyledOuterContainer as _StyledOuterContainer } from 'synapse-react-client/dist/components/styled/LeftRightPanel'
 
-export const StyledOuterContainer: StyledComponent<BoxProps> = styled(Box, {
-  label: 'StyledOuterContainer',
-})(({ theme }) => ({
-  minHeight: '100vh',
-  paddingTop: '50px',
-  paddingBottom: '50px',
-  background:
-    "linear-gradient(rgba(255,255,255,0.7), rgba(255,255,255,0.7)), url('https://s3.amazonaws.com/static.synapse.org/images/SynapseLoginPageBackground.svg')",
-  backgroundSize: 'cover',
-}))
+export const StyledOuterContainer: StyledComponent<BoxProps> =
+  _StyledOuterContainer
 
 export const StyledInnerContainer: StyledComponent<PaperProps> = styled(Paper, {
   label: 'StyledInnerContainer',

--- a/apps/SageAccountWeb/src/components/TermsOfUseRightPanelText.tsx
+++ b/apps/SageAccountWeb/src/components/TermsOfUseRightPanelText.tsx
@@ -15,7 +15,7 @@ export const TermsOfUseRightPanelText = (
     <>
       <Typography variant="headline2">What is the Synapse Pledge?</Typography>
       {sourceApp?.appId !== 'synapse.org' && (
-        <Typography variant="body2" sx={{ marginBottom: '20px' }}>
+        <Typography variant="body1" sx={{ marginBottom: '20px' }}>
           {sourceAppName} is powered by{' '}
           <Link href={'https://www.synapse.org/'} target="_blank">
             Synapse
@@ -23,7 +23,7 @@ export const TermsOfUseRightPanelText = (
           , and follows the Synapse Governance polices.
         </Typography>
       )}
-      <Typography variant="body2" sx={{ marginBottom: '20px' }}>
+      <Typography variant="body1" sx={{ marginBottom: '20px' }}>
         To ensure secure and confidential access to data, we ask all account
         holders to affirm their agreement with our governance policies before
         finishing registration.

--- a/apps/SageAccountWeb/src/components/TwoFactorAuth/TwoFactorAuthBackupCodesPage.tsx
+++ b/apps/SageAccountWeb/src/components/TwoFactorAuth/TwoFactorAuthBackupCodesPage.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { useHistory, useLocation } from 'react-router-dom'
+import TwoFactorBackupCodes from 'synapse-react-client/dist/containers/auth/TwoFactorBackupCodes'
+
+/**
+ * Shows a page used to regenerate 2FA backup codes.
+ *
+ * The page will show a warning unless the query parameter 'warn' is set to false
+ */
+export default function TwoFactorAuthBackupCodesPage() {
+  const history = useHistory()
+  const { search } = useLocation()
+  let showWarning = true
+  const warn = new URLSearchParams(search).get('warn')
+  if (warn === 'false') {
+    showWarning = false
+  }
+  return (
+    <TwoFactorBackupCodes
+      showReplaceOldCodesWarning={showWarning}
+      onClose={() => history.push('/authenticated/myaccount')}
+    />
+  )
+}

--- a/apps/SageAccountWeb/src/components/TwoFactorAuth/TwoFactorAuthEnrollmentPage.tsx
+++ b/apps/SageAccountWeb/src/components/TwoFactorAuth/TwoFactorAuthEnrollmentPage.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import TwoFactorEnrollmentForm from 'synapse-react-client/dist/containers/auth/TwoFactorEnrollmentForm'
+import { useHistory } from 'react-router-dom'
+
+export default function TwoFactorAuthEnrollmentPage() {
+  const history = useHistory()
+  return (
+    <TwoFactorEnrollmentForm
+      onTwoFactorEnrollmentSuccess={() =>
+        // explicitly skip the backup code overwrite warning and generate new codes
+        history.push('/authenticated/2fa/generatecodes?warn=false')
+      }
+      onBackClicked={() => {
+        history.goBack()
+      }}
+    />
+  )
+}

--- a/apps/SageAccountWeb/src/style/theme.ts
+++ b/apps/SageAccountWeb/src/style/theme.ts
@@ -1,9 +1,12 @@
-import { createTheme, Theme } from '@mui/material'
-import { mergeTheme } from 'synapse-react-client/dist/utils/theme'
+import { ThemeOptions } from '@mui/material'
 
 export const latoFont = ['Lato', 'Roboto', 'Helvetica', 'Arial'].join(',')
 
-export const themeOptions = mergeTheme({
+// Merge the default theme (defined in synapse-react-client) with the SageAccountWeb overrides defined here.
+export const sageAccountWebThemeOverrides: ThemeOptions = {
+  styledBackground:
+    "linear-gradient(rgba(255,255,255,0.7), rgba(255,255,255,0.7)), url('https://s3.amazonaws.com/static.synapse.org/images/SynapseLoginPageBackground.svg')",
+
   components: {
     MuiButton: {
       styleOverrides: {
@@ -26,7 +29,7 @@ export const themeOptions = mergeTheme({
           fontWeight: 700,
           '&:hover': {
             backgroundColor: '#FFFFFF',
-            border: '2px solid #EAECEE',
+            border: '1px solid #b5bcc3',
           },
         },
         containedSecondary: {
@@ -56,48 +59,6 @@ export const themeOptions = mergeTheme({
         },
       },
     },
-    MuiDialog: {
-      styleOverrides: {
-        paper: {},
-      },
-    },
-    MuiDialogTitle: {
-      styleOverrides: {
-        root: {
-          padding: '24px 24px 0px 24px',
-        },
-      },
-    },
-    MuiDialogContent: {
-      styleOverrides: {
-        root: {
-          color: '#4A5056',
-        },
-      },
-    },
-    MuiDialogActions: {
-      styleOverrides: {
-        root: {
-          padding: '24px',
-          '& .MuiButton-root': {
-            height: '36px',
-            padding: '0 16px',
-            borderRadius: '0px',
-            fontSize: '15px',
-            '&:first-child': {
-              marginRight: '14px',
-            },
-            '&.MuiButton-outlinedPrimary': {
-              borderWidth: '1px',
-              fontWeight: 700,
-              '&:hover': {
-                '&.MuiButton-outlinedPrimary:hover': { borderWidth: '1px' },
-              },
-            },
-          },
-        },
-      },
-    },
     MuiPaper: {
       styleOverrides: {
         root: {
@@ -112,7 +73,6 @@ export const themeOptions = mergeTheme({
       fontFamily: latoFont,
       fontSize: '14px',
     },
-    headline1: {},
     headline2: {
       fontWeight: 700,
       fontSize: '24px',
@@ -121,22 +81,11 @@ export const themeOptions = mergeTheme({
       alignItems: 'center',
       marginBottom: '20px',
     },
-    headline3: {
-      fontWeight: '700',
-      fontSize: '18px',
-      lineHeight: '20px',
-    },
-    body1: {
-      fontWeight: 400,
+    subtitle1: {
+      fontWeight: 500,
       fontSize: '20px',
       lineHeight: '150%',
       letterSpacing: '-0.019em',
-      color: '#4A5056',
-    },
-    body2: {
-      fontWeight: 400,
-      fontSize: '16px',
-      lineHeight: '24px',
     },
     smallText1: {
       fontWeight: 400,
@@ -145,8 +94,4 @@ export const themeOptions = mergeTheme({
       color: '#878E95',
     },
   },
-})
-
-const theme: Theme = createTheme(themeOptions)
-
-export default theme
+}

--- a/packages/synapse-react-client/src/lib/components/styled/LeftRightPanel.tsx
+++ b/packages/synapse-react-client/src/lib/components/styled/LeftRightPanel.tsx
@@ -4,12 +4,11 @@ import { StyledComponent } from '@emotion/styled'
 
 export const StyledOuterContainer: StyledComponent<BoxProps> = styled(Box, {
   label: 'StyledOuterContainer',
-})(() => ({
+})(({ theme }) => ({
   minHeight: '100vh',
   paddingTop: '50px',
   paddingBottom: '50px',
-  background:
-    "linear-gradient(rgba(255,255,255,0), rgba(255,255,255,0)), url('https://s3.amazonaws.com/static.synapse.org/images/SynapseLoginPageBackground.svg')",
+  background: theme.styledBackground,
   backgroundSize: 'cover',
 }))
 

--- a/packages/synapse-react-client/src/lib/containers/StorybookComponentWrapper.tsx
+++ b/packages/synapse-react-client/src/lib/containers/StorybookComponentWrapper.tsx
@@ -14,7 +14,7 @@ import {
 } from '../utils/SynapseClient'
 import { SynapseClientError } from '../utils/SynapseClientError'
 import { STACK_MAP, SynapseStack } from '../utils/functions/getEndpoint'
-import defaultMuiTheme from '../utils/theme/DefaultTheme'
+import defaultMuiThemeOptions from '../utils/theme/DefaultTheme'
 import {
   adKnowledgePortalPalette,
   arkPortalPalette,
@@ -140,7 +140,7 @@ export function StorybookComponentWrapper(props: {
       key={accessToken}
       synapseContext={synapseContext}
       theme={{
-        ...defaultMuiTheme,
+        ...defaultMuiThemeOptions,
         palette: paletteMap[storybookContext.globals.palette],
       }}
     >

--- a/packages/synapse-react-client/src/lib/containers/auth/TwoFactorEnrollmentForm.tsx
+++ b/packages/synapse-react-client/src/lib/containers/auth/TwoFactorEnrollmentForm.tsx
@@ -4,6 +4,7 @@ import {
   BoxProps,
   Button,
   Divider,
+  IconButton,
   Link,
   Paper,
   Stack,
@@ -23,6 +24,7 @@ import {
   useStartTwoFactorEnrollment,
 } from '../../utils/hooks/SynapseAPI/auth/useTwoFactorEnrollment'
 import TwoFactorSecretDialog from './TwoFactorSecretDialog'
+import IconSvg from '../IconSvg'
 
 /**
  * Returns a URL that can be used to generate a QR code that 2FA authenticator apps can interpret
@@ -64,12 +66,13 @@ export const TWO_FACTOR_DOCS_LINK = ''
 
 export type TwoFactorEnrollmentFormProps = {
   onTwoFactorEnrollmentSuccess: () => void
+  onBackClicked: () => void
 }
 
 export default function TwoFactorEnrollmentForm(
   props: TwoFactorEnrollmentFormProps,
 ) {
-  const { onTwoFactorEnrollmentSuccess } = props
+  const { onTwoFactorEnrollmentSuccess, onBackClicked } = props
 
   const [totp, setTotp] = useState('')
   const [hasQrCode, setHasQrCode] = useState(false)
@@ -113,12 +116,32 @@ export default function TwoFactorEnrollmentForm(
     <StyledOuterContainer>
       <Paper
         sx={{
+          position: 'relative',
           width: '800px',
           py: 6.5,
           px: 8,
           mx: 'auto',
         }}
       >
+        {onBackClicked && (
+          <IconButton
+            type="button"
+            onClick={() => {
+              onBackClicked()
+            }}
+            sx={theme => ({
+              position: 'absolute',
+              top: theme.spacing(2),
+              left: theme.spacing(2),
+            })}
+          >
+            <IconSvg
+              icon="arrowBack"
+              wrap={false}
+              sx={{ height: '24px', width: '24px' }}
+            />
+          </IconButton>
+        )}
         <Section>
           <Typography variant="headline2" sx={{ mb: 3 }}>
             Activate Two-factor Authentication

--- a/packages/synapse-react-client/src/lib/utils/theme/DefaultTheme.ts
+++ b/packages/synapse-react-client/src/lib/utils/theme/DefaultTheme.ts
@@ -4,7 +4,7 @@ import palette from './palette/Palettes'
 import { Fade } from '@mui/material'
 import linkTheme from './typography/Link'
 
-const defaultMuiTheme: ThemeOptions = {
+const defaultMuiThemeOptions: ThemeOptions = {
   typography: typographyOptions,
   palette: palette,
   components: {
@@ -55,36 +55,50 @@ const defaultMuiTheme: ThemeOptions = {
     MuiDialog: {
       defaultProps: {
         PaperProps: {
-          sx: {
+          sx: theme => ({
             borderRadius: '0px',
-            padding: '35px',
+            padding: theme.spacing(5.5),
             alignSelf: 'flex-start',
-          },
+          }),
         },
       },
     },
     MuiDialogTitle: {
       styleOverrides: {
         root: ({ theme }) => ({
-          borderBottom: `1px solid ${theme.palette.grey[300]}`,
-          padding: '0px 0px 20px',
-          marginBottom: '20px',
+          fontSize: '24px',
+          fontWeight: 700,
+          paddingLeft: '0px',
+          paddingRight: '0px',
+          paddingBottom: theme.spacing(3),
         }),
       },
     },
     MuiDialogContent: {
+      defaultProps: {
+        dividers: true,
+      },
       styleOverrides: {
-        root: {
-          padding: '0px',
-        },
+        root: ({ theme }) => ({
+          color: theme.palette.text.secondary,
+          paddingTop: theme.spacing(3),
+          paddingBottom: theme.spacing(3),
+          paddingLeft: '0px',
+          paddingRight: '0px',
+        }),
       },
     },
     MuiDialogActions: {
       styleOverrides: {
         root: ({ theme }) => ({
-          padding: '20px 0px 0px',
-          marginTop: '20px',
-          borderTop: `1px solid ${theme.palette.grey[300]}`,
+          paddingLeft: '0px',
+          paddingRight: '0px',
+          paddingTop: theme.spacing(3),
+          '& .MuiButton-root': {
+            height: '36px',
+            padding: '0px 16px',
+            borderRadius: 0,
+          },
         }),
       },
     },
@@ -138,6 +152,8 @@ const defaultMuiTheme: ThemeOptions = {
       },
     },
   },
+  styledBackground:
+    "url('https://s3.amazonaws.com/static.synapse.org/images/SynapseLoginPageBackground.svg')",
 }
 
-export default defaultMuiTheme
+export default defaultMuiThemeOptions

--- a/packages/synapse-react-client/src/lib/utils/theme/ThemeTypes.ts
+++ b/packages/synapse-react-client/src/lib/utils/theme/ThemeTypes.ts
@@ -32,6 +32,13 @@ type RecordWithCustomVariantKeys<Value> = {
 // To add custom Typography variants to the MUI theme, we have to extend the MUI theme type.
 // See https://mui.com/material-ui/customization/theming/#theme-configuration-variables CTRL+F TypeScript
 declare module '@mui/material/styles' {
+  interface Theme {
+    styledBackground: string
+  }
+  interface ThemeOptions {
+    styledBackground?: string
+  }
+
   interface TypographyVariants
     extends RecordWithCustomVariantKeys<React.CSSProperties> {}
 

--- a/packages/synapse-react-client/src/lib/utils/theme/useTheme.tsx
+++ b/packages/synapse-react-client/src/lib/utils/theme/useTheme.tsx
@@ -2,14 +2,14 @@ import { createTheme, StyledEngineProvider, ThemeOptions } from '@mui/material'
 import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles'
 import { deepmerge } from '@mui/utils'
 import React, { useMemo } from 'react'
-import defaultMuiTheme from './DefaultTheme'
+import defaultMuiThemeOptions from './DefaultTheme'
 import type { PartialDeep } from 'type-fest'
 
 export function mergeTheme(
   themeOverrides: PartialDeep<ThemeOptions>,
 ): ThemeOptions {
   // TODO: Handle merging color palettes where an entire palette can be generated from a single base color.
-  return deepmerge(defaultMuiTheme, themeOverrides)
+  return deepmerge(defaultMuiThemeOptions, themeOverrides)
 }
 
 export type ThemeProviderProps = React.PropsWithChildren<{
@@ -17,7 +17,7 @@ export type ThemeProviderProps = React.PropsWithChildren<{
 }>
 
 export const ThemeProvider = ({
-  theme = defaultMuiTheme,
+  theme = defaultMuiThemeOptions,
   children,
 }: ThemeProviderProps) => {
   const mergedTheme = useMemo(() => mergeTheme(theme), [theme])

--- a/packages/synapse-react-client/test/lib/utils/hooks/useTheme.test.tsx
+++ b/packages/synapse-react-client/test/lib/utils/hooks/useTheme.test.tsx
@@ -1,6 +1,6 @@
 import { mergeTheme } from '../../../../src/lib/utils/theme/useTheme'
 import { ThemeOptions } from '@mui/material'
-import defaultMuiTheme from '../../../../src/lib/utils/theme/DefaultTheme'
+import defaultMuiThemeOptions from '../../../../src/lib/utils/theme/DefaultTheme'
 
 describe('Synapse Theme tests', () => {
   it('properly merges a custom theme with the default theme', () => {
@@ -18,9 +18,15 @@ describe('Synapse Theme tests', () => {
     const mergedTheme = mergeTheme(customTheme)
 
     expect(mergedTheme.palette!.success!.main).toEqual(customColor)
-    expect(mergedTheme.palette.warning).toEqual(defaultMuiTheme.palette.warning)
-    expect(mergedTheme.palette.info).toEqual(defaultMuiTheme.palette.info)
-    expect(mergedTheme.palette.error).toEqual(defaultMuiTheme.palette.error)
+    expect(mergedTheme.palette.warning).toEqual(
+      defaultMuiThemeOptions.palette.warning,
+    )
+    expect(mergedTheme.palette.info).toEqual(
+      defaultMuiThemeOptions.palette.info,
+    )
+    expect(mergedTheme.palette.error).toEqual(
+      defaultMuiThemeOptions.palette.error,
+    )
   })
 
   // TODO: Test merging color palettes and validate that an entire palette is generated when providing one color


### PR DESCRIPTION
synapse-react-client:
- add back button to TwoFactorEnrollmentForm
- StyledOuterContainer background is applied via theme
- migrate certain theme overrides from SageAccountWeb to apply to all apps

SageAccountWeb:
- Add routes and pages for TwoFactorAuth enrollment, backup code generation
- Add TwoFactorAuth panel to settings page
- Use Typography in settings page
- Replace all Typography `body1` variant with `subtitle1`
- Replace all Typography `body2` variant with `body1`
- Remove unnecessary theme overrides
- Outline button border should not change on hover (causes layout shifts). Added slight border change to maintain interactivity
- Merge all theme options at once in the following order: shared, SageAccountWeb-specific, app palette