### PR TITLE
PORTALS-2701 - refactor QueryWrapper to deprecate `getLastQueryRequest`

### DIFF
--- a/packages/synapse-react-client/src/components/FullTextSearch.tsx
+++ b/packages/synapse-react-client/src/components/FullTextSearch.tsx
@@ -1,6 +1,9 @@
 import { Collapse } from '@mui/material'
 import React, { useRef, useState } from 'react'
-import { TextMatchesQueryFilter } from '@sage-bionetworks/synapse-types'
+import {
+  QueryBundleRequest,
+  TextMatchesQueryFilter,
+} from '@sage-bionetworks/synapse-types'
 import {
   QUERY_FILTERS_COLLAPSED_CSS,
   QUERY_FILTERS_EXPANDED_CSS,
@@ -9,6 +12,7 @@ import {
 import { useQueryVisualizationContext } from './QueryVisualizationWrapper'
 import { HelpPopover } from './HelpPopover'
 import IconSvg from './IconSvg/IconSvg'
+import { cloneDeep } from 'lodash-es'
 
 // See PLFM-7011
 const MIN_SEARCH_QUERY_LENGTH = 3
@@ -22,7 +26,7 @@ export const FullTextSearch: React.FunctionComponent<FullTextSearchProps> = ({
   helpMessage = 'This search bar is powered by MySQL Full Text Search.',
   helpUrl,
 }: FullTextSearchProps) => {
-  const { executeQueryRequest, getLastQueryRequest } = useQueryContext()
+  const { executeQueryRequest, lastQueryRequest } = useQueryContext()
   const {
     topLevelControlsState: { showSearchBar, showFacetFilter },
   } = useQueryVisualizationContext()
@@ -39,7 +43,9 @@ export const FullTextSearch: React.FunctionComponent<FullTextSearchProps> = ({
         `Search term must have a minimum of ${MIN_SEARCH_QUERY_LENGTH} characters`,
       )
     } else {
-      const lastQueryRequestDeepClone = getLastQueryRequest()
+      const lastQueryRequestDeepClone = cloneDeep(
+        lastQueryRequest,
+      ) as QueryBundleRequest
 
       const { additionalFilters = [] } = lastQueryRequestDeepClone.query
 

--- a/packages/synapse-react-client/src/components/InfiniteQueryWrapper.tsx
+++ b/packages/synapse-react-client/src/components/InfiniteQueryWrapper.tsx
@@ -51,6 +51,7 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
   const {
     entityId,
     versionNumber,
+    lastQueryRequest,
     getInitQueryRequest,
     getLastQueryRequest,
     setQuery,
@@ -66,10 +67,6 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
     onQueryChange,
   })
 
-  const lastQueryRequest = useMemo(() => {
-    return getLastQueryRequest()
-  }, [getLastQueryRequest])
-
   const {
     data: infiniteData,
     hasNextPage,
@@ -80,7 +77,7 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
     error,
     isPreviousData: newQueryIsFetching,
   } = useInfiniteQueryResultBundle(
-    lastQueryRequest,
+    lastQueryRequest as QueryBundleRequest,
     {
       // We use `keepPreviousData` because we don't want to clear out the current data when the query is modified via the UI
       keepPreviousData: true,
@@ -183,9 +180,8 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
   }, [data, lockedColumn])
 
   const hasResettableFilters = useMemo(() => {
-    const request = getLastQueryRequest()
-    return isFilteredUtil(request.query, lockedColumn)
-  }, [getLastQueryRequest, lockedColumn])
+    return isFilteredUtil(lastQueryRequest.query, lockedColumn)
+  }, [lastQueryRequest, lockedColumn])
 
   const getColumnModel = useCallback(
     (columnName: string) => {
@@ -200,6 +196,8 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
     hasNextPage: !!hasNextPage,
     hasPreviousPage: hasPreviousPage,
     isLoadingNewBundle: isLoadingNewBundle,
+    initQueryRequest,
+    lastQueryRequest,
     getLastQueryRequest,
     getInitQueryRequest,
     error: error,

--- a/packages/synapse-react-client/src/components/ProgrammaticTableDownload/ProgrammaticTableDownload.tsx
+++ b/packages/synapse-react-client/src/components/ProgrammaticTableDownload/ProgrammaticTableDownload.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Link } from '@mui/material'
-import { QueryBundleRequest } from '@sage-bionetworks/synapse-types'
 import { ProgrammaticInstructionsModal } from '../ProgrammaticInstructionsModal'
 import { useGetQueryResultBundleWithAsyncStatus } from '../../synapse-queries'
 import { SynapseConstants } from '../../utils'
+import { ReadonlyDeep } from 'type-fest'
+import { QueryBundleRequest } from '@sage-bionetworks/synapse-types'
 
 export type ProgrammaticTableDownloadProps = {
-  queryBundleRequest: QueryBundleRequest
+  queryBundleRequest: ReadonlyDeep<QueryBundleRequest>
   onHide: () => void
 }
 
@@ -22,7 +23,7 @@ export function ProgrammaticTableDownload({
     isPreviousData: newQueryIsFetching,
   } = useGetQueryResultBundleWithAsyncStatus(
     {
-      ...queryBundleRequest,
+      ...(queryBundleRequest as QueryBundleRequest),
       partMask: SynapseConstants.BUNDLE_MASK_COMBINED_SQL,
     },
     {

--- a/packages/synapse-react-client/src/components/QueryContext/QueryContext.tsx
+++ b/packages/synapse-react-client/src/components/QueryContext/QueryContext.tsx
@@ -9,7 +9,7 @@ import {
   Table,
 } from '@sage-bionetworks/synapse-types'
 import { ImmutableTableQueryResult } from '../useImmutableTableQuery'
-import { SetRequired } from 'type-fest'
+import { ReadonlyDeep, SetRequired } from 'type-fest'
 
 export const QUERY_FILTERS_EXPANDED_CSS: string = 'isShowingFacetFilters'
 export const QUERY_FILTERS_COLLAPSED_CSS: string = 'isHidingFacetFilters'
@@ -51,12 +51,16 @@ export type QueryContextType<
           : never
       >
     | undefined
+  /** The current query bundle request */
+  lastQueryRequest: ReadonlyDeep<QueryBundleRequest>
+  /** The initial query bundle request */
+  initQueryRequest: ReadonlyDeep<QueryBundleRequest>
   /** Returns a deep clone of the current query bundle request */
   getLastQueryRequest: () => QueryBundleRequest
   /** Returns a deep clone of the initial query bundle request */
   getInitQueryRequest: () => QueryBundleRequest
-  /** Updates the current query with the passed request */
-  executeQueryRequest: (param: QueryBundleRequest) => void
+  /** Updates the current query with the passed request. Also accepts a dispatch function. */
+  executeQueryRequest: ImmutableTableQueryResult['setQuery']
   /** Resets the query to its initial state, clearing all filters added by the user */
   resetQuery: ImmutableTableQueryResult['resetQuery']
   removeSelectedFacet: ImmutableTableQueryResult['removeSelectedFacet']

--- a/packages/synapse-react-client/src/components/QuerySortSelector.tsx
+++ b/packages/synapse-react-client/src/components/QuerySortSelector.tsx
@@ -1,11 +1,16 @@
 import React, { useState } from 'react'
 import { SortConfiguration } from './CardContainerLogic'
 import { useQueryContext } from './QueryContext/QueryContext'
-import { SortDirection, SortItem } from '@sage-bionetworks/synapse-types'
+import {
+  QueryBundleRequest,
+  SortDirection,
+  SortItem,
+} from '@sage-bionetworks/synapse-types'
 import { Typography } from '@mui/material'
 import Select, { components, ControlProps, GroupBase } from 'react-select'
 import { findValueOption } from './SchemaDrivenAnnotationEditor/widget/SelectWidget'
 import { useQueryVisualizationContext } from './QueryVisualizationWrapper'
+import { cloneDeep } from 'lodash-es'
 
 export type QuerySortSelectorProps = {
   sortConfig: SortConfiguration
@@ -32,7 +37,7 @@ const QuerySortSelector: React.FunctionComponent<QuerySortSelectorProps> = ({
 }) => {
   const { defaultColumn, defaultDirection, sortableColumns } = sortConfig
   const queryContext = useQueryContext()
-  const { getLastQueryRequest, executeQueryRequest } = queryContext
+  const { executeQueryRequest, lastQueryRequest } = queryContext
   const { getColumnDisplayName } = useQueryVisualizationContext()
   const [sortColumn, setSortColumn] = useState<string | undefined>(
     defaultColumn,
@@ -47,7 +52,9 @@ const QuerySortSelector: React.FunctionComponent<QuerySortSelectorProps> = ({
   })
 
   const onChange = (value?: string) => {
-    const lastQueryRequestDeepClone = getLastQueryRequest()
+    const lastQueryRequestDeepClone = cloneDeep(
+      lastQueryRequest,
+    ) as QueryBundleRequest
     let newSortDirection: SortDirection = 'ASC'
     if (value === sortColumn) {
       // flip sort direction

--- a/packages/synapse-react-client/src/components/QueryVisualizationWrapper.tsx
+++ b/packages/synapse-react-client/src/components/QueryVisualizationWrapper.tsx
@@ -110,7 +110,7 @@ export function QueryVisualizationWrapper(
   const { noContentPlaceholderType = NoContentPlaceholderType.INTERACTIVE } =
     props
 
-  const { data, getLastQueryRequest, isFacetsAvailable, hasResettableFilters } =
+  const { data, lastQueryRequest, isFacetsAvailable, hasResettableFilters } =
     useQueryContext()
 
   const { columnAliases = {} } = props
@@ -138,8 +138,6 @@ export function QueryVisualizationWrapper(
   }, [isFacetsAvailable])
   const [visibleColumns, setVisibleColumns] = useState<string[]>([])
   const [selectedRows, setSelectedRows] = useState<Row[]>([])
-
-  const lastQueryRequest = getLastQueryRequest()
 
   // We deep-compare-memoize the selectColumns so we don't reset visible columns when the reference changes, but not the contents (e.g. on page change)
   const selectColumns = useDeepCompareMemoize(data?.selectColumns)

--- a/packages/synapse-react-client/src/components/QueryWrapper/QueryWrapper.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapper/QueryWrapper.tsx
@@ -56,6 +56,7 @@ export function QueryWrapper(props: QueryWrapperProps) {
   const {
     entityId,
     versionNumber,
+    lastQueryRequest,
     getInitQueryRequest,
     getLastQueryRequest,
     setQuery,
@@ -75,17 +76,13 @@ export function QueryWrapper(props: QueryWrapperProps) {
     onQueryChange,
   })
 
-  const lastQueryRequest = useMemo(() => {
-    return getLastQueryRequest()
-  }, [getLastQueryRequest])
-
   const {
     data: asyncJobStatus,
     isLoading: queryIsLoading,
     error,
     isPreviousData: newQueryIsFetching,
   } = useGetQueryResultBundleWithAsyncStatus(
-    lastQueryRequest,
+    lastQueryRequest as QueryBundleRequest,
     {
       // We use `keepPreviousData` because we don't want to clear out the current data when the query is modified via the UI
       keepPreviousData: true,
@@ -121,9 +118,8 @@ export function QueryWrapper(props: QueryWrapperProps) {
   }, [data, lockedColumn])
 
   const hasResettableFilters = useMemo(() => {
-    const request = getLastQueryRequest()
-    return hasResettableFiltersUtil(request.query, lockedColumn)
-  }, [getLastQueryRequest, lockedColumn])
+    return hasResettableFiltersUtil(lastQueryRequest.query, lockedColumn)
+  }, [lastQueryRequest, lockedColumn])
 
   const getColumnModel = useCallback(
     (columnName: string) => {
@@ -138,6 +134,8 @@ export function QueryWrapper(props: QueryWrapperProps) {
     pageSize,
     setPageSize,
     isLoadingNewBundle: isLoadingNewBundle,
+    initQueryRequest,
+    lastQueryRequest,
     getLastQueryRequest,
     getInitQueryRequest,
     error: error,

--- a/packages/synapse-react-client/src/components/QueryWrapperErrorBanner.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperErrorBanner.tsx
@@ -8,9 +8,11 @@ import { useSynapseContext } from '../utils'
  * Error banner that automatically pulls the error from QueryContext.  If 403, shows entity actions required
  */
 export const QueryWrapperErrorBanner = () => {
-  const { error, getLastQueryRequest, onViewSharingSettingsClicked } =
-    useQueryContext()
-  const { entityId } = getLastQueryRequest()
+  const {
+    error,
+    lastQueryRequest: { entityId },
+    onViewSharingSettingsClicked,
+  } = useQueryContext()
   const { accessToken } = useSynapseContext()
 
   if (error?.status == 403 && accessToken) {

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
@@ -253,7 +253,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = (
                       />
                       {showExportMetadata && (
                         <ModalDownload
-                          getLastQueryRequest={queryContext.getLastQueryRequest}
+                          queryBundleRequest={queryContext?.lastQueryRequest}
                           onClose={() => setShowExportMetadata(false)}
                         />
                       )}

--- a/packages/synapse-react-client/src/components/SearchV2.tsx
+++ b/packages/synapse-react-client/src/components/SearchV2.tsx
@@ -8,6 +8,7 @@ import {
   ColumnSingleValueFilterOperator,
   ColumnSingleValueQueryFilter,
   ColumnTypeEnum,
+  QueryBundleRequest,
   QueryFilter,
 } from '@sage-bionetworks/synapse-types'
 import { QueryVisualizationContextType } from './QueryVisualizationWrapper'
@@ -22,6 +23,7 @@ import {
   isColumnMultiValueFunctionQueryFilter,
   isColumnSingleValueQueryFilter,
 } from '../utils/types/IsType'
+import { cloneDeep } from 'lodash-es'
 
 type SearchState = {
   show: boolean
@@ -134,9 +136,11 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
     this.setState({
       show: false,
     })
-    const { executeQueryRequest, getLastQueryRequest } = this.props.queryContext
+    const { executeQueryRequest, lastQueryRequest } = this.props.queryContext
 
-    const lastQueryRequestDeepClone = getLastQueryRequest()
+    const lastQueryRequestDeepClone = cloneDeep(
+      lastQueryRequest,
+    ) as QueryBundleRequest
 
     const { additionalFilters = [] } = lastQueryRequestDeepClone.query
 

--- a/packages/synapse-react-client/src/components/SqlEditor.tsx
+++ b/packages/synapse-react-client/src/components/SqlEditor.tsx
@@ -8,6 +8,8 @@ import {
   QUERY_FILTERS_EXPANDED_CSS,
   useQueryContext,
 } from './QueryContext/QueryContext'
+import { QueryBundleRequest } from '@sage-bionetworks/synapse-types'
+import { cloneDeep } from 'lodash-es'
 
 export type SqlEditorProps = {
   helpMessage?: string
@@ -23,7 +25,7 @@ export const SqlEditor: React.FunctionComponent<SqlEditorProps> = ({
   helpMessage = helpMessageCopy,
   helpUrl = helpLink,
 }: SqlEditorProps) => {
-  const { executeQueryRequest, getLastQueryRequest } = useQueryContext()
+  const { executeQueryRequest, lastQueryRequest } = useQueryContext()
   const {
     topLevelControlsState: { showSqlEditor, showFacetFilter },
   } = useQueryVisualizationContext()
@@ -32,16 +34,18 @@ export const SqlEditor: React.FunctionComponent<SqlEditorProps> = ({
   const inputRef = useRef<HTMLInputElement>(null)
   useEffect(() => {
     if (showSqlEditor) {
-      const defaultSql = getLastQueryRequest().query.sql
+      const defaultSql = lastQueryRequest.query.sql
 
       setSql(defaultSql)
       inputRef.current?.focus()
     }
-  }, [showSqlEditor, getLastQueryRequest])
+  }, [showSqlEditor, lastQueryRequest])
 
   const search = (event: React.SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const lastQueryRequestDeepClone = getLastQueryRequest()
+    const lastQueryRequestDeepClone = cloneDeep(
+      lastQueryRequest,
+    ) as QueryBundleRequest
     lastQueryRequestDeepClone.query.sql = sql
     lastQueryRequestDeepClone.query.offset = 0
     lastQueryRequestDeepClone.query.additionalFilters = []

--- a/packages/synapse-react-client/src/components/SynapseTable/EntityIDColumnCopyIcon.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/EntityIDColumnCopyIcon.tsx
@@ -3,11 +3,16 @@ import { useQueryContext } from '../QueryContext/QueryContext'
 import { useSynapseContext } from '../../utils/context/SynapseContext'
 import { InteractiveCopyIdsIcon } from '../InteractiveCopyIdsIcon'
 import { displayToast } from '../ToastMessage/ToastMessage'
-import { QueryResultBundle, Row } from '@sage-bionetworks/synapse-types'
+import {
+  QueryBundleRequest,
+  QueryResultBundle,
+  Row,
+} from '@sage-bionetworks/synapse-types'
 import { SynapseSpinner } from '../LoadingScreen'
 import { SynapseConstants } from '../../utils'
 import { getFullQueryTableResults } from '../../synapse-client/SynapseClient'
 import { parseEntityIdAndVersionFromSqlStatement } from '../../utils/functions/SqlFunctions'
+import { cloneDeep } from 'lodash-es'
 
 const EntityIDColumnCopyIcon = () => {
   const synapseContext = useSynapseContext()
@@ -35,8 +40,8 @@ const EntityIDColumnCopyIcon = () => {
     setIsLoading(true)
 
     // ask for all pages of data
-    const { getLastQueryRequest } = queryContext
-    const queryRequestClone = getLastQueryRequest()
+    const { lastQueryRequest } = queryContext
+    const queryRequestClone = cloneDeep(lastQueryRequest) as QueryBundleRequest
     const { sql: oldSql } = queryRequestClone.query
     const { entityId, versionNumber } =
       parseEntityIdAndVersionFromSqlStatement(oldSql)!

--- a/packages/synapse-react-client/src/components/SynapseTable/TopLevelControls.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/TopLevelControls.tsx
@@ -101,12 +101,13 @@ const TopLevelControls = (props: TopLevelControlsProps) => {
     data,
     entity,
     executeQueryRequest,
-    getLastQueryRequest,
+    lastQueryRequest,
     getInitQueryRequest,
     lockedColumn,
   } = useQueryContext()
+
   const exportToCavatica = useExportToCavatica(
-    getLastQueryRequest(),
+    lastQueryRequest,
     data?.queryResult?.queryResults.headers,
   )
 
@@ -146,7 +147,7 @@ const TopLevelControls = (props: TopLevelControlsProps) => {
     // clear selection
     setSelectedRows([])
     // refresh the data
-    executeQueryRequest(getLastQueryRequest())
+    executeQueryRequest(qrb => qrb)
   }
 
   /**

--- a/packages/synapse-react-client/src/components/SynapseTable/table-top/DownloadOptions.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/table-top/DownloadOptions.tsx
@@ -12,6 +12,7 @@ import { useQueryContext } from '../../QueryContext/QueryContext'
 import { ElementWithTooltip } from '../../widgets/ElementWithTooltip'
 import { DownloadLoginModal } from './DownloadLoginModal'
 import ProgrammaticTableDownload from '../../ProgrammaticTableDownload/ProgrammaticTableDownload'
+import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
 
 export const DOWNLOAD_OPTIONS_CONTAINER_CLASS = 'SRC-download-options-container'
 
@@ -21,6 +22,8 @@ export type DownloadOptionsProps = {
 }
 
 export const DOWNLOAD_FILES_MENU_TEXT = 'Add To Download Cart'
+export const DOWNLOAD_SELECTED_FILES_MENU_TEXT =
+  'Add Selected Files To Download Cart'
 
 export const DownloadOptions: React.FunctionComponent<
   DownloadOptionsProps
@@ -29,9 +32,9 @@ export const DownloadOptions: React.FunctionComponent<
   const {
     entity,
     data: queryResultBundle,
-    getLastQueryRequest,
+    lastQueryRequest: queryBundleRequest,
   } = useQueryContext()
-  const queryBundleRequest = getLastQueryRequest()
+  const { isRowSelectionVisible, selectedRows } = useQueryVisualizationContext()
   const [showLoginModal, setShowLoginModal] = React.useState(false)
   const [showExportMetadata, setShowExportMetadata] = React.useState(false)
   const [showProgrammaticOptions, setShowProgrammaticOptions] =
@@ -90,6 +93,23 @@ export const DownloadOptions: React.FunctionComponent<
               </Dropdown.Item>
             </Tooltip>
           )}
+          {isFileViewOrDataset &&
+            isRowSelectionVisible &&
+            selectedRows.length > 0 && (
+              <Dropdown.Item
+                role="button"
+                className={disableDownload ? 'ignoreLink' : undefined}
+                disabled={disableDownload}
+                // If disabled, add pointer-events-auto so the tooltip still works
+                style={disableDownload ? { pointerEvents: 'auto' } : {}}
+                onClick={() =>
+                  accessToken ? onDownloadFiles() : setShowLoginModal(true)
+                }
+              >
+                {DOWNLOAD_SELECTED_FILES_MENU_TEXT}
+              </Dropdown.Item>
+            )}
+
           <Tooltip
             title={
               disableDownload

--- a/packages/synapse-react-client/src/components/download_list/DownloadConfirmation.tsx
+++ b/packages/synapse-react-client/src/components/download_list/DownloadConfirmation.tsx
@@ -166,15 +166,15 @@ const DownloadConfirmationContent = (props: {
 
 //============= DownloadConfirmation component =============
 
-export const DownloadConfirmation: React.FunctionComponent<
-  DownloadConfirmationProps
-> = ({
-  getLastQueryRequest,
-  folderId,
-  fnClose,
-  setTopLevelControlsState,
-  topLevelControlsState,
-}) => {
+export function DownloadConfirmation(props: DownloadConfirmationProps) {
+  const {
+    getLastQueryRequest,
+    folderId,
+    fnClose,
+    setTopLevelControlsState,
+    topLevelControlsState,
+  } = props
+
   const { accessToken, downloadCartPageUrl } = useSynapseContext()
   const { showDownloadConfirmation = true } = topLevelControlsState ?? {}
   const [status, setStatus] = useState<StatusEnum>(

--- a/packages/synapse-react-client/src/components/useImmutableTableQuery.ts
+++ b/packages/synapse-react-client/src/components/useImmutableTableQuery.ts
@@ -14,13 +14,18 @@ import {
   isColumnSingleValueQueryFilter,
   isFacetColumnValuesRequest,
 } from '../utils/types/IsType'
+import { ReadonlyDeep } from 'type-fest'
 
 export type ImmutableTableQueryResult = {
   /** The ID of the table parsed from the SQL query */
   entityId: string
   /** The version number of the table parsed from the SQL query */
   versionNumber?: number
+  initQueryRequest: ReadonlyDeep<QueryBundleRequest>
+  /** @deprecated */
   getInitQueryRequest: () => QueryBundleRequest
+  lastQueryRequest: ReadonlyDeep<QueryBundleRequest>
+  /** @deprecated */
   getLastQueryRequest: () => QueryBundleRequest
   setQuery: (
     queryRequest:
@@ -134,7 +139,7 @@ export default function useImmutableTableQuery(
     ): void => {
       let newQueryRequest: QueryBundleRequest
       if (typeof queryRequest === 'function') {
-        newQueryRequest = queryRequest(getLastQueryRequest())
+        newQueryRequest = queryRequest(lastQueryRequest)
       } else {
         newQueryRequest = queryRequest
       }
@@ -158,7 +163,7 @@ export default function useImmutableTableQuery(
         }
       }
     },
-    [componentIndex, getLastQueryRequest, onQueryChange, shouldDeepLink],
+    [componentIndex, lastQueryRequest, onQueryChange, shouldDeepLink],
   )
 
   const { entityId, versionNumber } = useMemo(
@@ -305,7 +310,9 @@ export default function useImmutableTableQuery(
   return {
     entityId,
     versionNumber,
+    initQueryRequest,
     getInitQueryRequest,
+    lastQueryRequest,
     getLastQueryRequest,
     setQuery,
     pageSize,

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNav.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNav.tsx
@@ -63,7 +63,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
 }: FacetNavProps): JSX.Element => {
   const {
     data,
-    getLastQueryRequest,
+    lastQueryRequest,
     isLoadingNewBundle,
     executeQueryRequest,
     error,
@@ -74,8 +74,6 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
   const [facetUiStateArray, setFacetUiStateArray] = useState<UiFacetState[]>([])
   const [isFirstTime, setIsFirstTime] = useState(true)
   const { showFacetVisualization, showFacetFilter } = topLevelControlsState
-
-  const lastQueryRequest = getLastQueryRequest()
 
   useEffect(() => {
     const result = getFacets(data, facetsToPlot)
@@ -110,9 +108,16 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
 
   // what needs to happen after the filters are adjusted from the plot
   const applyChangesFromQueryFilter = (facets: FacetColumnRequest[]) => {
-    lastQueryRequest.query.selectedFacets = facets
-    lastQueryRequest.query.offset = 0
-    executeQueryRequest(lastQueryRequest)
+    executeQueryRequest(lastQueryRequest => {
+      return {
+        ...lastQueryRequest,
+        query: {
+          ...lastQueryRequest.query,
+          selectedFacets: facets,
+          offset: 0,
+        },
+      }
+    })
   }
 
   // don't show hidden facets

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNavPanel.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNavPanel.tsx
@@ -277,7 +277,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
     onSetPlotType,
   } = props
   const { accessToken } = useSynapseContext()
-  const { data, isLoadingNewBundle, getLastQueryRequest } = useQueryContext()
+  const { data, isLoadingNewBundle, lastQueryRequest } = useQueryContext()
 
   const { getColumnDisplayName } = useQueryVisualizationContext()
 
@@ -379,7 +379,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
                   }
                   onChange={facetNamesMap => {
                     applyMultipleChangesToValuesColumn(
-                      getLastQueryRequest(),
+                      lastQueryRequest,
                       facetToPlot,
                       applyChangesToFacetFilter,
                       facetNamesMap,
@@ -387,7 +387,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
                   }}
                   onClear={() => {
                     applyChangesToValuesColumn(
-                      getLastQueryRequest(),
+                      lastQueryRequest,
                       facetToPlot,
                       applyChangesToFacetFilter,
                     )
@@ -428,7 +428,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
                   }
                   onChange={facetNamesMap => {
                     applyMultipleChangesToValuesColumn(
-                      getLastQueryRequest(),
+                      lastQueryRequest,
                       facetToPlot,
                       applyChangesToFacetFilter,
                       facetNamesMap,
@@ -436,7 +436,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
                   }}
                   onClear={() => {
                     applyChangesToValuesColumn(
-                      getLastQueryRequest(),
+                      lastQueryRequest,
                       facetToPlot,
                       applyChangesToFacetFilter,
                     )

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/SelectionCriteriaPills.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/SelectionCriteriaPills.tsx
@@ -25,6 +25,7 @@ import {
   isTextMatchesQueryFilter,
 } from '../../../utils/types/IsType'
 import pluralize from 'pluralize'
+import { ReadonlyDeep } from 'type-fest'
 
 const MAX_VALUES_IN_FILTER_FOR_INDIVIDUAL_PILLS = 4
 
@@ -96,7 +97,7 @@ function getPillPropsFromTextMatchesQueryFilter(
 }
 
 function getPillPropsFromQueryFilters(
-  queryFilters: QueryFilter[],
+  queryFilters: ReadonlyDeep<QueryFilter[]>,
   queryContext: QueryContextType,
   queryVisualizationContext: QueryVisualizationContextType,
 ): SelectionCriteriaPillProps[] {
@@ -123,7 +124,7 @@ function getPillPropsFromQueryFilters(
 }
 
 function getPillPropsFromFacetFilters(
-  selectedFacets: FacetColumnRequest[],
+  selectedFacets: ReadonlyDeep<FacetColumnRequest[]>,
   queryContext: QueryContextType,
   queryVisualizationContext: QueryVisualizationContextType,
 ): SelectionCriteriaPillProps[] {
@@ -195,8 +196,7 @@ function getPillPropsFromFacetFilters(
 function SelectionCriteriaPills() {
   const queryContext = useQueryContext()
   const queryVisualizationContext = useQueryVisualizationContext()
-  const { getLastQueryRequest } = queryContext
-  const lastQueryRequest = getLastQueryRequest()
+  const { lastQueryRequest } = queryContext
 
   const queryFilterPillProps = getPillPropsFromQueryFilters(
     lastQueryRequest.query?.additionalFilters ?? [],

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -626,7 +626,7 @@ export const getAsyncResultFromJobId = async <TRequest, TResponse>(
   )
   setCurrentAsyncStatus?.(response)
   while (response.jobState && response.jobState === 'PROCESSING') {
-    await delay(500)
+    await delay(1000)
     response = await doGet<AsynchronousJobStatus<TRequest, TResponse>>(
       ASYNCHRONOUS_JOB_TOKEN(asyncJobId),
       accessToken,

--- a/packages/synapse-react-client/src/synapse-queries/entity/useExportToCavatica.ts
+++ b/packages/synapse-react-client/src/synapse-queries/entity/useExportToCavatica.ts
@@ -4,12 +4,15 @@ import { parseEntityIdFromSqlStatement } from '../../utils/functions/SqlFunction
 import { useSynapseContext } from '../../utils/context/SynapseContext'
 import {
   DownloadFromTableRequest,
+  FacetColumnRequest,
   QueryBundleRequest,
+  QueryFilter,
   SelectColumn,
 } from '@sage-bionetworks/synapse-types'
+import { ReadonlyDeep } from 'type-fest'
 
 export function useExportToCavatica(
-  queryBundleRequest: QueryBundleRequest,
+  queryBundleRequest: ReadonlyDeep<QueryBundleRequest>,
   selectColumns?: SelectColumn[],
 ) {
   const { accessToken } = useSynapseContext()
@@ -27,13 +30,15 @@ export function useExportToCavatica(
       const downloadFromTableRequest: DownloadFromTableRequest = {
         sql,
         entityId: parseEntityIdFromSqlStatement(sql),
-        selectedFacets: queryBundleRequest.query.selectedFacets,
+        selectedFacets: queryBundleRequest.query
+          .selectedFacets as FacetColumnRequest[],
         concreteType:
           'org.sagebionetworks.repo.model.table.DownloadFromTableRequest',
         writeHeader,
         includeRowIdAndRowVersion,
         csvTableDescriptor: { separator },
-        additionalFilters: queryBundleRequest.query.additionalFilters,
+        additionalFilters: queryBundleRequest.query
+          .additionalFilters as QueryFilter[],
       }
       const result = await SynapseClient.getDownloadFromTableRequest(
         downloadFromTableRequest,

--- a/packages/synapse-react-client/src/utils/functions/queryUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/queryUtils.ts
@@ -6,6 +6,7 @@ import {
   FacetColumnResult,
   Query,
   QueryBundleRequest,
+  QueryFilter,
   QueryResultBundle,
   SelectColumn,
 } from '@sage-bionetworks/synapse-types'
@@ -14,6 +15,7 @@ import {
   isColumnMultiValueFunctionQueryFilter,
   isColumnSingleValueQueryFilter,
 } from '../types/IsType'
+import { ReadonlyDeep } from 'type-fest'
 
 type PartialStateObject = {
   hasMoreData: boolean
@@ -131,7 +133,7 @@ export function removeLockedColumnFromFacetData(
  * This includes facet filters and additional filters that are not applied to a locked column.
  */
 export function hasResettableFilters(
-  query: Query,
+  query: ReadonlyDeep<Query>,
   lockedColumn?: LockedColumn,
 ): boolean {
   const hasFacetFilters =
@@ -141,7 +143,7 @@ export function hasResettableFilters(
     ).length > 0
   const hasAdditionalFilters =
     Array.isArray(query.additionalFilters) &&
-    query.additionalFilters.filter(queryFilter =>
+    query.additionalFilters.filter((queryFilter: ReadonlyDeep<QueryFilter>) =>
       isColumnSingleValueQueryFilter(queryFilter) ||
       isColumnMultiValueFunctionQueryFilter(queryFilter)
         ? queryFilter.columnName !== lockedColumn?.columnName

--- a/packages/synapse-react-client/src/utils/types/IsType.ts
+++ b/packages/synapse-react-client/src/utils/types/IsType.ts
@@ -45,7 +45,9 @@ import {
  */
 export function isTypeViaConcreteTypeFactory<
   TTypeChecked extends ObjectType, // The type that you are trying to verify/assert
-  ObjectType extends { concreteType: string } = { concreteType: string },
+  ObjectType extends { readonly concreteType: string } = {
+    readonly concreteType: string
+  },
 >(...expectedConcreteTypes: TTypeChecked['concreteType'][]) {
   return (object: ObjectType): object is TTypeChecked =>
     !!(

--- a/packages/synapse-react-client/stories/DownloadConfirmation.stories.tsx
+++ b/packages/synapse-react-client/stories/DownloadConfirmation.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { DownloadConfirmation } from '../src/components/download_list'
+
+const meta = {
+  title: 'Explore/DownloadConfirmation',
+  component: DownloadConfirmation,
+  args: {
+    getLastQueryRequest: () => ({
+      query: 'select * from syn123',
+    }),
+  },
+} satisfies Meta
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  args: {},
+}


### PR DESCRIPTION
- Deprecate `getLastQueryRequest` and just use a readonly `lastQueryRequest` object
- Expose dispatch signature for `executeQueryRequest`

Every call to `getLastQueryRequest` triggered an unnecessary `deepClone` call. Most of these instances are able to just use the object. Cases where the query is updated are able to use the dispatch signature for `executeQueryRequest`. This may have a slight impact on performance.