### PR TITLE
Run chromatic builds for PRs when "chromatic" label is applied

### DIFF
--- a/.github/workflows/deploy-to-chromatic.yml
+++ b/.github/workflows/deploy-to-chromatic.yml
@@ -7,40 +7,24 @@ on:
   push:
     branches:
       - main
-  issue_comment:
-    types: [created]
+  pull_request:
+    types: [labeled]
 
 jobs:
   deploy-to-chromatic:
     name: Deploy to Chromatic
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR if triggered by comment
-        if: github.event.issue.pull_request
-        uses: alessbell/pull-request-comment-branch@v1.1
-        id: comment-branch
-      - name: Configure to use main
-        if: github.event_name == 'push'
+      - name: Check PR label
+        if: ${{ github.event_name == 'pull_request' && github.event.label.name != 'chromatic' }}
         env:
-          FULL_REPO_NAME: ${{ github.repository }}
-          HEAD_REF: ${{ github.ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # The following script will cancel the rest of the job
         run: |
-          echo "FULL_REPO_NAME=$FULL_REPO_NAME" >> "$GITHUB_ENV"
-          echo "HEAD_REF=$HEAD_REF" >> "$GITHUB_ENV"
-      - name: Configure to use PR
-        if: github.event.issue.pull_request
-        env:
-          FULL_REPO_NAME: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}"
-          HEAD_REF: ${{ steps.comment-branch.outputs.head_ref }}
-        run: |
-          echo "FULL_REPO_NAME=$FULL_REPO_NAME" >> "$GITHUB_ENV"
-          echo "HEAD_REF=$HEAD_REF" >> "$GITHUB_ENV"
-      - name: Output configuration
-        run: echo "Deploying $FULL_REPO_NAME to Chromatic using branch $HEAD_REF"
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
       - uses: actions/checkout@v3.1.0
         with:
-          repository: ${{ env.FULL_REPO_NAME }}
-          ref: ${{ env.HEAD_REF }}
           # Chromatic requires full git history to track changes
           fetch-depth: 0
       - uses: ./.github/actions/pnpm-setup-action
@@ -53,26 +37,5 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/synapse-react-client
           exitZeroOnChanges: true
-          exitOnceUploaded: false # Wait for snapshot tests to complete so we can report the results
+          exitOnceUploaded: true # Wait for snapshot tests to complete so we can report the results
           autoAcceptChanges: 'main'
-          repositorySlug: ${{ env.FULL_REPO_NAME }}
-          branchName: ${{ env.HEAD_REF }}
-      - name: Add comment to PR
-        uses: actions/github-script@v6
-        if: github.event.issue.pull_request
-        with:
-          script: |
-            const name = '${{ github.workflow }}';
-            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
-            const success = '${{ job.status }}' === 'success';
-            let body = `${name}: ${success ? 'succeeded ✅' : 'failed ❌'}\n${url}\n\n`;
-            body += "| Task | Result |\n|---|---|\n"
-            body += `| Deployed Storybook | ${{ steps.chromatic-deploy.outputs.storybookUrl }} |\n`
-            body += `| Snapshot Tests | [${{ steps.chromatic-deploy.outputs.changeCount }} / ${{ steps.chromatic-deploy.outputs.actualCaptureCount }} changed](${{ steps.chromatic-deploy.outputs.buildUrl }}) |`
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            })

--- a/.github/workflows/deploy-to-chromatic.yml
+++ b/.github/workflows/deploy-to-chromatic.yml
@@ -17,6 +17,14 @@ jobs:
     name: Deploy to Chromatic
     runs-on: ubuntu-latest
     steps:
+      - name: Check PR label
+        if: ${{ github.event_name == 'pull_request' && github.event.label.name != 'chromatic' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # The following script will cancel the rest of the job
+        run: |
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
       - uses: actions/checkout@v3.1.0
         with:
           ref: ${{ github.event.pull_request.head.ref }}
@@ -35,5 +43,3 @@ jobs:
           exitZeroOnChanges: true
           exitOnceUploaded: true # Wait for snapshot tests to complete so we can report the results
           autoAcceptChanges: 'main'
-          # Only run UI Tests for PRs with label "chromatic"
-          skip: ${{ !(github.event_name == 'pull_request_target' && github.event.label.name != 'chromatic') }}

--- a/.github/workflows/deploy-to-chromatic.yml
+++ b/.github/workflows/deploy-to-chromatic.yml
@@ -7,24 +7,20 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [labeled]
+    branches:
+      - main
 
 jobs:
   deploy-to-chromatic:
     name: Deploy to Chromatic
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR label
-        if: ${{ github.event_name == 'pull_request' && github.event.label.name != 'chromatic' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # The following script will cancel the rest of the job
-        run: |
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
       - uses: actions/checkout@v3.1.0
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           # Chromatic requires full git history to track changes
           fetch-depth: 0
       - uses: ./.github/actions/pnpm-setup-action
@@ -39,3 +35,5 @@ jobs:
           exitZeroOnChanges: true
           exitOnceUploaded: true # Wait for snapshot tests to complete so we can report the results
           autoAcceptChanges: 'main'
+          # Only run UI Tests for PRs with label "chromatic"
+          skip: ${{ !(github.event_name == 'pull_request_target' && github.event.label.name != 'chromatic') }}

--- a/.github/workflows/deploy-to-chromatic.yml
+++ b/.github/workflows/deploy-to-chromatic.yml
@@ -11,12 +11,36 @@ on:
     types: [created]
 
 jobs:
-  main-deploy-to-chromatic:
-    if: github.event_name == 'push'
+  deploy-to-chromatic:
+    name: Deploy to Chromatic
     runs-on: ubuntu-latest
     steps:
+      - name: Get PR if triggered by comment
+        if: github.event.issue.pull_request
+        uses: alessbell/pull-request-comment-branch@v1.1
+        id: comment-branch
+      - name: Configure to use main
+        if: github.event_name == 'push'
+        env:
+          FULL_REPO_NAME: ${{ github.repository }}
+          HEAD_REF: ${{ github.ref }}
+        run: |
+          echo "FULL_REPO_NAME=$FULL_REPO_NAME" >> "$GITHUB_ENV"
+          echo "HEAD_REF=$HEAD_REF" >> "$GITHUB_ENV"
+      - name: Configure to use PR
+        if: github.event.issue.pull_request
+        env:
+          FULL_REPO_NAME: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}"
+          HEAD_REF: ${{ steps.comment-branch.outputs.head_ref }}
+        run: |
+          echo "FULL_REPO_NAME=$FULL_REPO_NAME" >> "$GITHUB_ENV"
+          echo "HEAD_REF=$HEAD_REF" >> "$GITHUB_ENV"
+      - name: Output configuration
+        run: echo "Deploying $FULL_REPO_NAME to Chromatic using branch $HEAD_REF"
       - uses: actions/checkout@v3.1.0
         with:
+          repository: ${{ env.FULL_REPO_NAME }}
+          ref: ${{ env.HEAD_REF }}
           # Chromatic requires full git history to track changes
           fetch-depth: 0
       - uses: ./.github/actions/pnpm-setup-action
@@ -29,40 +53,13 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/synapse-react-client
           exitZeroOnChanges: true
-          exitOnceUploaded: true
-          autoAcceptChanges: 'main'
-  pr-deploy-to-chromatic:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/chromatic')
-    runs-on: ubuntu-latest
-    steps:
-      - if: github.event.issue.pull_request
-        name: Get PR branch
-        uses: alessbell/pull-request-comment-branch@v1.1
-        id: comment-branch
-      - uses: actions/checkout@v3.1.0
-        with:
-          repository: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
-          # Chromatic requires full git history to track changes
-          fetch-depth: 0
-      - uses: ./.github/actions/pnpm-setup-action
-      - name: Prebuild dependencies
-        # we technically only need to build the dependencies of SRC, but Nx doesn't expose an easy way to do that
-        run: pnpm nx run synapse-react-client:build
-      - id: chromatic-deploy
-        name: Publish to Chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          workingDir: packages/synapse-react-client
-          exitZeroOnChanges: true
           exitOnceUploaded: false # Wait for snapshot tests to complete so we can report the results
           autoAcceptChanges: 'main'
-          repositorySlug: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
-          branchName: ${{ steps.comment-branch.outputs.head_ref }}
+          repositorySlug: ${{ env.FULL_REPO_NAME }}
+          branchName: ${{ env.HEAD_REF }}
       - name: Add comment to PR
         uses: actions/github-script@v6
-        if: always()
+        if: github.event.issue.pull_request
         with:
           script: |
             const name = '${{ github.workflow }}';

--- a/.github/workflows/deploy-to-chromatic.yml
+++ b/.github/workflows/deploy-to-chromatic.yml
@@ -7,19 +7,16 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
-    branches:
-      - main
+  issue_comment:
+    types: [created]
 
 jobs:
-  build:
-    if: github.event.pull_request.draft == false
+  main-deploy-to-chromatic:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
           # Chromatic requires full git history to track changes
           fetch-depth: 0
       - uses: ./.github/actions/pnpm-setup-action
@@ -34,3 +31,51 @@ jobs:
           exitZeroOnChanges: true
           exitOnceUploaded: true
           autoAcceptChanges: 'main'
+  pr-deploy-to-chromatic:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/chromatic')
+    runs-on: ubuntu-latest
+    steps:
+      - if: github.event.issue.pull_request
+        name: Get PR branch
+        uses: alessbell/pull-request-comment-branch@v1.1
+        id: comment-branch
+      - uses: actions/checkout@v3.1.0
+        with:
+          repository: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          # Chromatic requires full git history to track changes
+          fetch-depth: 0
+      - uses: ./.github/actions/pnpm-setup-action
+      - name: Prebuild dependencies
+        # we technically only need to build the dependencies of SRC, but Nx doesn't expose an easy way to do that
+        run: pnpm nx run synapse-react-client:build
+      - id: chromatic-deploy
+        name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/synapse-react-client
+          exitZeroOnChanges: true
+          exitOnceUploaded: false # Wait for snapshot tests to complete so we can report the results
+          autoAcceptChanges: 'main'
+          repositorySlug: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
+          branchName: ${{ steps.comment-branch.outputs.head_ref }}
+      - name: Add comment to PR
+        uses: actions/github-script@v6
+        if: always()
+        with:
+          script: |
+            const name = '${{ github.workflow }}';
+            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const success = '${{ job.status }}' === 'success';
+            let body = `${name}: ${success ? 'succeeded ✅' : 'failed ❌'}\n${url}\n\n`;
+            body += "| Task | Result |\n|---|---|\n"
+            body += `| Deployed Storybook | ${{ steps.chromatic-deploy.outputs.storybookUrl }} |\n`
+            body += `| Snapshot Tests | [${{ steps.chromatic-deploy.outputs.changeCount }} / ${{ steps.chromatic-deploy.outputs.actualCaptureCount }} changed](${{ steps.chromatic-deploy.outputs.buildUrl }}) |`
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })

--- a/.github/workflows/deploy-to-chromatic.yml
+++ b/.github/workflows/deploy-to-chromatic.yml
@@ -41,5 +41,5 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/synapse-react-client
           exitZeroOnChanges: true
-          exitOnceUploaded: true # Wait for snapshot tests to complete so we can report the results
+          exitOnceUploaded: true
           autoAcceptChanges: 'main'


### PR DESCRIPTION
Our Chromatic trial has expired so we are now limited to 5000 snapshots per month. The Chromatic deployments are not necessarily useful for every PR, so one measure we can take to stay close to our limit is to explicitly enable the Chromatic deployment and UI Snapshot tests for those PRs where a developer or reviewer knows they would be particularly useful.

Once this PR is merged, to trigger a Chromatic deployment, a PR author or reviewer can apply the "chromatic" label in GitHub (applied to this issue for clarity). Once applied, a job will be triggered that deploys the latest commit to Chromatic.

Jobs will not be automatically triggered on new commits after the label is applied; to trigger additional runs on the same PR, remove and re-apply the "chromatic" label again.

For an example, see https://github.com/nickgros/synapse-web-monorepo/pull/10