### PR TITLE
trivial fix for 2fa verification code input

### DIFF
--- a/packages/synapse-react-client/src/components/Authentication/TOTPForm.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/TOTPForm.tsx
@@ -25,7 +25,7 @@ export default function TOTPForm(props: TOTPFormProps) {
         validateChar={(character: string) => {
           return DIGIT_CHARACTERS.includes(character) || character === ''
         }}
-        gap={0}
+        gap={'2px'}
         sx={{
           '.MuiInputBase-root': {
             paddingLeft: '5px',


### PR DESCRIPTION
Before:
<img width="336" alt="Screen Shot 2023-05-22 at 10 55 40 AM" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/1864447/2335f61c-61c4-41c4-8da5-e360d96683c9">

After:
<img width="335" alt="Screen Shot 2023-05-22 at 10 57 16 AM" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/1864447/ee351891-bff4-4de9-8fcc-593257cf799d">
