### PR TITLE
PORTALS-2624: remove bootstrap-4-backport class from CreateProjectModal

### DIFF
--- a/packages/synapse-react-client/src/lib/containers/ConfirmationDialog.tsx
+++ b/packages/synapse-react-client/src/lib/containers/ConfirmationDialog.tsx
@@ -38,7 +38,7 @@ export type ConfirmationDialogProps = {
   confirmButtonText?: string
   confirmButtonColor?: ButtonProps['color']
   className?: string
-  onConfirm: () => void
+  onConfirm: () => unknown | Promise<void>
   onCancel: () => void
   hasCloseButton?: boolean
   helpMarkdown?: string

--- a/packages/synapse-react-client/src/lib/containers/ConfirmationDialog.tsx
+++ b/packages/synapse-react-client/src/lib/containers/ConfirmationDialog.tsx
@@ -38,7 +38,7 @@ export type ConfirmationDialogProps = {
   confirmButtonText?: string
   confirmButtonColor?: ButtonProps['color']
   className?: string
-  onConfirm: () => unknown | Promise<void>
+  onConfirm: () => void
   onCancel: () => void
   hasCloseButton?: boolean
   helpMarkdown?: string

--- a/packages/synapse-react-client/src/lib/containers/CreateProjectModal.tsx
+++ b/packages/synapse-react-client/src/lib/containers/CreateProjectModal.tsx
@@ -1,9 +1,10 @@
+import { Alert } from '@mui/material'
 import React, { useState } from 'react'
-import { Alert, Button, Modal } from 'react-bootstrap'
 import { SynapseClient } from '../utils'
 import { useSynapseContext } from '../utils/SynapseContext'
+import { ConfirmationDialog } from './ConfirmationDialog'
 import FullWidthAlert from './FullWidthAlert'
-import { Form } from 'react-bootstrap'
+import TextField from './TextField'
 
 export type CreateProjectModalProps = {
   isShowingModal?: boolean
@@ -40,55 +41,33 @@ export const CreateProjectModal: React.FunctionComponent<
       }
     }
   }
+
+  const dialogContent = (
+    <>
+      <TextField
+        id="projectInput"
+        label="Project Name"
+        value={projectName}
+        fullWidth
+        onChange={event => {
+          setProjectName(event.target.value)
+        }}
+      />
+      {errorMessage && <Alert severity="error">{errorMessage}</Alert>}
+    </>
+  )
+
   return (
     <>
-      <Modal
-        className="CreateProjectModal bootstrap-4-backport"
-        show={isShowingModal}
-        animation={false}
-        onHide={hide}
-        backdrop="static"
-      >
-        <Modal.Header closeButton>
-          <Modal.Title>Create a new Project</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <Form.Group>
-            <Form.Label htmlFor={'projectInput'}>Project Name</Form.Label>
-            <Form.Control
-              id="projectInput"
-              data-testid="projectInput"
-              value={projectName}
-              onChange={event => {
-                setProjectName(event.target.value)
-              }}
-              onKeyDown={(event: any) => {
-                if (event.key === 'Enter') {
-                  if (projectName !== '') {
-                    onCreateProject()
-                  }
-                }
-              }}
-            />
-          </Form.Group>
-          {errorMessage && <Alert variant="danger">{errorMessage}</Alert>}
-        </Modal.Body>
-        <Modal.Footer>
-          <div className="ButtonContainer">
-            <Button variant="default" onClick={onClose}>
-              Cancel
-            </Button>
-            <Button
-              variant="primary"
-              onClick={() => {
-                onCreateProject()
-              }}
-            >
-              Save
-            </Button>
-          </div>
-        </Modal.Footer>
-      </Modal>
+      <ConfirmationDialog
+        open={isShowingModal}
+        title="Create a new Project"
+        content={dialogContent}
+        confirmButtonText="Save"
+        onConfirm={onCreateProject}
+        onCancel={hide}
+        maxWidth="md"
+      />
       <FullWidthAlert
         show={isShowingSuccessAlert}
         variant="info"

--- a/packages/synapse-react-client/src/lib/containers/CreateProjectModal.tsx
+++ b/packages/synapse-react-client/src/lib/containers/CreateProjectModal.tsx
@@ -73,7 +73,9 @@ export const CreateProjectModal: React.FunctionComponent<
         title="Create a new Project"
         content={dialogContent}
         confirmButtonText="Save"
-        onConfirm={onCreateProject}
+        onConfirm={() => {
+          void onCreateProject()
+        }}
         onCancel={hide}
         maxWidth="md"
       />

--- a/packages/synapse-react-client/src/lib/containers/CreateProjectModal.tsx
+++ b/packages/synapse-react-client/src/lib/containers/CreateProjectModal.tsx
@@ -52,6 +52,15 @@ export const CreateProjectModal: React.FunctionComponent<
         onChange={event => {
           setProjectName(event.target.value)
         }}
+        inputProps={{
+          onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === 'Enter') {
+              if (projectName !== '') {
+                onCreateProject()
+              }
+            }
+          },
+        }}
       />
       {errorMessage && <Alert severity="error">{errorMessage}</Alert>}
     </>

--- a/packages/synapse-react-client/stories/CreateProjectModal.stories.tsx
+++ b/packages/synapse-react-client/stories/CreateProjectModal.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Meta, StoryObj } from '@storybook/react'
+import { CreateProjectModal } from '../src/lib/containers/CreateProjectModal'
+
+const meta = {
+  title: 'Synapse/CreateProjectModal',
+  component: CreateProjectModal,
+} satisfies Meta
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  args: {
+    isShowingModal: true,
+  },
+}

--- a/packages/synapse-react-client/test/lib/containers/CreateProjectModal.test.tsx
+++ b/packages/synapse-react-client/test/lib/containers/CreateProjectModal.test.tsx
@@ -53,6 +53,17 @@ describe('CreateProjectModal tests', () => {
     await screen.findByText('Project created')
   })
 
+  it('Creates project on enter', async () => {
+    const { user, input, saveButton } = setUp()
+
+    await user.type(input, MOCK_PROJECT_NAME)
+    expect(input.value).toBe(MOCK_PROJECT_NAME)
+    await user.keyboard('{ENTER}')
+
+    // should show success alert
+    await screen.findByText('Project created')
+  })
+
   it('Shows error if creation fails', async () => {
     const { user, input, saveButton } = setUp()
 

--- a/packages/synapse-react-client/test/lib/containers/CreateProjectModal.test.tsx
+++ b/packages/synapse-react-client/test/lib/containers/CreateProjectModal.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import {
   CreateProjectModal,
@@ -23,6 +24,14 @@ function renderComponent(wrapperProps?: SynapseContextType) {
   })
 }
 
+function setUp(wrapperProps?: SynapseContextType) {
+  const user = userEvent.setup()
+  const component = renderComponent(wrapperProps)
+  const input = screen.getByRole('textbox', { name: /project name/i })
+  const saveButton = screen.getByRole('button', { name: /save/i })
+  return { component, user, input, saveButton }
+}
+
 describe('CreateProjectModal tests', () => {
   beforeAll(() => server.listen())
   afterEach(() => server.restoreHandlers())
@@ -34,28 +43,56 @@ describe('CreateProjectModal tests', () => {
   })
 
   it('Creates project on submit', async () => {
-    renderComponent()
-    const input: HTMLInputElement = (await screen.findByTestId(
-      'projectInput',
-    )) as HTMLInputElement
-    fireEvent.change(input, { target: { value: MOCK_PROJECT_NAME } })
+    const { user, input, saveButton } = setUp()
+
+    await user.type(input, MOCK_PROJECT_NAME)
     expect(input.value).toBe(MOCK_PROJECT_NAME)
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.click(saveButton)
 
     // should show success alert
     await screen.findByText('Project created')
   })
 
   it('Shows error if creation fails', async () => {
-    renderComponent()
-    const input: HTMLInputElement = (await screen.findByTestId(
-      'projectInput',
-    )) as HTMLInputElement
-    fireEvent.change(input, { target: { value: MOCK_INVALID_PROJECT_NAME } })
+    const { user, input, saveButton } = setUp()
+
+    await user.type(input, MOCK_INVALID_PROJECT_NAME)
     expect(input.value).toBe(MOCK_INVALID_PROJECT_NAME)
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.click(saveButton)
 
     // should show error alert
     await screen.findByText('Invalid project name')
+  })
+
+  it('Clears alert and project name on cancel', async () => {
+    const { user, input, saveButton } = setUp()
+
+    await user.type(input, MOCK_INVALID_PROJECT_NAME)
+    await user.click(saveButton)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Invalid project name')
+
+    const cancelButton = screen.getByRole('button', { name: /cancel/i })
+    await user.click(cancelButton)
+
+    expect(alert).not.toBeInTheDocument()
+    expect(input.value).toBe('')
+  })
+
+  it('Clears alert and project name on closing dialog', async () => {
+    const { user, input, saveButton } = setUp()
+
+    await user.type(input, MOCK_INVALID_PROJECT_NAME)
+    await user.click(saveButton)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Invalid project name')
+
+    const closeButton = screen.getByRole('button', { name: /close/i })
+    await user.click(closeButton)
+
+    expect(alert).not.toBeInTheDocument()
+    expect(input.value).toBe('')
   })
 })


### PR DESCRIPTION
Before: 
<img width="1328" alt="main_CreateProjectModal" src="https://user-images.githubusercontent.com/26949006/234350554-4ff7ac0b-43c6-4b81-a138-7ed7853954e7.png">

After:
<img width="1323" alt="feature_CreateProjectModal" src="https://user-images.githubusercontent.com/26949006/234350537-f2d68efa-0dd7-446d-bea9-c7740f3ccf3b.png">
