### PR TITLE
PORTALS-2752 - add useCommittedState hook

### DIFF
--- a/packages/synapse-react-client/src/utils/hooks/useCommittedState.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useCommittedState.ts
@@ -1,0 +1,41 @@
+import React from 'react'
+
+type UseCommittedStateReturn<T> = {
+  committedState: T
+  uncommittedState: T
+  commit: () => void
+  setUncommittedState: React.Dispatch<React.SetStateAction<T>>
+  isDirty: boolean
+}
+
+/**
+ * A hook that allows you to track an 'uncommitted' version of a state variable, and batch all state updates into
+ * one transaction.
+ * @param initialCommittedState
+ */
+export default function useCommittedState<T>(
+  initialCommittedState: T,
+): UseCommittedStateReturn<T> {
+  const [committedState, setCommittedState] = React.useState<T>(
+    initialCommittedState,
+  )
+  const [uncommittedState, setUncommittedState] = React.useState<T>(
+    initialCommittedState,
+  )
+
+  const isDirty = committedState !== uncommittedState
+
+  const commit = React.useCallback(() => {
+    if (isDirty) {
+      setCommittedState(uncommittedState)
+    }
+  }, [isDirty, uncommittedState])
+
+  return {
+    committedState,
+    uncommittedState,
+    commit,
+    setUncommittedState,
+    isDirty: committedState !== uncommittedState,
+  }
+}

--- a/packages/synapse-react-client/test/utils/hooks/useCommittedState.test.ts
+++ b/packages/synapse-react-client/test/utils/hooks/useCommittedState.test.ts
@@ -1,0 +1,46 @@
+import { act, renderHook } from '@testing-library/react'
+import useCommittedState from '../../../src/utils/hooks/useCommittedState'
+
+describe('useCommittedState', () => {
+  it('tracks two versions of state and updates on commit', () => {
+    const initialState = {
+      foo: 'bar',
+    }
+
+    const hook = renderHook(() => useCommittedState(initialState))
+
+    expect(hook.result.current.committedState).toEqual(initialState)
+    expect(hook.result.current.uncommittedState).toBe(
+      hook.result.current.committedState,
+    )
+    expect(hook.result.current.isDirty).toBe(false)
+
+    const newState = {
+      foo: 'baz',
+    }
+
+    // Update the uncommitted state
+    act(() => {
+      hook.result.current.setUncommittedState(newState)
+    })
+
+    expect(hook.result.current.uncommittedState).not.toBe(
+      hook.result.current.committedState,
+    )
+    expect(hook.result.current.committedState).toEqual(initialState)
+    expect(hook.result.current.uncommittedState).toEqual(newState)
+    expect(hook.result.current.isDirty).toBe(true)
+
+    // Commit the state update transaction
+    act(() => {
+      hook.result.current.commit()
+    })
+
+    expect(hook.result.current.uncommittedState).toBe(
+      hook.result.current.committedState,
+    )
+    expect(hook.result.current.committedState).toEqual(newState)
+    expect(hook.result.current.uncommittedState).toEqual(newState)
+    expect(hook.result.current.isDirty).toBe(false)
+  })
+})


### PR DESCRIPTION
useCommittedState will be used to track two versions of a query request in state. This could be useful for any form with an intermediate set of changes that should all be committed in one transaction.