### PR TITLE
PORTALS-2597: buttons radius and text need to be consistent

### DIFF
--- a/apps/portals/src/Navbar.tsx
+++ b/apps/portals/src/Navbar.tsx
@@ -214,7 +214,7 @@ function Navbar() {
                     setShowLoginDialog(true)
                   }}
                 >
-                  SIGN&nbsp;IN
+                  Sign&nbsp;In
                 </Button>
                 <Dialog
                   onClose={() => {

--- a/apps/portals/src/Navbar.tsx
+++ b/apps/portals/src/Navbar.tsx
@@ -194,12 +194,12 @@ function Navbar() {
                 <Button
                   id="signin-button"
                   variant="secondary"
-                  className="pill signout-button-mb"
+                  className="signout-button-mb"
                   onClick={() => {
                     clearSession()
                   }}
                 >
-                  SIGN OUT
+                  Sign Out
                 </Button>
               </div>
             )}
@@ -209,7 +209,6 @@ function Navbar() {
                 <Button
                   id="signin-button"
                   variant="secondary"
-                  className="pill"
                   onClick={() => {
                     setShowLoginDialog(true)
                   }}

--- a/apps/portals/src/_Core.scss
+++ b/apps/portals/src/_Core.scss
@@ -389,7 +389,6 @@ button.dropdown-toggle.nav-button:hover {
   font-weight: bold;
   font-size: 16px;
   height: 39px;
-  border-radius: 30px;
   padding: 5px 38px;
   border: none;
   &:hover {

--- a/apps/portals/src/configurations/adknowledgeportal/routesConfig.ts
+++ b/apps/portals/src/configurations/adknowledgeportal/routesConfig.ts
@@ -180,7 +180,7 @@ const routes: GenericRoute[] = [
           size: SynapseConstants.MEDIUM_USER_CARD,
           useQueryResultUserData: true,
           summaryLink: 'Explore/People',
-          summaryLinkText: 'EXPLORE ALL PEOPLE',
+          summaryLinkText: 'Explore All People',
         },
       },
       {

--- a/apps/portals/src/configurations/adknowledgeportal/synapseConfigs/studies.ts
+++ b/apps/portals/src/configurations/adknowledgeportal/synapseConfigs/studies.ts
@@ -151,7 +151,7 @@ export const studiesDetailsPageProps: DetailsPageProps = {
             allowCategories: [],
             // mailChimpListName: 'study specific list name????',
             // mailChimpUrl:'https://study specific url????'
-            viewAllNewsButtonText: 'VIEW ALL DATA UPDATES',
+            viewAllNewsButtonText: 'View All Data Updates',
           },
         },
         {

--- a/apps/portals/src/configurations/arkportal/style/_style_overrides.scss
+++ b/apps/portals/src/configurations/arkportal/style/_style_overrides.scss
@@ -113,7 +113,7 @@ $ARK-gray-900: #1d1d22 !default;
       line-height: 1.5;
       color: $ARK-gray-700;
       margin-bottom: 40px;
-      &__link.btn.pill {
+      &__link.btn {
         border-color: transparent;
         display: block;
         box-sizing: border-box;

--- a/apps/portals/src/configurations/bsmn/routesConfig.ts
+++ b/apps/portals/src/configurations/bsmn/routesConfig.ts
@@ -56,7 +56,7 @@ const routes: GenericRoute[] = [
           ],
           size: SynapseConstants.MEDIUM_USER_CARD,
           useQueryResultUserData: true,
-          summaryLinkText: 'EXPLORE ALL PEOPLE',
+          summaryLinkText: 'Explore All People',
           summaryLink: '/Explore/People',
           count: 6,
         },

--- a/apps/portals/src/configurations/elportal/routesConfig.ts
+++ b/apps/portals/src/configurations/elportal/routesConfig.ts
@@ -180,7 +180,7 @@ const routes: GenericRoute[] = [
           size: SynapseConstants.MEDIUM_USER_CARD,
           useQueryResultUserData: true,
           summaryLink: 'Explore/People',
-          summaryLinkText: 'EXPLORE ALL PEOPLE',
+          summaryLinkText: 'Explore All People',
         },
       },
       {

--- a/apps/portals/src/configurations/elportal/synapseConfigs/studies.ts
+++ b/apps/portals/src/configurations/elportal/synapseConfigs/studies.ts
@@ -151,7 +151,7 @@ export const studiesDetailsPageProps: DetailsPageProps = {
             allowCategories: [],
             // mailChimpListName: 'study specific list name????',
             // mailChimpUrl:'https://study specific url????'
-            viewAllNewsButtonText: 'VIEW ALL DATA UPDATES',
+            viewAllNewsButtonText: 'View All Data Updates',
           },
         },
         {

--- a/apps/portals/src/configurations/nf/routesConfig.ts
+++ b/apps/portals/src/configurations/nf/routesConfig.ts
@@ -94,7 +94,7 @@ const routes: GenericRoute[] = [
           size: SynapseConstants.LARGE_USER_CARD,
           useQueryResultUserData: true,
           // summaryLink: 'Explore/People',
-          // summaryLinkText: 'EXPLORE ALL PEOPLE',
+          // summaryLinkText: 'Explore All People',
         },
       },
       {

--- a/apps/portals/src/configurations/psychencode/routesConfig.ts
+++ b/apps/portals/src/configurations/psychencode/routesConfig.ts
@@ -55,7 +55,7 @@ const routes: GenericRoute[] = [
           maxBarCount: 20,
           setName: '# Individuals per assay',
           combinationName: '# Individuals',
-          summaryLinkText: 'EXPLORE ALL DATA',
+          summaryLinkText: 'Explore All Data',
           summaryLink: '/Explore/Data',
         },
       },
@@ -68,7 +68,7 @@ const routes: GenericRoute[] = [
           sql: `${peopleSql} where feature=true`,
           count: 3,
           summaryLink: 'Explore/People',
-          summaryLinkText: 'EXPLORE ALL PEOPLE',
+          summaryLinkText: 'Explore All People',
         },
       },
       {

--- a/apps/portals/src/portal-components/DetailsPage/DetailsPage.tsx
+++ b/apps/portals/src/portal-components/DetailsPage/DetailsPage.tsx
@@ -165,7 +165,7 @@ export default function DetailsPage(props: DetailsPageProps) {
           onClick={goToExplorePage}
           className="SRC-standard-button-shape SRC-primary-background-color SRC-whiteText"
         >
-          CONTINUE EXPLORING
+          Continue Exploring
         </button>
       </div>
     )

--- a/apps/portals/src/portal-components/Versions.tsx
+++ b/apps/portals/src/portal-components/Versions.tsx
@@ -74,7 +74,7 @@ const Versions: React.FunctionComponent = () => {
               className="Versions footer-item"
               target="_blank"
               rel="noopener noreferrer"
-              href="https://github.com/Sage-Bionetworks/portals"
+              href="https://github.com/Sage-Bionetworks/synapse-web-monorepo"
             >
               VERSION
             </a>

--- a/apps/portals/src/portal-components/nf/BrowseToolsPage.tsx
+++ b/apps/portals/src/portal-components/nf/BrowseToolsPage.tsx
@@ -103,7 +103,7 @@ const BrowseToolsPage = () => {
           </button>
         </div>
         <div className="center-content bootstrap-4-backport">
-          <Button className="pill-xl" variant="primary" onClick={() => gotoExploreTools()}>VIEW ALL TOOLS</Button>
+          <Button className="pill-xl" variant="primary" onClick={() => gotoExploreTools()}>View All Tools</Button>
         </div>
       </Layout>
       <div className="home-container-description  home-bg-dark home-spacer">
@@ -180,7 +180,7 @@ const BrowseToolsPage = () => {
           </div>
         </div>
         <div className="center-content bootstrap-4-backport">
-          <Button href="https://help.nf.synapse.org/NFdocs/2555543592.html" className="pill-xl highlightSubmitToolButton" variant="secondary" target="_blank">SUBMIT A TOOL</Button>
+          <Button href="https://help.nf.synapse.org/NFdocs/2555543592.html" className="pill-xl highlightSubmitToolButton" variant="secondary" target="_blank">Submit A Tool</Button>
         </div>
       </Layout>
     </div>

--- a/apps/portals/src/portal-components/nf/BrowseToolsPage.tsx
+++ b/apps/portals/src/portal-components/nf/BrowseToolsPage.tsx
@@ -15,16 +15,20 @@ import { ReactComponent as CellLines } from './assets/cell-lines.svg'
 import { ReactComponent as PlasmidsReagents } from './assets/plasmids-reagents.svg'
 import PopularSearches from './PopularSearches'
 
-export const gotoExploreToolsWithFullTextSearch = (fullTextSearchString: string) => {
+export const gotoExploreToolsWithFullTextSearch = (
+  fullTextSearchString: string,
+) => {
   const filter: TextMatchesQueryFilter = {
-    concreteType: "org.sagebionetworks.repo.model.table.TextMatchesQueryFilter",
+    concreteType: 'org.sagebionetworks.repo.model.table.TextMatchesQueryFilter',
     searchExpression: fullTextSearchString,
   }
   const query: Query = {
     sql: toolsSql,
     additionalFilters: [filter],
   }
-  window.location.assign(`/Explore/Tools?QueryWrapper0=${JSON.stringify(query)}`)
+  window.location.assign(
+    `/Explore/Tools?QueryWrapper0=${JSON.stringify(query)}`,
+  )
 }
 
 const BrowseToolsPage = () => {
@@ -38,13 +42,16 @@ const BrowseToolsPage = () => {
       sql: toolsSql,
       selectedFacets: [
         {
-          concreteType: "org.sagebionetworks.repo.model.table.FacetColumnValuesRequest",
+          concreteType:
+            'org.sagebionetworks.repo.model.table.FacetColumnValuesRequest',
           columnName: 'resourceType',
-          facetValues: [selectedResource]
-        }
+          facetValues: [selectedResource],
+        },
       ],
     }
-    window.location.assign(`/Explore/Tools?QueryWrapper0=${JSON.stringify(query)}`)
+    window.location.assign(
+      `/Explore/Tools?QueryWrapper0=${JSON.stringify(query)}`,
+    )
   }
 
   return (
@@ -57,7 +64,12 @@ const BrowseToolsPage = () => {
           <div className="center-content">
             <div className="description">
               <Typography variant="body1">
-                The NF Research Tools Database aims to support the development of a robust research toolkit and lower the barrier of entry to neurofibromatosis (NF) research. The database includes NF-associated animal models, cell lines, antibodies, and genetic reagents and details on tool characteristics and sourcing, as well as observational and experimental data.
+                The NF Research Tools Database aims to support the development
+                of a robust research toolkit and lower the barrier of entry to
+                neurofibromatosis (NF) research. The database includes
+                NF-associated animal models, cell lines, antibodies, and genetic
+                reagents and details on tool characteristics and sourcing, as
+                well as observational and experimental data.
               </Typography>
             </div>
           </div>
@@ -71,39 +83,47 @@ const BrowseToolsPage = () => {
           Drill-down to explore specific types of NF research tools.
         </Typography>
         <div className="categories">
-          <button onClick={() => gotoExploreToolsWithSelectedResource('Animal Model')}>
+          <button
+            onClick={() => gotoExploreToolsWithSelectedResource('Animal Model')}
+          >
             <AnimalModels />
-            <Typography variant="headline3">
-              Animal Models
-            </Typography>
+            <Typography variant="headline3">Animal Models</Typography>
           </button>
-          <button onClick={() => gotoExploreToolsWithSelectedResource('Antibody')}>
+          <button
+            onClick={() => gotoExploreToolsWithSelectedResource('Antibody')}
+          >
             <Antibodies />
-            <Typography variant="headline3">
-              Antibodies
-            </Typography>
+            <Typography variant="headline3">Antibodies</Typography>
           </button>
-          <button onClick={() => gotoExploreToolsWithSelectedResource('Genetic Reagent')}>
+          <button
+            onClick={() =>
+              gotoExploreToolsWithSelectedResource('Genetic Reagent')
+            }
+          >
             <PlasmidsReagents />
-            <Typography variant="headline3">
-              Genetic Reagents
-            </Typography>
+            <Typography variant="headline3">Genetic Reagents</Typography>
           </button>
-          <button onClick={() => gotoExploreToolsWithSelectedResource('Cell Line')}>
+          <button
+            onClick={() => gotoExploreToolsWithSelectedResource('Cell Line')}
+          >
             <CellLines />
-            <Typography variant="headline3">
-              Cell Lines
-            </Typography>
+            <Typography variant="headline3">Cell Lines</Typography>
           </button>
-          <button onClick={() => gotoExploreToolsWithSelectedResource('Biobank')}>
+          <button
+            onClick={() => gotoExploreToolsWithSelectedResource('Biobank')}
+          >
             <Biobanks />
-            <Typography variant="headline3">
-              Biobanks
-            </Typography>
+            <Typography variant="headline3">Biobanks</Typography>
           </button>
         </div>
         <div className="center-content bootstrap-4-backport">
-          <Button className="pill-xl" variant="primary" onClick={() => gotoExploreTools()}>View All Tools</Button>
+          <Button
+            className="btn-wide"
+            variant="primary"
+            onClick={() => gotoExploreTools()}
+          >
+            View All Tools
+          </Button>
         </div>
       </Layout>
       <div className="home-container-description  home-bg-dark home-spacer">
@@ -113,13 +133,15 @@ const BrowseToolsPage = () => {
         <div className="center-content">
           <div className="searchToolsRow">
             <div className="searchInputWithIcon">
-              <IconSvg icon='searchOutlined' />
-              <Form.Control type="search" placeholder=""
+              <IconSvg icon="searchOutlined" />
+              <Form.Control
+                type="search"
+                placeholder=""
                 value={searchText}
-                onChange={event => {
+                onChange={(event) => {
                   setSearchText(event.target.value)
                 }}
-                onKeyPress={evt => {
+                onKeyPress={(evt) => {
                   if (evt.key === 'Enter') {
                     gotoExploreToolsWithFullTextSearch(searchText)
                   }
@@ -127,12 +149,22 @@ const BrowseToolsPage = () => {
               />
             </div>
             <div className="search-button-container bootstrap-4-backport">
-              <Button className="pill-xl" variant="primary" onClick={() => gotoExploreToolsWithFullTextSearch(searchText)}>SEARCH</Button>
+              <Button
+                className="btn-wide"
+                variant="primary"
+                onClick={() => gotoExploreToolsWithFullTextSearch(searchText)}
+              >
+                Search
+              </Button>
             </div>
             <div className="help-popover">
               <HelpPopover
-                markdownText={'This search bar is powered by MySQL Full Text Search.'}
-                helpUrl={'https://help.nf.synapse.org/NFdocs/Tips-for-Search.2640478225.html'}
+                markdownText={
+                  'This search bar is powered by MySQL Full Text Search.'
+                }
+                helpUrl={
+                  'https://help.nf.synapse.org/NFdocs/Tips-for-Search.2640478225.html'
+                }
                 placement="left"
               />
             </div>
@@ -145,7 +177,7 @@ const BrowseToolsPage = () => {
           <PopularSearches sql={popularSearchesSql} />
         </div>
       </div>
-      
+
       <Layout outsideContainerClassName="home-spacer">
         <Typography variant="sectionTitle" className="sectionTitle">
           Recently Added Tools
@@ -165,7 +197,13 @@ const BrowseToolsPage = () => {
           />
         </div>
         <div className="center-content bootstrap-4-backport">
-          <Button className="pill-xl" variant="primary" onClick={() => gotoExploreTools()}>VIEW ALL TOOLS</Button>
+          <Button
+            className="btn-wide"
+            variant="primary"
+            onClick={() => gotoExploreTools()}
+          >
+            View All Tools
+          </Button>
         </div>
       </Layout>
       <Layout outsideContainerClassName="home-spacer highlightSubmitToolContainer">
@@ -175,12 +213,23 @@ const BrowseToolsPage = () => {
         <div className="center-content">
           <div className="description">
             <Typography variant="body1">
-              We are currently accepting submissions that describe any NF1-related mouse model, cell line, genetic reagent (e.g. plasmid, CRISPR), antibody, or biobank. If you have a tool that you would like to add to the Research Tools Database, please click the {'"'}Submit a Tool{'"'} button below to learn more.
+              We are currently accepting submissions that describe any
+              NF1-related mouse model, cell line, genetic reagent (e.g. plasmid,
+              CRISPR), antibody, or biobank. If you have a tool that you would
+              like to add to the Research Tools Database, please click the {'"'}
+              Submit a Tool{'"'} button below to learn more.
             </Typography>
           </div>
         </div>
         <div className="center-content bootstrap-4-backport">
-          <Button href="https://help.nf.synapse.org/NFdocs/2555543592.html" className="pill-xl highlightSubmitToolButton" variant="secondary" target="_blank">Submit A Tool</Button>
+          <Button
+            href="https://help.nf.synapse.org/NFdocs/2555543592.html"
+            className="btn-wide highlightSubmitToolButton"
+            variant="secondary"
+            target="_blank"
+          >
+            Submit A Tool
+          </Button>
         </div>
       </Layout>
     </div>

--- a/apps/portals/src/portal-components/nf/style/_BrowseToolsPage.scss
+++ b/apps/portals/src/portal-components/nf/style/_BrowseToolsPage.scss
@@ -21,7 +21,7 @@
     margin: 10px 0px 25px 0px;
     text-align: center;
   }
-  .center-content > .pill-xl {
+  .center-content > .btn-wide {
     margin-top: 50px;
   }
   .searchToolsRow {

--- a/packages/synapse-react-client/demo/containers/playground/ButtonDemo.tsx
+++ b/packages/synapse-react-client/demo/containers/playground/ButtonDemo.tsx
@@ -19,7 +19,7 @@ export const ButtonDemo: React.FunctionComponent = () => {
     undefined,
   )
 
-  const shapeClasses: string[] = ['', 'pill', 'pill-xl']
+  const shapeClasses: string[] = ['', 'btn-wide']
   const colorVariants: string[] = [
     'sds-primary',
     'outline',

--- a/packages/synapse-react-client/src/lib/containers/CardContainer.tsx
+++ b/packages/synapse-react-client/src/lib/containers/CardContainer.tsx
@@ -89,7 +89,7 @@ export const CardContainer = (props: CardContainerProps) => {
     <div className="SRC-viewMore bootstrap-4-backport">
       <Button
         variant="secondary"
-        className="pill-xl"
+        className="btn-wide"
         onClick={() => {
           appendNextPageToResults()
         }}

--- a/packages/synapse-react-client/src/lib/containers/RssFeedCards.tsx
+++ b/packages/synapse-react-client/src/lib/containers/RssFeedCards.tsx
@@ -190,7 +190,6 @@ export default class RssFeedCards extends React.Component<
                 <Button
                   variant="secondary"
                   size="lg"
-                  className="pill"
                   onClick={() =>
                     window.open(this.state.allItemsUrl, '_blank', 'noopener')
                   }

--- a/packages/synapse-react-client/src/lib/containers/RssFeedCards.tsx
+++ b/packages/synapse-react-client/src/lib/containers/RssFeedCards.tsx
@@ -196,7 +196,7 @@ export default class RssFeedCards extends React.Component<
                   }
                   target="_blank"
                 >
-                  {viewAllNewsButtonText ?? 'VIEW ALL NEWS'}
+                  {viewAllNewsButtonText ?? 'View All News'}
                 </Button>
               </div>
             )}

--- a/packages/synapse-react-client/src/lib/containers/TableFeedCards.tsx
+++ b/packages/synapse-react-client/src/lib/containers/TableFeedCards.tsx
@@ -114,10 +114,9 @@ const TableFeedCards: React.FunctionComponent<TableFeedCardsProps> = ({
           <Button
             variant="primary"
             size="lg"
-            className="pill"
             onClick={() => setItemCountShowing(itemCountShowing + 3)}
           >
-            VIEW MORE NEWS
+            View More News
           </Button>
         </div>
       )}

--- a/packages/synapse-react-client/src/lib/containers/UpsetPlot.tsx
+++ b/packages/synapse-react-client/src/lib/containers/UpsetPlot.tsx
@@ -182,12 +182,7 @@ const UpsetPlot: React.FunctionComponent<UpsetPlotProps> = ({
               />
               {summaryLink && summaryLinkText && (
                 <div className="UpsetPlot__summary">
-                  <Button
-                    variant="secondary"
-                    size="lg"
-                    className="pill"
-                    href={summaryLink}
-                  >
+                  <Button variant="secondary" size="lg" href={summaryLink}>
                     {summaryLinkText}
                   </Button>
                 </div>

--- a/packages/synapse-react-client/src/lib/containers/UserCardListRotate.tsx
+++ b/packages/synapse-react-client/src/lib/containers/UserCardListRotate.tsx
@@ -151,12 +151,7 @@ const UserCardListRotate: React.FunctionComponent<UserCardListRotateProps> = ({
       )}
       {summaryLink && summaryLinkText && (
         <div className="UserCardListRotate__summary">
-          <Button
-            className="pill"
-            variant="secondary"
-            size="lg"
-            href={summaryLink}
-          >
+          <Button variant="secondary" size="lg" href={summaryLink}>
             {summaryLinkText}
           </Button>
         </div>

--- a/packages/synapse-react-client/src/lib/containers/home_page/featured-data/FeaturedDataTabs.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/featured-data/FeaturedDataTabs.tsx
@@ -64,7 +64,6 @@ const FeaturedDataTabs: React.FunctionComponent<
           {selectedTabProps.explorePagePath && (
             <div className="bootstrap-4-backport FeaturedDataTabs__explore-all">
               <Button
-                className="pill"
                 variant="secondary"
                 size="lg"
                 href={selectedTabProps.explorePagePath}

--- a/packages/synapse-react-client/src/lib/containers/home_page/featured-data/FeaturedDataTabs.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/featured-data/FeaturedDataTabs.tsx
@@ -69,7 +69,7 @@ const FeaturedDataTabs: React.FunctionComponent<
                 size="lg"
                 href={selectedTabProps.explorePagePath}
               >
-                EXPLORE ALL {selectedTabProps.exploreObjectType?.toUpperCase()}
+                Explore All {selectedTabProps.exploreObjectType}
               </Button>
             </div>
           )}

--- a/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Desktop.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Desktop.tsx
@@ -28,7 +28,7 @@ export default function GoalsDesktop({
       <div className="Goals__Card__summary">
         <p> {summary} </p>
         <Button
-          className="pill Goals__Card__summary__link"
+          className="Goals__Card__summary__link"
           variant="secondary"
           href={link}
         >

--- a/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Desktop.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Desktop.tsx
@@ -32,7 +32,7 @@ export default function GoalsDesktop({
           variant="secondary"
           href={link}
         >
-          EXPLORE
+          Explore
         </Button>
       </div>
     </div>

--- a/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Mobile.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Mobile.tsx
@@ -28,7 +28,7 @@ export default function GoalsMobile({
         className="pill Goals__Mobile__Content__Link"
         href={link}
       >
-        EXPLORE
+        Explore
       </Button>
     </div>
   )

--- a/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Mobile.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Mobile.tsx
@@ -25,7 +25,7 @@ export default function GoalsMobile({
       <p>{summary}</p>
       <Button
         variant="secondary"
-        className="pill Goals__Mobile__Content__Link"
+        className="Goals__Mobile__Content__Link"
         href={link}
       >
         Explore

--- a/packages/synapse-react-client/src/lib/containers/home_page/people/UserCardListGroups.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/people/UserCardListGroups.tsx
@@ -33,12 +33,7 @@ export default function UserCardListGroups(props: UserCardListGroupsProps) {
         )}
         {summaryLink && summaryLinkText && (
           <div className="UserCardListGroups__summary">
-            <Button
-              variant="secondary"
-              size="lg"
-              className="pill"
-              href={summaryLink}
-            >
+            <Button variant="secondary" size="lg" href={summaryLink}>
               {summaryLinkText}
             </Button>
           </div>

--- a/packages/synapse-react-client/src/lib/containers/home_page/programs/Programs.Desktop.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/programs/Programs.Desktop.tsx
@@ -40,12 +40,7 @@ export default function ProgramsDesktop({
       </div>
       <div className="Programs__Card__summary">
         <p> {summary} </p>
-        <Button
-          variant="secondary"
-          size="lg"
-          href={exploreLink}
-          className="pill"
-        >
+        <Button variant="secondary" size="lg" href={exploreLink}>
           Explore
         </Button>
       </div>

--- a/packages/synapse-react-client/src/lib/containers/home_page/programs/Programs.Desktop.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/programs/Programs.Desktop.tsx
@@ -46,7 +46,7 @@ export default function ProgramsDesktop({
           href={exploreLink}
           className="pill"
         >
-          EXPLORE
+          Explore
         </Button>
       </div>
     </div>

--- a/packages/synapse-react-client/src/lib/containers/home_page/programs/Programs.Mobile.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/programs/Programs.Mobile.tsx
@@ -38,7 +38,7 @@ export default function ProgramsMobile({
       )}
       <p>{summary}</p>
       <Button variant="secondary" size="lg" href={exploreLink} className="pill">
-        EXPLORE
+        Explore
       </Button>
     </div>
   )

--- a/packages/synapse-react-client/src/lib/containers/home_page/programs/Programs.Mobile.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/programs/Programs.Mobile.tsx
@@ -37,7 +37,7 @@ export default function ProgramsMobile({
         </p>
       )}
       <p>{summary}</p>
-      <Button variant="secondary" size="lg" href={exploreLink} className="pill">
+      <Button variant="secondary" size="lg" href={exploreLink}>
         Explore
       </Button>
     </div>

--- a/packages/synapse-react-client/src/lib/containers/markdown/widget/MarkdownButton.tsx
+++ b/packages/synapse-react-client/src/lib/containers/markdown/widget/MarkdownButton.tsx
@@ -11,7 +11,7 @@ export type ButtonLinkWidgetParams = {
 export default function MarkdownButton(
   widgetParamsMapped: ButtonLinkWidgetParams,
 ) {
-  let buttonClasses = 'pill-xl '
+  let buttonClasses = 'btn-wide '
   const { align = '', highlight = '' } = widgetParamsMapped
   const alignLowerCase = align.toLowerCase()
   if (alignLowerCase === 'left') {

--- a/packages/synapse-react-client/src/lib/containers/row_renderers/Dataset.tsx
+++ b/packages/synapse-react-client/src/lib/containers/row_renderers/Dataset.tsx
@@ -85,7 +85,7 @@ class Dataset extends React.Component<DatasetProps, never> {
             <p className="SRC-description-text">{summary}</p>
             <div className="SRC-cardAction bootstrap-4-backport">
               <Button
-                className="pill SRC-datasetButton"
+                className="SRC-datasetButton"
                 onClick={this.handleLinkClick(id)}
                 variant="secondary"
               >

--- a/packages/synapse-react-client/src/lib/containers/row_renderers/Funder.tsx
+++ b/packages/synapse-react-client/src/lib/containers/row_renderers/Funder.tsx
@@ -39,7 +39,7 @@ export default class Funder extends React.Component<FunderProps, never> {
       showOrgLink = (
         <div className="SRC-marginAuto SRC-cardAction bootstrap-4-backport">
           <Button
-            className="pill-xl"
+            className="btn-wide"
             href={organizationPath}
             variant="secondary"
           >

--- a/packages/synapse-react-client/src/lib/containers/synapse_form_wrapper/SynapseForm.tsx
+++ b/packages/synapse-react-client/src/lib/containers/synapse_form_wrapper/SynapseForm.tsx
@@ -611,7 +611,7 @@ export default class SynapseForm extends React.Component<
             className="btn btn-link"
             onClick={() => this.toggleExcludeStep(currentStep.id, false)}
           >
-            INCLUDE
+            Include
           </button>
         </div>
       )
@@ -626,7 +626,7 @@ export default class SynapseForm extends React.Component<
               this.showExcludeStateWarningModal(this.state.currentStep.id)
             }
           >
-            SKIP
+            Skip
           </button>
         </div>
       )

--- a/packages/synapse-react-client/src/lib/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid.tsx
+++ b/packages/synapse-react-client/src/lib/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid.tsx
@@ -271,7 +271,7 @@ export default class SynapseFormSubmissionGrid extends React.Component<
               Please sign in or register to initiate or continue your submission
             </p>
             <Button
-              className={`${SRC_SIGN_IN_CLASS} pill`}
+              className={`${SRC_SIGN_IN_CLASS}`}
               variant="primary"
               size="lg"
             >
@@ -466,7 +466,7 @@ export default class SynapseFormSubmissionGrid extends React.Component<
 
                 <div className="text-center bootstrap-4-backport">
                   <Button
-                    className="pill-xl btn-large" // .btn-large is a custom class, don't use size="lg"
+                    className="btn-wide btn-large" // .btn-large is a custom class, don't use size="lg"
                     variant="primary"
                     href={`${this.props.pathpart}?formGroupId=${this.props.formGroupId}`}
                   >

--- a/packages/synapse-react-client/src/lib/containers/synapse_form_wrapper/SynapseFormWrapper.tsx
+++ b/packages/synapse-react-client/src/lib/containers/synapse_form_wrapper/SynapseFormWrapper.tsx
@@ -373,7 +373,7 @@ class SynapseFormWrapper extends React.Component<
           <Button
             variant="light-primary-base"
             style={{ margin: '10px' }}
-            className={`pill ${SRC_SIGN_IN_CLASS}`}
+            className={`${SRC_SIGN_IN_CLASS}`}
           >
             sign in
           </Button>

--- a/packages/synapse-react-client/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/packages/synapse-react-client/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -257,7 +257,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
               <div className="FacetNav__showMoreContainer bootstrap-4-backport">
                 <Button
                   variant="secondary"
-                  className="pill-xl FacetNav__showMore"
+                  className="btn-wide FacetNav__showMore"
                   onClick={() =>
                     onShowMoreClick(showMoreButtonState === 'MORE')
                   }

--- a/packages/synapse-react-client/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
+++ b/packages/synapse-react-client/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
@@ -438,8 +438,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
             <div className="bootstrap-4-backport SaveFiltersButtonContainer">
               <Button
                 variant="secondary"
-                className="pill-xl SaveFiltersButton"
-                size="sm"
+                className="SaveFiltersButton"
                 onClick={() => setShowModal(false)}
               >
                 Apply Filters

--- a/packages/synapse-react-client/src/lib/style/abstracts/_variables.scss
+++ b/packages/synapse-react-client/src/lib/style/abstracts/_variables.scss
@@ -120,12 +120,17 @@ $breakpoints: (
   'large': 1024px,
 ) !default;
 
+// Buttons
+$button-border-radius: 3px;
+$button-text-transform: capitalize;
+
 // To reset bootstrap button style
 %button-reset {
   border: 0;
   outline: none;
   box-shadow: none;
-  border-radius: 2px;
+  border-radius: $button-border-radius;
+  text-transform: $button-text-transform;
 }
 
 // Form Control

--- a/packages/synapse-react-client/src/lib/style/base/_core.scss
+++ b/packages/synapse-react-client/src/lib/style/base/_core.scss
@@ -1320,10 +1320,10 @@ main,
 
 .SRC-tag {
   border: 1px solid SRC.$primary-action-color;
-  border-radius: SRC.$button-border-radius;
+  border-radius: 100px;
   padding: 5px 10px;
   color: SRC.$primary-action-color;
-  text-transform: SRC.$button-text-transform;
+  text-transform: uppercase;
 }
 
 .SRC-margin-left-5 {

--- a/packages/synapse-react-client/src/lib/style/base/_core.scss
+++ b/packages/synapse-react-client/src/lib/style/base/_core.scss
@@ -1018,7 +1018,6 @@ button {
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  border-radius: 24px;
   min-width: 168px;
   padding: 10px;
   height: 40px;
@@ -1321,10 +1320,10 @@ main,
 
 .SRC-tag {
   border: 1px solid SRC.$primary-action-color;
-  border-radius: 100px;
+  border-radius: SRC.$button-border-radius;
   padding: 5px 10px;
   color: SRC.$primary-action-color;
-  text-transform: uppercase;
+  text-transform: SRC.$button-text-transform;
 }
 
 .SRC-margin-left-5 {

--- a/packages/synapse-react-client/src/lib/style/bootstrap4_backports/_base-import.scss
+++ b/packages/synapse-react-client/src/lib/style/bootstrap4_backports/_base-import.scss
@@ -7,7 +7,11 @@
   //initial bootstrap config based on Synapse design
   $primary: SRC.$primary-action-color;
   $secondary: SRC.$secondary-action-color;
+  $border-radius: 0.2rem;
   $btn-box-shadow: SRC.$box-shadow-soft;
+  $btn-border-radius: SRC.$button-border-radius;
+  $btn-border-radius-sm: SRC.$button-border-radius;
+  $btn-border-radius-lg: SRC.$button-border-radius;
   $input-height: 50px;
   $input-padding-x: 0.75rem;
   $input-padding-y: 0.5rem;
@@ -28,6 +32,7 @@
   }
 
   // PORTALS-2597, SWC-6413: all buttons should be rounded
+  // style button directly so MuiButtons within bootstrap-4-backport class divs are styled, e.g. DiscussionThread
   button {
     border-radius: SRC.$button-border-radius;
     text-transform: SRC.$button-text-transform;
@@ -35,32 +40,20 @@
 
   // For all buttons, make the box shadow more intense on hover
   .btn {
-    border-radius: SRC.$button-border-radius;
     @include hover() {
       box-shadow: SRC.$box-shadow-med;
     }
   }
 
-  // Add the 'pill' class for a pill shape
-  .btn.pill.btn-lg {
+  // Large buttons
+  .btn.btn-lg {
     font-size: 16px;
     padding: 10px 24px;
   }
 
-  // Extra-long pill shape
-  .btn.pill-xl {
+  // Extra-wide button
+  .btn.btn-wide {
     min-width: 168px;
-    padding: 10px;
-  }
-
-  .btn.pill-xl.btn-sm {
-    min-width: 150px;
-    min-height: 20px;
-    padding: 5px;
-  }
-
-  .btn.pill-xl.btn-lg {
-    min-width: 220px;
     padding: 10px;
   }
 

--- a/packages/synapse-react-client/src/lib/style/bootstrap4_backports/_base-import.scss
+++ b/packages/synapse-react-client/src/lib/style/bootstrap4_backports/_base-import.scss
@@ -7,7 +7,6 @@
   //initial bootstrap config based on Synapse design
   $primary: SRC.$primary-action-color;
   $secondary: SRC.$secondary-action-color;
-  $border-radius: 0.2rem;
   $btn-box-shadow: SRC.$box-shadow-soft;
   $input-height: 50px;
   $input-padding-x: 0.75rem;
@@ -27,18 +26,22 @@
       SRC.$bootstrap-4-danger-text-color
     );
   }
+
+  // PORTALS-2597, SWC-6413: all buttons should be rounded
+  button {
+    border-radius: SRC.$button-border-radius;
+    text-transform: SRC.$button-text-transform;
+  }
+
   // For all buttons, make the box shadow more intense on hover
   .btn {
+    border-radius: SRC.$button-border-radius;
     @include hover() {
       box-shadow: SRC.$box-shadow-med;
     }
   }
 
   // Add the 'pill' class for a pill shape
-  .btn.pill {
-    border-radius: 24px;
-  }
-
   .btn.pill.btn-lg {
     font-size: 16px;
     padding: 10px 24px;
@@ -46,7 +49,6 @@
 
   // Extra-long pill shape
   .btn.pill-xl {
-    border-radius: 24px;
     min-width: 168px;
     padding: 10px;
   }
@@ -175,7 +177,6 @@
       $active-background: map.get(SRC.$primary-color-palette, 700),
       $active-border: map.get(SRC.$primary-color-palette, 700)
     );
-    border-radius: 0px;
     font-weight: 900;
     &:hover {
       box-shadow: none; // ?
@@ -197,7 +198,6 @@
       $active-background: rgba(255, 255, 255, 0),
       $active-border: map.get(SRC.$primary-color-palette, 700)
     );
-    border-radius: 0px;
     font-weight: 900;
     &:hover {
       box-shadow: none; // ?

--- a/packages/synapse-react-client/src/lib/style/components/_cards.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_cards.scss
@@ -213,7 +213,6 @@ $text-color-lighter: #898989;
       display: inline-block;
       height: 40px;
       margin-right: 10px;
-      border-radius: 20px;
       padding: 5px 20px !important;
     }
   }

--- a/packages/synapse-react-client/src/lib/style/components/_feed-cards.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_feed-cards.scss
@@ -73,9 +73,9 @@
           border: 1px solid SRC.$primary-action-color;
           display: inline-flex;
           align-content: flex-start;
-          border-radius: SRC.$button-border-radius;
+          border-radius: 100px;
           padding: 5px 20px;
-          text-transform: SRC.$button-text-transform;
+          text-transform: uppercase;
           color: SRC.$primary-action-color;
           margin-right: 5px;
           margin-bottom: 5px;

--- a/packages/synapse-react-client/src/lib/style/components/_feed-cards.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_feed-cards.scss
@@ -73,9 +73,9 @@
           border: 1px solid SRC.$primary-action-color;
           display: inline-flex;
           align-content: flex-start;
-          border-radius: 100px;
+          border-radius: SRC.$button-border-radius;
           padding: 5px 20px;
-          text-transform: uppercase;
+          text-transform: SRC.$button-text-transform;
           color: SRC.$primary-action-color;
           margin-right: 5px;
           margin-bottom: 5px;

--- a/packages/synapse-react-client/src/lib/style/components/_markdown-editor.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_markdown-editor.scss
@@ -14,7 +14,7 @@
         height: 45px;
         padding-left: 30px;
         padding-right: 30px;
-
+        border-radius: 0px;
         display: flex;
         align-items: center;
         text-decoration: none !important;

--- a/packages/synapse-react-client/src/lib/style/components/_total-query-results.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_total-query-results.scss
@@ -32,7 +32,7 @@
   padding-left: 10px;
   display: inline-flex;
   justify-content: center;
-  border-radius: 20px;
+  border-radius: SRC.$button-border-radius;
   line-height: 100%;
   cursor: default;
   background-color: color.change(SRC.$secondary-action-color, $alpha: 0.1);
@@ -52,7 +52,7 @@
 
   &__btnRemove {
     color: map.get(SRC.$colors, 'gray-900');
-    border-radius: 100%;
+    border-radius: SRC.$button-border-radius;
     padding: 3px;
     margin-left: 1px;
     cursor: pointer;

--- a/packages/synapse-react-client/src/lib/style/components/_total-query-results.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_total-query-results.scss
@@ -32,7 +32,7 @@
   padding-left: 10px;
   display: inline-flex;
   justify-content: center;
-  border-radius: SRC.$button-border-radius;
+  border-radius: 20px;
   line-height: 100%;
   cursor: default;
   background-color: color.change(SRC.$secondary-action-color, $alpha: 0.1);
@@ -52,7 +52,7 @@
 
   &__btnRemove {
     color: map.get(SRC.$colors, 'gray-900');
-    border-radius: SRC.$button-border-radius;
+    border-radius: 100%;
     padding: 3px;
     margin-left: 1px;
     cursor: pointer;

--- a/packages/synapse-react-client/src/lib/style/components/_user-card-list-groups.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_user-card-list-groups.scss
@@ -19,6 +19,7 @@
         flex-grow: 1;
         overflow-y: auto;
         button {
+          border-radius: 0px;
           max-height: 120px;
           text-align: left;
           color: #515359;

--- a/packages/synapse-react-client/src/lib/style/components/facet_nav/_facet-nav-panel.scss
+++ b/packages/synapse-react-client/src/lib/style/components/facet_nav/_facet-nav-panel.scss
@@ -119,10 +119,11 @@ $facetNavPanel-btn-margin: 0 1px;
   margin: auto;
   .SaveFiltersButton {
     display: block;
-    text-transform: uppercase;
     margin: auto;
     width: 250px;
-    padding: 5px 10px;
+    min-width: 150px;
+    min-height: 20px;
+    padding: 5px;
     font-size: 16px;
   }
 }

--- a/packages/synapse-react-client/src/lib/style/components/facet_nav/_facet-nav.scss
+++ b/packages/synapse-react-client/src/lib/style/components/facet_nav/_facet-nav.scss
@@ -27,7 +27,6 @@
     button.FacetNav__showMore {
       // padding: 5px 70px;
       width: 250px;
-      text-transform: uppercase;
     }
   }
 }

--- a/packages/synapse-react-client/src/lib/style/components/query_filter/_facet-chip.scss
+++ b/packages/synapse-react-client/src/lib/style/components/query_filter/_facet-chip.scss
@@ -2,7 +2,7 @@
 @use 'sass:map';
 
 .Chip {
-  border-radius: 3px;
+  border-radius: SRC.$button-border-radius;
   padding: 4px 6px;
   margin: 4px 4px 4px 0;
   &:hover {

--- a/packages/synapse-react-client/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
+++ b/packages/synapse-react-client/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
@@ -135,7 +135,6 @@
     .btn-large {
       color: #fff;
       background-color: SrcVariables.$primary-action-color;
-      text-transform: uppercase;
       padding: 0.75rem 1.5rem;
     }
   }
@@ -228,7 +227,6 @@
       color: SrcVariables.$primary-action-color;
       font-weight: 700;
       font-style: normal;
-      text-transform: uppercase;
     }
   }
 

--- a/packages/synapse-react-client/src/lib/utils/theme/DefaultTheme.ts
+++ b/packages/synapse-react-client/src/lib/utils/theme/DefaultTheme.ts
@@ -31,8 +31,8 @@ const defaultMuiThemeOptions: ThemeOptions = {
         root: {
           fontWeight: 900,
           padding: '6px 12px',
-          borderRadius: '0px',
-          textTransform: 'none',
+          borderRadius: '3px',
+          textTransform: 'capitalize',
           '&:hover': {
             transition: '0.2s',
           },
@@ -97,7 +97,6 @@ const defaultMuiThemeOptions: ThemeOptions = {
           '& .MuiButton-root': {
             height: '36px',
             padding: '0px 16px',
-            borderRadius: 0,
           },
         }),
       },

--- a/packages/synapse-react-client/stories/Button.stories.tsx
+++ b/packages/synapse-react-client/stories/Button.stories.tsx
@@ -21,10 +21,14 @@ const meta: Meta = {
         'light',
       ],
     },
+    size: {
+      control: 'select',
+      options: ['', 'sm', 'lg'],
+    },
     className: {
       name: 'shape',
       control: 'select',
-      options: ['', 'pill', 'pill-xl'],
+      options: ['', 'btn-wide'],
     },
   },
   render: args => (

--- a/packages/synapse-react-client/stories/RssFeedCards.stories.ts
+++ b/packages/synapse-react-client/stories/RssFeedCards.stories.ts
@@ -17,6 +17,6 @@ export const Demo: Story = {
     mailChimpUrl:
       'https://sagebase.us7.list-manage.com/subscribe/post?u=b146de537186191a9d2110f3a&amp;id=96b614587a',
     lockedColumn: { value: 'MSBB' },
-    viewAllNewsButtonText: 'VIEW ALL AD NEWS',
+    viewAllNewsButtonText: 'View All AD News',
   },
 }

--- a/packages/synapse-react-client/stories/SelectionCriteriaPill.stories.ts
+++ b/packages/synapse-react-client/stories/SelectionCriteriaPill.stories.ts
@@ -10,6 +10,7 @@ type Story = StoryObj<typeof meta>
 
 export const Pill: Story = {
   args: {
+    key: 'key',
     innerText: 'Facet Value: ABC',
     tooltipText: 'You can add tooltip text too.',
   },

--- a/packages/synapse-react-client/stories/UpsetPlot.stories.ts
+++ b/packages/synapse-react-client/stories/UpsetPlot.stories.ts
@@ -16,6 +16,6 @@ export const Demo: Story = {
     setName: 'Individuals (#) per Assay',
     combinationName: 'Individuals (#)',
     summaryLink: '#',
-    summaryLinkText: 'EXPLORE ALL OF SOMETHING',
+    summaryLinkText: 'Explore All Of Something',
   },
 }

--- a/packages/synapse-react-client/stories/UserCardListGroups.stories.ts
+++ b/packages/synapse-react-client/stories/UserCardListGroups.stories.ts
@@ -28,7 +28,7 @@ export const Demo: Story = {
     ],
     size: MEDIUM_USER_CARD,
     useQueryResultUserData: false,
-    summaryLinkText: 'EXPLORE ALL PEOPLE',
+    summaryLinkText: 'Explore All People',
     summaryLink: '/Explore/People',
     count: 6,
   },

--- a/packages/synapse-react-client/stories/UserCardListRotate.stories.ts
+++ b/packages/synapse-react-client/stories/UserCardListRotate.stories.ts
@@ -15,7 +15,7 @@ export const Demo: Story = {
     count: 3,
     useQueryResultUserData: true,
     size: MEDIUM_USER_CARD,
-    summaryLinkText: 'EXPLORE ALL PEOPLE',
+    summaryLinkText: 'Explore All People',
     summaryLink: '/Explore/People',
   },
 }

--- a/packages/synapse-react-client/test/lib/containers/markdown/__snapshots__/MarkdownSynapse.test.tsx.snap
+++ b/packages/synapse-react-client/test/lib/containers/markdown/__snapshots__/MarkdownSynapse.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`MarkdownSynapse tests Snapshot tests works with two inline widgets 1`] 
           class="bootstrap-4-backport"
         >
           <a
-            class="pill-xl  btn btn-secondary"
+            class="btn-wide  btn btn-secondary"
             href="#/Help/How It Works"
           >
             sometext
@@ -93,7 +93,7 @@ exports[`MarkdownSynapse tests Snapshot tests works with two inline widgets 1`] 
           class="bootstrap-4-backport"
         >
           <a
-            class="pill-xl  btn btn-secondary"
+            class="btn-wide  btn btn-secondary"
             href="#/Apply"
           >
             APPLY


### PR DESCRIPTION
Updates: 
- Change border-radius and text-transform for buttons
- Remove `pill` class
- Rename `pill-xl` to `btn-wide`
- Fix GitHub link in version footer

portal page | main | feature
:----:|:----:|:----:
ADKP Home | ![main_ADKP_Home](https://user-images.githubusercontent.com/26949006/231308333-f4944aeb-1a05-43d9-8c21-dcfa3aeecb6c.png) | ![feature_ADKP_home](https://user-images.githubusercontent.com/26949006/231908858-a7a41e2f-f0ff-432d-95ca-84f54443250d.png)
ADKP Explore People | ![main_ADKP_Explore_People](https://user-images.githubusercontent.com/26949006/231308330-0aaf02c7-6bab-407c-97a3-52d58787ab89.png) | ![feature_ADKP_explore_people](https://user-images.githubusercontent.com/26949006/231908857-210f3715-f7bb-4655-aefd-a41410abfc59.png)
ADKP Analytical Workspace | ![main_ADKP_AnalyticalWorkspace](https://user-images.githubusercontent.com/26949006/231308324-704ecfc1-5724-4765-b32e-63a63ab66325.png) | ![feature_ADKP_analyticalworkspace](https://user-images.githubusercontent.com/26949006/231908855-09560959-063c-410c-b6a6-f6fa38c25414.png)
NF Home | ![main_NF_home](https://user-images.githubusercontent.com/26949006/231308554-579f699a-cf49-46df-9d14-d1bee54b043c.png) | ![feature_NF_home](https://user-images.githubusercontent.com/26949006/231908863-ac2f5ea3-cdc2-49ff-ae08-145b1c4b779f.png)
NF Browse Tools | ![main_NF_browsetools](https://user-images.githubusercontent.com/26949006/231308551-041baac6-f924-4c79-ab13-e03cede818a7.png) | ![feature_NF_browsetools](https://user-images.githubusercontent.com/26949006/231908860-d2c14fa1-63fa-4dd2-b6c3-db3f225ea9f9.png)