### PR TITLE
SWC-6412 - Input, Dialog component theme changes

### DIFF
--- a/apps/SageAccountWeb/src/LoginPage.tsx
+++ b/apps/SageAccountWeb/src/LoginPage.tsx
@@ -45,20 +45,22 @@ function LoginPage(props: LoginPageProps) {
             <div className={'panel-logo'}>
               <SourceAppLogo />
             </div>
-            <StandaloneLoginForm
-              sessionCallback={() => {
-                redirectAfterSSO(history, returnToUrl)
-                // If we didn't redirect, refresh the session
-                refreshSession()
-              }}
-              registerAccountUrl={'/register1'}
-              resetPasswordUrl={'/resetPassword'}
-              onBeginOAuthSignIn={() => {
-                // save current route (so that we can go back here after SSO)
-                preparePostSSORedirect()
-              }}
-              twoFactorAuthenticationRequired={twoFactorAuthErrorResponse}
-            />
+            <Box sx={{ my: 4 }}>
+              <StandaloneLoginForm
+                sessionCallback={() => {
+                  redirectAfterSSO(history, returnToUrl)
+                  // If we didn't redirect, refresh the session
+                  refreshSession()
+                }}
+                registerAccountUrl={'/register1'}
+                resetPasswordUrl={'/resetPassword'}
+                onBeginOAuthSignIn={() => {
+                  // save current route (so that we can go back here after SSO)
+                  preparePostSSORedirect()
+                }}
+                twoFactorAuthenticationRequired={twoFactorAuthErrorResponse}
+              />
+            </Box>
           </Box>
         </Box>
         <Box

--- a/apps/SageAccountWeb/src/components/AccountSettings.tsx
+++ b/apps/SageAccountWeb/src/components/AccountSettings.tsx
@@ -42,7 +42,7 @@ import { InputLabel } from '@mui/material'
 import { TextField } from '@mui/material'
 import { useSourceAppConfigs } from './SourceApp'
 import TwoFactorAuthSettingsPanel from 'synapse-react-client/dist/containers/auth/TwoFactorAuthSettingsPanel'
-
+import SRCTextField from 'synapse-react-client/dist/containers/TextField'
 const CompletionStatus: React.FC<{ isComplete: boolean | undefined }> = ({
   isComplete,
 }) => {
@@ -399,24 +399,17 @@ export const AccountSettings = () => {
                       })}
                     </Grid>
                   </StyledFormControl>
-                  <StyledFormControl
+                  <SRCTextField
                     fullWidth
-                    variant="standard"
                     margin="normal"
-                    sx={{ marginBottom: '10px' }}
-                  >
-                    <InputLabel shrink htmlFor="bio">
-                      Bio
-                    </InputLabel>
-                    <TextField
-                      id="bio"
-                      name="bio"
-                      fullWidth
-                      multiline
-                      onChange={e => setBio(e.target.value)}
-                      value={bio}
-                    />
-                  </StyledFormControl>
+                    label="Bio"
+                    id="bio"
+                    name="bio"
+                    multiline
+                    rows={5}
+                    onChange={e => setBio(e.target.value)}
+                    value={bio}
+                  />
                   <div className="primary-button-container">
                     <Button
                       onClick={() => {

--- a/apps/SageAccountWeb/src/components/StyledComponents.ts
+++ b/apps/SageAccountWeb/src/components/StyledComponents.ts
@@ -1,19 +1,7 @@
-import {
-  alpha,
-  Box,
-  BoxProps,
-  Paper,
-  PaperProps,
-  FormControl,
-  FormControlProps,
-  formHelperTextClasses,
-  inputBaseClasses,
-  styled,
-  textFieldClasses,
-} from '@mui/material'
-import { latoFont } from 'style/theme'
+import { BoxProps, Paper, PaperProps, styled } from '@mui/material'
 import { StyledComponent } from '@mui/styles'
 import { StyledOuterContainer as _StyledOuterContainer } from 'synapse-react-client/dist/components/styled/LeftRightPanel'
+import { StyledFormControl as _StyledFormControl } from 'synapse-react-client/dist/components/styled/StyledFormControl'
 
 export const StyledOuterContainer: StyledComponent<BoxProps> =
   _StyledOuterContainer
@@ -38,56 +26,4 @@ export const StyledInnerContainer: StyledComponent<PaperProps> = styled(Paper, {
   },
 }))
 
-/* bootstrap-like label/text inputs 
- usage: 
-        <StyledFormControl fullWidth variant="standard" margin="normal">
-          <InputLabel shrink htmlFor="someinput">
-            labelText
-          </InputLabel>
-          <TextField
-            id="someinput"/>
-        </StyledFormControl>
-*/
-export const StyledFormControl: StyledComponent<FormControlProps> = styled(
-  FormControl,
-  {
-    label: 'StyledFormControl',
-  },
-)(({ theme }) => ({
-  '& label': {
-    fontSize: '14px',
-    transform: 'none',
-  },
-  [`& .${formHelperTextClasses.root}`]: {
-    marginLeft: '0',
-    [`&.Mui-error`]: {
-      color: '#c13415',
-    },
-  },
-  [`& .${textFieldClasses.root}`]: {
-    marginTop: theme.spacing(3),
-
-    [`& .${inputBaseClasses.root}`]: {
-      borderRadius: '3px',
-    },
-    '& .MuiInputBase-multiline': {
-      padding: '0px',
-    },
-    '& .MuiInputBase-input': {
-      borderRadius: '3px',
-      fontSize: '14px',
-      position: 'relative',
-      backgroundColor: theme.palette.mode === 'light' ? '#F1F3F5' : '#F1F3F5',
-      border: 'none',
-      padding: '14px 12px',
-      fontFamily: latoFont,
-      '&:focus': {
-        boxShadow: `${alpha(theme.palette.primary.main, 0.25)} 0 0 0 0.1rem`,
-        borderColor: theme.palette.primary.main,
-      },
-    },
-    '& fieldset': {
-      border: 'none',
-    },
-  },
-}))
+export const StyledFormControl = _StyledFormControl

--- a/apps/portals/src/Navbar.tsx
+++ b/apps/portals/src/Navbar.tsx
@@ -234,7 +234,7 @@ function Navbar() {
                       sx={{ color: 'grey.700' }}
                     />
                   </IconButton>
-                  <DialogContent>
+                  <DialogContent dividers={false}>
                     <SynapseComponents.Login
                       twoFactorAuthenticationRequired={
                         twoFactorAuthSSOErrorResponse

--- a/apps/synapse-oauth-signin/src/OAuth2Form.tsx
+++ b/apps/synapse-oauth-signin/src/OAuth2Form.tsx
@@ -397,7 +397,7 @@ export function OAuth2Form() {
           oauthClientInfo &&
           oauthClientInfo.verified &&
           oidcRequestDescription)) && (
-        <Paper sx={{ width: '400px', padding: '30px', margin: '0 auto' }}>
+        <Paper sx={{ width: '400px', py: 8, px: 4, margin: '0 auto' }}>
           <StandaloneLoginForm
             onBeginOAuthSignIn={() => {
               // save current route (so that we can go back here after SSO)

--- a/packages/synapse-react-client/src/lib/components/styled/StyledFormControl.tsx
+++ b/packages/synapse-react-client/src/lib/components/styled/StyledFormControl.tsx
@@ -13,8 +13,7 @@ import { StyledComponent } from '@emotion/styled'
           <InputLabel shrink htmlFor="someinput">
             labelText
           </InputLabel>
-          <TextField
-            id="someinput"/>
+          <InputBase id="someinput"/>
         </StyledFormControl>
 */
 export const StyledFormControl: StyledComponent<FormControlProps> = styled(

--- a/packages/synapse-react-client/src/lib/components/styled/StyledFormControl.tsx
+++ b/packages/synapse-react-client/src/lib/components/styled/StyledFormControl.tsx
@@ -1,0 +1,48 @@
+import {
+  FormControl,
+  FormControlProps,
+  formHelperTextClasses,
+  inputBaseClasses,
+  styled,
+} from '@mui/material'
+import { StyledComponent } from '@emotion/styled'
+
+/* bootstrap-like label/text inputs
+ usage:
+        <StyledFormControl fullWidth variant="standard" margin="normal">
+          <InputLabel shrink htmlFor="someinput">
+            labelText
+          </InputLabel>
+          <TextField
+            id="someinput"/>
+        </StyledFormControl>
+*/
+export const StyledFormControl: StyledComponent<FormControlProps> = styled(
+  FormControl,
+  {
+    label: 'StyledFormControl',
+  },
+)(({ theme }) => ({
+  '& label': {
+    fontSize: '14px',
+    transform: 'none',
+  },
+  [`& .${formHelperTextClasses.root}`]: {
+    marginLeft: '0',
+    [`&.Mui-error`]: {
+      color: '#c13415',
+    },
+  },
+
+  [`& .${inputBaseClasses.root}`]: {
+    marginTop: theme.spacing(3),
+  },
+  '& .MuiInputBase-multiline': {
+    padding: '0px',
+  },
+  '& fieldset': {
+    border: 'none',
+  },
+}))
+
+export default StyledFormControl

--- a/packages/synapse-react-client/src/lib/containers/TextField.tsx
+++ b/packages/synapse-react-client/src/lib/containers/TextField.tsx
@@ -1,12 +1,11 @@
 import React, { useId, useMemo } from 'react'
 import {
   Box,
-  FormControl,
   InputBase,
+  InputLabel,
   TextFieldProps as MuiTextFieldProps,
-  Typography,
-  useTheme,
 } from '@mui/material'
+import StyledFormControl from '../components/styled/StyledFormControl'
 
 type TextFieldProps = Pick<
   MuiTextFieldProps,
@@ -25,6 +24,7 @@ type TextFieldProps = Pick<
   | 'onChange'
   | 'placeholder'
   | 'required'
+  | 'rows'
   | 'sx'
   | 'type'
   | 'value'
@@ -35,8 +35,7 @@ type TextFieldProps = Pick<
  */
 export default function TextField(props: TextFieldProps) {
   const id = useId()
-  const { palette } = useTheme()
-  const { noWrapInFormControl, ...rest } = props
+  const { noWrapInFormControl, label, ...rest } = props
   const Wrapper = useMemo(
     () =>
       noWrapInFormControl
@@ -44,19 +43,18 @@ export default function TextField(props: TextFieldProps) {
             <React.Fragment>{props.children}</React.Fragment>
           )
         : (props: React.PropsWithChildren<object>) => (
-            <FormControl fullWidth sx={{ my: 1 }}>
+            <StyledFormControl fullWidth sx={{ my: 1 }}>
               {props.children}
-            </FormControl>
+            </StyledFormControl>
           ),
     [noWrapInFormControl],
   )
   return (
     <Wrapper>
       {props.label && (
-        <Typography
+        <InputLabel
           component={'label'}
           htmlFor={props.id || id}
-          variant={'body1'}
           sx={{ fontWeight: 700, mb: '4px' }}
         >
           {props.label}
@@ -67,22 +65,9 @@ export default function TextField(props: TextFieldProps) {
           ) : (
             <></>
           )}
-        </Typography>
+        </InputLabel>
       )}
-      <InputBase
-        {...rest}
-        id={props.id || id}
-        sx={{
-          backgroundColor: 'grey.200',
-          px: 2,
-          py: 1,
-          ...props.sx,
-          '&.Mui-focused': {
-            backgroundColor: palette.background.default,
-            outline: `1px solid ${palette.primary.main}`,
-          },
-        }}
-      ></InputBase>
+      <InputBase id={id} {...rest}></InputBase>
     </Wrapper>
   )
 }

--- a/packages/synapse-react-client/src/lib/containers/TextField.tsx
+++ b/packages/synapse-react-client/src/lib/containers/TextField.tsx
@@ -53,9 +53,8 @@ export default function TextField(props: TextFieldProps) {
     <Wrapper>
       {props.label && (
         <InputLabel
-          component={'label'}
           htmlFor={props.id || id}
-          sx={{ fontWeight: 700, mb: '4px' }}
+          sx={{ fontWeight: 700, mb: '4px', pointerEvents: 'unset' }}
         >
           {props.label}
           {props.required ? (

--- a/packages/synapse-react-client/src/lib/containers/auth/StandaloneLoginForm.tsx
+++ b/packages/synapse-react-client/src/lib/containers/auth/StandaloneLoginForm.tsx
@@ -41,7 +41,6 @@ export default function StandaloneLoginForm(props: StandaloneLoginFormProps) {
         width: '325px',
         p: 0,
         mx: 'auto',
-        my: 4,
         bgColor: 'transparent',
       }}
     >

--- a/packages/synapse-react-client/src/lib/containers/auth/TOTPForm.tsx
+++ b/packages/synapse-react-client/src/lib/containers/auth/TOTPForm.tsx
@@ -27,6 +27,10 @@ export default function TOTPForm(props: TOTPFormProps) {
         }}
         gap={0}
         sx={{
+          '.MuiInputBase-root': {
+            paddingLeft: '5px',
+            paddingRight: '5px',
+          },
           '.MuiFormControl-root:first-of-type > .MuiInputBase-root': {
             borderTopRightRadius: 0,
             borderBottomRightRadius: 0,

--- a/packages/synapse-react-client/src/lib/utils/theme/DefaultTheme.ts
+++ b/packages/synapse-react-client/src/lib/utils/theme/DefaultTheme.ts
@@ -83,8 +83,8 @@ const defaultMuiThemeOptions: ThemeOptions = {
       styleOverrides: {
         root: ({ ownerState, theme }) => ({
           color: theme.palette.text.secondary,
-          paddingTop: theme.spacing(3),
-          paddingBottom: theme.spacing(3),
+          paddingTop: ownerState.dividers ? theme.spacing(3) : 0,
+          paddingBottom: ownerState.dividers ? theme.spacing(3) : 0,
           // Hack - set add a small padding and offset with a negative margin so box-shadow effects on full width elements (like input fields) are shown
           paddingLeft: DIALOG_INNER_PADDING,
           paddingRight: DIALOG_INNER_PADDING,

--- a/packages/synapse-react-client/src/lib/utils/theme/DefaultTheme.ts
+++ b/packages/synapse-react-client/src/lib/utils/theme/DefaultTheme.ts
@@ -1,8 +1,10 @@
 import { ThemeOptions } from '@mui/material/styles'
 import { typographyOptions } from './typography/Typography'
 import palette from './palette/Palettes'
-import { Fade } from '@mui/material'
+import { alpha, Fade } from '@mui/material'
 import linkTheme from './typography/Link'
+
+const DIALOG_INNER_PADDING = '2px'
 
 const defaultMuiThemeOptions: ThemeOptions = {
   typography: typographyOptions,
@@ -79,12 +81,19 @@ const defaultMuiThemeOptions: ThemeOptions = {
         dividers: true,
       },
       styleOverrides: {
-        root: ({ theme }) => ({
+        root: ({ ownerState, theme }) => ({
           color: theme.palette.text.secondary,
           paddingTop: theme.spacing(3),
           paddingBottom: theme.spacing(3),
-          paddingLeft: '0px',
-          paddingRight: '0px',
+          // Hack - set add a small padding and offset with a negative margin so box-shadow effects on full width elements (like input fields) are shown
+          paddingLeft: DIALOG_INNER_PADDING,
+          paddingRight: DIALOG_INNER_PADDING,
+          marginLeft: `-${DIALOG_INNER_PADDING}`,
+          marginRight: `-${DIALOG_INNER_PADDING}`,
+          // Add a filter on the `dividers` borders so that the borders are transparent on the edges based on the DIALOG_INNER_PADDING length
+          borderImage: ownerState.dividers
+            ? `linear-gradient(to right, transparent 0px, transparent ${DIALOG_INNER_PADDING}, ${theme.palette.grey[400]} ${DIALOG_INNER_PADDING}, ${theme.palette.grey[400]} calc(100% - ${DIALOG_INNER_PADDING}), transparent calc(100% - ${DIALOG_INNER_PADDING})) 1`
+            : undefined,
         }),
       },
     },
@@ -98,6 +107,27 @@ const defaultMuiThemeOptions: ThemeOptions = {
             height: '36px',
             padding: '0px 16px',
           },
+        }),
+      },
+    },
+    MuiInputBase: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          borderRadius: '3px',
+          fontSize: '14px',
+          position: 'relative',
+          backgroundColor: theme.palette.grey[200],
+          border: 'none',
+          '&.Mui-focused': {
+            boxShadow: `${alpha(
+              theme.palette.primary.main,
+              0.25,
+            )} 0 0 0 0.1rem`,
+            borderColor: theme.palette.primary.main,
+          },
+        }),
+        input: ({ theme }) => ({
+          padding: '14px 12px',
         }),
       },
     },


### PR DESCRIPTION
In SWC-6412 I am reworking the AccessRequirementList component and submission flow. I'm using MUI where possible, so some theme updates were necessary.

- Move StyledFormControl to SRC
- Apply most StyledFormControl > InputBase styles to all InputBase components in the theme
- Use StyledFormControl in custom TextField component
- Apply 2px padding to modal content to ensure input borders and box shadow are shown; use `border-image` to hide first and last 2px of modal border

For input fields, SageAccountWeb uses StyledFormControl with an inner MUI TextField. This is flawed because TextField actually contains its own FormControl component. The input fields look fine for now (no visual change), but we should aim to fix this in the future.

#### Screenshots

Modal changes

|Before|After|
|---|---|
| <img width="446" alt="image" src="https://user-images.githubusercontent.com/17580037/232800903-3231a748-60c1-4dd7-af91-a92bf188c993.png"> | <img width="446" alt="image" src="https://user-images.githubusercontent.com/17580037/232800969-6153fc72-d357-466d-9464-ccabe85b3511.png"> |