### PR TITLE
Upgrade react-flow-renderer to reactflow v11 to resolve intermittent test failures

### DIFF
--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -69,7 +69,7 @@
     "react-compound-slider": "^2.5.0",
     "react-datetime": "^3.0.4",
     "react-error-boundary": "^3.1.1",
-    "react-flow-renderer": "^10.3.11",
+    "reactflow": "^11.7.0",
     "react-hot-toast": "^2.1.0",
     "react-intersection-observer": "^9.4.0",
     "react-mailchimp-subscribe": "^2.1.0",

--- a/packages/synapse-react-client/src/lib/containers/provenance/ProvenanceGraph.tsx
+++ b/packages/synapse-react-client/src/lib/containers/provenance/ProvenanceGraph.tsx
@@ -8,7 +8,7 @@ import ReactFlow, {
   getConnectedEdges,
   ReactFlowProvider,
   useReactFlow,
-} from 'react-flow-renderer'
+} from 'reactflow'
 import {
   getLayoutedElements,
   isArrayEqual,
@@ -41,6 +41,7 @@ import {
   findEntityNode,
   isRootEntity,
 } from './ProvenanceGraphUtils'
+import 'reactflow/dist/style.css'
 
 export type ProvenanceProps = {
   // what entity nodes should we start with?
@@ -403,7 +404,7 @@ const ProvenanceReactFlow = (props: ProvenanceProps) => {
       style={{ width: '100%', height: containerHeight }}
     >
       <ReactFlow
-        defaultZoom={DEFAULT_ZOOM}
+        defaultViewport={{ x: 0, y: 0, zoom: DEFAULT_ZOOM }}
         nodes={nodes}
         edges={edges}
         onNodeClick={onClickNode}

--- a/packages/synapse-react-client/src/lib/containers/provenance/ProvenanceGraphUtils.ts
+++ b/packages/synapse-react-client/src/lib/containers/provenance/ProvenanceGraphUtils.ts
@@ -1,4 +1,4 @@
-import { Edge, Node } from 'react-flow-renderer'
+import { Edge, Node } from 'reactflow'
 import { EntityHeader, Reference } from '../../utils/synapseTypes'
 import {
   Activity,

--- a/packages/synapse-react-client/src/lib/containers/provenance/ProvenanceUtils.tsx
+++ b/packages/synapse-react-client/src/lib/containers/provenance/ProvenanceUtils.tsx
@@ -1,11 +1,5 @@
 import React from 'react'
-import {
-  Node,
-  Position,
-  ConnectionLineType,
-  Edge,
-  MarkerType,
-} from 'react-flow-renderer'
+import { Node, Position, ConnectionLineType, Edge, MarkerType } from 'reactflow'
 import { ActivityNodeLabel } from './ActivityNodeLabel'
 import { EntityNodeLabel } from './EntityNodeLabel'
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,9 +888,6 @@ importers:
       react-error-boundary:
         specifier: ^3.1.1
         version: 3.1.4(react@18.2.0)
-      react-flow-renderer:
-        specifier: ^10.3.11
-        version: 10.3.17(react-dom@18.2.0)(react@18.2.0)
       react-hot-toast:
         specifier: 2.2.0
         version: 2.2.0(csstype@3.1.2)(react-dom@18.2.0)(react@18.2.0)
@@ -945,6 +942,9 @@ importers:
       react-window:
         specifier: ^1.8.6
         version: 1.8.8(react-dom@18.2.0)(react@18.2.0)
+      reactflow:
+        specifier: ^11.7.0
+        version: 11.7.0(react-dom@18.2.0)(react@18.2.0)
       regenerator-runtime:
         specifier: ^0.13.2
         version: 0.13.11
@@ -5912,6 +5912,107 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@reactflow/background@11.2.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Fd8Few2JsLuE/2GaIM6fkxEBaAJvfzi2Lc106HKi/ddX+dZs8NUsSwMsJy1Ajs8b4GbiX8v8axfKpbK6qFMV8w==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/core': 11.7.0(react-dom@18.2.0)(react@18.2.0)
+      classcat: 5.0.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.3.7(react@18.2.0)
+    transitivePeerDependencies:
+      - immer
+    dev: false
+
+  /@reactflow/controls@11.1.11(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-g6WrsszhNkQjzkJ9HbVUBkGGoUy2z8dQVgH6CYQEjuoonD15cWAPGvjyg8vx8oGG7CuktUhWu5JPivL6qjECow==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/core': 11.7.0(react-dom@18.2.0)(react@18.2.0)
+      classcat: 5.0.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - immer
+    dev: false
+
+  /@reactflow/core@11.7.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-UJcpbNRSupSSoMWh5UmRp6UUr0ug7xVKmMvadnkKKiNi9584q57nz4HMfkqwN3/ESbre7LD043yh2n678d/5FQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@types/d3': 7.4.0
+      '@types/d3-drag': 3.0.2
+      '@types/d3-selection': 3.0.4
+      '@types/d3-zoom': 3.0.2
+      classcat: 5.0.4
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.3.7(react@18.2.0)
+    transitivePeerDependencies:
+      - immer
+    dev: false
+
+  /@reactflow/minimap@11.5.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-n/3tlaknLpi3zaqCC+tDDPvUTOjd6jglto9V3RB1F2wlaUEbCwmuoR2GYTkiRyZMvuskKyAoQW8+0DX0+cWwsA==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/core': 11.7.0(react-dom@18.2.0)(react@18.2.0)
+      '@types/d3-selection': 3.0.4
+      '@types/d3-zoom': 3.0.2
+      classcat: 5.0.4
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.3.7(react@18.2.0)
+    transitivePeerDependencies:
+      - immer
+    dev: false
+
+  /@reactflow/node-resizer@2.1.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-DVL8nnWsltP8/iANadAcTaDB4wsEkx2mOLlBEPNE3yc5loSm3u9l5m4enXRcBym61MiMuTtDPzZMyYYQUjuYIg==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/core': 11.7.0(react-dom@18.2.0)(react@18.2.0)
+      classcat: 5.0.4
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.3.7(react@18.2.0)
+    transitivePeerDependencies:
+      - immer
+    dev: false
+
+  /@reactflow/node-toolbar@1.1.11(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-+hKtx+cvXwfCa9paGxE+G34rWRIIVEh68ZOqAtivClVmfqGzH/sEoGWtIOUyg9OEDNE1nEmZ1NrnpBGSmHHXFg==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/core': 11.7.0(react-dom@18.2.0)(react@18.2.0)
+      classcat: 5.0.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.3.7(react@18.2.0)
+    transitivePeerDependencies:
+      - immer
+    dev: false
+
   /@restart/context@2.1.4(react@18.2.0):
     resolution: {integrity: sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==}
     peerDependencies:
@@ -8106,10 +8207,6 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.2
-
-  /@types/resize-observer-browser@0.1.7:
-    resolution: {integrity: sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg==}
-    dev: false
 
   /@types/resolve@1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
@@ -19746,26 +19843,6 @@ packages:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
     dev: false
 
-  /react-flow-renderer@10.3.17(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-bywiqVErlh5kCDqw3x0an5Ur3mT9j9CwJsDwmhmz4i1IgYM1a0SPqqEhClvjX+s5pU4nHjmVaGXWK96pwsiGcQ==}
-    engines: {node: '>=14'}
-    deprecated: react-flow-renderer has been renamed to reactflow, please use this package from now on https://reactflow.dev/docs/guides/migrate-to-v11/
-    peerDependencies:
-      react: 16 || 17 || 18
-      react-dom: 16 || 17 || 18
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@types/d3': 7.4.0
-      '@types/resize-observer-browser': 0.1.7
-      classcat: 5.0.4
-      d3-drag: 3.0.0
-      d3-selection: 3.0.0
-      d3-zoom: 3.0.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      zustand: 3.7.2(react@18.2.0)
-    dev: false
-
   /react-hot-toast@2.2.0(csstype@3.1.2)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-248rXw13uhf/6TNDVzagX+y7R8J183rp7MwUMNkcrBRyHj/jWOggfXTGlM8zAOuh701WyVW+eUaWG2LeSufX9g==}
     engines: {node: '>=10'}
@@ -20312,6 +20389,24 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+
+  /reactflow@11.7.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-bjfJV1iQZ+VwIlvsnd4TbXNs6kuJ5ONscud6fNkF8RY/oU2VUZpdjA3q1zwmgnjmJcIhxuBiBI5VLGajYx/Ozg==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/background': 11.2.0(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/controls': 11.1.11(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.7.0(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/minimap': 11.5.0(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/node-resizer': 2.1.0(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/node-toolbar': 1.1.11(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - immer
+    dev: false
 
   /read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
@@ -22801,6 +22896,14 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
+  /use-sync-external-store@1.2.0(react@18.2.0):
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -23874,14 +23977,18 @@ packages:
       cwise-compiler: 1.1.3
     dev: false
 
-  /zustand@3.7.2(react@18.2.0):
-    resolution: {integrity: sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==}
+  /zustand@4.3.7(react@18.2.0):
+    resolution: {integrity: sha512-dY8ERwB9Nd21ellgkBZFhudER8KVlelZm8388B5nDAXhO/+FZDhYMuRnqDgu5SYyRgz/iaf8RKnbUs/cHfOGlQ==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
+      immer: '>=9.0'
       react: '>=16.8'
     peerDependenciesMeta:
+      immer:
+        optional: true
       react:
         optional: true
     dependencies:
       react: 18.2.0
+      use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false


### PR DESCRIPTION
After the upgrade, I could not see any differences apart from these:
- Mouse cursor indicates panning, when possible
- Can pan when the cursor is over nodes (links in nodes still work)

Motivation was intermittent test failures reported here: https://github.com/wbkd/react-flow/issues/2108

I followed this migration guide, which also has more information about changes in v11 https://reactflow.dev/docs/guides/migrate-to-v11/