### PR TITLE
PORTALS-2604: button for 'view all charts' should live underneath the 'search field dropdown'

### DIFF
--- a/packages/synapse-react-client/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/packages/synapse-react-client/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -261,7 +261,6 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
                   onClick={() =>
                     onShowMoreClick(showMoreButtonState === 'MORE')
                   }
-                  style={{ zIndex: 500 }}
                 >
                   {showMoreButtonState === 'LESS'
                     ? 'Hide Charts'


### PR DESCRIPTION
Before: 

https://user-images.githubusercontent.com/26949006/231316716-582fc1a0-6bfc-48ec-90df-561c0d32134a.mov

After: 

https://user-images.githubusercontent.com/26949006/231316722-27556467-d54f-4428-8c77-4210d84fd157.mov