### PR TITLE
Auto-accept changes on `main` to set an accurate baseline

### DIFF
--- a/.github/workflows/deploy-to-chromatic.yml
+++ b/.github/workflows/deploy-to-chromatic.yml
@@ -32,3 +32,4 @@ jobs:
           workingDir: packages/synapse-react-client
           exitZeroOnChanges: true
           exitOnceUploaded: true
+          autoAcceptChanges: 'main'


### PR DESCRIPTION
See https://www.chromatic.com/docs/branching-and-baselines

Currently, screenshot diffs have a baseline of a very early commit because we aren't marking changes as 'accepted'.

If we auto-accept the changes on main, then the screenshot diffs in a PR will always diff between the PR and main branch (unless a UI change was accepted in an ancestor commit in the PR nearer than `main`).