### PR TITLE
PORTALS-2626

### DIFF
--- a/packages/synapse-react-client/src/lib/containers/GenericCard.tsx
+++ b/packages/synapse-react-client/src/lib/containers/GenericCard.tsx
@@ -232,7 +232,7 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
     rowId,
   } = props
   if (!value) {
-    return <>{value}</>
+    return <p>{value}</p>
   }
   const { strList, str, columnModelType } = getValueOrMultiValue({
     columnName,
@@ -243,7 +243,7 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
 
   if (!str) {
     // the array came back empty
-    return <>{str}</>
+    return <p>{str}</p>
   }
 
   let newClassName = className
@@ -254,10 +254,10 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
   // PORTALS-1913: special rendering for user ID lists
   if (columnModelType === ColumnTypeEnum.USERID_LIST && strList) {
     return (
-      <>
+      <p>
         {strList.map((val: string, index: number) => {
           return (
-            <span key={val}>
+            <React.Fragment key={val}>
               <UserCard
                 ownerId={val}
                 size={SMALL_USER_CARD}
@@ -265,10 +265,10 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
               />
               {/* \u00a0 is a nbsp; */}
               {index < strList.length - 1 && ',\u00a0\u00a0'}
-            </span>
+            </React.Fragment>
           )
         })}
-      </>
+      </p>
     )
   }
   if (columnModelType === ColumnTypeEnum.USERID && str) {
@@ -293,7 +293,7 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
       )
     } else {
       // they don't need a link
-      return <>{str}</>
+      return <p>{str}</p>
     }
   }
 
@@ -301,17 +301,17 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
   if (labelLink.isMarkdown) {
     if (strList) {
       labelContent = (
-        <>
+        <p>
           {strList.map((el, index) => {
             return (
-              <span key={el}>
+              <React.Fragment key={el}>
                 <MarkdownSynapse key={el} renderInline={true} markdown={el} />
                 {/* \u00a0 is a nbsp; */}
                 {index < strList.length - 1 && ',\u00a0\u00a0'}
-              </span>
+              </React.Fragment>
             )
           })}
-        </>
+        </p>
       )
     } else {
       labelContent = <MarkdownSynapse renderInline={true} markdown={value} />
@@ -340,7 +340,7 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
           labelContent = <>{value}</>
         } else {
           labelContent = (
-            <>
+            <p>
               {split.map((el, index) => {
                 return (
                   <React.Fragment key={el}>
@@ -360,13 +360,13 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
                   </React.Fragment>
                 )
               })}
-            </>
+            </p>
           )
         }
       }
     } else {
       labelContent = (
-        <>
+        <p>
           {split.map((el, index) => {
             const { baseURL, URLColumnName, wrapValueWithParens } = labelLink
             const elOrRowId = labelLink.overrideValueWithRowID
@@ -392,7 +392,7 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
               </React.Fragment>
             )
           })}
-        </>
+        </p>
       )
     }
   }

--- a/packages/synapse-react-client/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
+++ b/packages/synapse-react-client/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
@@ -171,7 +171,11 @@ export const SynapseTableCell: React.FC<SynapseTableCellProps> = ({
       )
     case ColumnTypeEnum.ENTITYID_LIST: {
       const jsonData: string[] = JSON.parse(columnValue)
-      return <EntityIdList entityIdList={jsonData} />
+      return (
+        <p>
+          <EntityIdList entityIdList={jsonData} />
+        </p>
+      )
     }
     case ColumnTypeEnum.USERID_LIST: {
       const jsonData: string[] = JSON.parse(columnValue)
@@ -182,13 +186,13 @@ export const SynapseTableCell: React.FC<SynapseTableCellProps> = ({
     case ColumnTypeEnum.INTEGER_LIST: {
       const jsonData: string[] = JSON.parse(columnValue)
       return (
-        <p>
+        <p className={isBold}>
           {jsonData.map((val: string, index: number) => {
             return (
-              <span key={val} className={isBold}>
+              <React.Fragment key={val}>
                 {val}
                 {index !== jsonData.length - 1 ? ', ' : ''}
-              </span>
+              </React.Fragment>
             )
           })}
         </p>


### PR DESCRIPTION
Use a paragraph in a number of renderers to enable the expand behavior in the context of a Table Cell (but does not impact rendering in a Card context):
<img width="880" alt="Screen Shot 2023-04-13 at 11 27 15 AM" src="https://user-images.githubusercontent.com/1864447/231881355-a59dd943-d9a8-4349-b979-8d7d68535e3b.png">
<img width="624" alt="Screen Shot 2023-04-13 at 12 21 36 PM" src="https://user-images.githubusercontent.com/1864447/231881385-83ab70e6-f3d7-4662-9b24-85360d475d7f.png">
