### PR TITLE
EC-123: append another wiki page to the Data Access route

### DIFF
--- a/apps/portals/src/configurations/elportal/routesConfig.ts
+++ b/apps/portals/src/configurations/elportal/routesConfig.ts
@@ -350,6 +350,14 @@ const routes: GenericRoute[] = [
           loadingSkeletonRowCount: 10,
         },
       },
+      {
+        name: 'Markdown',
+        props: {
+          ownerId: 'syn27229419',
+          wikiId: '622372',
+          loadingSkeletonRowCount: 10,
+        },
+      },
     ],
   },
 


### PR DESCRIPTION
<img width="1313" alt="Screen Shot 2023-05-23 at 3 17 58 PM" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/1864447/bba9ad34-68bd-49ed-8a0a-5854750ff53a">
