### PR TITLE
Add test:ci, align plotly versions

### DIFF
--- a/apps/SageAccountWeb/package.json
+++ b/apps/SageAccountWeb/package.json
@@ -12,7 +12,7 @@
     "@mui/system": "^5.11.16",
     "@mui/utils": "^5.11.13",
     "lodash-es": "^4.17.21",
-    "plotly.js-basic-dist": "^1.47.3",
+    "plotly.js-basic-dist": "^2.22.0",
     "react": "18.2.0",
     "react-bootstrap": "^1.5.2",
     "react-cookie": "4.0.0",
@@ -31,7 +31,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/katex": "^0.5.0",
     "@types/node": "11.10.4",
-    "@types/plotly.js": "^1.54.10",
+    "@types/plotly.js": "^2.12.18",
     "@types/react": "18.0.17",
     "@types/react-dom": "18.0.6",
     "@types/react-easy-crop": "^2.0.0",
@@ -82,7 +82,7 @@
     "start": "vite",
     "build": "vite build",
     "test": "vitest",
-    "test:coverage": "vitest --coverage.enabled=true"
+    "test:ci": "vitest run --coverage"
   },
   "browserslist": {
     "production": [

--- a/apps/portals/package.json
+++ b/apps/portals/package.json
@@ -14,7 +14,7 @@
     "dayjs": "^1.11.6",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
-    "plotly.js-basic-dist": "^2.18.0",
+    "plotly.js-basic-dist": "^2.22.0",
     "react": "^18.2.0",
     "react-bootstrap": "^1.5.2",
     "react-cookie": "4.0.0",
@@ -37,7 +37,7 @@
     "build": "pnpm copy-assets; pnpm save-build-date; vite build",
     "copy-test-configuration": "cp -r src/test-configuration/ src/config/",
     "test": "pnpm run copy-test-configuration && vitest",
-    "test:coverage": "pnpm run copy-test-configuration && vitest run --coverage",
+    "test:ci": "pnpm run copy-test-configuration && vitest run --coverage",
     "generate-sitemap": "node sitemap/generate-sitemap.cjs"
   },
   "devDependencies": {
@@ -47,7 +47,7 @@
     "@types/katex": "^0.5.0",
     "@types/lodash": "^4.14.191",
     "@types/node": "11.10.4",
-    "@types/plotly.js": "^1.54.22",
+    "@types/plotly.js": "^2.12.18",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
     "@types/react-plotly.js": "^2.6.0",
@@ -112,7 +112,6 @@
     "js-yaml": "3.13.1",
     "react": "18.2.0",
     "react-hot-toast": "2.2.0",
-    "@types/plotly.js": "^1.54.10",
     "@types/react": "^18.0.17",
     "minimatch": "^3.1.2"
   }

--- a/apps/synapse-oauth-signin/package.json
+++ b/apps/synapse-oauth-signin/package.json
@@ -13,7 +13,7 @@
     "history": "^5.3.0",
     "lodash-es": "^4.17.21",
     "moment": "^2.29.4",
-    "plotly.js-basic-dist": "^1.47.3",
+    "plotly.js-basic-dist": "^2.22.0",
     "react": "^18.2.0",
     "react-app-polyfill": "^3.0.0",
     "react-bootstrap": "^1.5.2",
@@ -32,7 +32,7 @@
     "@types/jest": "^27.5.0",
     "@types/katex": "^0.5.0",
     "@types/node": "11.10.4",
-    "@types/plotly.js": "^1.54.10",
+    "@types/plotly.js": "^2.12.18",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
     "@types/react-plotly.js": "^2.6.0",
@@ -86,7 +86,7 @@
     "start": "vite",
     "build": "vite build",
     "test": "vitest",
-    "test:coverage": "vitest run --coverage",
+    "test:ci": "vitest run --coverage",
     "lint": "eslint src"
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare": "husky install",
     "build": "nx run-many --target=build",
     "lint": "nx run-many --target=lint",
-    "test": "nx run-many --target=test -- --watchAll=false --silent=true",
+    "test": "nx run-many --target=test:ci",
     "clean": "nx run-many --target=clean"
   },
   "devDependencies": {
@@ -31,10 +31,7 @@
   },
   "npmClient": "pnpm",
   "resolutions": {
-    "@types/plotly.js": "1.54.22",
-    "@types/plotly.js-basic-dist": "1.54.1",
     "@types/react": "18.0.27",
-    "@types/react-plotly.js": "^2.6.0",
     "goober": "2.1.9",
     "react-hot-toast": "2.2.0"
   },

--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -5,14 +5,14 @@
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "module": "dist/index.js",
-  "homepage": "https://sage-bionetworks.github.io/Synapse-React-Client/",
+  "homepage": "https://sage-bionetworks.github.io/synapse-web-monorepo/",
   "files": [
     "dist",
     "README.md"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Sage-Bionetworks/Synapse-React-Client"
+    "url": "https://github.com/Sage-Bionetworks/synapse-web-monorepo/packages/synapse-react-client"
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
@@ -60,7 +60,7 @@
     "markdown-it-synapse-math": "^3.0.4",
     "markdown-it-synapse-table": "^1.0.6",
     "mui-one-time-password-input": "^1.1.0",
-    "plotly.js-basic-dist": "^2.11.1",
+    "plotly.js-basic-dist": "^2.22.0",
     "pluralize": "^8.0.0",
     "qrcode": "^1.5.1",
     "raf": "^3.4.1",
@@ -146,8 +146,8 @@
     "@types/lodash-es": "4.17.3",
     "@types/markdown-it": "^12.0.1",
     "@types/node": "^14.14.31",
-    "@types/plotly.js": "^1.54.20",
-    "@types/plotly.js-basic-dist": "^1.54.0",
+    "@types/plotly.js": "^2.12.18",
+    "@types/plotly.js-basic-dist": "^1.54.1",
     "@types/pluralize": "^0.0.29",
     "@types/qrcode": "^1.5.0",
     "@types/react": "^18.0.27",
@@ -220,6 +220,7 @@
     "start": "pnpm storybook",
     "start-deprecated-demo": "start-js",
     "test": "jest",
+    "test:ci": "jest --watchAll=false --coverage",
     "test:coverage": "jest --coverage",
     "build": "pnpm build:js && pnpm build:copy-assets && pnpm build:esbuild",
     "build:js": "tsc --build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,10 +1,7 @@
 lockfileVersion: '6.0'
 
 overrides:
-  '@types/plotly.js': 1.54.22
-  '@types/plotly.js-basic-dist': 1.54.1
   '@types/react': 18.0.27
-  '@types/react-plotly.js': ^2.6.0
   goober: 2.1.9
   react-hot-toast: 2.2.0
 
@@ -87,8 +84,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       plotly.js-basic-dist:
-        specifier: ^1.47.3
-        version: 1.58.5
+        specifier: ^2.22.0
+        version: 2.22.0
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -139,8 +136,8 @@ importers:
         specifier: 11.10.4
         version: 11.10.4
       '@types/plotly.js':
-        specifier: 1.54.22
-        version: 1.54.22
+        specifier: ^2.12.18
+        version: 2.12.18
       '@types/react':
         specifier: 18.0.27
         version: 18.0.27
@@ -307,8 +304,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       plotly.js-basic-dist:
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.22.0
+        version: 2.22.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -365,8 +362,8 @@ importers:
         specifier: 11.10.4
         version: 11.10.4
       '@types/plotly.js':
-        specifier: 1.54.22
-        version: 1.54.22
+        specifier: ^2.12.18
+        version: 2.12.18
       '@types/react':
         specifier: 18.0.27
         version: 18.0.27
@@ -524,8 +521,8 @@ importers:
         specifier: ^2.29.4
         version: 2.29.4
       plotly.js-basic-dist:
-        specifier: ^1.47.3
-        version: 1.58.5
+        specifier: ^2.22.0
+        version: 2.22.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -576,8 +573,8 @@ importers:
         specifier: 11.10.4
         version: 11.10.4
       '@types/plotly.js':
-        specifier: 1.54.22
-        version: 1.54.22
+        specifier: ^2.12.18
+        version: 2.12.18
       '@types/react':
         specifier: 18.0.27
         version: 18.0.27
@@ -858,8 +855,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(@emotion/react@11.10.6)(@emotion/styled@11.10.6)(@mui/material@5.11.16)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       plotly.js-basic-dist:
-        specifier: ^2.11.1
-        version: 2.18.0
+        specifier: ^2.22.0
+        version: 2.22.0
       pluralize:
         specifier: ^8.0.0
         version: 8.0.0
@@ -1099,10 +1096,10 @@ importers:
         specifier: ^14.14.31
         version: 14.18.36
       '@types/plotly.js':
-        specifier: 1.54.22
-        version: 1.54.22
+        specifier: ^2.12.18
+        version: 2.12.18
       '@types/plotly.js-basic-dist':
-        specifier: 1.54.1
+        specifier: ^1.54.1
         version: 1.54.1
       '@types/pluralize':
         specifier: ^0.0.29
@@ -6761,10 +6758,6 @@ packages:
       '@types/d3-selection': 3.0.4
     dev: false
 
-  /@types/d3@3.5.47:
-    resolution: {integrity: sha512-VkWIQoZXLFdcBGe5pdBKJmTU3fmpXvo/KV6ixvTzOMl1yJ2hbTXpfvsziag0kcaerPDwas2T0vxojwQG3YwivQ==}
-    dev: true
-
   /@types/d3@7.4.0:
     resolution: {integrity: sha512-jIfNVK0ZlxcuRDKtRS/SypEyOQ6UHaFQBKv032X45VvxSJ6Yi5G9behy9h6tNTHTDGh5Vq+KbmBjUWLgY4meCA==}
     dependencies:
@@ -7064,13 +7057,11 @@ packages:
   /@types/plotly.js-basic-dist@1.54.1:
     resolution: {integrity: sha512-PAowclM1Z9nfTGqLn2KrN3dDXF2M9TalggShN/k/6jyUZTkxfgSoJ3HGReyUqjxsRBgUZnWRIPmLOA+sDsGWFA==}
     dependencies:
-      '@types/plotly.js': 1.54.22
+      '@types/plotly.js': 2.12.18
     dev: true
 
-  /@types/plotly.js@1.54.22:
-    resolution: {integrity: sha512-/xL9++eA7VnIIZqNQOw6sZ7DtEmfoHj5rAD2CjU2LCOqem/BxTA1KlpdUWEHOiou6za4HKnM+Nvho3jTBPYJ/w==}
-    dependencies:
-      '@types/d3': 3.5.47
+  /@types/plotly.js@2.12.18:
+    resolution: {integrity: sha512-ff+CIEWnqZNjZqHtQZvkEAVuLs9fkm1f54QnPVmgoET7wMHdSqUka2hasVN4e5yfHD05YwGjsAtCseewJh/BMw==}
     dev: true
 
   /@types/pluralize@0.0.29:
@@ -7152,7 +7143,7 @@ packages:
   /@types/react-plotly.js@2.6.0:
     resolution: {integrity: sha512-nJJ57U0/CNDAO+F3dpnMgM8PtjLE/O1I3O6gq4+5Q13uKqrPnHGYOttfdzQJ4D7KYgF609miVzEYakUS2zds8w==}
     dependencies:
-      '@types/plotly.js': 1.54.22
+      '@types/plotly.js': 2.12.18
       '@types/react': 18.0.27
     dev: true
 
@@ -15470,12 +15461,8 @@ packages:
       uniq: 1.0.1
     dev: false
 
-  /plotly.js-basic-dist@1.58.5:
-    resolution: {integrity: sha512-Srbt1ACLknY2r655udWwc8cxEan0FvhQUDkX/VW9NATNs5g38mc+OTLmZIRmUrJu2Sr/jDXqZ4EqFnzN9dOXvQ==}
-    dev: false
-
-  /plotly.js-basic-dist@2.18.0:
-    resolution: {integrity: sha512-LnIcc6TBK25VdW605Njp2wNL9PVkFS6IRIWR0gCLx49GeOJYv6E+i/lr7KqKQj1MVBo4f/qNDKL5q/xWlpkzGQ==}
+  /plotly.js-basic-dist@2.22.0:
+    resolution: {integrity: sha512-aNOXARIJ60OzGpOLi3HEyV1dIZDtNW0iQbwYCNZmKLMzeT5dWWqLVcLq9hGWxS8R0rGmzlcz0YmZCflfQGlckw==}
     dev: false
 
   /plotly.js@1.58.5:


### PR DESCRIPTION
- In SRC we're using Plotly.js v2, so bump that to the most recent v2 release in all packages
- Fix plotly types packages to avoid conflict
- Add test:ci so the Nx parallel runner doesn't enter interactive mode locally, and coverage will be collected in CI