### PR TITLE
PORTALS-2624: refactor ModalDownload to use MUI components

### DIFF
--- a/packages/synapse-react-client/src/lib/containers/ModalDownload.FormSchema.ts
+++ b/packages/synapse-react-client/src/lib/containers/ModalDownload.FormSchema.ts
@@ -9,7 +9,6 @@ export const tsvOption = 'Tab Separated Values (TSV)'
 
 // Step 1
 const stepOneFormSchema: JSONSchema7 = {
-  title: 'Download query results',
   type: 'object',
   properties: {
     'File Type': {
@@ -48,7 +47,6 @@ const stepOneFormUISchema: UiSchema = {
 
 // Step 2
 const stepTwoFormSchema: JSONSchema7 = {
-  title: 'Download query results',
   description:
     'File is ready for download. Select the download button to download the file.',
   type: 'object',

--- a/packages/synapse-react-client/src/lib/containers/ModalDownload.tsx
+++ b/packages/synapse-react-client/src/lib/containers/ModalDownload.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Button, Modal } from 'react-bootstrap'
+import { Button } from '@mui/material'
 import Form, { IChangeEvent } from '@rjsf/core'
 import { SynapseClient } from '../utils'
 import {
@@ -18,7 +18,7 @@ import {
 } from './ModalDownload.FormSchema'
 import { parseEntityIdFromSqlStatement } from '../utils/functions/sqlFunctions'
 import { SynapseContext } from '../utils/SynapseContext'
-import IconSvg from './IconSvg'
+import { DialogBase } from './DialogBase'
 
 export type ModalDownloadState = {
   isLoading: boolean
@@ -126,59 +126,59 @@ export default class ModalDownload extends React.Component<
   }
 
   render() {
-    const closeBtn: React.CSSProperties = {
-      position: 'absolute',
-      top: 10,
-      right: 10,
-      zIndex: 10,
-    }
     const spinnerStyle: React.CSSProperties = {
       height: 50,
       width: 50,
       backgroundSize: 50,
     }
     return (
-      <Modal
-        animation={false}
-        show={true}
-        onHide={this.props.onClose}
-        backdrop="static"
-      >
-        <Modal.Body>
-          <button style={closeBtn} onClick={this.props.onClose}>
-            <IconSvg icon="close" />
-          </button>
-          <Form
-            schema={formSchemaArray[this.state.step]}
-            uiSchema={formSchemaUIArray[this.state.step]}
-            onChange={this.handleChange}
-            formData={this.state.formData}
-            onSubmit={this.handleSubmit}
-          >
-            {this.state.isLoading && (
-              <div className="SRC-centerAndJustifyContent">
-                <div className="SRC-center-text">
-                  <p> Creating the File </p>
-                  <div style={spinnerStyle} className="spinner" />
-                  <p> Loading... </p>
+      <DialogBase
+        open={true}
+        onCancel={this.props.onClose}
+        title="Download query results"
+        content={
+          <>
+            <Form
+              id="modal-download-form"
+              schema={formSchemaArray[this.state.step]}
+              uiSchema={formSchemaUIArray[this.state.step]}
+              onChange={this.handleChange}
+              formData={this.state.formData}
+              onSubmit={this.handleSubmit}
+            >
+              {this.state.isLoading && (
+                <div className="SRC-centerAndJustifyContent">
+                  <div className="SRC-center-text">
+                    <p> Creating the File </p>
+                    <div style={spinnerStyle} className="spinner" />
+                    <p> Loading... </p>
+                  </div>
                 </div>
-              </div>
-            )}
-            <div style={{ textAlign: 'right' }}>
-              <Button
-                variant="default"
-                onClick={this.props.onClose}
-                style={{ marginRight: '5px' }}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" variant="primary">
-                {this.state.step === 0 ? 'Next' : 'Download'}
-              </Button>
-            </div>
-          </Form>
-        </Modal.Body>
-      </Modal>
+              )}
+              <React.Fragment />
+            </Form>
+          </>
+        }
+        actions={
+          <>
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={this.props.onClose}
+            >
+              Cancel
+            </Button>
+            <Button
+              form="modal-download-form"
+              type="submit"
+              variant="contained"
+              color="primary"
+            >
+              {this.state.step === 0 ? 'Next' : 'Download'}
+            </Button>
+          </>
+        }
+      />
     )
   }
 }

--- a/packages/synapse-react-client/stories/ModalDownload.stories.ts
+++ b/packages/synapse-react-client/stories/ModalDownload.stories.ts
@@ -1,0 +1,21 @@
+import { Meta, StoryObj } from '@storybook/react'
+import ModalDownload from '../src/lib/containers/ModalDownload'
+
+const meta = {
+  title: 'UI/ModalDownload',
+  component: ModalDownload,
+} satisfies Meta
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  args: {
+    queryBundleRequest: {
+      concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+      entityId: '',
+      // @ts-ignore
+      partMask: undefined,
+      query: { sql: 'SELECT * FROM syn26438037 LIMIT 5' },
+    },
+  },
+}


### PR DESCRIPTION
step | main | feature
:---:|:---:|:---:
1 | <img width="677" alt="main_ModalDownload_1" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/670d087d-58a2-410d-bd16-29b3037e6d5c"> | <img width="645" alt="feature_ModalDownload_1" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/bb66aef8-95e3-47d9-8101-e4015e2fddca">
2 | <img width="722" alt="main_ModalDownload_2" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/f7497c36-fba8-4960-9625-7eaf4b92eca6"> | <img width="648" alt="feature_ModalDownload_2" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/d16f9152-d856-4ef8-8c8d-8d735798b2ad">

