### PR TITLE
PORTALS-2656: fix secondary color contrast color

### DIFF
--- a/apps/portals/src/configurations/elportal/routesConfig.ts
+++ b/apps/portals/src/configurations/elportal/routesConfig.ts
@@ -15,7 +15,6 @@ import {
 } from './synapseConfigs/studies'
 import {
   projectCardConfiguration,
-  projectHomePageCardConfiguration,
   projectsDetailsPageConfiguration,
 } from './synapseConfigs/projects'
 import {

--- a/packages/synapse-react-client/src/lib/utils/theme/palette/Palettes.ts
+++ b/packages/synapse-react-client/src/lib/utils/theme/palette/Palettes.ts
@@ -116,7 +116,7 @@ export const arkPortalPalette: PaletteOptions = {
 export const adKnowledgePortalPalette: PaletteOptions = {
   ...palette,
   primary: generatePalette('#4d5491'),
-  secondary: generatePalette('#2f8e94'),
+  secondary: { ...generatePalette('#2f8e94'), contrastText: '#ffffff' },
 }
 
 const elPortalPrimaryPalette = {


### PR DESCRIPTION
Before:
<img width="1434" alt="Screen Shot 2023-05-09 at 9 51 00 AM" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/1864447/966edc3e-50ee-48b3-bf23-6c58bd63f79a">

After:
<img width="1423" alt="Screen Shot 2023-05-09 at 9 53 10 AM" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/1864447/a6c932b0-4d2b-43b1-a553-c47f8b6b47bb">
