### PR TITLE
PORTALS-2507: all '-' within cells should be left aligned just like the content

### DIFF
--- a/packages/synapse-react-client/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
+++ b/packages/synapse-react-client/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
@@ -67,9 +67,7 @@ export const SynapseTableCell: React.FC<SynapseTableCellProps> = ({
   const { entity } = useQueryContext()
 
   if (!columnValue) {
-    return (
-      <p className="SRC-center-text SRC-inactive"> {NOT_SET_DISPLAY_VALUE}</p>
-    )
+    return <p className="SRC-inactive"> {NOT_SET_DISPLAY_VALUE}</p>
   }
 
   if (columnLinkConfig) {


### PR DESCRIPTION
Before: 
![main_notsetdisplayvalue](https://user-images.githubusercontent.com/26949006/232633414-28781091-43fd-4070-8d40-1cad9a95d30c.png)

After: 
![feature_notsetdisplayvalue](https://user-images.githubusercontent.com/26949006/232633420-d8c343ba-4605-4097-8c36-62efe0b7f667.png)
