### PR TITLE
[bug fix]: set version number as optional in DownloadListItemResult

### DIFF
--- a/packages/synapse-react-client/src/components/DownloadCart/DownloadListTable.tsx
+++ b/packages/synapse-react-client/src/components/DownloadCart/DownloadListTable.tsx
@@ -322,12 +322,7 @@ export default function DownloadListTable(props: DownloadListTableProps) {
                               associatedObjectType={
                                 FileHandleAssociateType.FileEntity
                               }
-                              {...(item.versionNumber !== null
-                                ? {
-                                    entityVersionNumber:
-                                      item.versionNumber.toString(),
-                                  }
-                                : {})}
+                              entityVersionNumber={item.versionNumber?.toString()}
                               displayFileName={false}
                               onClickCallback={(isExternalLink: boolean) => {
                                 // SWC-5944: remove the item from the download list, unless it's an external link.

--- a/packages/synapse-react-client/src/components/DownloadCart/DownloadListTable.tsx
+++ b/packages/synapse-react-client/src/components/DownloadCart/DownloadListTable.tsx
@@ -322,7 +322,12 @@ export default function DownloadListTable(props: DownloadListTableProps) {
                               associatedObjectType={
                                 FileHandleAssociateType.FileEntity
                               }
-                              entityVersionNumber={item.versionNumber.toString()}
+                              {...(item.versionNumber !== null
+                                ? {
+                                    entityVersionNumber:
+                                      item.versionNumber.toString(),
+                                  }
+                                : {})}
                               displayFileName={false}
                               onClickCallback={(isExternalLink: boolean) => {
                                 // SWC-5944: remove the item from the download list, unless it's an external link.

--- a/packages/synapse-types/src/DownloadListV2/DownloadListItemResult.ts
+++ b/packages/synapse-types/src/DownloadListV2/DownloadListItemResult.ts
@@ -9,6 +9,6 @@ export type DownloadListItemResult = {
   createdOn: string //The date-time when this file was created.
   fileSizeBytes: number //The size of the file in bytes.
   fileEntityId: string //The 'syn' identifier of a file entity.
-  versionNumber: number //When included, indicates that a specific version of a files was added to the user's download list. When excluded, the current version was added.
+  versionNumber?: number //When included, indicates that a specific version of a files was added to the user's download list. When excluded, the current version was added.
   isEligibleForPackaging: boolean //Only files that are managed by Synapse storage are eligible for packaging into a zip file. If true, then the file is eligible for packaging into a zip file.
 }


### PR DESCRIPTION
Related to: https://sagebionetworks.jira.com/browse/SWC-6332

## Changelog

* Updated type `DownloadListItemResult` to allow versionNumber to be optional
* In `DownloadListTable.tsx`, call entityVersionNumber.toString() only when entityVersionNumber is not null. If entityVersionNumber is null, then exclude it from prop. 