### PR TITLE
PORTALS-2508: adjust margin to prevent tables from running off edge of screens

### DIFF
--- a/apps/portals/src/_Core.scss
+++ b/apps/portals/src/_Core.scss
@@ -177,6 +177,12 @@ body {
     margin-top: 0px;
   }
 }
+.explore-content {
+  margin-right: 65px; 
+  @media screen and (max-width: 768px) {
+      margin-right: 18px;
+  }
+}
 .DownloadCartPage .pageHeader {
   padding: 30px 30px 0px 30px;
 }
@@ -282,6 +288,8 @@ a.nav-button {
   @extend %hoverFade;
   @extend %bottomBorderNav;
   border-radius: 0;
+  border-right: 0;
+  border-left: 0;
 }
 
 // override src behavior
@@ -299,6 +307,9 @@ button.dropdown-toggle.nav-button:hover {
   color: #404b63;
   box-shadow: none;
   outline: none;
+  border-radius: 0; 
+  border-right: 0;
+  border-left: 0;
 }
 .nav-link-container .show button.dropdown-toggle {
   border-bottom-color: Portal.$secondary-action-color;
@@ -713,7 +724,7 @@ div[data-id='tooltip'] {
 .QueryWrapperPlotNav {
   .TopLevelControls,
   .FacetFilterControls {
-    padding: 10px 30px;
+    padding: 10px 5px 10px 30px;
   }
   .TotalQueryResults.hasFilters > * {
     margin-left: 30px;

--- a/apps/portals/src/portal-components/RouteControlWrapper.tsx
+++ b/apps/portals/src/portal-components/RouteControlWrapper.tsx
@@ -74,7 +74,7 @@ const RouteControlWrapper: React.FunctionComponent<Props> = ({
           </div>
         )}
       </div>
-      <div>
+      <div className={'explore-content'}>
         {synapseConfig && (
           <SynapseComponent
             synapseConfig={synapseConfig}


### PR DESCRIPTION
page | main | feature
:----:|:----:|:----:
Explore Programs | ![main_Explore_Programs](https://user-images.githubusercontent.com/26949006/232620501-90565bdf-c1e8-4d65-91fe-74f57894261a.png) | ![feature_Explore_Programs](https://user-images.githubusercontent.com/26949006/232620488-92b6f869-f73b-48cb-b0f7-9e042bd04e2e.png)
Explore Data | ![main_Explore_Data](https://user-images.githubusercontent.com/26949006/232620494-3cac0fbe-f649-44b8-a253-edd34d4c1797.png) | ![feature_Explore_Data](https://user-images.githubusercontent.com/26949006/232620483-95354c89-0c0b-40d3-8701-947409198510.png)