### PR TITLE
Don't run chromatic deploy on draft PRs

### DIFF
--- a/.github/workflows/deploy-to-chromatic.yml
+++ b/.github/workflows/deploy-to-chromatic.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0

--- a/README.md
+++ b/README.md
@@ -43,9 +43,13 @@ Sometimes, due to Synapse.org's deployment cadence, a hotfix must be based on an
 
 ## CI/CD
 
-On latest commit for a PR where changes will be merged to main `main`, multiple jobs will be triggered in GitHub Actions.
+On the latest commit for a PR where changes will be merged to `main`, multiple jobs will be triggered in GitHub Actions.
 
-All changed projects and their dependents will be built, linted, and tested. Some notes:
+All changed projects and their dependents will be built, linted, tested, and type-checked.
+
+Additionally, the project Storybook(s) will be published to Chromatic, where each story will be tested and snapshotted. To reduce usage, this job only runs on pull requests that are "ready-for-review" i.e. not drafts. For this reason, please mark your pull request as a draft until these checks are necessary.
+
+Some notes:
 
 - If the test step fails, you can find the failed tests by downloading the artifacts from the job, which includes HTML reports of the tests.
 - We currently have many warnings and errors emitted in each test, so we have configured each test run to silence the output. If you need to see these warnings and errors, remove the 'silent' parameter from the script or configuration file.


### PR DESCRIPTION
One way to reduce our snapshot usage is to only run the snapshots on ready-to-review PRs. If you don't yet need snapshots/deployment, mark your PR as a draft.