### PR TITLE
PORTALS-2624: convert bootstrap btn-wide buttons to styled MUI buttons

### DIFF
--- a/apps/portals/src/Navbar.tsx
+++ b/apps/portals/src/Navbar.tsx
@@ -6,8 +6,7 @@ import { SynapseComponents } from 'synapse-react-client'
 import NavLink from 'portal-components/NavLink'
 import NavUserLink from './portal-components/NavUserLink'
 import { ConfigRoute, GenericRoute } from 'types/portal-config'
-import Button from 'react-bootstrap/esm/Button'
-import { Dialog, DialogContent, IconButton } from '@mui/material'
+import { Button, Dialog, DialogContent, IconButton } from '@mui/material'
 import IconSvg from 'synapse-react-client/dist/containers/IconSvg'
 import {
   preparePostSSORedirect,
@@ -190,10 +189,11 @@ function Navbar() {
         <div className="nav-link-container">
           {isSignedIn &&
             isSynapseSubdomainOrLocal && ( // mobile sign out
-              <div className="center-content nav-button nav-button-signin bootstrap-4-backport mobile-signout-container">
+              <div className="center-content nav-button nav-button-signin mobile-signout-container">
                 <Button
                   id="signin-button"
-                  variant="secondary"
+                  color="secondary"
+                  variant="contained"
                   className="signout-button-mb"
                   onClick={() => {
                     clearSession()
@@ -205,10 +205,11 @@ function Navbar() {
             )}
           {!isSignedIn &&
             isSynapseSubdomainOrLocal && ( // desktop sign in
-              <div className="center-content nav-button nav-button-signin bootstrap-4-backport">
+              <div className="center-content nav-button nav-button-signin">
                 <Button
                   id="signin-button"
-                  variant="secondary"
+                  color="secondary"
+                  variant="contained"
                   onClick={() => {
                     setShowLoginDialog(true)
                   }}

--- a/apps/portals/src/configurations/arkportal/style/_style_overrides.scss
+++ b/apps/portals/src/configurations/arkportal/style/_style_overrides.scss
@@ -47,15 +47,6 @@ td.SRC_noBorderTop:nth-child(n + 4) {
     }
   }
 }
-.bootstrap-4-backport {
-  .btn-secondary,
-  .btn-secondary-base {
-    color: white;
-    &:hover {
-      color: white;
-    }
-  }
-}
 
 .AboutPage {
   margin-top: 25px !important;
@@ -74,6 +65,14 @@ $ARK-gray-900: #1d1d22 !default;
 .Goals {
   &__Desktop {
     gap: 30px;  
+  }
+  &__Mobile__Content {
+    & > &__Link {
+      color: white;
+      &:hover {
+        color: white;
+      }
+    }
   }
   &__Card {
     position: relative;
@@ -113,7 +112,7 @@ $ARK-gray-900: #1d1d22 !default;
       line-height: 1.5;
       color: $ARK-gray-700;
       margin-bottom: 40px;
-      &__link.btn {
+      &__link.MuiButton-root {
         border-color: transparent;
         display: block;
         box-sizing: border-box;

--- a/apps/portals/src/configurations/arkportal/style/_style_overrides.scss
+++ b/apps/portals/src/configurations/arkportal/style/_style_overrides.scss
@@ -52,13 +52,6 @@ td.SRC_noBorderTop:nth-child(n + 4) {
   margin-top: 25px !important;
 }
 
-.MuiButtonBase-root.MuiButton-root.MuiButton-contained.MuiButton-containedSecondary {
-  color: white;
-  &:hover {
-    color: white;
-  }
-}
-
 /** 
 Adam's style hacks
 **/

--- a/apps/portals/src/configurations/arkportal/style/_style_overrides.scss
+++ b/apps/portals/src/configurations/arkportal/style/_style_overrides.scss
@@ -52,6 +52,13 @@ td.SRC_noBorderTop:nth-child(n + 4) {
   margin-top: 25px !important;
 }
 
+.MuiButtonBase-root.MuiButton-root.MuiButton-contained.MuiButton-containedSecondary {
+  color: white;
+  &:hover {
+    color: white;
+  }
+}
+
 /** 
 Adam's style hacks
 **/
@@ -65,14 +72,6 @@ $ARK-gray-900: #1d1d22 !default;
 .Goals {
   &__Desktop {
     gap: 30px;  
-  }
-  &__Mobile__Content {
-    & > &__Link {
-      color: white;
-      &:hover {
-        color: white;
-      }
-    }
   }
   &__Card {
     position: relative;

--- a/apps/portals/src/portal-components/nf/BrowseToolsPage.tsx
+++ b/apps/portals/src/portal-components/nf/BrowseToolsPage.tsx
@@ -6,6 +6,7 @@ import FeaturedToolsList from 'synapse-react-client/dist/containers/home_page/fe
 import IconSvg from 'synapse-react-client/dist/containers/IconSvg'
 import { Query } from 'synapse-react-client/dist/utils/synapseTypes'
 import { TextMatchesQueryFilter } from 'synapse-react-client/dist/utils/synapseTypes/Table/QueryFilter'
+import { WideButton } from 'synapse-react-client/dist/components/styled/WideButton'
 import { ReactComponent as AnimalModels } from './assets/animalmodels.svg'
 import { ReactComponent as Antibodies } from './assets/antibodies.svg'
 import { ReactComponent as Biobanks } from './assets/biobanks.svg'
@@ -53,6 +54,8 @@ const BrowseToolsPage = () => {
       `/Explore/Tools?QueryWrapper0=${JSON.stringify(query)}`,
     )
   }
+
+  const wideButtonSx = { marginTop: '50px' }
 
   return (
     <div className="browse-tools-page">
@@ -117,24 +120,41 @@ const BrowseToolsPage = () => {
           </button>
         </div>
         <div className="center-content">
-          <Button
-            className="btn-wide"
-            variant='contained'
+          <WideButton
+            sx={wideButtonSx}
+            variant="contained"
             onClick={() => gotoExploreTools()}
           >
             View All Tools
-          </Button>
+          </WideButton>
         </div>
       </Layout>
       <div className="home-container-description  home-bg-dark home-spacer">
-        <Typography variant="sectionTitle" sx={{textAlign:'center', paddingTop:'50px', paddingBottom: '15px'}}>
+        <Typography
+          variant="sectionTitle"
+          sx={{
+            textAlign: 'center',
+            paddingTop: '50px',
+            paddingBottom: '15px',
+          }}
+        >
           What Tools Can We Help You Find?
         </Typography>
-        <Typography variant="body1" sx={{textAlign:'center', paddingBottom: '15px'}}>
-            For the greatest success with your search, ensure your spelling is correct and avoid pluralization or suffixes.
+        <Typography
+          variant="body1"
+          sx={{ textAlign: 'center', paddingBottom: '15px' }}
+        >
+          For the greatest success with your search, ensure your spelling is
+          correct and avoid pluralization or suffixes.
         </Typography>
-        <Typography variant="body1" sx={{textAlign:'center', paddingBottom: '40px'}}>
-          <Link href="https://help.nf.synapse.org/NFdocs/Tips-for-Search.2640478225.html" target="_blank">
+        <Typography
+          variant="body1"
+          sx={{ textAlign: 'center', paddingBottom: '40px' }}
+        >
+          <Link
+            href="https://help.nf.synapse.org/NFdocs/Tips-for-Search.2640478225.html"
+            target="_blank"
+          >
             Learn More About MySQL Full Text Search
           </Link>
         </Typography>
@@ -158,7 +178,7 @@ const BrowseToolsPage = () => {
             </div>
             <div className="search-button-container">
               <Button
-                variant='contained'
+                variant="contained"
                 onClick={() => gotoExploreToolsWithFullTextSearch(searchText)}
               >
                 Search
@@ -193,13 +213,13 @@ const BrowseToolsPage = () => {
           />
         </div>
         <div className="center-content">
-          <Button
-            className="btn-wide"
-            variant='contained'
+          <WideButton
+            sx={wideButtonSx}
+            variant="contained"
             onClick={() => gotoExploreTools()}
           >
             View All Tools
-          </Button>
+          </WideButton>
         </div>
       </Layout>
       <Layout outsideContainerClassName="home-spacer highlightSubmitToolContainer">
@@ -218,14 +238,16 @@ const BrowseToolsPage = () => {
           </div>
         </div>
         <div className="center-content">
-          <Button
+          <WideButton
+            sx={wideButtonSx}
             href="https://forms.gle/htFkH5yewLzP1RAu7"
-            className="btn-wide highlightSubmitToolButton"
-            variant='contained'
+            className="highlightSubmitToolButton"
+            variant="contained"
+            // @ts-ignore - target prop exists, but TS doesn't recognize on styled component
             target="_blank"
           >
             Submit A Tool
-          </Button>
+          </WideButton>
         </div>
       </Layout>
     </div>

--- a/apps/portals/src/portal-components/nf/style/_BrowseToolsPage.scss
+++ b/apps/portals/src/portal-components/nf/style/_BrowseToolsPage.scss
@@ -21,9 +21,6 @@
     margin: 10px 0px 25px 0px;
     text-align: center;
   }
-  .center-content > .btn-wide {
-    margin-top: 50px;
-  }
   .searchToolsRow {
     margin-top: 20px;
     display: grid;
@@ -68,5 +65,8 @@
   .highlightSubmitToolButton {
     background-color: #e27134;
     color: white;
+    &:hover {
+      background-color: #dc6525;
+    }
   }
 }

--- a/apps/portals/src/portal-components/nf/style/_BrowseToolsPage.scss
+++ b/apps/portals/src/portal-components/nf/style/_BrowseToolsPage.scss
@@ -63,6 +63,7 @@
   }
 
   .highlightSubmitToolButton {
+    // TODO: Use theme to provide this color and hover state, see PORTALS-2653
     background-color: #e27134;
     color: white;
     &:hover {

--- a/packages/synapse-react-client/demo/containers/playground/ButtonDemo.tsx
+++ b/packages/synapse-react-client/demo/containers/playground/ButtonDemo.tsx
@@ -19,7 +19,7 @@ export const ButtonDemo: React.FunctionComponent = () => {
     undefined,
   )
 
-  const shapeClasses: string[] = ['', 'btn-wide']
+  const shapeClasses: string[] = ['']
   const colorVariants: string[] = [
     'sds-primary',
     'outline',

--- a/packages/synapse-react-client/src/lib/components/styled/WideButton.tsx
+++ b/packages/synapse-react-client/src/lib/components/styled/WideButton.tsx
@@ -1,0 +1,12 @@
+import { Button, ButtonProps, styled } from '@mui/material'
+import { StyledComponent } from '@emotion/styled'
+
+export const WideButton: StyledComponent<ButtonProps> = styled(Button, {
+  label: 'WideButton',
+})(({ theme }) => ({
+  minWidth: '168px',
+  padding: '10px',
+  fontSize: '16px',
+}))
+
+export default WideButton

--- a/packages/synapse-react-client/src/lib/containers/CardContainer.tsx
+++ b/packages/synapse-react-client/src/lib/containers/CardContainer.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Button } from 'react-bootstrap'
 import useGetInfoFromIds from '../utils/hooks/useGetInfoFromIds'
 import {
   DATASET,
@@ -21,6 +20,8 @@ import {
 } from './row_renderers/ObservationCard'
 import TotalQueryResults from './TotalQueryResults'
 import UserCardList from './UserCardList'
+import WideButton from '../components/styled/WideButton'
+import { Box } from '@mui/material'
 
 export type CardContainerProps = {
   isHeader?: boolean
@@ -86,17 +87,18 @@ export const CardContainer = (props: CardContainerProps) => {
     schema[element.name] = index
   })
   const showViewMoreButton = hasNextPage && (
-    <div className="SRC-viewMore bootstrap-4-backport">
-      <Button
-        variant="secondary"
-        className="btn-wide"
+    <Box display="flex" justifyContent="flex-end">
+      <WideButton
+        variant="contained"
+        color="secondary"
+        size="large"
         onClick={() => {
           appendNextPageToResults()
         }}
       >
         View More
-      </Button>
-    </div>
+      </WideButton>
+    </Box>
   )
   let cards
   if (type === MEDIUM_USER_CARD) {

--- a/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Desktop.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Desktop.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { GoalsDataProps } from './Goals'
 import QueryCount from '../../../containers/QueryCount'
-import { Button } from 'react-bootstrap'
+import { Button } from '@mui/material'
 
 export default function GoalsDesktop({
   asset,
@@ -11,7 +11,7 @@ export default function GoalsDesktop({
   title,
 }: GoalsDataProps) {
   return (
-    <div className="Goals__Card bootstrap-4-backport">
+    <div className="Goals__Card">
       <div
         className="Goals__Card__header"
         style={{ background: `url('${asset}')` }}
@@ -29,7 +29,8 @@ export default function GoalsDesktop({
         <p> {summary} </p>
         <Button
           className="Goals__Card__summary__link"
-          variant="secondary"
+          variant="contained"
+          color="secondary"
           href={link}
         >
           Explore

--- a/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Mobile.tsx
+++ b/packages/synapse-react-client/src/lib/containers/home_page/goals/Goals.Mobile.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { GoalsDataProps } from './Goals'
 import ExpandableContent from '../ExpandableContent'
 import QueryCount from '../../../containers/QueryCount'
-import { Button } from 'react-bootstrap'
+import { Button } from '@mui/material'
 
 export default function GoalsMobile({
   link,
@@ -21,10 +21,11 @@ export default function GoalsMobile({
     </div>
   )
   const content = (
-    <div className="Goals__Mobile__Content bootstrap-4-backport">
+    <div className="Goals__Mobile__Content">
       <p>{summary}</p>
       <Button
-        variant="secondary"
+        variant="contained"
+        color="secondary"
         className="Goals__Mobile__Content__Link"
         href={link}
       >

--- a/packages/synapse-react-client/src/lib/containers/markdown/widget/MarkdownButton.tsx
+++ b/packages/synapse-react-client/src/lib/containers/markdown/widget/MarkdownButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button } from 'react-bootstrap'
+import WideButton from '../../../components/styled/WideButton'
 
 export type ButtonLinkWidgetParams = {
   align?: string
@@ -11,38 +11,38 @@ export type ButtonLinkWidgetParams = {
 export default function MarkdownButton(
   widgetParamsMapped: ButtonLinkWidgetParams,
 ) {
-  let buttonClasses = 'btn-wide '
+  let buttonClasses = ''
   const { align = '', highlight = '' } = widgetParamsMapped
   const alignLowerCase = align.toLowerCase()
   if (alignLowerCase === 'left') {
-    buttonClasses += 'floatLeft '
+    buttonClasses += 'floatleft '
   }
   if (alignLowerCase === 'right') {
     buttonClasses += 'floatright '
   }
-  const buttonVariant = highlight === 'true' ? 'secondary' : 'light-secondary'
-  if (alignLowerCase === 'center') {
-    return (
-      <div className="bootstrap-4-backport" style={{ textAlign: 'center' }}>
-        <Button
-          href={widgetParamsMapped.url}
-          className={buttonClasses}
-          variant={buttonVariant}
-        >
-          {widgetParamsMapped.text}
-        </Button>
-      </div>
-    )
-  }
-  return (
-    <span className="bootstrap-4-backport">
-      <Button
-        href={widgetParamsMapped.url}
-        className={buttonClasses}
-        variant={buttonVariant}
-      >
-        {widgetParamsMapped.text}
-      </Button>
-    </span>
+  const buttonIsCenterAligned = alignLowerCase === 'center'
+  const buttonVariant = highlight === 'true' ? 'secondary' : 'inherit'
+  const button = (
+    <WideButton
+      href={widgetParamsMapped.url}
+      className={buttonClasses}
+      variant="contained"
+      color={buttonVariant}
+      sx={{
+        '&:hover': { backgroundColor: 'secondary.main', color: 'white' },
+        ...(!buttonIsCenterAligned &&
+          widgetParamsMapped.url && {
+            margin: '20px 20px 20px 0px',
+          }),
+      }}
+    >
+      {widgetParamsMapped.text}
+    </WideButton>
+  )
+
+  return buttonIsCenterAligned ? (
+    <div style={{ textAlign: 'center' }}>{button}</div>
+  ) : (
+    <span>{button}</span>
   )
 }

--- a/packages/synapse-react-client/src/lib/containers/row_renderers/Funder.tsx
+++ b/packages/synapse-react-client/src/lib/containers/row_renderers/Funder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Button } from 'react-bootstrap'
+import WideButton from '../../components/styled/WideButton'
 
 export type FunderProps = {
   data?: any
@@ -37,14 +37,15 @@ export default class Funder extends React.Component<FunderProps, never> {
     let showOrgLink
     if (!isOnOrgPath) {
       showOrgLink = (
-        <div className="SRC-marginAuto SRC-cardAction bootstrap-4-backport">
-          <Button
-            className="btn-wide"
+        <div className="SRC-marginAuto SRC-cardAction">
+          <WideButton
             href={organizationPath}
-            variant="secondary"
+            variant="contained"
+            color="secondary"
+            sx={{ '&:hover': { color: 'common.white' } }} // otherwise tab-focus.less overrides color
           >
             View Funded Research
-          </Button>
+          </WideButton>
         </div>
       )
     } else {

--- a/packages/synapse-react-client/src/lib/containers/row_renderers/Funder.tsx
+++ b/packages/synapse-react-client/src/lib/containers/row_renderers/Funder.tsx
@@ -42,6 +42,7 @@ export default class Funder extends React.Component<FunderProps, never> {
             href={organizationPath}
             variant="contained"
             color="secondary"
+            // TODO: remove this line after we have removed bootstrap
             sx={{ '&:hover': { color: 'common.white' } }} // otherwise tab-focus.less overrides color
           >
             View Funded Research

--- a/packages/synapse-react-client/src/lib/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid.tsx
+++ b/packages/synapse-react-client/src/lib/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid.tsx
@@ -8,14 +8,15 @@ import {
   ListResponse,
 } from '../../utils/synapseTypes/'
 import WarningDialog from './WarningDialog'
-import { Button } from 'react-bootstrap'
-import { Modal } from 'react-bootstrap'
-
+import { ConfirmationDialog } from '../ConfirmationDialog'
+import WideButton from '../../components/styled/WideButton'
+import { Box, Button, IconButton, Link, Typography } from '@mui/material'
+import DeleteTwoToneIcon from '@mui/icons-material/DeleteTwoTone'
+import PhoneTwoToneIcon from '@mui/icons-material/PhoneTwoTone'
 import dayjs from 'dayjs'
 import calendar from 'dayjs/plugin/calendar'
 import { SRC_SIGN_IN_CLASS } from '../../utils/SynapseConstants'
 import { ReactComponent as NoSubmissionsIcon } from '../../assets/icons/json-form-tool-no-submissions.svg'
-import IconSvg from '../IconSvg'
 
 dayjs.extend(calendar)
 /**
@@ -264,19 +265,20 @@ export default class SynapseFormSubmissionGrid extends React.Component<
       return <></>
     } else {
       return (
-        <div className="bootstrap-4-backport file-grid">
-          <h3>Your Submissions</h3>
+        <div className="file-grid">
+          <Typography variant="h3">Your Submissions</Typography>
           <div className="panel padding-full unauthenticated text-center">
             <p className="padding-full">
               Please sign in or register to initiate or continue your submission
             </p>
-            <Button
+            <WideButton
               className={`${SRC_SIGN_IN_CLASS}`}
-              variant="primary"
-              size="lg"
+              variant="contained"
+              color="primary"
+              size="large"
             >
               Sign In
-            </Button>
+            </WideButton>
           </div>
         </div>
       )
@@ -322,16 +324,16 @@ export default class SynapseFormSubmissionGrid extends React.Component<
       </h5>
     )
     const viewMore = nextPageToken ? (
-      <div className="view-more">
-        <button
-          className="btn btn-link"
+      <Box sx={{ textAlign: 'right', paddingTop: '5px' }}>
+        <Button
+          variant="text"
           onClick={() => {
             this.getMore(fileListType, nextPageToken)
           }}
         >
-          more ...
-        </button>
-      </div>
+          More...
+        </Button>
+      </Box>
     ) : (
       <></>
     )
@@ -348,18 +350,18 @@ export default class SynapseFormSubmissionGrid extends React.Component<
                       key={`${dataFileRecord.formDataId}-${key}-${fileListType}`}
                     >
                       <td>
-                        <a
+                        <Link
                           href={`${pathpart}?formGroupId=${formGroupId}&formDataId=${dataFileRecord.formDataId}&dataFileHandleId=${dataFileRecord.dataFileHandleId}`}
                         >
                           {dataFileRecord.name}
-                        </a>
+                        </Link>
                       </td>
                       <td>{dayjs(dataFileRecord.modifiedOn).calendar()}</td>
                       <td>&nbsp;</td>
                       <td className="text-right">
-                        <button
-                          className="btn"
+                        <IconButton
                           aria-label="delete"
+                          color="primary"
                           onClick={() =>
                             this.setModalConfirmationState(
                               this.props.token!,
@@ -367,8 +369,8 @@ export default class SynapseFormSubmissionGrid extends React.Component<
                             )
                           }
                         >
-                          <IconSvg icon="delete" aria-hidden="true" />
-                        </button>
+                          <DeleteTwoToneIcon />
+                        </IconButton>
                       </td>
                     </tr>
                   )
@@ -376,24 +378,24 @@ export default class SynapseFormSubmissionGrid extends React.Component<
                   return (
                     <tr key={`${dataFileRecord.formDataId}-${key}`}>
                       <td>
-                        <a
+                        <Link
                           href={`${pathpart}?formGroupId=${formGroupId}&formDataId=${dataFileRecord.formDataId}&dataFileHandleId=${dataFileRecord.dataFileHandleId}&submitted=1`}
                         >
                           {dataFileRecord.name}
-                        </a>
+                        </Link>
                       </td>
                       <td>{dayjs(dataFileRecord.modifiedOn).calendar()}</td>
                       <td>{dataFileRecord.submissionStatus.state}</td>
                       <td className="text-right">
-                        <button
-                          className="btn"
+                        <IconButton
+                          color="primary"
                           aria-label="information"
                           onClick={() =>
                             this.setState({ isShowInfoModal: true })
                           }
                         >
-                          <IconSvg icon="phone" aria-hidden="true" />
-                        </button>
+                          <PhoneTwoToneIcon />
+                        </IconButton>
                       </td>
                     </tr>
                   )
@@ -453,9 +455,9 @@ export default class SynapseFormSubmissionGrid extends React.Component<
           {this.renderLoading(this.props.token, this.state.isLoading)}
           {this.renderUnauthenticatedView(this.props.token)}
 
-          {!this.state.isLoading && (
+          {this.props.token && !this.state.isLoading && (
             <div className="file-grid ">
-              <h3>Your Submissions</h3>
+              <Typography variant="h3">Your Submissions</Typography>
               <div className="panel panel-default padding-full">
                 {this.renderSubmissionsTables(
                   this.state.inProgress,
@@ -464,15 +466,19 @@ export default class SynapseFormSubmissionGrid extends React.Component<
                   this.props.formGroupId,
                 )}
 
-                <div className="text-center bootstrap-4-backport">
-                  <Button
-                    className="btn-wide btn-large" // .btn-large is a custom class, don't use size="lg"
-                    variant="primary"
+                <Box textAlign={'center'}>
+                  <WideButton
+                    variant="contained"
+                    color="primary"
+                    sx={{
+                      padding: '0.75rem 1.5rem',
+                      '&:hover': { color: 'common.white' }, // otherwise tab-focus.less overrides color
+                    }}
                     href={`${this.props.pathpart}?formGroupId=${this.props.formGroupId}`}
                   >
                     Add new {this.props.itemNoun}
-                  </Button>
-                </div>
+                  </WideButton>
+                </Box>
               </div>
             </div>
           )}
@@ -489,32 +495,22 @@ export default class SynapseFormSubmissionGrid extends React.Component<
               }
             />
           )}
-
-          <Modal
-            show={this.state.isShowInfoModal}
-            animation={false}
+          <ConfirmationDialog
+            open={this.state.isShowInfoModal}
+            title="More Information"
+            content={
+              <>
+                Please <Link href="mailto:ModelAD@iupui.edu">contact us</Link>{' '}
+                for more information about your submission
+              </>
+            }
             className={`theme-${this.props.formClass}`}
-            backdrop="static"
-          >
-            <Modal.Header
-              closeButton={false}
-              onHide={() => this.setState({ isShowInfoModal: false })}
-            >
-              <Modal.Title>More Information</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-              Please <a href="mailto:ModelAD@iupui.edu">contact us</a> for more
-              information about your submission
-            </Modal.Body>
-            <Modal.Footer>
-              <Button
-                variant="success"
-                onClick={() => this.setState({ isShowInfoModal: false })}
-              >
-                OK
-              </Button>
-            </Modal.Footer>
-          </Modal>
+            hasCloseButton={false}
+            hasCancelButton={false}
+            confirmButtonColor="success"
+            onCancel={() => this.setState({ isShowInfoModal: false })}
+            onConfirm={() => this.setState({ isShowInfoModal: false })}
+          />
         </div>
       </div>
     )

--- a/packages/synapse-react-client/src/lib/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid.tsx
+++ b/packages/synapse-react-client/src/lib/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid.tsx
@@ -472,6 +472,7 @@ export default class SynapseFormSubmissionGrid extends React.Component<
                     color="primary"
                     sx={{
                       padding: '0.75rem 1.5rem',
+                      // TODO: remove this line after we have removed bootstrap
                       '&:hover': { color: 'common.white' }, // otherwise tab-focus.less overrides color
                     }}
                     href={`${this.props.pathpart}?formGroupId=${this.props.formGroupId}`}

--- a/packages/synapse-react-client/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/packages/synapse-react-client/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { Button } from 'react-bootstrap'
 import { isSingleNotSetValue } from '../../../utils/functions/queryUtils'
 import {
   FacetColumnRequest,
@@ -17,6 +16,7 @@ import { useQueryContext } from '../../QueryContext'
 import { applyChangesToValuesColumn } from '../query-filter/FacetFilterControls'
 import FacetNavPanel, { PlotType } from './FacetNavPanel'
 import TotalQueryResults from '../../TotalQueryResults'
+import WideButton from '../../../components/styled/WideButton'
 
 /*
 TODO: This component has a few bugs when its props are updated with new data, this should be handled
@@ -254,18 +254,19 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
               ))}
             </div>
             {showMoreButtonState !== 'NONE' && (
-              <div className="FacetNav__showMoreContainer bootstrap-4-backport">
-                <Button
-                  variant="secondary"
-                  className="btn-wide FacetNav__showMore"
+              <div className="FacetNav__showMoreContainer">
+                <WideButton
+                  variant="contained"
+                  color="secondary"
                   onClick={() =>
                     onShowMoreClick(showMoreButtonState === 'MORE')
                   }
+                  sx={{ width: '250px' }}
                 >
                   {showMoreButtonState === 'LESS'
                     ? 'Hide Charts'
                     : 'View All Charts'}
-                </Button>
+                </WideButton>
               </div>
             )}
           </div>

--- a/packages/synapse-react-client/src/lib/style/bootstrap4_backports/_base-import.scss
+++ b/packages/synapse-react-client/src/lib/style/bootstrap4_backports/_base-import.scss
@@ -51,12 +51,6 @@
     padding: 10px 24px;
   }
 
-  // Extra-wide button
-  .btn.btn-wide {
-    min-width: 168px;
-    padding: 10px;
-  }
-
   // default variant is in BS3 but not BS4, so we recreate it here
   .btn-default {
     @include button-variant(

--- a/packages/synapse-react-client/src/lib/style/components/_cards.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_cards.scss
@@ -332,11 +332,6 @@ $text-color-lighter: #898989;
   }
 }
 
-.SRC-viewMore {
-  display: flex;
-  justify-content: flex-end;
-}
-
 .cardContainer {
   box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.05);
 }

--- a/packages/synapse-react-client/src/lib/style/components/_goals.scss
+++ b/packages/synapse-react-client/src/lib/style/components/_goals.scss
@@ -1,4 +1,5 @@
 @use '../abstracts/variables' as SRC;
+@use 'sass:map';
 
 // have space between items
 %space-between {
@@ -78,6 +79,9 @@
         padding: 10px;
         margin-top: 20px;
         margin-left: 0px;
+        &:hover {
+          color: map.get(SRC.$colors, 'white');
+        }
       }
     }
   }
@@ -109,6 +113,9 @@
         padding: 10px;
         margin-top: 20px;
         margin-left: 0px;
+        &:hover {
+          color: map.get(SRC.$colors, 'white');
+        }
       }
     }
   }

--- a/packages/synapse-react-client/src/lib/style/components/facet_nav/_facet-nav.scss
+++ b/packages/synapse-react-client/src/lib/style/components/facet_nav/_facet-nav.scss
@@ -24,9 +24,5 @@
     justify-content: center;
     padding: 10px;
     margin-top: 10px;
-    button.FacetNav__showMore {
-      // padding: 5px 70px;
-      width: 250px;
-    }
   }
 }

--- a/packages/synapse-react-client/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
+++ b/packages/synapse-react-client/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
@@ -99,9 +99,6 @@
       button.btn {
         color: SrcVariables.$primary-action-color;
       }
-      .view-more {
-        text-align: right;
-      }
 
       table {
         border-bottom: 1px solid #ddd;
@@ -126,16 +123,7 @@
         td {
           vertical-align: middle;
         }
-        a {
-          color: SrcVariables.$primary-action-color;
-        }
       }
-    }
-
-    .btn-large {
-      color: #fff;
-      background-color: SrcVariables.$primary-action-color;
-      padding: 0.75rem 1.5rem;
     }
   }
 

--- a/packages/synapse-react-client/src/lib/utils/theme/palette/Palettes.ts
+++ b/packages/synapse-react-client/src/lib/utils/theme/palette/Palettes.ts
@@ -95,6 +95,7 @@ export const arkPortalPalette: PaletteOptions = {
   ...palette,
   primary: generatePalette('#e79776'),
   secondary: generatePalette('#e79776'),
+  contrastThreshold: 2.3,
 }
 
 export const adKnowledgePortalPalette: PaletteOptions = {

--- a/packages/synapse-react-client/stories/Button.stories.tsx
+++ b/packages/synapse-react-client/stories/Button.stories.tsx
@@ -26,9 +26,8 @@ const meta: Meta = {
       options: ['', 'sm', 'lg'],
     },
     className: {
-      name: 'shape',
-      control: 'select',
-      options: ['', 'btn-wide'],
+      name: 'className',
+      control: 'text',
     },
   },
   render: args => (

--- a/packages/synapse-react-client/stories/CardContainerLogic.stories.ts
+++ b/packages/synapse-react-client/stories/CardContainerLogic.stories.ts
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 import {
+  FUNDER,
   GENERIC_CARD,
   OBSERVATION_CARD,
   PUBLICATION,
@@ -54,6 +55,14 @@ export const ObservationCard: Story = {
   args: {
     sql: `SELECT "Observation Submitter Name" as "submitterName", Synapse_id as "submitterUserId", "Observation Time" as "time", "Observation Time Units" as "timeUnits", "Observation Text" as "text", "Observation Type" as "tag" FROM syn26344832 WHERE "Observation Time" IS NOT NULL`,
     type: OBSERVATION_CARD,
+    limit: 3,
+  },
+}
+
+export const FunderCard: Story = {
+  args: {
+    sql: `SELECT * FROM syn16858699`,
+    type: FUNDER,
     limit: 3,
   },
 }

--- a/packages/synapse-react-client/stories/SynapseFormSubmissionsGrid.stories.tsx
+++ b/packages/synapse-react-client/stories/SynapseFormSubmissionsGrid.stories.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { Meta, StoryObj } from '@storybook/react'
+import { rest } from 'msw'
+import { MOCK_REPO_ORIGIN } from '../src/lib/utils/functions/getEndpoint'
+import SynapseFormSubmissionGrid from '../src/lib/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid'
+import { SynapseContextConsumer } from '../src/lib/utils/SynapseContext'
+import FullContextProvider from '../src/lib/utils/FullContextProvider'
+import { ListRequest, StatusEnum } from '../src/lib/utils/synapseTypes'
+import {
+  formListDataInProgress,
+  formListDataSubmitted,
+} from '../mocks/mock_drug_tool_data'
+import { getHandlers } from '../mocks/msw/handlers'
+
+const meta: Meta = {
+  title: 'Portals/SynapseFormSubmissionsGrid',
+  component: SynapseFormSubmissionGrid,
+  argTypes: {
+    isAuthenticated: {
+      control: { type: 'boolean' },
+      defaultValue: true,
+    },
+  },
+  render: args => {
+    const { isAuthenticated, ...rest } = args
+    return (
+      <SynapseContextConsumer>
+        {context => {
+          const token = isAuthenticated
+            ? context.accessToken ?? 'fake token'
+            : undefined
+          return (
+            <FullContextProvider
+              synapseContext={{
+                ...context,
+                accessToken: token,
+              }}
+            >
+              <p>
+                First, use the StackChanger component to switch to the Mocked
+                Data stack. Then, change `isAuthenticated` to 'true'.
+              </p>
+
+              <SynapseFormSubmissionGrid token={token} {...rest} />
+            </FullContextProvider>
+          )
+        }}
+      </SynapseContextConsumer>
+    )
+  },
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+function listFormDataHandlers() {
+  return [
+    rest.post(
+      `${MOCK_REPO_ORIGIN}/repo/v1/form/data/list`,
+      async (req, res, ctx) => {
+        const listRequest = req.body as ListRequest
+        const status = ctx.status(200)
+        if (
+          listRequest.filterByState?.includes(StatusEnum.WAITING_FOR_SUBMISSION)
+        ) {
+          return res(status, ctx.json(formListDataInProgress))
+        }
+        return res(status, ctx.json(formListDataSubmitted))
+      },
+    ),
+  ]
+}
+
+export const NoSubmissions: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        getHandlers(MOCK_REPO_ORIGIN),
+        rest.post(
+          `${MOCK_REPO_ORIGIN}/repo/v1/form/data/list`,
+          async (req, res, ctx) => {
+            return res(ctx.status(200), ctx.json({ page: [] }))
+          },
+        ),
+      ],
+    },
+  },
+  args: {
+    pathpart: '/Apply/FormSubmission',
+    formGroupId: '9',
+    itemNoun: 'Compound',
+    formClass: 'drug-upload-tool',
+  },
+}
+
+export const HasSubmissions: Story = {
+  parameters: {
+    msw: {
+      handlers: [...getHandlers(MOCK_REPO_ORIGIN), ...listFormDataHandlers()],
+    },
+  },
+  args: {
+    ...NoSubmissions.args,
+  },
+}

--- a/packages/synapse-react-client/test/lib/containers/markdown/__snapshots__/MarkdownSynapse.integration.test.tsx.snap
+++ b/packages/synapse-react-client/test/lib/containers/markdown/__snapshots__/MarkdownSynapse.integration.test.tsx.snap
@@ -79,22 +79,20 @@ exports[`MarkdownSynapse tests Snapshot tests works with two inline widgets 1`] 
   >
     <span>
       <p>
-        <span
-          class="bootstrap-4-backport"
-        >
+        <span>
           <a
-            class="btn-wide  btn btn-secondary"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium  css-qnfplt-MuiButtonBase-root-MuiButton-root-WideButton"
             href="#/Help/How It Works"
+            tabindex="0"
           >
             sometext
           </a>
         </span>
-        <span
-          class="bootstrap-4-backport"
-        >
+        <span>
           <a
-            class="btn-wide  btn btn-secondary"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium  css-qnfplt-MuiButtonBase-root-MuiButton-root-WideButton"
             href="#/Apply"
+            tabindex="0"
           >
             APPLY
           </a>


### PR DESCRIPTION
Updates:
- Convert bootstrap `btn-wide` buttons to MUI styled WideButton components
- Remove `btn-wide` class
- Add stories for `Funder` and `SynapseFormSubmissionsGrid`
- Convert bootstrap components to MUI in `SynapseFormSubmissionsGrid`
- Convert bootstrap buttons to MUI in Portals `Navbar`