### PR TITLE
Stabilize a few UI checks in Chromatic

### DIFF
--- a/.github/workflows/deploy-to-chromatic.yml
+++ b/.github/workflows/deploy-to-chromatic.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
           # Chromatic requires full git history to track changes
           fetch-depth: 0
       - uses: ./.github/actions/pnpm-setup-action

--- a/packages/synapse-react-client/.storybook/preview-head.html
+++ b/packages/synapse-react-client/.storybook/preview-head.html
@@ -1,8 +1,8 @@
 <script>
   window.global = window
-  window.sql = {}
 </script>
 
+<link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" />
 <link
   rel="stylesheet"
   href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
@@ -51,18 +51,3 @@
 <script src="https://cdn.jsdelivr.net/npm/markdown-it-container@2.0.0/dist/markdown-it-container.min.js"></script>
 <!-- end synapse markdown imports -->
 <script crossorigin src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-<script
-  crossorigin
-  src="https://unpkg.com/react-plotly.js@1.0.2/dist/create-plotly-component.js"
-></script>
-
-<script>
-  const currentStack = JSON.parse(
-    window.localStorage.getItem('SynapseReactClientStyleGuideStack') ?? 'null',
-  )
-  if (currentStack) {
-    window.SRC = {
-      OVERRIDE_ENDPOINT_CONFIG: currentStack,
-    }
-  }
-</script>

--- a/packages/synapse-react-client/.storybook/preview-head.html
+++ b/packages/synapse-react-client/.storybook/preview-head.html
@@ -1,9 +1,7 @@
 <script>
   window.global = window
 </script>
-<!-- Preload the Lato font because delayed font loads can cause screenshot instability in Chromatic -->
-<link rel="preload" href="https://fonts.googleapis.com/css?family=Lato" as="style">
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato">
+
 <link
   rel="stylesheet"
   href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"

--- a/packages/synapse-react-client/.storybook/preview-head.html
+++ b/packages/synapse-react-client/.storybook/preview-head.html
@@ -2,7 +2,7 @@
   window.global = window
 </script>
 
-<link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" />
+<link rel="preload" href="https://fonts.googleapis.com/css?family=Lato" onload="this.rel='stylesheet'" />
 <link
   rel="stylesheet"
   href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"

--- a/packages/synapse-react-client/.storybook/preview-head.html
+++ b/packages/synapse-react-client/.storybook/preview-head.html
@@ -1,8 +1,9 @@
 <script>
   window.global = window
 </script>
-
-<link rel="preload" href="https://fonts.googleapis.com/css?family=Lato" onload="this.rel='stylesheet'" />
+<!-- Preload the Lato font because delayed font loads can cause screenshot instability in Chromatic -->
+<link rel="preload" href="https://fonts.googleapis.com/css?family=Lato" as="style">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato">
 <link
   rel="stylesheet"
   href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"

--- a/packages/synapse-react-client/.storybook/preview.jsx
+++ b/packages/synapse-react-client/.storybook/preview.jsx
@@ -6,6 +6,7 @@ import { StorybookComponentWrapper } from '../src/components/StorybookComponentW
 import { initialize, mswLoader } from 'msw-storybook-addon'
 import { getHandlers } from '../mocks/msw/handlers'
 import { MOCK_REPO_ORIGIN } from '../src/utils/functions/getEndpoint'
+import isChromatic from 'chromatic/isChromatic'
 
 globalThis.Buffer = Buffer
 globalThis.process = {
@@ -113,7 +114,15 @@ initialize({
   },
 })
 
+const fontLoader = async () => ({
+  fonts: await Promise.all([document.fonts.load('700 1em Lato')]),
+})
+
 export const loaders = [mswLoader]
+
+if (isChromatic && document.fonts) {
+  loaders.push(fontLoader)
+}
 
 export const decorators = [
   (Story, context) => {

--- a/packages/synapse-react-client/stories/SubsectionRowRenderer.stories.ts
+++ b/packages/synapse-react-client/stories/SubsectionRowRenderer.stories.ts
@@ -9,9 +9,12 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Demo: Story = {
+  name: 'SubsectionRowRenderer',
   args: {
-    sql: 'SELECT funderName as "Funding Agency" FROM syn26344829',
-    searchParams: { Resource_id: '844b598c-0171-4972-91c3-27aa21b45d52' },
+    sql: 'SELECT abstract as "Summary" FROM syn21918972',
+    searchParams: {
+      grantNumber: 'CA217655',
+    },
     isMarkdown: false,
   },
 }

--- a/packages/synapse-react-client/stories/SubsectionRowRenderer.stories.ts
+++ b/packages/synapse-react-client/stories/SubsectionRowRenderer.stories.ts
@@ -11,7 +11,7 @@ type Story = StoryObj<typeof meta>
 export const Demo: Story = {
   name: 'SubsectionRowRenderer',
   args: {
-    sql: 'SELECT abstract as "Summary" FROM syn21918972',
+    sql: 'SELECT abstract as "Summary" FROM syn21918972.488',
     searchParams: {
       grantNumber: 'CA217655',
     },


### PR DESCRIPTION
- Update action to reference the pull request ref so the actual changes get deployed and tested
- Load Lato font in Storybook preview-head, since it looks like UI tests commonly get flagged as changed when the font doesn't load in time for the screenshot. See https://www.chromatic.com/docs/resource-loading
- Update SubsectionRowRenderer demo to use existing table. The previous table used in the demo no longer exists, and when that happens we show a skeleton that uses a random number to determine its appearance, which is obviously not stable for snapshots.