### PR TITLE
Enable Turbosnap to reduce Chromatic snapshot usage

### DIFF
--- a/.github/workflows/deploy-to-chromatic.yml
+++ b/.github/workflows/deploy-to-chromatic.yml
@@ -43,3 +43,4 @@ jobs:
           exitZeroOnChanges: true
           exitOnceUploaded: true
           autoAcceptChanges: 'main'
+          onlyChanged: true

--- a/packages/synapse-react-client/.storybook/main.ts
+++ b/packages/synapse-react-client/.storybook/main.ts
@@ -1,5 +1,6 @@
 import { mergeConfig, defineConfig } from 'vite'
 import { StorybookConfig } from '@storybook/react-vite'
+import turbosnap from 'vite-plugin-turbosnap'
 
 const config: StorybookConfig = {
   stories: [
@@ -50,13 +51,16 @@ const config: StorybookConfig = {
   },
   staticDirs: ['../public'],
   async viteFinal(config, { configType }) {
-    let base = undefined
+    let base,
+      plugins = undefined
     // Fix deployment to github pages
     if (configType === 'PRODUCTION') {
       base = './'
+      plugins = [turbosnap({ rootDir: config.root ?? process.cwd() })]
     }
     const customStorybookConfig = defineConfig({
       base,
+      plugins,
     })
 
     // return the customized config

--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -229,6 +229,7 @@
     "util": "^0.12.5",
     "vite": "^4.4.2",
     "vite-plugin-svgr": "^3.2.0",
+    "vite-plugin-turbosnap": "^1.0.2",
     "weak-napi": "^2.0.2",
     "whatwg-fetch": "^3.6.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1336,6 +1336,9 @@ importers:
       vite-plugin-svgr:
         specifier: ^3.2.0
         version: 3.2.0(rollup@2.79.1)(vite@4.4.2)
+      vite-plugin-turbosnap:
+        specifier: ^1.0.2
+        version: 1.0.2
       weak-napi:
         specifier: ^2.0.2
         version: 2.0.2
@@ -18128,6 +18131,10 @@ packages:
     transitivePeerDependencies:
       - rollup
       - supports-color
+    dev: true
+
+  /vite-plugin-turbosnap@1.0.2:
+    resolution: {integrity: sha512-irjKcKXRn7v5bPAg4mAbsS6DgibpP1VUFL9tlgxU6lloK6V9yw9qCZkS+s2PtbkZpWNzr3TN3zVJAc6J7gJZmA==}
     dev: true
 
   /vite@4.4.2(@types/node@18.16.19)(less@4.1.3)(sass@1.63.6):


### PR DESCRIPTION
[TurboSnap](https://www.chromatic.com/docs/turbosnap) uses the commit history + Vite build to attempt to reduce the snapshots taken by only snapshotting changed stories.