### PR TITLE
PORTALS-2622: Fix substitution

### DIFF
--- a/.github/workflows/build-and-deploy-app.yml
+++ b/.github/workflows/build-and-deploy-app.yml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ inputs.branch-or-tag }}
       - uses: ./.github/actions/pnpm-setup-action
       - name: build
-        run: pnpm nx run ${ inputs.app-name }:build
+        run: pnpm nx run ${{ inputs.app-name }}:build
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v2
         with:


### PR DESCRIPTION
There's an error when the deploy-app run, this variable is handled by GHA, not shell (typo).