### PR TITLE
PORTALS-2701 - refactor location of `isRowSelectionVisible`

### DIFF
--- a/apps/portals/src/configurations/adknowledgeportal/synapseConfigs/target_enabling_resources.ts
+++ b/apps/portals/src/configurations/adknowledgeportal/synapseConfigs/target_enabling_resources.ts
@@ -62,7 +62,6 @@ export const targetEnablingResourcesTableConfiguration: QueryWrapperPlotNavProps
       },
     ],
     hideDownload: true,
-    isRowSelectionVisible: false,
   }
 
 const rgbIndex = 6

--- a/apps/portals/src/configurations/crc-researcher/synapseConfigs/hidden.ts
+++ b/apps/portals/src/configurations/crc-researcher/synapseConfigs/hidden.ts
@@ -16,9 +16,8 @@ export const hidden: SynapseConfig = {
     name: 'Hidden Participants',
     columnAliases,
     facetsToPlot: allFacetsToPlot,
-    tableConfiguration: {
-      isRowSelectionVisible: true,
-    },
+    tableConfiguration: {},
+    isRowSelectionVisible: true,
     visibleColumnCount: 10,
     customControls: [
       {

--- a/apps/portals/src/configurations/crc-researcher/synapseConfigs/potential.ts
+++ b/apps/portals/src/configurations/crc-researcher/synapseConfigs/potential.ts
@@ -16,9 +16,8 @@ export const potential: SynapseConfig = {
     name: 'Potential Participants',
     columnAliases,
     facetsToPlot: allFacetsToPlot,
-    tableConfiguration: {
-      isRowSelectionVisible: true,
-    },
+    tableConfiguration: {},
+    isRowSelectionVisible: true,
     visibleColumnCount: 10,
     customControls: [
       {

--- a/apps/portals/src/configurations/crc-researcher/synapseConfigs/uncategorized.ts
+++ b/apps/portals/src/configurations/crc-researcher/synapseConfigs/uncategorized.ts
@@ -57,9 +57,8 @@ export const uncategorized: SynapseConfig = {
     sql,
     name: 'Uncategorized Participants',
     columnAliases,
-    tableConfiguration: {
-      isRowSelectionVisible: true,
-    },
+    tableConfiguration: {},
+    isRowSelectionVisible: true,
     facetsToPlot: allFacetsToPlot,
     customControls: [
       {

--- a/packages/synapse-react-client/src/components/QueryVisualizationWrapper.tsx
+++ b/packages/synapse-react-client/src/components/QueryVisualizationWrapper.tsx
@@ -34,6 +34,7 @@ export type QueryVisualizationContextType = {
   getDisplayValue: (value: string, columnType: ColumnType) => string
   /** React node to display in place of cards/table when there are no results. */
   NoContentPlaceholder: () => JSX.Element
+  isRowSelectionVisible: boolean
 }
 
 /**
@@ -87,6 +88,7 @@ export type QueryVisualizationWrapperProps = {
   showLastUpdatedOn?: boolean
   /** Default is INTERACTIVE */
   noContentPlaceholderType?: NoContentPlaceholderType
+  isRowSelectionVisible?: boolean
 }
 
 export type TopLevelControlsState = {
@@ -107,8 +109,10 @@ export type TopLevelControlsState = {
 export function QueryVisualizationWrapper(
   props: QueryVisualizationWrapperProps,
 ) {
-  const { noContentPlaceholderType = NoContentPlaceholderType.INTERACTIVE } =
-    props
+  const {
+    noContentPlaceholderType = NoContentPlaceholderType.INTERACTIVE,
+    isRowSelectionVisible = false,
+  } = props
 
   const { data, getLastQueryRequest, isFacetsAvailable, hasResettableFilters } =
     useQueryContext()
@@ -197,6 +201,7 @@ export function QueryVisualizationWrapper(
     getColumnDisplayName,
     getDisplayValue,
     NoContentPlaceholder,
+    isRowSelectionVisible,
   }
   /**
    * Render the children without any formatting

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
@@ -76,6 +76,7 @@ type QueryWrapperPlotNavOwnProps = {
     | 'rgbIndex'
     | 'showLastUpdatedOn'
     | 'noContentPlaceholderType'
+    | 'isRowSelectionVisible'
   >
 
 export type SearchParams = {
@@ -115,6 +116,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = (
     showExportToCavatica = false,
     cavaticaHelpURL,
     customControls,
+    isRowSelectionVisible,
   } = props
 
   const entityId = parseEntityIdFromSqlStatement(sql)
@@ -167,6 +169,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = (
         }
         showLastUpdatedOn={showLastUpdatedOn}
         noContentPlaceholderType={NoContentPlaceholderType.INTERACTIVE}
+        isRowSelectionVisible={isRowSelectionVisible}
       >
         <QueryContextConsumer>
           {queryContext => {

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
@@ -87,7 +87,6 @@ export type SynapseTableProps = {
   showDownloadColumn?: boolean
   columnLinks?: LabelLinkConfig
   hideDownload?: boolean
-  isRowSelectionVisible?: boolean
 }
 
 export class SynapseTable extends React.Component<
@@ -422,9 +421,9 @@ export class SynapseTable extends React.Component<
     const lastQueryRequest = this.props.queryContext.getLastQueryRequest?.()!
     const {
       queryContext: { entity },
+      queryVisualizationContext: { isRowSelectionVisible },
       showAccessColumn,
       showDownloadColumn,
-      isRowSelectionVisible,
     } = this.props
 
     /**

--- a/packages/synapse-react-client/stories/QueryWrapperPlotNav.stories.ts
+++ b/packages/synapse-react-client/stories/QueryWrapperPlotNav.stories.ts
@@ -229,9 +229,8 @@ const handleCustomCommandClick = async (event: CustomControlCallbackData) => {
 export const TableRowSelectionWithCustomCommand: Story = {
   args: {
     sql: 'SELECT * FROM syn51186974',
-    tableConfiguration: {
-      isRowSelectionVisible: true,
-    },
+    isRowSelectionVisible: true,
+    tableConfiguration: {},
     name: 'Row Selection Demo',
     hideSqlEditorControl: true,
     shouldDeepLink: false,


### PR DESCRIPTION
- Move isRowSelectionVisible to QueryVisualizationWrapper from SynapseTableProps

In order for other table components to be aware of row selection (such as TopLevelControls or DownloadOptions), row visibility must be exposed through context, rather than props provided exclusively to the SynapseTable component.