### PR TITLE
SWC-6418 - Release AR Reviewer dashboard from experimental mode

### DIFF
--- a/packages/synapse-react-client/src/lib/containers/SynapseNavDrawer.tsx
+++ b/packages/synapse-react-client/src/lib/containers/SynapseNavDrawer.tsx
@@ -1,17 +1,17 @@
-import { Badge, Drawer, List, ListItem } from '@mui/material'
+import { Badge, Drawer, List, ListItemButton, Tooltip } from '@mui/material'
 import React, { useState } from 'react'
 import { Form } from 'react-bootstrap'
 import SynapseIconWhite from '../assets/icons/SynapseIconWhite'
 import SynapseLogoName from '../assets/icons/SynapseLogoName'
 import { SynapseClient } from '../utils'
-import { useSearchAccessSubmissionsInfinite } from '../utils/hooks/SynapseAPI/dataaccess/useDataAccessSubmission'
-import { useGetDownloadListStatistics } from '../utils/hooks/SynapseAPI/download/useDownloadList'
-import { useGetCurrentUserBundle } from '../utils/hooks/SynapseAPI/user/useUserBundle'
-import { isInSynapseExperimentalMode } from '../utils/SynapseClient'
+import {
+  useGetCurrentUserBundle,
+  useGetDownloadListStatistics,
+  useSearchAccessSubmissionsInfinite,
+} from '../utils/hooks/SynapseAPI'
 import { useSynapseContext } from '../utils/SynapseContext'
 import { Direction, SubmissionState } from '../utils/synapseTypes'
 import { SubmissionSortField } from '../utils/synapseTypes/AccessSubmission'
-import { Tooltip } from '@mui/material'
 import { CreateProjectModal } from './CreateProjectModal'
 import IconSvg, { Icon } from './IconSvg'
 import UserCard from './UserCard'
@@ -47,7 +47,7 @@ export enum NavItem {
 // To support project search, we send this json object in the url.
 // We update the queryTerm array based on user input.
 const projectSearchJson = {
-  queryTerm: [],
+  queryTerm: [] as string[],
   booleanQuery: [
     {
       key: 'node_type',
@@ -123,10 +123,8 @@ const NavDrawerListItem = (props: MenuItemParams) => {
 
   const listItem = (
     <Tooltip title={tooltip} placement="right">
-      <ListItem
-        button
+      <ListItemButton
         key={iconName}
-        data-testid={`${tooltip}`}
         onClick={handler}
         className="SRC-whiteText"
         selected={isCurrentlySelectedItem}
@@ -134,7 +132,7 @@ const NavDrawerListItem = (props: MenuItemParams) => {
         <Badge badgeContent={badgeContent} color="secondary">
           {item}
         </Badge>
-      </ListItem>
+      </ListItemButton>
     </Tooltip>
   )
 
@@ -190,8 +188,7 @@ export const SynapseNavDrawer: React.FunctionComponent<
       ],
     },
     {
-      enabled:
-        currentUserBundle?.isACTMember || currentUserBundle?.isARReviewer,
+      enabled: currentUserBundle?.isARReviewer,
     },
   )
 
@@ -221,8 +218,7 @@ export const SynapseNavDrawer: React.FunctionComponent<
   }
 
   const onProjectSearch = (searchTerm: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    projectSearchJson.queryTerm = searchTerm.split(/[ ,]+/) as any
+    projectSearchJson.queryTerm = searchTerm.split(/[ ,]+/)
     window.location.href = `/#!Search:${encodeURI(
       JSON.stringify(projectSearchJson),
     )}`
@@ -286,17 +282,16 @@ export const SynapseNavDrawer: React.FunctionComponent<
                 handleDrawerClose={handleDrawerClose}
                 handleDrawerOpen={handleDrawerOpen}
               />
-              {isInSynapseExperimentalMode() &&
-                currentUserBundle?.isARReviewer && (
-                  <NavDrawerListItem
-                    tooltip="Data Access Management"
-                    iconName="accessManagement"
-                    onClickGoToUrl="/#!DataAccessManagement:default/Submissions"
-                    badgeContent={countOfOpenSubmissionsForReview}
-                    handleDrawerClose={handleDrawerClose}
-                    handleDrawerOpen={handleDrawerOpen}
-                  />
-                )}
+              {currentUserBundle?.isARReviewer && (
+                <NavDrawerListItem
+                  tooltip="Data Access Management"
+                  iconName="accessManagement"
+                  onClickGoToUrl="/#!DataAccessManagement:default/Submissions"
+                  badgeContent={countOfOpenSubmissionsForReview}
+                  handleDrawerClose={handleDrawerClose}
+                  handleDrawerOpen={handleDrawerOpen}
+                />
+              )}
             </>
           )}
           <NavDrawerListItem

--- a/packages/synapse-react-client/src/lib/style/components/_synapse-nav-drawer.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_synapse-nav-drawer.scss
@@ -8,7 +8,7 @@
     display: block;
   }
   .SynapseNavDrawerMenu {
-    .MuiListItem-button:hover,
+    .MuiListItemButton-root:hover,
     .Mui-selected {
       border-left: 7px solid SRC.$secondary-action-color;
       padding-left: 9px;
@@ -24,7 +24,7 @@
       flex-grow: 1;
     }
   }
-  .MuiListItem-root {
+  .MuiListItemButton-root {
     padding-top: 14px;
     padding-bottom: 14px;
   }

--- a/packages/synapse-react-client/test/lib/containers/SynapseNavDrawer.test.tsx
+++ b/packages/synapse-react-client/test/lib/containers/SynapseNavDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import React from 'react'
 import {
   SynapseNavDrawer,
@@ -6,36 +6,155 @@ import {
 } from '../../../src/lib/containers/SynapseNavDrawer'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
 import { SynapseContextType } from '../../../src/lib/utils/SynapseContext'
-import { server } from '../../../mocks/msw/server'
-import { INVALID_ACCESS_TOKEN_CAUSES_GET_PROFILE_ERROR } from '../../../mocks/user/mock_user_profile'
+import {
+  MOCK_USER_ID,
+  MOCK_USER_ID_2,
+  mockUserBundle,
+} from '../../../mocks/user/mock_user_profile'
+import { SynapseClient } from '../../../src/lib'
+import { SubmissionState } from '../../../src/lib/utils/synapseTypes'
+import { SubmissionSearchResult } from '../../../src/lib/utils/synapseTypes/AccessSubmission'
+import { mockManagedACTAccessRequirement } from '../../../mocks/mockAccessRequirements'
+import { mockSubmittedSubmission } from '../../../mocks/dataaccess/MockSubmission'
 
 const defaultProps: SynapseNavDrawerProps = {
   initIsOpen: false,
   signoutCallback: jest.fn(),
 }
 
-function renderComponent(wrapperProps?: SynapseContextType) {
+function renderComponent(wrapperProps?: Partial<SynapseContextType>) {
   render(<SynapseNavDrawer {...defaultProps} />, {
     wrapper: createWrapper(wrapperProps),
   })
 }
 
-describe('SynapseNavDrawer tests', () => {
-  beforeAll(() => server.listen())
-  afterEach(() => server.restoreHandlers())
-  afterAll(() => server.close())
+const numFilesInDownloadList = 10
 
-  it('Shows Synapse Nav Drawer with logged in user items', () => {
-    // mock successful response set up in handlers.ts (when an access token is provided)
+jest.spyOn(SynapseClient, 'getDownloadListStatistics').mockResolvedValue({
+  concreteType:
+    'org.sagebionetworks.repo.model.download.FilesStatisticsResponse',
+  totalNumberOfFiles: numFilesInDownloadList,
+  numberOfFilesAvailableForDownload: 5,
+  numberOfFilesAvailableForDownloadAndEligibleForPackaging: 4,
+  numberOfFilesRequiringAction: 5,
+  sumOfFileSizesAvailableForDownload: 1561981,
+})
+
+const openSubmissions: SubmissionSearchResult[] = [
+  {
+    id: mockSubmittedSubmission.id,
+    createdOn: mockSubmittedSubmission.submittedOn,
+    modifiedOn: mockSubmittedSubmission.submittedOn,
+    accessRequirementId: `${mockManagedACTAccessRequirement.id}`,
+    accessRequirementVersion: `${mockManagedACTAccessRequirement.versionNumber}`,
+    accessRequirementName: mockManagedACTAccessRequirement.name,
+    accessRequirementReviewerIds: [MOCK_USER_ID.toString()],
+    submitterId: MOCK_USER_ID_2.toString(),
+    accessorChanges: [],
+    state: SubmissionState.SUBMITTED,
+  },
+]
+
+jest.spyOn(SynapseClient, 'searchAccessSubmission').mockResolvedValue({
+  results: openSubmissions,
+})
+
+const mockGetUserBundle = jest.spyOn(SynapseClient, 'getMyUserBundle')
+
+describe('SynapseNavDrawer tests', () => {
+  it('Shows logged-out user items', async () => {
+    renderComponent({
+      accessToken: undefined,
+    })
+
+    const buttonGroups = await screen.findAllByRole('list')
+    expect(buttonGroups).toHaveLength(2)
+
+    const topButtonGroup = buttonGroups[0]
+    const bottomButtonGroup = buttonGroups[1]
+
+    await within(topButtonGroup).findByLabelText('Search')
+    expect(screen.queryByLabelText('Projects')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Favorites')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Teams')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Challenges')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Download Cart')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Trash Can')).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText('Data Access Management'),
+    ).not.toBeInTheDocument()
+
+    await within(bottomButtonGroup).findByLabelText('Sign in')
+    await within(bottomButtonGroup).findByLabelText('Help')
+    expect(screen.queryByLabelText('Your Account')).not.toBeInTheDocument()
+  })
+
+  it('Shows Synapse Nav Drawer with logged in user items', async () => {
+    mockGetUserBundle.mockResolvedValue({
+      ...mockUserBundle,
+      isARReviewer: false,
+    })
+
     renderComponent()
 
-    // provide waitForElementOptions to allow time to update the component state (with user info)
-    screen.findByTestId('Projects', undefined, { timeout: 1000 })
-    screen.findByTestId('Favorites', undefined, { timeout: 1000 })
-    screen.findByTestId('Teams', undefined, { timeout: 1000 })
-    screen.findByTestId('Challenges', undefined, { timeout: 1000 })
-    screen.findByTestId('Search')
-    screen.findByTestId('Help')
-    screen.findByTestId('Your Account', undefined, { timeout: 1000 })
+    const buttonGroups = await screen.findAllByRole('list')
+    expect(buttonGroups).toHaveLength(2)
+
+    const topButtonGroup = buttonGroups[0]
+    const bottomButtonGroup = buttonGroups[1]
+
+    await within(topButtonGroup).findByLabelText('Projects')
+    await within(topButtonGroup).findByLabelText('Favorites')
+    await within(topButtonGroup).findByLabelText('Teams')
+    await within(topButtonGroup).findByLabelText('Challenges')
+    const downloadCartButton = await within(topButtonGroup).findByLabelText(
+      'Download Cart',
+    )
+    await within(downloadCartButton).findByText(`${numFilesInDownloadList}`)
+    await within(topButtonGroup).findByLabelText('Trash Can')
+    await within(topButtonGroup).findByLabelText('Search')
+    expect(
+      screen.queryByLabelText('Data Access Management'),
+    ).not.toBeInTheDocument()
+
+    await within(bottomButtonGroup).findByLabelText('Your Account')
+    await within(bottomButtonGroup).findByLabelText('Help')
+    expect(screen.queryByLabelText('Sign in')).not.toBeInTheDocument()
+  })
+
+  it('Shows the data access button for AR reviewers', async () => {
+    mockGetUserBundle.mockResolvedValue({
+      ...mockUserBundle,
+      isARReviewer: true,
+    })
+
+    renderComponent()
+
+    const buttonGroups = await screen.findAllByRole('list')
+    expect(buttonGroups).toHaveLength(2)
+
+    const topButtonGroup = buttonGroups[0]
+    const bottomButtonGroup = buttonGroups[1]
+
+    await within(topButtonGroup).findByLabelText('Projects')
+    await within(topButtonGroup).findByLabelText('Favorites')
+    await within(topButtonGroup).findByLabelText('Teams')
+    await within(topButtonGroup).findByLabelText('Challenges')
+    const downloadCartButton = await within(topButtonGroup).findByLabelText(
+      'Download Cart',
+    )
+    await within(downloadCartButton).findByText(`${numFilesInDownloadList}`)
+    await within(topButtonGroup).findByLabelText('Trash Can')
+    await within(topButtonGroup).findByLabelText('Search')
+
+    // Data access management button should appear with a count of the number of open submissions
+    const dataAccessButton = await within(topButtonGroup).findByLabelText(
+      'Data Access Management',
+    )
+    within(dataAccessButton).findByText(openSubmissions.length.toString())
+
+    await within(bottomButtonGroup).findByLabelText('Your Account')
+    await within(bottomButtonGroup).findByLabelText('Help')
+    expect(screen.queryByLabelText('Sign in')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
synapse-react-client:
- Release AR Reviewer dashboard from experimental mode
- SynapseNavDrawer: Replace ListItem w/ deprecated button prop with ListItemButton
- SynapseNavDrawer: Add/refine tests for checking which buttons are visible