### PR TITLE
PORTALS-2624: refactor SynapseTable modal view to use MUI components

### DIFF
--- a/packages/synapse-react-client/src/lib/containers/AddToDownloadListV2.tsx
+++ b/packages/synapse-react-client/src/lib/containers/AddToDownloadListV2.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import IconSvg from './IconSvg'
 import { useSynapseContext } from '../utils/SynapseContext'
 import { displayToast } from './ToastMessage'
-import { Tooltip } from '@mui/material'
+import { Link, Tooltip } from '@mui/material'
 import { useAddFileToDownloadList } from '../utils/hooks/SynapseAPI/download/useDownloadList'
 import { useGetEntity } from '../utils/hooks/SynapseAPI'
 
@@ -48,7 +48,7 @@ const AddToDownloadListV2: React.FunctionComponent<
         placement="right"
         enterNextDelay={300}
       >
-        <a
+        <Link
           data-testid="AddToDownloadListV2"
           onClick={() => {
             addToDownloadList({ entityId, entityVersionNumber })
@@ -56,7 +56,7 @@ const AddToDownloadListV2: React.FunctionComponent<
           className="ignoreLink"
         >
           <IconSvg icon={'addToCart'} />
-        </a>
+        </Link>
       </Tooltip>
     </>
   )

--- a/packages/synapse-react-client/src/lib/containers/EntityLink.tsx
+++ b/packages/synapse-react-client/src/lib/containers/EntityLink.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@mui/material'
+import { Link, Skeleton } from '@mui/material'
 import React from 'react'
 import {
   convertToEntityType,
@@ -53,7 +53,7 @@ export const EntityLink = (props: EntityLinkProps) => {
 
     if (link) {
       return (
-        <a
+        <Link
           className={className}
           target="_blank"
           rel="noopener noreferrer"
@@ -65,7 +65,7 @@ export const EntityLink = (props: EntityLinkProps) => {
             <EntityTypeIcon type={type} style={{ marginRight: '6px' }} />
           )}
           {entity[displayTextField]}
-        </a>
+        </Link>
       )
     } else {
       return (

--- a/packages/synapse-react-client/src/lib/containers/table/SynapseTable.tsx
+++ b/packages/synapse-react-client/src/lib/containers/table/SynapseTable.tsx
@@ -1,7 +1,7 @@
 import ColumnResizer from 'column-resizer'
 import { cloneDeep, eq } from 'lodash-es'
 import * as React from 'react'
-import { Modal } from 'react-bootstrap'
+import { DialogBase } from '../DialogBase'
 import { SynapseClient } from '../../utils'
 import {
   hasFilesInView,
@@ -370,21 +370,22 @@ export default class SynapseTable extends React.Component<
     return (
       <React.Fragment>
         {isExpanded && (
-          <Modal
-            animation={false}
-            show={true}
-            // @ts-ignore
-            onHide={() => this.setState({ isExpanded: false })}
-            dialogClassName={'modal-90w'}
-            backdrop="static"
-          >
-            <Modal.Header
-              // @ts-ignore
-              onHide={() => this.setState({ isExpanded: false })}
-              closeButton={true}
-            ></Modal.Header>
-            <Modal.Body>{content}</Modal.Body>
-          </Modal>
+          <DialogBase
+            open={true}
+            onCancel={() => this.setState({ isExpanded: false })}
+            content={content}
+            title={undefined}
+            maxWidth="xl"
+            fullWidth
+            sx={{
+              '.MuiDialogTitle-root': {
+                padding: 0,
+              },
+              '.MuiDialogContent-root': {
+                border: 'transparent',
+              },
+            }}
+          />
         )}
         {!isExpanded && content}
       </React.Fragment>

--- a/packages/synapse-react-client/src/lib/style/base/_core.scss
+++ b/packages/synapse-react-client/src/lib/style/base/_core.scss
@@ -1233,6 +1233,7 @@ hr ~ .SRC-wrapper {
 // Links created with MUI get their styling from the MUI theme.
 main,
 .modal,
+.MuiDialog-root,
 #rootPanel {
   a,
   .bootstrap-4-backport a,

--- a/packages/synapse-react-client/src/lib/style/base/_core.scss
+++ b/packages/synapse-react-client/src/lib/style/base/_core.scss
@@ -1233,7 +1233,6 @@ hr ~ .SRC-wrapper {
 // Links created with MUI get their styling from the MUI theme.
 main,
 .modal,
-.MuiDialog-root,
 #rootPanel {
   a,
   .bootstrap-4-backport a,

--- a/packages/synapse-react-client/src/lib/template_style/_theme.scss
+++ b/packages/synapse-react-client/src/lib/template_style/_theme.scss
@@ -35,7 +35,8 @@
 }
 
 .SRC-primary-background-color-hover {
-  &:hover, &[aria-expanded="true"] {
+  &:hover,
+  &[aria-expanded='true'] {
     background-color: SRC.$primary-action-color !important;
     color: white !important;
     fill: white !important;
@@ -47,7 +48,8 @@
 }
 
 .SRC-secondary-background-color-hover {
-  &:hover, &[aria-expanded="true"] {
+  &:hover,
+  &[aria-expanded='true'] {
     background-color: SRC.$secondary-action-color !important;
     color: white !important;
     fill: white !important;
@@ -146,20 +148,6 @@
 .SRC-portalCard {
   .SRC-downloadData {
     background-color: SRC.$primary-action-color;
-  }
-}
-
-// Table Modal View
-.modal-90w {
-  width: 95%;
-  // hide modal border
-  .modal-header {
-    border: none;
-    button.close {
-      font-size: 25px;
-      color: SRC.$primary-action-color;
-      opacity: 1;
-    }
   }
 }
 


### PR DESCRIPTION
main | feature
:---:|:---:
<img width="1357" alt="main_SyanpseTable_Modal" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/2e324c01-94fb-4291-94c5-0d751d7f5703"> | <img width="1436" alt="feature_SynapseTable_Modal" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/e7ab76f9-7037-4239-b5cc-d6a06798c8f8">
