### PR TITLE
PORTALS-2624: refactor SubscribersModal and ProfileAvatar to use MUI components

### DIFF
--- a/apps/SageAccountWeb/src/components/ProfileAvatar.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileAvatar.tsx
@@ -1,7 +1,7 @@
 import Slider from '@mui/material/Slider'
 import React, { useEffect, useState } from 'react'
-import { Button, IconButton, SxProps } from '@mui/material'
-import { Modal } from 'react-bootstrap'
+import { Box, IconButton, SxProps } from '@mui/material'
+import { ConfirmationDialog } from 'synapse-react-client/dist/containers/ConfirmationDialog'
 import Cropper from 'react-easy-crop'
 import { Area } from 'react-easy-crop/types'
 import Person from '@mui/icons-material/Person'
@@ -130,6 +130,8 @@ export const ProfileAvatar = (props: ProfileAvatarProps) => {
     setOpenCropModal(false)
   }
 
+  const cropperSize = '400px'
+
   return (
     <div className="profile-avatar">
       <>
@@ -153,51 +155,46 @@ export const ProfileAvatar = (props: ProfileAvatarProps) => {
         <UploadImageButton />
       </>
 
-      <Modal
-        className="bootstrap-4-backport"
-        show={openCropModal}
-        onHide={() => setOpenCropModal(false)}
-        animation={false}
-        centered
-      >
-        <Modal.Body className="cropper-modal-body">
-          <div>
-            <Cropper
-              image={image}
-              crop={crop}
-              zoom={zoom}
-              aspect={1}
-              cropShape="round"
-              onCropChange={setCrop}
-              onZoomChange={setZoom}
-              onCropComplete={onCropComplete}
-            />
-          </div>
-        </Modal.Body>
-        <Slider
-          min={1}
-          max={3}
-          step={0.1}
-          value={zoom}
-          onChange={(e, zoom) => setZoom(zoom as number)}
-        />
-        <div className="modal-btn-container">
-          <Button
-            className="modal-btn btn-container emptyButton"
-            onClick={closeCropModal}
-          >
-            Cancel
-          </Button>
-          <Button
-            disabled={imageLoading}
-            className="modal-btn btn-container"
-            variant="contained"
-            onClick={!imageLoading ? onCrop : () => ''}
-          >
-            {imageLoading ? 'Loading...' : 'Save'}
-          </Button>
-        </div>
-      </Modal>
+      <ConfirmationDialog
+        open={openCropModal}
+        title="Crop Image"
+        fullWidth
+        onCancel={() => setOpenCropModal(false)}
+        content={
+          <>
+            <Box
+              width={cropperSize}
+              height={cropperSize}
+              margin="20px auto"
+              position="relative"
+            >
+              <Cropper
+                image={image}
+                crop={crop}
+                zoom={zoom}
+                aspect={1}
+                cropShape="round"
+                onCropChange={setCrop}
+                onZoomChange={setZoom}
+                onCropComplete={onCropComplete}
+              />
+            </Box>
+            <Box justifyContent="center" display="flex">
+              <Slider
+                min={1}
+                max={3}
+                step={0.1}
+                value={zoom}
+                onChange={(e, zoom) => setZoom(zoom as number)}
+                sx={{ width: cropperSize }}
+              />
+            </Box>
+          </>
+        }
+        onConfirm={!imageLoading ? onCrop : () => ''}
+        confirmButtonDisabled={imageLoading}
+        confirmButtonText={imageLoading ? 'Loading...' : 'Save'}
+      />
     </div>
   )
 }

--- a/apps/SageAccountWeb/src/style/_ProfileAvatar.scss
+++ b/apps/SageAccountWeb/src/style/_ProfileAvatar.scss
@@ -22,23 +22,4 @@
       }
     }
   }
-
-  .modal-content {
-    .cropper-modal-body {
-      width: 400px;
-      height: 400px;
-      margin: 20px auto;
-    }
-  }
-
-  .modal-btn-container {
-    margin: auto;
-    padding: 20px;
-
-    .modal-btn {
-      display: inline-block;
-      width: 150px;
-      min-width: 0;
-    }
-  }
 }

--- a/apps/SageAccountWeb/src/style/theme.ts
+++ b/apps/SageAccountWeb/src/style/theme.ts
@@ -27,6 +27,7 @@ export const sageAccountWebThemeOverrides: ThemeOptions = {
             '0px 4px 4px rgba(0, 0, 0, 0.03), 0px 2px 2px rgba(0, 0, 0, 0.03), 0px 1px 1px rgba(0, 0, 0, 0.03)',
           borderRadius: '3px',
           fontWeight: 700,
+          fontSize: '16px',
           '&:hover': {
             backgroundColor: '#FFFFFF',
             border: '1px solid #b5bcc3',

--- a/apps/SageAccountWeb/src/style/theme.ts
+++ b/apps/SageAccountWeb/src/style/theme.ts
@@ -16,7 +16,6 @@ export const sageAccountWebThemeOverrides: ThemeOptions = {
           padding: '14px 16px',
           height: '52px',
           fontWeight: '900',
-          fontSize: '16px',
           borderRadius: '3px',
         },
         outlined: {
@@ -27,7 +26,6 @@ export const sageAccountWebThemeOverrides: ThemeOptions = {
             '0px 4px 4px rgba(0, 0, 0, 0.03), 0px 2px 2px rgba(0, 0, 0, 0.03), 0px 1px 1px rgba(0, 0, 0, 0.03)',
           borderRadius: '3px',
           fontWeight: 700,
-          fontSize: '16px',
           '&:hover': {
             backgroundColor: '#FFFFFF',
             border: '1px solid #b5bcc3',
@@ -73,6 +71,9 @@ export const sageAccountWebThemeOverrides: ThemeOptions = {
     allVariants: {
       fontFamily: latoFont,
       fontSize: '14px',
+    },
+    button: {
+      fontSize: '16px',
     },
     headline2: {
       fontWeight: 700,

--- a/packages/synapse-react-client/src/lib/containers/ConfirmationDialog.tsx
+++ b/packages/synapse-react-client/src/lib/containers/ConfirmationDialog.tsx
@@ -9,6 +9,7 @@ export type ConfirmationButtonsProps = {
   confirmButtonClassName?: string
   confirmButtonColor?: ButtonProps['color']
   confirmButtonVariant?: ButtonProps['variant']
+  confirmButtonDisabled?: boolean
   hasCancelButton?: boolean
 }
 
@@ -20,6 +21,7 @@ export const ConfirmationButtons = (props: ConfirmationButtonsProps) => {
     confirmButtonClassName,
     confirmButtonColor = 'primary',
     confirmButtonVariant = 'contained',
+    confirmButtonDisabled = false,
     onConfirm,
     onCancel,
     hasCancelButton = true,
@@ -36,6 +38,7 @@ export const ConfirmationButtons = (props: ConfirmationButtonsProps) => {
         className={confirmButtonClassName}
         color={confirmButtonColor}
         onClick={() => onConfirm()}
+        disabled={confirmButtonDisabled}
       >
         {confirmButtonText}
       </Button>

--- a/packages/synapse-react-client/src/lib/containers/discussion_forum/SubscribersModal.tsx
+++ b/packages/synapse-react-client/src/lib/containers/discussion_forum/SubscribersModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Modal } from 'react-bootstrap'
+import { ConfirmationDialog } from '../ConfirmationDialog'
 import { useSubscription } from '../../utils/hooks/SynapseAPI/subscription/useSubscription'
 import { SubscriptionObjectType } from '../../utils/synapseTypes/Subscription'
-import { Button } from '@mui/material'
+import { Link } from '@mui/material'
 import UserCard from '../UserCard'
 import { SMALL_USER_CARD } from '../../utils/SynapseConstants'
 
@@ -24,36 +24,29 @@ export const SubscribersModal: React.FC<SubscribersModalProps> = ({
   return (
     <div className="SubscribersModal">
       {subscribers && subscribers.subscribers.length > 0 && (
-        <a
+        <Link
           onClick={() => handleModal(true)}
-        >{`Followers (${subscribers.subscribers.length})`}</a>
+        >{`Followers (${subscribers.subscribers.length})`}</Link>
       )}
-      <Modal
-        className="bootstrap-4-backport"
-        show={showModal}
-        onHide={() => handleModal(false)}
-        animation={false}
-      >
-        <Modal.Header closeButton>
-          <Modal.Title>Followers</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          {subscribers &&
-            subscribers.subscribers.map(user => (
-              <UserCard
-                key={user}
-                ownerId={user}
-                size={SMALL_USER_CARD}
-                showCardOnHover={true}
-              />
-            ))}
-        </Modal.Body>
-        <Modal.Footer>
-          <Button variant="contained" onClick={() => handleModal(false)}>
-            Ok
-          </Button>
-        </Modal.Footer>
-      </Modal>
+      <ConfirmationDialog
+        open={showModal}
+        onCancel={() => handleModal(false)}
+        title="Followers"
+        content={
+          subscribers &&
+          subscribers.subscribers.map(user => (
+            <UserCard
+              key={user}
+              ownerId={user}
+              size={SMALL_USER_CARD}
+              showCardOnHover={true}
+            />
+          ))
+        }
+        onConfirm={() => handleModal(false)}
+        confirmButtonText="Ok"
+        hasCancelButton={false}
+      />
     </div>
   )
 }


### PR DESCRIPTION
component | main | feature
:---:|:---:|:---:
SubscribersModal | <img width="1628" alt="main_SubscribersModal" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/1275036f-f6cb-4df9-b7a8-7ea19208252e"> | <img width="1629" alt="feature_SubscribersModal" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/a6bbe770-f499-4b85-8391-5427a0c23dc2">
ProfileAvatar | <img width="1352" alt="main_ProfileAvatar" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/a261d252-8457-4d23-aebe-dc5497278c01"> | <img width="1348" alt="feature_ProfileAvatar" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/5cf90b8b-73d0-4fa4-bf7f-c6ae992492a0">
