### PR TITLE
PORTALS-2621 - Fix NF stale data issue by resetting table query on prop change

### DIFF
--- a/apps/portals/package.json
+++ b/apps/portals/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@emotion/react": "^11.10.5",
-    "@emotion/styled": "^11.10.5",
+    "@emotion/react": "^11.10.6",
+    "@emotion/styled": "^11.10.6",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.11.16",
     "@mui/styles": "^5.11.16",

--- a/apps/portals/src/SynapseComponent.tsx
+++ b/apps/portals/src/SynapseComponent.tsx
@@ -42,9 +42,8 @@ export const SynapseComponent: React.FC<SynapseComponentWithContextProps> = ({
 }) => {
   // return the synapse object but with token/search params injected into its props from the context created in AppInitializer
   const { props, ...rest } = synapseConfig
-  const key = JSON.stringify(props)
   return (
-    <SynapseContextConsumer key={key}>
+    <SynapseContextConsumer>
       {(ctx?: SynapseContextType) => {
         const propsWithSearchAndToken = {
           ...props,

--- a/apps/portals/src/configurations/nf/routesConfig.ts
+++ b/apps/portals/src/configurations/nf/routesConfig.ts
@@ -52,7 +52,7 @@ const routes: GenericRoute[] = [
       {
         name: 'NFSurveyToast',
         centerTitle: true,
-        outsideContainerClassName: 'home-spacer',
+        outsideContainerClassName: '',
         props: undefined,
       },
     ],

--- a/apps/portals/src/types/portal-config.ts
+++ b/apps/portals/src/types/portal-config.ts
@@ -33,6 +33,7 @@ import { RedirectProps } from 'react-router-dom'
 import { MarkdownCollapseProps } from 'synapse-react-client/dist/containers/MarkdownCollapse'
 import { DownloadListActionsRequiredProps } from 'synapse-react-client/dist/containers/download_list_v2/DownloadListActionsRequired'
 import { ToggleSynapseObjectsProps } from 'portal-components/ToggleSynapseObjects'
+import { CSSProperties } from 'react'
 
 // For styling the header on the home page -- the main title and the summary text
 export type HomePageHeaderConfig = {
@@ -210,7 +211,7 @@ type Metadata = {
   centerTitle?: boolean
   subtitle?: string
   link?: string
-  style?: React.CSSProperties
+  style?: CSSProperties
   isOutsideContainer?: boolean
   // applied to the inner most container of the object
   className?: string

--- a/packages/synapse-react-client/src/lib/containers/CardContainerLogic.tsx
+++ b/packages/synapse-react-client/src/lib/containers/CardContainerLogic.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import { SynapseConstants } from '../utils'
 import {
   generateQueryFilterFromSearchParams,
@@ -142,49 +142,38 @@ export type CardContainerLogicProps = {
  */
 export const CardContainerLogic = (props: CardContainerLogicProps) => {
   const entityId = parseEntityIdFromSqlStatement(props.sql)
-  const { sortConfig, columnAliases } = props
-  const initQueryRequest: QueryBundleRequest = useMemo(() => {
-    const defaultSortItems = sortConfig
-      ? [
-          {
-            column: sortConfig.defaultColumn,
-            direction: sortConfig.defaultDirection,
-          },
-        ]
-      : undefined
-
-    const queryFilters = generateQueryFilterFromSearchParams(
-      props.searchParams,
-      props.sqlOperator,
-    )
-
-    return {
-      concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
-      entityId: entityId,
-      query: {
-        sql: props.sql,
-        limit: props.limit ?? DEFAULT_PAGE_SIZE,
-        sort: defaultSortItems,
-        additionalFilters: queryFilters,
-      },
-      partMask:
-        SynapseConstants.BUNDLE_MASK_QUERY_RESULTS |
-        SynapseConstants.BUNDLE_MASK_QUERY_COUNT |
-        SynapseConstants.BUNDLE_MASK_QUERY_SELECT_COLUMNS |
-        SynapseConstants.BUNDLE_MASK_QUERY_MAX_ROWS_PER_PAGE |
-        SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS |
-        SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
-        SynapseConstants.BUNDLE_MASK_SUM_FILES_SIZE_BYTES |
-        SynapseConstants.BUNDLE_MASK_LAST_UPDATED_ON,
-    }
-  }, [
-    entityId,
-    props.limit,
+  const queryFilters = generateQueryFilterFromSearchParams(
     props.searchParams,
-    props.sql,
     props.sqlOperator,
-    sortConfig,
-  ])
+  )
+  const { sortConfig, columnAliases } = props
+  const defaultSortItems = sortConfig
+    ? [
+        {
+          column: sortConfig.defaultColumn,
+          direction: sortConfig.defaultDirection,
+        },
+      ]
+    : undefined
+  const initQueryRequest: QueryBundleRequest = {
+    concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+    entityId: entityId,
+    query: {
+      sql: props.sql,
+      limit: props.limit ?? DEFAULT_PAGE_SIZE,
+      sort: defaultSortItems,
+      additionalFilters: queryFilters,
+    },
+    partMask:
+      SynapseConstants.BUNDLE_MASK_QUERY_RESULTS |
+      SynapseConstants.BUNDLE_MASK_QUERY_COUNT |
+      SynapseConstants.BUNDLE_MASK_QUERY_SELECT_COLUMNS |
+      SynapseConstants.BUNDLE_MASK_QUERY_MAX_ROWS_PER_PAGE |
+      SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS |
+      SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
+      SynapseConstants.BUNDLE_MASK_SUM_FILES_SIZE_BYTES |
+      SynapseConstants.BUNDLE_MASK_LAST_UPDATED_ON,
+  }
 
   return (
     <InfiniteQueryWrapper {...props} initQueryRequest={initQueryRequest}>

--- a/packages/synapse-react-client/src/lib/containers/CardContainerLogic.tsx
+++ b/packages/synapse-react-client/src/lib/containers/CardContainerLogic.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { SynapseConstants } from '../utils'
 import {
   generateQueryFilterFromSearchParams,
@@ -142,38 +142,49 @@ export type CardContainerLogicProps = {
  */
 export const CardContainerLogic = (props: CardContainerLogicProps) => {
   const entityId = parseEntityIdFromSqlStatement(props.sql)
-  const queryFilters = generateQueryFilterFromSearchParams(
-    props.searchParams,
-    props.sqlOperator,
-  )
   const { sortConfig, columnAliases } = props
-  const defaultSortItems = sortConfig
-    ? [
-        {
-          column: sortConfig.defaultColumn,
-          direction: sortConfig.defaultDirection,
-        },
-      ]
-    : undefined
-  const initQueryRequest: QueryBundleRequest = {
-    concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
-    entityId: entityId,
-    query: {
-      sql: props.sql,
-      limit: props.limit ?? DEFAULT_PAGE_SIZE,
-      sort: defaultSortItems,
-      additionalFilters: queryFilters,
-    },
-    partMask:
-      SynapseConstants.BUNDLE_MASK_QUERY_RESULTS |
-      SynapseConstants.BUNDLE_MASK_QUERY_COUNT |
-      SynapseConstants.BUNDLE_MASK_QUERY_SELECT_COLUMNS |
-      SynapseConstants.BUNDLE_MASK_QUERY_MAX_ROWS_PER_PAGE |
-      SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS |
-      SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
-      SynapseConstants.BUNDLE_MASK_SUM_FILES_SIZE_BYTES |
-      SynapseConstants.BUNDLE_MASK_LAST_UPDATED_ON,
-  }
+  const initQueryRequest: QueryBundleRequest = useMemo(() => {
+    const defaultSortItems = sortConfig
+      ? [
+          {
+            column: sortConfig.defaultColumn,
+            direction: sortConfig.defaultDirection,
+          },
+        ]
+      : undefined
+
+    const queryFilters = generateQueryFilterFromSearchParams(
+      props.searchParams,
+      props.sqlOperator,
+    )
+
+    return {
+      concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+      entityId: entityId,
+      query: {
+        sql: props.sql,
+        limit: props.limit ?? DEFAULT_PAGE_SIZE,
+        sort: defaultSortItems,
+        additionalFilters: queryFilters,
+      },
+      partMask:
+        SynapseConstants.BUNDLE_MASK_QUERY_RESULTS |
+        SynapseConstants.BUNDLE_MASK_QUERY_COUNT |
+        SynapseConstants.BUNDLE_MASK_QUERY_SELECT_COLUMNS |
+        SynapseConstants.BUNDLE_MASK_QUERY_MAX_ROWS_PER_PAGE |
+        SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS |
+        SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
+        SynapseConstants.BUNDLE_MASK_SUM_FILES_SIZE_BYTES |
+        SynapseConstants.BUNDLE_MASK_LAST_UPDATED_ON,
+    }
+  }, [
+    entityId,
+    props.limit,
+    props.searchParams,
+    props.sql,
+    props.sqlOperator,
+    sortConfig,
+  ])
 
   return (
     <InfiniteQueryWrapper {...props} initQueryRequest={initQueryRequest}>

--- a/packages/synapse-react-client/src/lib/containers/useImmutableTableQuery.ts
+++ b/packages/synapse-react-client/src/lib/containers/useImmutableTableQuery.ts
@@ -194,6 +194,11 @@ export default function useImmutableTableQuery(
     setQuery(initQueryRequest)
   }, [initQueryRequest, setQuery])
 
+  /* If the initial query changes, then reset the query to match the new prop */
+  useEffect(() => {
+    resetQuery()
+  }, [initQueryRequest])
+
   const removeSelectedFacet = useCallback(
     (facetColumnRequest: FacetColumnRequest) => {
       setQuery(currentQuery => {

--- a/packages/synapse-react-client/src/lib/containers/useImmutableTableQuery.ts
+++ b/packages/synapse-react-client/src/lib/containers/useImmutableTableQuery.ts
@@ -197,7 +197,9 @@ export default function useImmutableTableQuery(
 
   /* If the initial query changes, then reset the query to match the new prop */
   useDeepCompareEffect(() => {
-    resetQuery()
+    if (lastQueryRequest != initQueryRequest) {
+      resetQuery()
+    }
   }, [initQueryRequest])
 
   const removeSelectedFacet = useCallback(

--- a/packages/synapse-react-client/src/lib/containers/useImmutableTableQuery.ts
+++ b/packages/synapse-react-client/src/lib/containers/useImmutableTableQuery.ts
@@ -13,6 +13,7 @@ import {
   isColumnSingleValueQueryFilter,
   QueryFilter,
 } from '../utils/synapseTypes/Table/QueryFilter'
+import useDeepCompareEffect from 'use-deep-compare-effect'
 
 export type ImmutableTableQueryResult = {
   /** The ID of the table parsed from the SQL query */
@@ -195,7 +196,7 @@ export default function useImmutableTableQuery(
   }, [initQueryRequest, setQuery])
 
   /* If the initial query changes, then reset the query to match the new prop */
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     resetQuery()
   }, [initQueryRequest])
 

--- a/packages/synapse-react-client/test/lib/utils/hooks/useImmutableTableQuery.test.tsx
+++ b/packages/synapse-react-client/test/lib/utils/hooks/useImmutableTableQuery.test.tsx
@@ -130,6 +130,28 @@ describe('useImmutableTableQuery tests', () => {
     expect(onQueryChange).toHaveBeenCalledWith(JSON.stringify(newQuery.query))
   })
 
+  it('Updates the query if initQueryRequest changes', () => {
+    const onQueryChange = jest.fn()
+    const { result, rerender } = renderHook(
+      props => useImmutableTableQuery(props),
+      { initialProps: { ...options, onQueryChange } },
+    )
+
+    expect(onQueryChange).not.toHaveBeenCalled()
+
+    const newQuery = cloneDeep(options.initQueryRequest)
+    newQuery.query.sql = 'SELECT * FROM syn123.3 WHERE "foo"=\'baz\''
+
+    // Call under test - change the initQueryRequest
+    rerender({
+      ...options,
+      onQueryChange,
+      initQueryRequest: newQuery,
+    })
+
+    expect(onQueryChange).toHaveBeenCalledWith(JSON.stringify(newQuery.query))
+  })
+
   it('Updates the URL if shouldDeepLink is true', () => {
     const mockUpdateUrl = jest
       .spyOn(DeepLinkingUtils, 'updateUrlWithNewSearchParam')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,10 +275,10 @@ importers:
   apps/portals:
     dependencies:
       '@emotion/react':
-        specifier: ^11.10.5
+        specifier: ^11.10.6
         version: 11.10.6(@types/react@18.0.27)(react@18.2.0)
       '@emotion/styled':
-        specifier: ^11.10.5
+        specifier: ^11.10.6
         version: 11.10.6(@emotion/react@11.10.6)(@types/react@18.0.27)(react@18.2.0)
       '@mui/icons-material':
         specifier: ^5.11.16


### PR DESCRIPTION
See PORTALS-2621

Fix a case where CardContainerLogic did not update when the `searchParams` prop updated. The `searchParams` prop is used to create the `initQueryRequest` object, which is passed into `useImmutableTableQuery`.

Before this change, `useImmutableTableQuery` was not configured to update the query state when the `initQueryRequest` argument changed.