### PR TITLE
PORTALS-2624: remove bootstrap-4-backport from ExperimentalMode

### DIFF
--- a/packages/synapse-react-client/src/lib/components/styled/LightTooltip.tsx
+++ b/packages/synapse-react-client/src/lib/components/styled/LightTooltip.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Tooltip, TooltipProps, tooltipClasses, styled } from '@mui/material'
+import { StyledComponent } from '@emotion/styled'
+
+export const LightTooltip: StyledComponent<TooltipProps> = styled(
+  ({ className, ...props }: TooltipProps) => (
+    <Tooltip {...props} classes={{ popper: className }} />
+  ),
+)(({ theme }) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: theme.palette.common.white,
+    color: theme.palette.grey[1000],
+    boxShadow: theme.shadows[1],
+    border: `1px solid ${theme.palette.grey[500]}`,
+  },
+  [`& .${tooltipClasses.arrow}`]: {
+    '&:before': {
+      boxShadow: theme.shadows[1],
+      border: `1px solid ${theme.palette.grey[500]}`,
+    },
+    color: theme.palette.common.white,
+  },
+}))
+
+export default LightTooltip

--- a/packages/synapse-react-client/src/lib/containers/ExperimentalMode.tsx
+++ b/packages/synapse-react-client/src/lib/containers/ExperimentalMode.tsx
@@ -1,12 +1,21 @@
 import * as React from 'react'
-import { Button, OverlayTrigger, Popover } from 'react-bootstrap'
+import { Button, IconButton } from '@mui/material'
 import { useEffect, useState } from 'react'
 import UniversalCookies from 'universal-cookie'
 import { isInSynapseExperimentalMode } from '../utils/SynapseClient'
 import { EXPERIMENTAL_MODE_COOKIE } from '../utils/SynapseConstants'
 import { InfoOutlined } from '@mui/icons-material'
+import LightTooltip from '../components/styled/LightTooltip'
+
+const experimentalModeText =
+  'This mode gives you early access to features that are still in development. Please note that we do not guarantee an absence of errors, and that the data created using these features may be lost during product upgrade.'
 
 const ExperimentalMode: React.FC = () => {
+  const [open, setOpen] = useState<boolean>(false)
+  const toggleOpen = () => {
+    setOpen(!open)
+  }
+
   const [isExperimentalModeOn, setIsExperimentalModeOn] =
     useState<boolean>(false)
   const cookies = new UniversalCookies()
@@ -34,24 +43,11 @@ const ExperimentalMode: React.FC = () => {
     setIsExperimentalModeOn(false)
   }
 
-  const popover = ({ ...props }) => (
-    <div className={'bootstrap-4-backport'}>
-      <Popover id={'experimental-mode-popover'} {...props}>
-        <Popover.Content>
-          This mode gives you early access to features that are still in
-          development. Please note that we do not guarantee an absence of
-          errors, and that the data created using these features may be lost
-          during product upgrade.
-        </Popover.Content>
-      </Popover>
-    </div>
-  )
-
   return (
     <span className={'experimental-mode-wrapper'}>
       <Button
         className={'experimental-mode'}
-        variant="link"
+        variant="text"
         onClick={
           isExperimentalModeOn
             ? deleteExperimentalModeCookie
@@ -60,9 +56,21 @@ const ExperimentalMode: React.FC = () => {
       >
         Experimental mode is {isExperimentalModeOn ? 'on' : 'off'}
       </Button>
-      <OverlayTrigger trigger="click" placement="top" overlay={popover}>
-        <InfoOutlined style={{ verticalAlign: 'middle' }} />
-      </OverlayTrigger>
+      <LightTooltip
+        title={experimentalModeText}
+        arrow
+        placement="top"
+        open={open}
+      >
+        <IconButton
+          aria-label="info"
+          color="inherit"
+          onClick={toggleOpen}
+          sx={{ '&:hover': { backgroundColor: 'transparent' } }}
+        >
+          <InfoOutlined sx={{ verticalAlign: 'middle' }} />
+        </IconButton>
+      </LightTooltip>
     </span>
   )
 }

--- a/packages/synapse-react-client/src/lib/containers/ExperimentalMode.tsx
+++ b/packages/synapse-react-client/src/lib/containers/ExperimentalMode.tsx
@@ -1,21 +1,15 @@
 import * as React from 'react'
-import { Button, IconButton } from '@mui/material'
+import { Button, IconButton, Tooltip } from '@mui/material'
 import { useEffect, useState } from 'react'
 import UniversalCookies from 'universal-cookie'
 import { isInSynapseExperimentalMode } from '../utils/SynapseClient'
 import { EXPERIMENTAL_MODE_COOKIE } from '../utils/SynapseConstants'
 import { InfoOutlined } from '@mui/icons-material'
-import LightTooltip from '../components/styled/LightTooltip'
 
 const experimentalModeText =
   'This mode gives you early access to features that are still in development. Please note that we do not guarantee an absence of errors, and that the data created using these features may be lost during product upgrade.'
 
 const ExperimentalMode: React.FC = () => {
-  const [open, setOpen] = useState<boolean>(false)
-  const toggleOpen = () => {
-    setOpen(!open)
-  }
-
   const [isExperimentalModeOn, setIsExperimentalModeOn] =
     useState<boolean>(false)
   const cookies = new UniversalCookies()
@@ -56,21 +50,15 @@ const ExperimentalMode: React.FC = () => {
       >
         Experimental mode is {isExperimentalModeOn ? 'on' : 'off'}
       </Button>
-      <LightTooltip
-        title={experimentalModeText}
-        arrow
-        placement="top"
-        open={open}
-      >
+      <Tooltip title={experimentalModeText} arrow placement="top">
         <IconButton
           aria-label="info"
           color="inherit"
-          onClick={toggleOpen}
           sx={{ '&:hover': { backgroundColor: 'transparent' } }}
         >
           <InfoOutlined sx={{ verticalAlign: 'middle' }} />
         </IconButton>
-      </LightTooltip>
+      </Tooltip>
     </span>
   )
 }

--- a/packages/synapse-react-client/src/lib/style/components/_experimental-mode.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_experimental-mode.scss
@@ -7,6 +7,7 @@
     text-transform: uppercase;
     padding-right: 0.2rem;
     color: inherit;
+    text-decoration-color: inherit;
     font-weight: normal;
 
     &.btn-link:focus,

--- a/packages/synapse-react-client/stories/ExperimentalMode.stories.tsx
+++ b/packages/synapse-react-client/stories/ExperimentalMode.stories.tsx
@@ -1,10 +1,17 @@
-import { Meta, StoryObj } from '@storybook/react'
+import React, { Meta, StoryObj } from '@storybook/react'
 
 import ExperimentalMode from '../src/lib/containers/ExperimentalMode'
 
 const meta = {
   title: 'Authentication/ExperimentalMode',
   component: ExperimentalMode,
+  render: () => {
+    return (
+      <div style={{ marginTop: '150px' }}>
+        <ExperimentalMode />
+      </div>
+    )
+  },
 } satisfies Meta
 export default meta
 type Story = StoryObj<typeof meta>


### PR DESCRIPTION
Before: 

https://user-images.githubusercontent.com/26949006/235269863-cc1947be-ed55-4d85-aca4-f4f040d67eae.mov

After: 

https://user-images.githubusercontent.com/26949006/235743088-66cad998-735c-4d41-8f48-235383c77d9b.mov