### PR TITLE
SWC-6432: Show wiki instructions with forms for ManagedACTAccessRequirement

### DIFF
--- a/packages/synapse-react-client/.storybook/preview.jsx
+++ b/packages/synapse-react-client/.storybook/preview.jsx
@@ -64,12 +64,13 @@ export const globalTypes = {
     title: 'Stack Changer',
     description:
       'Choose the stack that Synapse should point to. You may need to re-authenticate after changing stacks.',
-    defaultValue: 'production',
+    defaultValue: null,
     toolbar: {
       icon: 'database',
       dynamicTitle: true,
       showName: true,
       items: [
+        { value: null, title: 'default (usually production)' },
         { value: 'production', title: 'Production' },
         { value: 'staging', title: 'Staging' },
         { value: 'development', title: 'Development' },

--- a/packages/synapse-react-client/mocks/mockWiki.ts
+++ b/packages/synapse-react-client/mocks/mockWiki.ts
@@ -1,6 +1,9 @@
 import { WikiPage } from '@sage-bionetworks/synapse-types'
 import { MOCK_USER_ID, MOCK_USER_ID_2 } from './user/mock_user_profile'
 
+const mockWikiMarkdown =
+  '**You have access to these data under the following terms:**\n\nAccess to these data is controlled at the request of the data contributor(s) and due to the sensitive nature of the data. The terms for data access cannot be modified. \n&nbsp;\nClick the **Request Access** button below to start your application, where you will be prompted to enter:\n1.\tA brief Intended Data Use statement to be posted on the AD Knowledge Portal (500 words maximum in English). The Intended Data Use statement must include the following:\n     * **The names of the AD Knowledge Portal studies from which you plan to access data.** A full list of study names can be found **[here](https://adknowledgeportal.synapse.org/Explore/Studies)**.\n     * Objectives of the proposed research\n     * Study design and analysis plan\n2.\tList the Synapse username of all collaborators from your institution who will be accessing the data. \n3.\tSubmit the embedded [Data Use Certificate (DUC)](https://www.synapse.org/#!Synapse:syn25441378) signed by yourself, your institutional signing official, and all collaborating investigators from your institution who will be accessing the data\n\n&nbsp;\nFor annual renewal or to add an investigator to an existing DUC, please see the instructions provided on the [AD Portal Docs](https://help.adknowledgeportal.org/apd/Data-Use-Certificates.2623373330.html) help page.\n\nExpected data access application review time is one to two weeks.  Once approved, data may be used for one year.  You must submit a renewal at the conclusion of one year, otherwise your access will be revoked.\n\n**Please note that it is a violation of the Data Access Terms and Conditions to share Individual-level Human data and/or results outside of the AD Knowledge Portal**. This is true for files obtained directly from the AD Knowledge Portal and/or generated through your own analysis. Also, proper acknowledgment of data sources is mandatory in publications based on secondary data use.  See the [Data Use and Acknowledgement ](https://help.adknowledgeportal.org/apd/Data-Use-&-Acknowledgement.2623242281.html) instructions for more information.\n\n&nbsp;\nIf you have questions about the data access process, please contact the Synapse Access & Compliance Team by submitting your question to the [Access and Compliance Team Help Center Portal](https://sagebionetworks.jira.com/servicedesk/customer/portal/8) or by emailing the team at act@sagebionetworks.org.  \n'
+
 export const mockManagedACTAccessRequirementWikiPage: WikiPage = {
   id: '123',
   etag: '00924558-f46d-4f05-9f62-0686ddecf8ed',
@@ -9,9 +12,7 @@ export const mockManagedACTAccessRequirementWikiPage: WikiPage = {
   modifiedOn: '2022-12-06T23:18:27.877Z',
   modifiedBy: MOCK_USER_ID_2.toString(),
   title: '',
-  markdown:
-    'Access to these data is controlled at the request of the data contributor(s) and due to the sensitive nature of the data. ' +
-    'Click the **Request Access** button below to start your application, where you will be prompted to enter information about yourself and your research project.',
+  markdown: mockWikiMarkdown,
   attachmentFileHandleIds: [],
 }
 

--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { PRODUCTION_ENDPOINT_CONFIG } from '../../utils/functions/getEndpoint'
 import useGetInfoFromIds, {
   UseGetInfoFromIdsProps,
@@ -40,6 +40,7 @@ import {
 import TwoFactorAuthEnabledRequirement from './RequirementItem/TwoFactorAuthEnabledRequirement'
 import { AccessRequirementListItem } from './AccessRequirementListItem'
 import { useSynapseContext } from '../../utils/context/SynapseContext'
+import { useCanShowManagedACTWikiInWizard } from './AccessRequirementListUtils'
 
 export type AccessRequirementListProps = {
   entityId: string // will show this entity info
@@ -143,6 +144,7 @@ export default function AccessRequirementList(
     ids: [entityId],
     type: 'ENTITY_HEADER',
   }
+  const canShowManagedACTWikiInWizard = useCanShowManagedACTWikiInWizard()
 
   const entityInformation = useGetInfoFromIds<EntityHeader>(entityHeaderProps)
 
@@ -152,14 +154,14 @@ export default function AccessRequirementList(
       enabled: Boolean(!accessRequirementFromProps && teamId),
     },
   )
-  const { data: fetchedRequirementsForEntity } = useGetAccessRequirementsForEntity(
-    entityId,
-    {
+  const { data: fetchedRequirementsForEntity } =
+    useGetAccessRequirementsForEntity(entityId, {
       enabled: Boolean(!accessRequirementFromProps && entityId && !teamId),
-    },
-  )
+    })
 
-  const fetchedRequirements = teamId ? fetchedRequirementsForTeam : fetchedRequirementsForEntity
+  const fetchedRequirements = teamId
+    ? fetchedRequirementsForTeam
+    : fetchedRequirementsForEntity
 
   const accessRequirements = accessRequirementFromProps ?? fetchedRequirements
 
@@ -294,6 +296,14 @@ export default function AccessRequirementList(
     </>
   )
 
+  const dialogWidth =
+    [
+      RequestDataStep.UPDATE_ACCESSORS_AND_FILES,
+      RequestDataStep.UPDATE_RESEARCH_PROJECT,
+    ].includes(requestDataStep) && canShowManagedACTWikiInWizard
+      ? 'xl'
+      : 'md'
+
   let renderContent = content
   if (renderAsModal) {
     switch (requestDataStep) {
@@ -363,7 +373,7 @@ export default function AccessRequirementList(
         renderContent = content
     }
     return (
-      <Dialog maxWidth="md" fullWidth open={true} onClose={onHide}>
+      <Dialog maxWidth={dialogWidth} fullWidth open={true} onClose={onHide}>
         {renderContent}
       </Dialog>
     )

--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementListUtils.ts
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementListUtils.ts
@@ -1,5 +1,6 @@
 import { sortBy } from 'lodash-es'
 import { getAccessRequirementStatus } from '../../synapse-client/SynapseClient'
+import { useMediaQuery, useTheme } from '@mui/material'
 
 /**
  * Given an array of access requirement IDs, return the IDs sorted by the user's status, where
@@ -28,4 +29,14 @@ export const sortAccessRequirementsByCompletion = async (
       )
     )
   })
+}
+
+/**
+ * Determines if we can show ManagedACTAccessRequirement wiki content alongside the forms using a media query.
+ * See SWC-6432.
+ */
+export function useCanShowManagedACTWikiInWizard(): boolean {
+  const theme = useTheme()
+  const matchesBreakpoint = useMediaQuery(theme.breakpoints.up('md'))
+  return matchesBreakpoint
 }

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { useState } from 'react'
+import React, { useState } from 'react'
 import {
   AccessorChange,
   AccessType,
@@ -40,6 +39,7 @@ import DataAccessRequestAccessorsEditor, {
 } from './DataAccessRequestAccessorsEditor'
 import { UploadDocumentField } from './UploadDocumentField'
 import DocumentTemplate from './DocumentTemplate'
+import ManagedACTAccessRequirementFormWikiWrapper from './ManagedACTAccessRequirementFormWikiWrapper'
 
 export type DataAccessRequestAccessorsFilesFormProps = {
   /**
@@ -335,164 +335,168 @@ export default function DataAccessRequestAccessorsFilesForm(
         </Stack>
       </DialogTitle>
       <DialogContent>
-        <Box
-          component={'form'}
-          sx={{
-            // Must set a minHeight to ensure the user picker in the DataAccessRequestAccessorsEditor doesn't get cut off
-            minHeight: '475px',
-          }}
-          onSubmit={e => e.preventDefault()}
+        <ManagedACTAccessRequirementFormWikiWrapper
+          managedACTAccessRequirementId={String(managedACTAccessRequirement.id)}
         >
-          <Typography variant={'body1'} sx={{ mb: 2 }}>
-            Please provide the information below to submit the request for
-            access.
-          </Typography>
+          <Box
+            component={'form'}
+            sx={{
+              // Must set a minHeight to ensure the user picker in the DataAccessRequestAccessorsEditor doesn't get cut off
+              minHeight: '475px',
+            }}
+            onSubmit={e => e.preventDefault()}
+          >
+            <Typography variant={'body1'} sx={{ mb: 2 }}>
+              Please provide the information below to submit the request for
+              access.
+            </Typography>
 
-          {dataAccessRequest && (
-            <DataAccessRequestAccessorsEditor
-              accessorChanges={dataAccessRequest.accessorChanges || []}
-              onChange={onAccessorChange}
-              isRenewal={isRenewal}
-              helpText={<AccessorRequirementHelpText />}
-            />
-          )}
-
-          {(managedACTAccessRequirement?.isDUCRequired ||
-            managedACTAccessRequirement?.isIRBApprovalRequired ||
-            managedACTAccessRequirement?.areOtherAttachmentsRequired ||
-            isRenewal) && <Divider sx={{ my: 4 }} />}
-          {/* DUC */}
-          {managedACTAccessRequirement?.isDUCRequired && (
-            <>
-              {managedACTAccessRequirement?.ducTemplateFileHandleId && (
-                <DocumentTemplate
-                  title={'Download DUC Template'}
-                  description={
-                    'As a first step, you will need to download the most current version of the Data Use Certificate.'
-                  }
-                  fileHandleAssociation={{
-                    fileHandleId:
-                      managedACTAccessRequirement.ducTemplateFileHandleId,
-                    associateObjectType:
-                      FileHandleAssociateType.AccessRequirementAttachment,
-                    associateObjectId: String(managedACTAccessRequirement.id),
-                  }}
-                  downloadButtonText={'Download DUC Template'}
-                />
-              )}
-              <Typography variant={'headline3'} sx={{ mt: 4, mb: 2 }}>
-                Fill out and upload a Data Use Certificate
-              </Typography>
-              <Typography variant={'body1'} sx={{ my: 2 }}>
-                You must download and fill out a Data Use Certificate (DUC). Be
-                sure to upload the completed DUC below once you&apos;ve
-                completed it.
-              </Typography>
-              <Typography variant={'body1'} component={'ol'}>
-                <li>Download the DUC template file.</li>
-                <li>
-                  Fill out the DUC template, following the instructions in the
-                  file.
-                </li>
-                <li>
-                  Upload the completed certificate using the button below:
-                </li>
-              </Typography>
-              <UploadDocumentField
-                id={'duc'}
-                uploadCallback={resp => uploadCallback(resp, 'ducFileHandleId')}
-                documentName={'Data Use Certificate'}
-                fileHandleAssociations={ducFileHandleAssociation}
+            {dataAccessRequest && (
+              <DataAccessRequestAccessorsEditor
+                accessorChanges={dataAccessRequest.accessorChanges || []}
+                onChange={onAccessorChange}
+                isRenewal={isRenewal}
+                helpText={<AccessorRequirementHelpText />}
               />
-              {(managedACTAccessRequirement?.isIRBApprovalRequired ||
-                managedACTAccessRequirement?.areOtherAttachmentsRequired ||
-                isRenewal) && <Divider sx={{ my: 4 }} />}
-            </>
-          )}
+            )}
 
-          {/* IRB */}
-          {managedACTAccessRequirement?.isIRBApprovalRequired && (
-            <>
-              <Typography variant={'headline3'} sx={{ my: 2 }}>
-                IRB Approval
-              </Typography>
-              <Typography variant={'body1'} sx={{ my: 2 }}>
-                Upload a signed IRB letter on institutional letterhead. The
-                letter must include the names of all the datasets requested, as
-                well as the names of the data requesters above. Use the button
-                below to upload the document.
-              </Typography>
-              <UploadDocumentField
-                id={'irb'}
-                documentName={'IRB Approval Letter'}
-                uploadCallback={resp => uploadCallback(resp, 'irbFileHandleId')}
-                fileHandleAssociations={irbFileHandleAssociation}
-              />
-
-              {(managedACTAccessRequirement?.areOtherAttachmentsRequired ||
-                isRenewal) && <Divider sx={{ my: 4 }} />}
-            </>
-          )}
-
-          {
-            /* Attachments */
-            managedACTAccessRequirement?.areOtherAttachmentsRequired && (
+            {(managedACTAccessRequirement?.isDUCRequired ||
+              managedACTAccessRequirement?.isIRBApprovalRequired ||
+              managedACTAccessRequirement?.areOtherAttachmentsRequired ||
+              isRenewal) && <Divider sx={{ my: 4 }} />}
+            {/* DUC */}
+            {managedACTAccessRequirement?.isDUCRequired && (
               <>
-                <Typography variant={'headline3'} sx={{ my: 2 }}>
-                  Upload other required documents
+                {managedACTAccessRequirement?.ducTemplateFileHandleId && (
+                  <DocumentTemplate
+                    title={'Download DUC Template'}
+                    description={
+                      'As a first step, you will need to download the most current version of the Data Use Certificate.'
+                    }
+                    fileHandleAssociation={{
+                      fileHandleId:
+                        managedACTAccessRequirement.ducTemplateFileHandleId,
+                      associateObjectType:
+                        FileHandleAssociateType.AccessRequirementAttachment,
+                      associateObjectId: String(managedACTAccessRequirement.id),
+                    }}
+                    downloadButtonText={'Download DUC Template'}
+                  />
+                )}
+                <Typography variant={'headline3'} sx={{ mt: 4, mb: 2 }}>
+                  Fill out and upload a Data Use Certificate
                 </Typography>
                 <Typography variant={'body1'} sx={{ my: 2 }}>
-                  You must upload other required documents. Please review the
-                  instructions to gain data access to determine which documents
-                  must also be uploaded.
+                  You must download and fill out a Data Use Certificate (DUC).
+                  Be sure to upload the completed DUC below once you&apos;ve
+                  completed it.
+                </Typography>
+                <Typography variant={'body1'} component={'ol'}>
+                  <li>Download the DUC template file.</li>
+                  <li>
+                    Fill out the DUC template, following the instructions in the
+                    file.
+                  </li>
+                  <li>
+                    Upload the completed certificate using the button below:
+                  </li>
                 </Typography>
                 <UploadDocumentField
-                  id={'file-attachment'}
-                  documentName={'Attachment'}
-                  uploadCallback={res => uploadCallback(res, 'attachments')}
-                  isMultiFileUpload={true}
-                  fileHandleAssociations={attachmentFileHandleAssociations}
-                  onClearAttachment={onClearAttachment}
+                  id={'duc'}
+                  uploadCallback={resp =>
+                    uploadCallback(resp, 'ducFileHandleId')
+                  }
+                  documentName={'Data Use Certificate'}
+                  fileHandleAssociations={ducFileHandleAssociation}
                 />
-
-                {isRenewal && <Divider sx={{ my: 4 }} />}
+                {(managedACTAccessRequirement?.isIRBApprovalRequired ||
+                  managedACTAccessRequirement?.areOtherAttachmentsRequired ||
+                  isRenewal) && <Divider sx={{ my: 4 }} />}
               </>
-            )
-          }
+            )}
 
-          {
-            // Publications & Summary of Use
-            isRenewal && (
+            {/* IRB */}
+            {managedACTAccessRequirement?.isIRBApprovalRequired && (
               <>
-                <TextField
-                  id={'publications'}
-                  label={'Publication(s)'}
-                  multiline
-                  rows={3}
-                  value={dataAccessRequest?.publication}
-                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                    handleTextAreaInputChange(e, 'publication')
+                <Typography variant={'headline3'} sx={{ my: 2 }}>
+                  IRB Approval
+                </Typography>
+                <Typography variant={'body1'} sx={{ my: 2 }}>
+                  Upload a signed IRB letter on institutional letterhead. The
+                  letter must include the names of all the datasets requested,
+                  as well as the names of the data requesters above. Use the
+                  button below to upload the document.
+                </Typography>
+                <UploadDocumentField
+                  id={'irb'}
+                  documentName={'IRB Approval Letter'}
+                  uploadCallback={resp =>
+                    uploadCallback(resp, 'irbFileHandleId')
                   }
+                  fileHandleAssociations={irbFileHandleAssociation}
                 />
-                <TextField
-                  id={'summaryOfUse'}
-                  label={'Summary of use'}
-                  value={dataAccessRequest?.summaryOfUse}
-                  multiline
-                  rows={3}
-                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                    handleTextAreaInputChange(e, 'summaryOfUse')
-                  }
-                />
-              </>
-            )
-          }
 
-          {
-            /* Alert message */
-            alert && <Alert severity={alert.key}>{alert.message}</Alert>
-          }
-        </Box>
+                {(managedACTAccessRequirement?.areOtherAttachmentsRequired ||
+                  isRenewal) && <Divider sx={{ my: 4 }} />}
+              </>
+            )}
+
+            {
+              /* Attachments */
+              managedACTAccessRequirement?.areOtherAttachmentsRequired && (
+                <>
+                  <Typography variant={'headline3'} sx={{ my: 2 }}>
+                    Upload other required documents
+                  </Typography>
+                  <Typography variant={'body1'} sx={{ my: 2 }}>
+                    You must upload other required documents. Please review the
+                    instructions to gain data access to determine which
+                    documents must also be uploaded.
+                  </Typography>
+                  <UploadDocumentField
+                    id={'file-attachment'}
+                    documentName={'Attachment'}
+                    uploadCallback={res => uploadCallback(res, 'attachments')}
+                    isMultiFileUpload={true}
+                    fileHandleAssociations={attachmentFileHandleAssociations}
+                    onClearAttachment={onClearAttachment}
+                  />
+
+                  {isRenewal && <Divider sx={{ my: 4 }} />}
+                </>
+              )
+            }
+
+            {
+              // Publications & Summary of Use
+              isRenewal && (
+                <>
+                  <TextField
+                    id={'publications'}
+                    label={'Publication(s)'}
+                    multiline
+                    rows={3}
+                    value={dataAccessRequest?.publication}
+                    onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                      handleTextAreaInputChange(e, 'publication')
+                    }
+                  />
+                  <TextField
+                    id={'summaryOfUse'}
+                    label={'Summary of use'}
+                    value={dataAccessRequest?.summaryOfUse}
+                    multiline
+                    rows={3}
+                    onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                      handleTextAreaInputChange(e, 'summaryOfUse')
+                    }
+                  />
+                </>
+              )
+            }
+          </Box>
+        </ManagedACTAccessRequirementFormWikiWrapper>
+        {alert && <Alert severity={alert.key}>{alert.message}</Alert>}
       </DialogContent>
       <DialogActions>
         {

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DocumentTemplate.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DocumentTemplate.tsx
@@ -48,7 +48,12 @@ export default function DocumentTemplate(props: DownloadDocumentTemplateProps) {
         alignItems={'center'}
         justifyContent={'flex-start'}
         gap={2}
-        sx={{ backgroundColor: 'tertiary.100', p: 2.5, my: 2 }}
+        sx={{
+          backgroundColor: 'tertiary.100',
+          p: 2.5,
+          my: 2,
+          flexWrap: { xs: 'nowrap', md: 'wrap-reverse' },
+        }}
       >
         <DirectDownloadButton
           variant={'outlined'}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManagedACTAccessRequirementFormWikiWrapper.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManagedACTAccessRequirementFormWikiWrapper.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { useGetAccessRequirementWikiPageKey } from '../../../synapse-queries'
+import { useCanShowManagedACTWikiInWizard } from '../AccessRequirementListUtils'
+import { Grid, Typography } from '@mui/material'
+import MarkdownSynapse from '../../Markdown/MarkdownSynapse'
+
+type ManagedACTAccessRequirementFormWikiWrapperProps = React.PropsWithChildren<{
+  managedACTAccessRequirementId: string
+}>
+
+/**
+ * Renders the child content next to the wiki associated with the provided ManagedACTAccessRequirement. Utilizes a grid
+ * layout where the wiki content will not appear on small screen sizes.
+ *
+ * @param props
+ * @constructor
+ */
+export default function ManagedACTAccessRequirementFormWikiWrapper(
+  props: ManagedACTAccessRequirementFormWikiWrapperProps,
+) {
+  const { children, managedACTAccessRequirementId } = props
+  const { data: wikiPage } = useGetAccessRequirementWikiPageKey(
+    managedACTAccessRequirementId,
+    {
+      enabled: !!managedACTAccessRequirementId,
+    },
+  )
+
+  const canShowWiki = useCanShowManagedACTWikiInWizard()
+
+  return (
+    <Grid container spacing={5}>
+      <Grid
+        item
+        xs={12}
+        md={6}
+        lg={5}
+        sx={{
+          maxHeight: '500px',
+          overflow: 'auto',
+          pr: {
+            xs: 0,
+            md: 1,
+          },
+        }}
+      >
+        {children}
+      </Grid>
+      {canShowWiki && (
+        <Grid
+          item
+          md={6}
+          lg={7}
+          sx={{
+            maxHeight: '500px',
+            overflowY: 'scroll',
+            pr: 1,
+          }}
+        >
+          <Typography variant={'headline3'} sx={{ mb: 2 }}>
+            Instructions
+          </Typography>
+          {wikiPage && (
+            <MarkdownSynapse
+              wikiId={wikiPage.wikiPageId}
+              ownerId={wikiPage.ownerObjectId}
+              objectType={wikiPage.ownerObjectType}
+              loadingSkeletonRowCount={15}
+            />
+          )}
+        </Grid>
+      )}
+    </Grid>
+  )
+}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm.tsx
@@ -1,6 +1,8 @@
-import React from 'react'
-import { useState } from 'react'
-import { ManagedACTAccessRequirement } from '@sage-bionetworks/synapse-types'
+import React, { useState } from 'react'
+import {
+  ManagedACTAccessRequirement,
+  ResearchProject,
+} from '@sage-bionetworks/synapse-types'
 import { AlertProps } from './DataAccessRequestAccessorsFilesForm'
 import {
   Alert,
@@ -19,7 +21,7 @@ import {
   useUpdateResearchProject,
 } from '../../../synapse-queries'
 import TextField from '../../TextField/TextField'
-import { ResearchProject } from '@sage-bionetworks/synapse-types'
+import ManagedACTAccessRequirementFormWikiWrapper from './ManagedACTAccessRequirementFormWikiWrapper'
 
 export type ResearchProjectFormProps = {
   /* The access requirement to which the research project refers */
@@ -116,53 +118,56 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
         </Stack>
       </DialogTitle>
       <DialogContent>
-        <form onSubmit={handleSubmit}>
-          <Typography variant={'body1'}>
-            Please tell us about your project.
-          </Typography>
-          <TextField
-            id={'project-lead'}
-            label={'Project Lead'}
-            disabled={isLoading}
-            type="text"
-            value={projectLead}
-            required
-            onChange={e => setProjectLead(e.target.value)}
-          />
-          <TextField
-            id={'institution'}
-            label={'Institution'}
-            type="text"
-            disabled={isLoading}
-            value={institution}
-            required
-            onChange={e => setInstitution(e.target.value)}
-          />
-
-          {managedACTAccessRequirement.isIDURequired && (
+        <ManagedACTAccessRequirementFormWikiWrapper
+          managedACTAccessRequirementId={String(managedACTAccessRequirement.id)}
+        >
+          <form onSubmit={handleSubmit}>
+            <Typography variant={'body1'}>
+              Please tell us about your project.
+            </Typography>
             <TextField
-              id={'data-use'}
-              label={
-                <>
-                  Intended Data Use Statement -
-                  {managedACTAccessRequirement.isIDUPublic && (
-                    <i id={'idu-visible'}>this will be visible to the public</i>
-                  )}
-                </>
-              }
-              required
-              multiline
-              rows={10}
+              id={'project-lead'}
+              label={'Project Lead'}
               disabled={isLoading}
-              value={intendedDataUseStatement}
-              onChange={e => setIntendedDataUseStatement(e.target.value)}
+              type="text"
+              value={projectLead}
+              required
+              onChange={e => setProjectLead(e.target.value)}
             />
-          )}
-          {
-            /* Alert message */
-            alert && <Alert severity={alert.key}>{alert.message}</Alert>
-          }
-        </form>
+            <TextField
+              id={'institution'}
+              label={'Institution'}
+              type="text"
+              disabled={isLoading}
+              value={institution}
+              required
+              onChange={e => setInstitution(e.target.value)}
+            />
+
+            {managedACTAccessRequirement.isIDURequired && (
+              <TextField
+                id={'data-use'}
+                label={
+                  <>
+                    Intended Data Use Statement -
+                    {managedACTAccessRequirement.isIDUPublic && (
+                      <i id={'idu-visible'}>
+                        this will be visible to the public
+                      </i>
+                    )}
+                  </>
+                }
+                required
+                multiline
+                rows={9}
+                disabled={isLoading}
+                value={intendedDataUseStatement}
+                onChange={e => setIntendedDataUseStatement(e.target.value)}
+              />
+            )}
+          </form>
+        </ManagedACTAccessRequirementFormWikiWrapper>
+        {alert && <Alert severity={alert.key}>{alert.message}</Alert>}
       </DialogContent>
       <DialogActions>
         <Button variant="outlined" disabled={isLoading} onClick={onHide}>

--- a/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
+++ b/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
@@ -100,7 +100,10 @@ export function StorybookComponentWrapper(props: {
   const { storybookContext } = props
 
   useEffect(() => {
-    overrideEndpoint(storybookContext.globals.stack as SynapseStack)
+    overrideEndpoint(
+      (storybookContext.globals.stack as SynapseStack) ||
+        (storybookContext.parameters.stack as SynapseStack),
+    )
   }, [storybookContext.globals.stack])
 
   const [accessToken, setAccessToken] = React.useState<string | undefined>(

--- a/packages/synapse-react-client/stories/RejectDataAccessRequestModal.stories.ts
+++ b/packages/synapse-react-client/stories/RejectDataAccessRequestModal.stories.ts
@@ -7,12 +7,8 @@ import RejectDataAccessRequestModal from '../src/components/dataaccess/RejectDat
 const meta = {
   title: 'Governance/RejectDataAccessRequestModal',
   component: RejectDataAccessRequestModal,
-} satisfies Meta
-export default meta
-type Story = StoryObj<typeof meta>
-
-export const Demo: Story = {
   parameters: {
+    stack: 'mock',
     msw: {
       handlers: [
         ...getHandlersForTableQuery(
@@ -22,5 +18,11 @@ export const Demo: Story = {
       ],
     },
   },
+} satisfies Meta
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  name: 'RejectDataAccessRequestModal',
   args: { open: true, tableId: 'syn50683097' },
 }

--- a/packages/synapse-react-client/stories/SubmissionPage.stories.tsx
+++ b/packages/synapse-react-client/stories/SubmissionPage.stories.tsx
@@ -19,16 +19,7 @@ import { getUserProfileHandlers } from '../mocks/msw/handlers/userProfileHandler
 const meta = {
   title: 'Governance/SubmissionPage',
   component: SubmissionPage,
-  render: args => (
-    <>
-      <p>
-        First, use the StackChanger component to switch to the Mock Data stack
-      </p>
-      <SynapseErrorBoundary>
-        <SubmissionPage {...args} />
-      </SynapseErrorBoundary>
-    </>
-  ),
+  parameters: { stack: 'mock' },
 } satisfies Meta
 export default meta
 type Story = StoryObj<typeof meta>

--- a/packages/synapse-react-client/stories/SubscriptionPage.stories.ts
+++ b/packages/synapse-react-client/stories/SubscriptionPage.stories.ts
@@ -6,6 +6,9 @@ import { getHandlers } from '../mocks/msw/handlers'
 const meta = {
   title: 'Synapse/Following/SubscriptionPage',
   component: SubscriptionPage,
+  parameters: {
+    stack: 'mock',
+  },
 } satisfies Meta
 export default meta
 

--- a/packages/synapse-react-client/stories/SynapseFormSubmissionsGrid.stories.tsx
+++ b/packages/synapse-react-client/stories/SynapseFormSubmissionsGrid.stories.tsx
@@ -21,6 +21,7 @@ const meta: Meta = {
       defaultValue: true,
     },
   },
+  parameters: { stack: 'mock' },
   render: args => {
     const { isAuthenticated, ...rest } = args
     return (
@@ -36,11 +37,6 @@ const meta: Meta = {
                 accessToken: token,
               }}
             >
-              <p>
-                First, use the StackChanger component to switch to the Mocked
-                Data stack. Then, change `isAuthenticated` to 'true'.
-              </p>
-
               <SynapseFormSubmissionGrid token={token} {...rest} />
             </FullContextProvider>
           )

--- a/packages/synapse-react-client/stories/data-access-request/AccessRequirementList.stories.tsx
+++ b/packages/synapse-react-client/stories/data-access-request/AccessRequirementList.stories.tsx
@@ -44,6 +44,7 @@ const meta: Meta = {
       defaultValue: true,
     },
   },
+  parameters: { stack: 'mock' },
   render: args => (
     <SynapseContextConsumer>
       {context => (
@@ -55,11 +56,6 @@ const meta: Meta = {
               : undefined,
           }}
         >
-          <p>
-            First, use the StackChanger component to switch to the Mocked Data
-            stack
-          </p>
-
           <AccessRequirementList {...args} />
         </SynapseContextProvider>
       )}

--- a/packages/synapse-react-client/stories/data-access-request/AccessRequirementList.stories.tsx
+++ b/packages/synapse-react-client/stories/data-access-request/AccessRequirementList.stories.tsx
@@ -20,10 +20,10 @@ import {
   AccessRequirementStatus,
   ApprovalState,
   SubmissionState,
+  TwoFactorAuthStatus,
 } from '@sage-bionetworks/synapse-types'
 import { MOCK_USER_ID } from '../../mocks/user/mock_user_profile'
 import AccessRequirementList from '../../src/components/AccessRequirementList/AccessRequirementList'
-import { TwoFactorAuthStatus } from '@sage-bionetworks/synapse-types'
 import { getWikiHandlers } from '../../mocks/msw/handlers/wikiHandlers'
 import {
   getAccessRequirementEntityBindingHandlers,
@@ -33,6 +33,7 @@ import {
 import { getEntityHandlers } from '../../mocks/msw/handlers/entityHandlers'
 import { mockApprovedSubmission } from '../../mocks/dataaccess/MockSubmission'
 import { getCurrentUserCertifiedValidatedHandler } from '../../mocks/msw/handlers/userProfileHandlers'
+import { getResearchProjectHandlers } from '../../mocks/msw/handlers/researchProjectHandlers'
 
 const meta: Meta = {
   title: 'Governance/Data Access Request Flow/AccessRequirementList',
@@ -209,6 +210,7 @@ export const HasUnmetRequirements: Story = {
           },
         }),
         ...getWikiHandlers(MOCK_REPO_ORIGIN),
+        ...getResearchProjectHandlers(MOCK_REPO_ORIGIN),
         rest.post(
           `${MOCK_REPO_ORIGIN}${ACCESS_APPROVAL}`,
           async (req, res, ctx) => {

--- a/packages/synapse-react-client/stories/data-access-request/CertificationRequirement.stories.tsx
+++ b/packages/synapse-react-client/stories/data-access-request/CertificationRequirement.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta = {
   title:
     'Governance/Data Access Request Flow/Requirements/CertificationRequirement',
   component: CertificationRequirement,
+  parameters: { stack: 'mock' },
 } satisfies Meta
 
 export default meta

--- a/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep1.stories.tsx
+++ b/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep1.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta = {
   title:
     'Governance/Data Access Request Flow/Managed Access Requirement/Step 1 - Research Project Information',
   component: ResearchProjectForm,
+  parameters: { stack: 'mock' },
 } satisfies Meta
 
 export default meta

--- a/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep1.stories.tsx
+++ b/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep1.stories.tsx
@@ -11,7 +11,17 @@ const meta: Meta = {
   title:
     'Governance/Data Access Request Flow/Managed Access Requirement/Step 1 - Research Project Information',
   component: ResearchProjectForm,
-  parameters: { stack: 'mock' },
+  parameters: {
+    stack: 'mock',
+    chromatic: { viewports: [600, 1200] },
+    msw: {
+      handlers: [
+        ...getResearchProjectHandlers(MOCK_REPO_ORIGIN),
+        ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
+        ...getWikiHandlers(MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
 } satisfies Meta
 
 export default meta
@@ -22,15 +32,5 @@ export const Step1: Story = {
   name: 'Step 1 - Research Project Information',
   args: {
     managedACTAccessRequirement: mockManagedACTAccessRequirement,
-  },
-  parameters: {
-    chromatic: { viewports: ['600', '1200'] },
-    msw: {
-      handlers: [
-        ...getResearchProjectHandlers(MOCK_REPO_ORIGIN),
-        ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
-        ...getWikiHandlers(MOCK_REPO_ORIGIN),
-      ],
-    },
   },
 }

--- a/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep1.stories.tsx
+++ b/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep1.stories.tsx
@@ -4,6 +4,8 @@ import { mockManagedACTAccessRequirement } from '../../mocks/mockAccessRequireme
 import { MOCK_REPO_ORIGIN } from '../../src/utils/functions/getEndpoint'
 import ResearchProjectForm from '../../src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm'
 import { getResearchProjectHandlers } from '../../mocks/msw/handlers/researchProjectHandlers'
+import { getAccessRequirementHandlers } from '../../mocks/msw/handlers/accessRequirementHandlers'
+import { getWikiHandlers } from '../../mocks/msw/handlers/wikiHandlers'
 
 const meta: Meta = {
   title:
@@ -16,12 +18,18 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Step1: Story = {
+  name: 'Step 1 - Research Project Information',
   args: {
     managedACTAccessRequirement: mockManagedACTAccessRequirement,
   },
   parameters: {
+    chromatic: { viewports: ['600', '1200'] },
     msw: {
-      handlers: [...getResearchProjectHandlers(MOCK_REPO_ORIGIN)],
+      handlers: [
+        ...getResearchProjectHandlers(MOCK_REPO_ORIGIN),
+        ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
+        ...getWikiHandlers(MOCK_REPO_ORIGIN),
+      ],
     },
   },
 }

--- a/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep2.stories.tsx
+++ b/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep2.stories.tsx
@@ -12,6 +12,8 @@ import { MOCK_REPO_ORIGIN } from '../../src/utils/functions/getEndpoint'
 import { getDataAccessRequestHandlers } from '../../mocks/msw/handlers/dataAccessRequestHandlers'
 import { getUserProfileHandlers } from '../../mocks/msw/handlers/userProfileHandlers'
 import { getFileHandlers } from '../../mocks/msw/handlers/fileHandlers'
+import { getWikiHandlers } from '../../mocks/msw/handlers/wikiHandlers'
+import { getAccessRequirementHandlers } from '../../mocks/msw/handlers/accessRequirementHandlers'
 
 const meta: Meta = {
   title:
@@ -30,10 +32,13 @@ export const Request: Story = {
     researchProjectId: MOCK_RESEARCH_PROJECT_ID,
   },
   parameters: {
+    chromatic: { viewports: ['600', '1200'] },
     msw: {
       handlers: [
         ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
         ...getFileHandlers(MOCK_REPO_ORIGIN),
+        ...getWikiHandlers(MOCK_REPO_ORIGIN),
+        ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
         ...getDataAccessRequestHandlers(
           MOCK_REPO_ORIGIN,
           MOCK_DATA_ACCESS_REQUEST,
@@ -49,10 +54,13 @@ export const Renewal: Story = {
     researchProjectId: MOCK_RESEARCH_PROJECT_ID,
   },
   parameters: {
+    chromatic: { viewports: ['600', '1200'] },
     msw: {
       handlers: [
         ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
         ...getFileHandlers(MOCK_REPO_ORIGIN),
+        ...getWikiHandlers(MOCK_REPO_ORIGIN),
+        ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
         ...getDataAccessRequestHandlers(
           MOCK_REPO_ORIGIN,
           MOCK_DATA_ACCESS_RENEWAL,

--- a/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep2.stories.tsx
+++ b/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep2.stories.tsx
@@ -19,19 +19,8 @@ const meta: Meta = {
   title:
     'Governance/Data Access Request Flow/Managed Access Requirement/Step 2 - Accessors and Documentation',
   component: DataAccessRequestAccessorsFilesForm,
-} satisfies Meta
-
-export default meta
-
-type Story = StoryObj<typeof meta>
-
-export const Request: Story = {
-  args: {
-    entityId: MOCK_FOLDER_ID,
-    managedACTAccessRequirement: mockManagedACTAccessRequirement,
-    researchProjectId: MOCK_RESEARCH_PROJECT_ID,
-  },
   parameters: {
+    stack: 'mock',
     chromatic: { viewports: ['600', '1200'] },
     msw: {
       handlers: [
@@ -46,26 +35,23 @@ export const Request: Story = {
       ],
     },
   },
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Request: Story = {
+  args: {
+    entityId: MOCK_FOLDER_ID,
+    managedACTAccessRequirement: mockManagedACTAccessRequirement,
+    researchProjectId: MOCK_RESEARCH_PROJECT_ID,
+  },
 }
 export const Renewal: Story = {
   args: {
     entityId: MOCK_FOLDER_ID,
     managedACTAccessRequirement: mockManagedACTAccessRequirement,
     researchProjectId: MOCK_RESEARCH_PROJECT_ID,
-  },
-  parameters: {
-    chromatic: { viewports: ['600', '1200'] },
-    msw: {
-      handlers: [
-        ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
-        ...getFileHandlers(MOCK_REPO_ORIGIN),
-        ...getWikiHandlers(MOCK_REPO_ORIGIN),
-        ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
-        ...getDataAccessRequestHandlers(
-          MOCK_REPO_ORIGIN,
-          MOCK_DATA_ACCESS_RENEWAL,
-        ),
-      ],
-    },
   },
 }

--- a/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep2.stories.tsx
+++ b/packages/synapse-react-client/stories/data-access-request/RequestDataAccessStep2.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta = {
   component: DataAccessRequestAccessorsFilesForm,
   parameters: {
     stack: 'mock',
-    chromatic: { viewports: ['600', '1200'] },
+    chromatic: { viewports: [600, 1200] },
     msw: {
       handlers: [
         ...getUserProfileHandlers(MOCK_REPO_ORIGIN),

--- a/packages/synapse-react-client/stories/data-access-request/TwoFactorAuthEnabledRequirement.stories.tsx
+++ b/packages/synapse-react-client/stories/data-access-request/TwoFactorAuthEnabledRequirement.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta = {
   title:
     'Governance/Data Access Request Flow/Requirements/TwoFactorAuthEnabledRequirement',
   component: TwoFactorAuthEnabledRequirement,
+  parameters: { stack: 'mock' },
   render: args => (
     <SynapseContextConsumer>
       {context => (

--- a/packages/synapse-react-client/stories/data-access-request/ValidationRequirement.stories.tsx
+++ b/packages/synapse-react-client/stories/data-access-request/ValidationRequirement.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta = {
   title:
     'Governance/Data Access Request Flow/Requirements/ValidationRequirement',
   component: ValidationRequirement,
+  parameters: { stack: 'mock' },
 } satisfies Meta
 
 export default meta


### PR DESCRIPTION
- Show ManagedACTAccessRequirement wiki content if screen size is large enough
- Add Storybook parameter to set default stack, and set default stack to `mock` for those stories where we have configured mock data

[Demo Story](https://6464de5f2e01a2af614b79c7-bzzlyjkwgx.chromatic.com/?path=/story/governance-data-access-request-flow-accessrequirementlist--has-unmet-requirements)


![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/ea8f99ae-2256-41bf-ae1e-9ed0badcb6ee)

![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/f8f6687b-6db7-4c01-a6c3-4b8ef5b9c456)
