### PR TITLE
SWC-6501: Use treeOnly Entity Finder for access requirement related project selection

### DIFF
--- a/packages/synapse-react-client/src/components/EntityFinder/EntityFinderModal.tsx
+++ b/packages/synapse-react-client/src/components/EntityFinder/EntityFinderModal.tsx
@@ -42,7 +42,7 @@ export const EntityFinderModal = (props: EntityFinderModalProps) => {
         open={props.show}
         title={props.title}
         fullWidth={false}
-        maxWidth="lg"
+        maxWidth="xl"
         titleHelpPopoverProps={props.titleHelpPopoverProps}
         confirmButtonText={props.confirmButtonCopy}
         onConfirm={() => {

--- a/packages/synapse-react-client/src/components/dataaccess/AccessRequirementDashboard.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/AccessRequirementDashboard.tsx
@@ -127,6 +127,7 @@ export function AccessRequirementDashboard(
           initialContainer: null,
           selectMultiple: false,
           selectableTypes: [EntityType.PROJECT],
+          treeOnly: true,
         }}
         show={showEntityFinder}
         onCancel={() => {


### PR DESCRIPTION
Ann suggested that the current (two-pane) view was confusing. It isn't intuitive to use the two-pane view to pick all projects, since you have to pick the "fake" folder of "All projects" before you can pick a project.

Using the "treeOnly" view simplifies the interface, and makes selecting a project more intuitive.