### PR TITLE
EC-122

### DIFF
--- a/apps/portals/src/_Core.scss
+++ b/apps/portals/src/_Core.scss
@@ -23,7 +23,7 @@
 }
 
 %home-bg-util {
-  background: rgba(38, 153, 167, 0.03);
+  background: rgba(Portal.$primary-action-color, 0.05);
   &:last-child {
     // this handles the case when the last element on the home page
     // has its background colored and should not have padding on the bottom
@@ -722,9 +722,11 @@ div[data-id='tooltip'] {
 }
 
 .QueryWrapperPlotNav {
-  .TopLevelControls,
   .FacetFilterControls {
     padding: 10px 5px 10px 30px;
+  }
+  .TopLevelControls {
+    margin: 10px 5px 10px 30px;
   }
   .TotalQueryResults.hasFilters > * {
     margin-left: 30px;
@@ -734,9 +736,11 @@ div[data-id='tooltip'] {
 
 .DetailsPage {
   .QueryWrapperPlotNav {
-    .TopLevelControls,
     .FacetFilterControls {
       padding: 0px;
+    }
+    .TopLevelControls {
+      margin: 0px;
     }
     .TotalQueryResults.hasFilters > * {
       margin-left: 0px;

--- a/apps/portals/src/configurations/elportal/footerConfig.ts
+++ b/apps/portals/src/configurations/elportal/footerConfig.ts
@@ -1,7 +1,7 @@
 import { FooterConfig } from 'types/portal-config'
 
 const footer: FooterConfig = {
-  about: '/About',
+  contactUs: 'https://sagebionetworks.jira.com/servicedesk/customer/portal/12',
 }
 
 export default footer

--- a/apps/portals/src/configurations/elportal/routeControlWrapperProps.ts
+++ b/apps/portals/src/configurations/elportal/routeControlWrapperProps.ts
@@ -6,12 +6,12 @@ const routeControlWrapper: RouteControlWrapperProps = {
   customRoutes: [
     'Data by Files',
     'Data by Participants',
-    'Species',
     'Projects',
+    'Species',
     'Studies',
     'Publications',
+    'Computational Tools',
     'People',
-    'Computational Tools'
   ],
 }
 

--- a/apps/portals/src/configurations/elportal/routesConfig.ts
+++ b/apps/portals/src/configurations/elportal/routesConfig.ts
@@ -109,11 +109,6 @@ const routes: GenericRoute[] = [
         props: {
           config: [
             {
-              title: 'Cross-Species Research Partners',
-              ownerId: 'syn27229419',
-              wikiId: '621472',
-            },
-            {
               title: 'Data Portals',
               ownerId: 'syn27229419',
               wikiId: '621470',
@@ -123,12 +118,17 @@ const routes: GenericRoute[] = [
               ownerId: 'syn27229419',
               wikiId: '621471',
             },
+            {
+              title: 'Cross-Species Research Partners',
+              ownerId: 'syn27229419',
+              wikiId: '621472',
+            },
           ],
         },
       },
       {
         name: 'UserCardListRotate',
-        title: 'Our People and Institutions',
+        title: 'Our People & Institutions',
         outsideContainerClassName: 'home-spacer home-bg-dark',
         centerTitle: true,
         props: {
@@ -137,7 +137,7 @@ const routes: GenericRoute[] = [
           size: SynapseConstants.MEDIUM_USER_CARD,
           useQueryResultUserData: true,
           summaryLink: 'Explore/People',
-          summaryLinkText: 'Explore All People',
+          summaryLinkText: 'View All People',
         },
       },
       // {
@@ -191,20 +191,6 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        path: 'Species',
-        exact: true,
-        synapseConfigArray: [
-          {
-            name: 'RouteControlWrapper',
-            isOutsideContainer: true,
-            props: {
-              ...RouteControlWrapperProps,
-              synapseConfig: species,
-            },
-          },
-        ],
-      },
-      {
         path: 'Projects',
         routes: [
           {
@@ -239,6 +225,20 @@ const routes: GenericRoute[] = [
                 props: projectsDetailsPageConfiguration,
               },
             ],
+          },
+        ],
+      },
+      {
+        path: 'Species',
+        exact: true,
+        synapseConfigArray: [
+          {
+            name: 'RouteControlWrapper',
+            isOutsideContainer: true,
+            props: {
+              ...RouteControlWrapperProps,
+              synapseConfig: species,
+            },
           },
         ],
       },
@@ -283,20 +283,6 @@ const routes: GenericRoute[] = [
       },
       {
         exact: true,
-        path: 'People',
-        synapseConfigArray: [
-          {
-            name: 'RouteControlWrapper',
-            isOutsideContainer: true,
-            props: {
-              ...RouteControlWrapperProps,
-              synapseConfig: people,
-            },
-          },
-        ],
-      },
-      {
-        exact: true,
         path: 'Computational Tools',
         synapseConfigArray: [
           {
@@ -305,6 +291,20 @@ const routes: GenericRoute[] = [
             props: {
               ...RouteControlWrapperProps,
               synapseConfig: computationalTools,
+            },
+          },
+        ],
+      },
+      {
+        exact: true,
+        path: 'People',
+        synapseConfigArray: [
+          {
+            name: 'RouteControlWrapper',
+            isOutsideContainer: true,
+            props: {
+              ...RouteControlWrapperProps,
+              synapseConfig: people,
             },
           },
         ],

--- a/packages/synapse-react-client/src/style/components/_query-wrapper-plot-nav.scss
+++ b/packages/synapse-react-client/src/style/components/_query-wrapper-plot-nav.scss
@@ -151,8 +151,7 @@
       margin-top: 0px;
     }
   }
-  background-color: rgba(map.get(SRC.$primary-color-palette, 500), 0.05);
-  border-bottom: 1px solid map.get(SRC.$colors, 'gray-300');
+  background-color: map.get(SRC.$colors, 'gray-300');
   &__showhidefacetfilters {
     display: none;
   }


### PR DESCRIPTION
Moving a few items around in the ELITE portal config, and a few design-led changes to color and background.

Query plot nav header (gray instead of portal primary color based color, with slight change in size of panel):
<img width="1407" alt="Screen Shot 2023-05-19 at 5 57 12 PM" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/1864447/fffe46b9-cad5-4c0d-b88b-144c754571c6">

Home page alternating background colors, now based on the portal primary color instead of hard-coded to a light grey.
<img width="1399" alt="Screen Shot 2023-05-19 at 5 56 35 PM" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/1864447/72286caf-36c3-4d3f-91f7-040bc883d759">

<img width="1405" alt="Screen Shot 2023-05-19 at 5 56 05 PM" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/1864447/89bccc86-5581-4167-abf1-aafce5c88798">

