### PR TITLE
CPO-690: add new module called "Educational Resources"

### DIFF
--- a/apps/portals/src/configurations/cancercomplexity/resources.ts
+++ b/apps/portals/src/configurations/cancercomplexity/resources.ts
@@ -6,3 +6,4 @@ export const projectsSql = `SELECT * FROM syn21868602`
 export const publicationSql = 'SELECT * FROM syn21868591'
 export const toolsSql = 'SELECT * FROM syn26127427 WHERE portalDisplay = true'
 export const peopleSql = 'SELECT * FROM syn28073190 where portalDisplay = true'
+export const educationSql = 'SELECT * FROM syn51497305'

--- a/apps/portals/src/configurations/cancercomplexity/routeControlWrapperProps.ts
+++ b/apps/portals/src/configurations/cancercomplexity/routeControlWrapperProps.ts
@@ -3,7 +3,14 @@ import { RouteControlWrapperProps } from 'portal-components/RouteControlWrapper'
 const routeControlProps: RouteControlWrapperProps = {
   // this has to get overriden,
   synapseConfig: {} as SynapseConfig,
-  customRoutes: ['Grants', 'People', 'Publications', 'Datasets', 'Tools'],
+  customRoutes: [
+    'Grants',
+    'People',
+    'Publications',
+    'Datasets',
+    'Tools',
+    'Education',
+  ],
 }
 
 export default routeControlProps

--- a/apps/portals/src/configurations/cancercomplexity/routeControlWrapperProps.ts
+++ b/apps/portals/src/configurations/cancercomplexity/routeControlWrapperProps.ts
@@ -9,7 +9,7 @@ const routeControlProps: RouteControlWrapperProps = {
     'Publications',
     'Datasets',
     'Tools',
-    'Education',
+    'Educational Resources',
   ],
 }
 

--- a/apps/portals/src/configurations/cancercomplexity/routesConfig.ts
+++ b/apps/portals/src/configurations/cancercomplexity/routesConfig.ts
@@ -1,5 +1,12 @@
 import { GenericRoute } from 'types/portal-config'
-import { publications, datasets, grants, tools, people } from './synapseConfigs'
+import {
+  publications,
+  datasets,
+  grants,
+  tools,
+  people,
+  education,
+} from './synapseConfigs'
 import { projectCardConfiguration } from './synapseConfigs/projects'
 import { datasetCardConfiguration } from './synapseConfigs/datasets'
 import RouteControlWrapperProps from './routeControlWrapperProps'
@@ -8,6 +15,7 @@ import DatasetSvg from './style/Dataset.svg'
 import { publicationsCardConfiguration } from './synapseConfigs/publications'
 import { grantsCardConfiguration } from './synapseConfigs/grants'
 import { peopleCardConfiguration } from './synapseConfigs/people'
+import { educationCardConfiguration } from './synapseConfigs/education'
 import { onPointClick } from './synapseConfigs/onPointClick'
 import columnAliases from './columnAliases'
 import {
@@ -17,6 +25,7 @@ import {
   projectsSql,
   toolsSql,
   peopleSql,
+  educationSql,
 } from './resources'
 import consortiaHomePageConfig from './synapseConfigs/consortiaHomePage'
 import {
@@ -616,6 +625,64 @@ const routes: GenericRoute[] = [
                         sqlOperator: ColumnSingleValueFilterOperator.EQUAL,
                         sql: publicationSql,
                         ...publicationsCardConfiguration,
+                        columnAliases,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        path: 'Education',
+        routes: [
+          {
+            path: '',
+            exact: true,
+            synapseConfigArray: [
+              {
+                name: 'RouteControlWrapper',
+                isOutsideContainer: true,
+                props: {
+                  ...RouteControlWrapperProps,
+                  synapseConfig: education,
+                },
+              },
+            ],
+          },
+          {
+            path: 'DetailsPage',
+            exact: false,
+            synapseConfigArray: [
+              {
+                name: 'CardContainerLogic',
+                isOutsideContainer: true,
+                props: {
+                  isHeader: true,
+                  sqlOperator: ColumnSingleValueFilterOperator.EQUAL,
+                  ...educationCardConfiguration,
+                  secondaryLabelLimit: Infinity,
+                  sql: educationSql,
+                  columnAliases,
+                },
+              },
+              {
+                name: 'DetailsPage',
+                props: {
+                  sql: educationSql,
+                  sqlOperator: ColumnSingleValueFilterOperator.LIKE,
+                  synapseConfigArray: [
+                    {
+                      name: 'CardContainerLogic',
+                      columnName: 'resourceGrantNumber',
+                      title: 'Related Grants',
+                      tableSqlKeys: ['grantNumber'],
+                      props: {
+                        sqlOperator: ColumnSingleValueFilterOperator.EQUAL,
+                        sql: grantsSql,
+                        ...grantsCardConfiguration,
                         columnAliases,
                       },
                     },

--- a/apps/portals/src/configurations/cancercomplexity/routesConfig.ts
+++ b/apps/portals/src/configurations/cancercomplexity/routesConfig.ts
@@ -636,7 +636,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        path: 'Education',
+        path: 'Educational Resources',
         routes: [
           {
             path: '',

--- a/apps/portals/src/configurations/cancercomplexity/routesConfig.ts
+++ b/apps/portals/src/configurations/cancercomplexity/routesConfig.ts
@@ -15,7 +15,7 @@ import DatasetSvg from './style/Dataset.svg'
 import { publicationsCardConfiguration } from './synapseConfigs/publications'
 import { grantsCardConfiguration } from './synapseConfigs/grants'
 import { peopleCardConfiguration } from './synapseConfigs/people'
-import { educationCardConfiguration } from './synapseConfigs/education'
+import { educationDetailsCardConfiguration } from './synapseConfigs/education'
 import { onPointClick } from './synapseConfigs/onPointClick'
 import columnAliases from './columnAliases'
 import {
@@ -662,7 +662,7 @@ const routes: GenericRoute[] = [
                 props: {
                   isHeader: true,
                   sqlOperator: ColumnSingleValueFilterOperator.EQUAL,
-                  ...educationCardConfiguration,
+                  ...educationDetailsCardConfiguration,
                   secondaryLabelLimit: Infinity,
                   sql: educationSql,
                   columnAliases,
@@ -676,7 +676,7 @@ const routes: GenericRoute[] = [
                   synapseConfigArray: [
                     {
                       name: 'CardContainerLogic',
-                      columnName: 'resourceGrantNumber',
+                      columnName: 'grantNumber',
                       title: 'Related Grants',
                       tableSqlKeys: ['grantNumber'],
                       props: {

--- a/apps/portals/src/configurations/cancercomplexity/synapseConfigs/education.ts
+++ b/apps/portals/src/configurations/cancercomplexity/synapseConfigs/education.ts
@@ -1,0 +1,81 @@
+import {
+  CardConfiguration,
+  GenericCardSchema,
+  IconOptions,
+  SynapseComponents,
+  SynapseConstants,
+} from 'synapse-react-client'
+import { educationSql } from '../resources'
+import { SynapseConfig } from 'types/portal-config'
+
+const rgbIndex = 8
+
+export const educationSchema: GenericCardSchema = {
+  type: 'Educational Resource',
+  title: 'resourceTitle',
+  subTitle: 'resourceTopic',
+  description: 'resourceDescription',
+  secondaryLabels: [
+    'resourceLink',
+    'resourceActivityType',
+    'resourcePrimaryFormat',
+    'resourceIntendedUse',
+    'resourcePrimaryAudience',
+    'resourceEducationalLevel',
+    'resourceOriginInstitution',
+    'resourceLanguage',
+    'resourceLicense',
+    'resourceUseRequirements',
+    'resourceMediaAccessibility',
+    'resourceAccessHazard',
+    'resourceDatasetAlias',
+    'resourceToolLink',
+  ],
+}
+
+// TODO: Change iconOptions type to map () => string | JSX.Element and remove cast
+const iconOptions: IconOptions = {
+  Grant: SynapseComponents.ProjectIcon as unknown as string,
+}
+
+export const educationCardConfiguration: CardConfiguration = {
+  type: SynapseConstants.GENERIC_CARD,
+  secondaryLabelLimit: 3,
+  iconOptions,
+  genericCardSchema: educationSchema,
+  titleLinkConfig: {
+    isMarkdown: false,
+    URLColumnName: 'resourceTitle',
+    matchColumnName: 'resourceTitle',
+    baseURL: 'Explore/Education/DetailsPage',
+  },
+  labelLinkConfig: [
+    {
+      isMarkdown: true,
+      matchColumnName: 'resourceLink',
+    },
+    {
+      isMarkdown: true,
+      matchColumnName: 'resourceDatasetAlias',
+    },
+    {
+      isMarkdown: true,
+      matchColumnName: 'resourceToolLink',
+    },
+  ],
+}
+
+export const education: SynapseConfig = {
+  name: 'QueryWrapperPlotNav',
+  props: {
+    rgbIndex,
+    sql: educationSql,
+    cardConfiguration: educationCardConfiguration,
+    shouldDeepLink: true,
+    name: 'Educational Resources',
+    facetsToPlot: ['resourceTopic', 'resourceActivityType'],
+    searchConfiguration: {
+      searchable: ['resourceTitle', 'resourceDescription'],
+    },
+  },
+}

--- a/apps/portals/src/configurations/cancercomplexity/synapseConfigs/education.ts
+++ b/apps/portals/src/configurations/cancercomplexity/synapseConfigs/education.ts
@@ -31,7 +31,7 @@ export const educationCardConfiguration: CardConfiguration = {
     isMarkdown: false,
     URLColumnName: 'title',
     matchColumnName: 'title',
-    baseURL: 'Explore/Education/DetailsPage',
+    baseURL: 'Explore/Educational Resources/DetailsPage',
   },
   labelLinkConfig: [
     {

--- a/apps/portals/src/configurations/cancercomplexity/synapseConfigs/education.ts
+++ b/apps/portals/src/configurations/cancercomplexity/synapseConfigs/education.ts
@@ -38,6 +38,21 @@ const iconOptions: IconOptions = {
   Grant: SynapseComponents.ProjectIcon as unknown as string,
 }
 
+export const educationSchema: GenericCardSchema = {
+  type: 'Educational Resource',
+  title: 'title',
+  subTitle: 'topic',
+  description: 'description',
+  secondaryLabels: [
+    'link',
+    'activityType',
+    'primaryFormat',
+    'educationalLevel',
+    'originInstitution',
+    'language',
+  ],
+}
+
 export const educationCardConfiguration: CardConfiguration = {
   type: SynapseConstants.GENERIC_CARD,
   secondaryLabelLimit: 3,
@@ -45,22 +60,14 @@ export const educationCardConfiguration: CardConfiguration = {
   genericCardSchema: educationSchema,
   titleLinkConfig: {
     isMarkdown: false,
-    URLColumnName: 'resourceTitle',
-    matchColumnName: 'resourceTitle',
+    URLColumnName: 'title',
+    matchColumnName: 'title',
     baseURL: 'Explore/Education/DetailsPage',
   },
   labelLinkConfig: [
     {
       isMarkdown: true,
-      matchColumnName: 'resourceLink',
-    },
-    {
-      isMarkdown: true,
-      matchColumnName: 'resourceDatasetAlias',
-    },
-    {
-      isMarkdown: true,
-      matchColumnName: 'resourceToolLink',
+      matchColumnName: 'link',
     },
   ],
 }
@@ -73,9 +80,9 @@ export const education: SynapseConfig = {
     cardConfiguration: educationCardConfiguration,
     shouldDeepLink: true,
     name: 'Educational Resources',
-    facetsToPlot: ['resourceTopic', 'resourceActivityType'],
+    facetsToPlot: ['topic', 'activityType'],
     searchConfiguration: {
-      searchable: ['resourceTitle', 'resourceDescription'],
+      searchable: ['title', 'description'],
     },
   },
 }

--- a/apps/portals/src/configurations/cancercomplexity/synapseConfigs/education.ts
+++ b/apps/portals/src/configurations/cancercomplexity/synapseConfigs/education.ts
@@ -1,42 +1,12 @@
 import {
   CardConfiguration,
   GenericCardSchema,
-  IconOptions,
-  SynapseComponents,
   SynapseConstants,
 } from 'synapse-react-client'
 import { educationSql } from '../resources'
 import { SynapseConfig } from 'types/portal-config'
 
 const rgbIndex = 8
-
-export const educationSchema: GenericCardSchema = {
-  type: 'Educational Resource',
-  title: 'resourceTitle',
-  subTitle: 'resourceTopic',
-  description: 'resourceDescription',
-  secondaryLabels: [
-    'resourceLink',
-    'resourceActivityType',
-    'resourcePrimaryFormat',
-    'resourceIntendedUse',
-    'resourcePrimaryAudience',
-    'resourceEducationalLevel',
-    'resourceOriginInstitution',
-    'resourceLanguage',
-    'resourceLicense',
-    'resourceUseRequirements',
-    'resourceMediaAccessibility',
-    'resourceAccessHazard',
-    'resourceDatasetAlias',
-    'resourceToolLink',
-  ],
-}
-
-// TODO: Change iconOptions type to map () => string | JSX.Element and remove cast
-const iconOptions: IconOptions = {
-  Grant: SynapseComponents.ProjectIcon as unknown as string,
-}
 
 export const educationSchema: GenericCardSchema = {
   type: 'Educational Resource',
@@ -56,7 +26,6 @@ export const educationSchema: GenericCardSchema = {
 export const educationCardConfiguration: CardConfiguration = {
   type: SynapseConstants.GENERIC_CARD,
   secondaryLabelLimit: 3,
-  iconOptions,
   genericCardSchema: educationSchema,
   titleLinkConfig: {
     isMarkdown: false,
@@ -85,4 +54,51 @@ export const education: SynapseConfig = {
       searchable: ['title', 'description'],
     },
   },
+}
+
+/**
+ *  Request to show different labels on Details Page vs Explore page.
+ */
+export const educationDetailsSchema: GenericCardSchema = {
+  type: 'Educational Resource',
+  title: 'title',
+  subTitle: 'topic',
+  description: 'description',
+  secondaryLabels: [
+    'link',
+    'activityType',
+    'primaryFormat',
+    'intendedUse',
+    'primaryAudience',
+    'educationalLevel',
+    'originInstitution',
+    'language',
+    'contributors',
+    'license',
+    'useRequirements',
+    'mediaAccessibility',
+    'accessHazard',
+    'datasetLink',
+    'toolLink',
+  ],
+}
+
+export const educationDetailsCardConfiguration: CardConfiguration = {
+  type: SynapseConstants.GENERIC_CARD,
+  secondaryLabelLimit: 3,
+  genericCardSchema: educationDetailsSchema,
+  labelLinkConfig: [
+    {
+      isMarkdown: true,
+      matchColumnName: 'link',
+    },
+    {
+      isMarkdown: true,
+      matchColumnName: 'datasetLink',
+    },
+    {
+      isMarkdown: true,
+      matchColumnName: 'toolLink',
+    },
+  ],
 }

--- a/apps/portals/src/configurations/cancercomplexity/synapseConfigs/index.ts
+++ b/apps/portals/src/configurations/cancercomplexity/synapseConfigs/index.ts
@@ -5,7 +5,26 @@ import { publications } from './publications'
 import { projects } from './projects'
 import { tools } from './tools'
 import { people } from './people'
+import { education } from './education'
 
-export { files, datasets, grants, publications, projects, tools, people }
+export {
+  files,
+  datasets,
+  grants,
+  publications,
+  projects,
+  tools,
+  people,
+  education,
+}
 
-export default { files, datasets, grants, publications, projects, tools, people }
+export default {
+  files,
+  datasets,
+  grants,
+  publications,
+  projects,
+  tools,
+  people,
+  education,
+}


### PR DESCRIPTION
More information about the proposed feature in the parent ticket [here](https://sagebionetworks.jira.com/browse/CPO-512)

TL;DR -
Add a new section called "Educational Resources" to CCKP, which will display information about education-related SOPs generated by the MC2 Center community

CC: @aclayton555 

## Preview

**Explore Page**
![Screenshot 2023-07-12 at 4 36 25 PM](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/9377970/ab1ca87c-48f7-409f-a1b1-58088b69f47f)

**Details Page**
![Screenshot 2023-07-12 at 4 36 14 PM](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/9377970/9471f717-a3f4-4d43-a053-2ec2d239f7b7)

> **Note**: @aclayton555 is working on marking the education portal table as open-data