### PR TITLE
fix markdown-it-synapse publish and deployment

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -37,7 +37,7 @@ jobs:
               sha: context.sha
             })
       - name: Publish to NPM # or simulate the publish for PRs
-        run: pnpm publish --access public ${{ (github.event_name == 'pull_request' && '--dry-run --no-git-checks') || '' }}
+        run: pnpm publish --access public ${{ ((github.event_name == 'pull_request' || steps.package-version-check.outputs.changed == 'false') && '--dry-run --no-git-checks') || '' }}
         working-directory: ./packages/${{ matrix.publishablePackage }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/packages/markdown-it-synapse/package.json
+++ b/packages/markdown-it-synapse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-synapse",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "tag for markdown-it markdown parser.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -16,7 +16,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "rimraf ./dist && tsup ./src/index.ts --format esm,cjs --dts",
+    "build": "rimraf ./dist && tsup ./src/index.ts --format esm,cjs,iife --dts --minify --global-name markdownitSynapse",
     "lint": "eslint src/*",
     "test": "jest",
     "coverage": "jest --coverage",

--- a/packages/synapse-react-client/.storybook/preview-head.html
+++ b/packages/synapse-react-client/.storybook/preview-head.html
@@ -36,7 +36,7 @@
 ></script>
 
 <script src="https://cdn.jsdelivr.net/npm/markdown-it@8.4.2/dist/markdown-it.min.js"></script>
-<script src="https://unpkg.com/markdown-it-synapse@latest/dist/index.js"></script>
+<script src="https://unpkg.com/markdown-it-synapse@latest/dist/index.global.js"></script>
 <script src="https://unpkg.com/markdown-it-center-text@1.0.4/dist/markdown-it-center-text.min.js"></script>
 <script src="https://unpkg.com/markdown-it-synapse-heading@1.0.1/dist/markdown-it-synapse-heading.min.js"></script>
 <script src="https://unpkg.com/markdown-it-synapse-table@1.0.6/dist/markdown-it-synapse-table.min.js"></script>

--- a/packages/synapse-react-client/.storybook/preview-head.html
+++ b/packages/synapse-react-client/.storybook/preview-head.html
@@ -36,7 +36,7 @@
 ></script>
 
 <script src="https://cdn.jsdelivr.net/npm/markdown-it@8.4.2/dist/markdown-it.min.js"></script>
-<script src="https://unpkg.com/markdown-it-synapse@latest/dist/markdown-it-synapse.min.js"></script>
+<script src="https://unpkg.com/markdown-it-synapse@latest/dist/index.js"></script>
 <script src="https://unpkg.com/markdown-it-center-text@1.0.4/dist/markdown-it-center-text.min.js"></script>
 <script src="https://unpkg.com/markdown-it-synapse-heading@1.0.1/dist/markdown-it-synapse-heading.min.js"></script>
 <script src="https://unpkg.com/markdown-it-synapse-table@1.0.6/dist/markdown-it-synapse-table.min.js"></script>


### PR DESCRIPTION
- add back IIFE/UMD distribution
- If version did not increment, `pnpm publish` should include `--dry-run`