### PR TITLE
PORTALS-2752 , PORTALS-2758 - refactor QueryWrapper deep linking/onChange, fix lockedColumn issue, drop extraneous query params

### DIFF
--- a/packages/synapse-react-client/src/components/useImmutableTableQuery.ts
+++ b/packages/synapse-react-client/src/components/useImmutableTableQuery.ts
@@ -225,7 +225,6 @@ export default function useImmutableTableQuery(
   useEffect(() => {
     if (shouldDeepLink) {
       if (isEqual(initQueryRequest, lastQueryRequest)) {
-        // reset URL...somehow
         DeepLinkingUtils.updateUrlWithNewSearchParam(
           'QueryWrapper',
           componentIndex,

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/SelectionCriteriaPills.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/SelectionCriteriaPills.tsx
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  QueryContextType,
-  useQueryContext,
-} from '../../QueryContext/QueryContext'
+import { QueryContextType, useQueryContext } from '../../QueryContext'
 import {
   ColumnMultiValueFunctionQueryFilter,
   ColumnSingleValueQueryFilter,
@@ -25,6 +22,7 @@ import {
   isTextMatchesQueryFilter,
 } from '../../../utils/types/IsType'
 import pluralize from 'pluralize'
+import { ReadonlyDeep } from 'type-fest'
 
 const MAX_VALUES_IN_FILTER_FOR_INDIVIDUAL_PILLS = 4
 
@@ -96,7 +94,7 @@ function getPillPropsFromTextMatchesQueryFilter(
 }
 
 function getPillPropsFromQueryFilters(
-  queryFilters: QueryFilter[],
+  queryFilters: ReadonlyDeep<QueryFilter[]>,
   queryContext: QueryContextType,
   queryVisualizationContext: QueryVisualizationContextType,
 ): SelectionCriteriaPillProps[] {
@@ -105,7 +103,10 @@ function getPillPropsFromQueryFilters(
       isColumnSingleValueQueryFilter(queryFilter) ||
       isColumnMultiValueFunctionQueryFilter(queryFilter)
     ) {
-      if (queryFilter.columnName === queryContext.lockedColumn?.columnName) {
+      if (
+        queryFilter.columnName.toLowerCase() ===
+        queryContext.lockedColumn?.columnName?.toLowerCase()
+      ) {
         return []
       }
       return getPillPropsFromColumnQueryFilter(
@@ -116,22 +117,22 @@ function getPillPropsFromQueryFilters(
     } else if (isTextMatchesQueryFilter(queryFilter)) {
       return [getPillPropsFromTextMatchesQueryFilter(queryFilter, queryContext)]
     } else {
-      console.log(
-        'Unknown query filter type',
-        (queryFilter as any).concreteType,
-      )
+      console.log('Unknown query filter type', queryFilter)
       return []
     }
   })
 }
 
 function getPillPropsFromFacetFilters(
-  selectedFacets: FacetColumnRequest[],
+  selectedFacets: ReadonlyDeep<FacetColumnRequest[]>,
   queryContext: QueryContextType,
   queryVisualizationContext: QueryVisualizationContextType,
 ): SelectionCriteriaPillProps[] {
   return selectedFacets.flatMap(selectedFacet => {
-    if (selectedFacet.columnName === queryContext.lockedColumn?.columnName) {
+    if (
+      selectedFacet.columnName.toLowerCase() ===
+      queryContext.lockedColumn?.columnName?.toLowerCase()
+    ) {
       return []
     }
     const columnModel = queryContext.getColumnModel(selectedFacet.columnName)!

--- a/packages/synapse-react-client/src/utils/functions/deepLinkingUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/deepLinkingUtils.ts
@@ -35,12 +35,13 @@ export function updateUrlWithNewSearchParam(
   }
 
   const searchString = currentSearch.toString()
-
   window.history.replaceState(
     null,
     '',
     window.location.pathname +
-      (currentSearch.size > 0 ? `?${searchString.toString()}` : ''),
+      (Array.from(currentSearch).length > 0
+        ? `?${searchString.toString()}`
+        : ''),
   )
 }
 

--- a/packages/synapse-react-client/src/utils/functions/queryUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/queryUtils.ts
@@ -139,14 +139,17 @@ export function hasResettableFilters(
   const hasFacetFilters =
     Array.isArray(query.selectedFacets) &&
     query.selectedFacets.filter(
-      facet => facet.columnName !== lockedColumn?.columnName,
+      facet =>
+        facet.columnName.toLowerCase() !==
+        lockedColumn?.columnName?.toLowerCase(),
     ).length > 0
   const hasAdditionalFilters =
     Array.isArray(query.additionalFilters) &&
     query.additionalFilters.filter(queryFilter =>
       isColumnSingleValueQueryFilter(queryFilter) ||
       isColumnMultiValueFunctionQueryFilter(queryFilter)
-        ? queryFilter.columnName !== lockedColumn?.columnName
+        ? queryFilter.columnName.toLowerCase() !==
+          lockedColumn?.columnName?.toLowerCase()
         : true,
     ).length > 0
 
@@ -187,4 +190,36 @@ export function queryRequestsHaveSameTotalResults(
     }
     return isEqual(value1, value2)
   })
+}
+
+/**
+ * Remove null/empty values from the query parameters where an undefined value is equivalent.
+ *
+ * This will ensure a query object is as simple as possible for URL search parameters and also increases the
+ * likelihood of a cache hit.
+ * @param q
+ */
+export function removeEmptyQueryParams(q: Query) {
+  const query = cloneDeep(q)
+
+  if (query.limit == null) {
+    delete query.limit
+  }
+  if (query.offset == null) {
+    delete query.offset
+  }
+
+  if (query.sort == null || query.sort.length == 0) {
+    delete query.sort
+  }
+
+  if (query.selectedFacets == null || query.selectedFacets.length == 0) {
+    delete query.selectedFacets
+  }
+
+  if (query.additionalFilters == null || query.additionalFilters.length == 0) {
+    delete query.additionalFilters
+  }
+
+  return query
 }

--- a/packages/synapse-react-client/test/containers/QueryWrapper.test.tsx
+++ b/packages/synapse-react-client/test/containers/QueryWrapper.test.tsx
@@ -153,17 +153,26 @@ describe('QueryWrapper', () => {
         shouldDeepLink: true,
       })
 
+      const newSql = initialQueryRequest.query.sql + ' WHERE x = 1'
+
       await waitFor(() => expect(providedContext).toBeDefined())
-      act(() => {
-        providedContext!.executeQueryRequest(initialQueryRequest)
+
+      await act(async () => {
+        providedContext!.executeQueryRequest({
+          ...initialQueryRequest,
+          query: {
+            ...initialQueryRequest.query,
+            sql: newSql,
+          },
+        })
       })
+
       await waitFor(() => {
-        const location = window.location
         expect(location.search).toContain('QueryWrapper0')
         const query = JSON.parse(
-          decodeURIComponent(location.search.split('QueryWrapper0=')[1]),
+          new URLSearchParams(location.search).get('QueryWrapper0'),
         )
-        expect(query.sql).toEqual(initialQueryRequest.query.sql)
+        expect(query.sql).toEqual(newSql)
         expect(mockGetQueryTableAsyncJobResults).toHaveBeenCalled()
       })
     })

--- a/packages/synapse-react-client/test/containers/queryUtils.test.ts
+++ b/packages/synapse-react-client/test/containers/queryUtils.test.ts
@@ -22,6 +22,7 @@ import {
   isFacetAvailable,
   isSingleNotSetValue,
   queryRequestsHaveSameTotalResults,
+  removeEmptyQueryParams,
 } from '../../src/utils/functions/queryUtils'
 import { LockedColumn } from '../../src'
 import { mockTableEntity } from '../../mocks/entity/mockTableEntity'
@@ -387,5 +388,63 @@ describe('facet support', () => {
       ]
       expect(queryRequestsHaveSameTotalResults(query, newQuery)).toEqual(true)
     })
+  })
+})
+
+describe('removeEmptyQueryParams', () => {
+  it('removes empty arrays', () => {
+    const query: Query = {
+      sql: 'select * from syn123',
+      selectedFacets: [],
+      additionalFilters: [],
+      sort: [],
+      limit: 10,
+      offset: 20,
+    }
+
+    const expected = {
+      sql: 'select * from syn123',
+      limit: 10,
+      offset: 20,
+    }
+
+    const actual = removeEmptyQueryParams(query)
+    expect(actual).toEqual(expected)
+  })
+
+  it('removes null values', () => {
+    const query: Query = {
+      sql: 'select * from syn123',
+      selectedFacets: null,
+      additionalFilters: null,
+      sort: null,
+      limit: null,
+      offset: null,
+    }
+
+    const expected = {
+      sql: 'select * from syn123',
+    }
+
+    const actual = removeEmptyQueryParams(query)
+    expect(actual).toEqual(expected)
+  })
+
+  it('removes undefined values', () => {
+    const query: Query = {
+      sql: 'select * from syn123',
+      selectedFacets: undefined,
+      additionalFilters: undefined,
+      sort: undefined,
+      limit: undefined,
+      offset: undefined,
+    }
+
+    const expected = {
+      sql: 'select * from syn123',
+    }
+
+    const actual = removeEmptyQueryParams(query)
+    expect(actual).toEqual(expected)
   })
 })

--- a/packages/synapse-react-client/test/utils/hooks/useImmutableTableQuery.test.tsx
+++ b/packages/synapse-react-client/test/utils/hooks/useImmutableTableQuery.test.tsx
@@ -164,7 +164,8 @@ describe('useImmutableTableQuery tests', () => {
       }),
     )
 
-    expect(mockUpdateUrl).not.toHaveBeenCalled()
+    // called with `null`, which would remove the query parameter, if it exists
+    expect(mockUpdateUrl).toHaveBeenCalledWith('QueryWrapper', 4, null)
 
     const newQuery = cloneDeep(options.initQueryRequest)
     newQuery.query.sql = 'SELECT * FROM syn123.3 WHERE "foo"=\'baz\''
@@ -176,7 +177,7 @@ describe('useImmutableTableQuery tests', () => {
     expect(mockUpdateUrl).toHaveBeenCalledWith(
       'QueryWrapper',
       4,
-      encodeURIComponent(JSON.stringify(newQuery.query)),
+      JSON.stringify(newQuery.query),
     )
   })
 

--- a/packages/synapse-react-client/test/utils/hooks/useImmutableTableQuery.test.tsx
+++ b/packages/synapse-react-client/test/utils/hooks/useImmutableTableQuery.test.tsx
@@ -179,6 +179,12 @@ describe('useImmutableTableQuery tests', () => {
       4,
       JSON.stringify(newQuery.query),
     )
+
+    // Change the query back to the initial query, and the parameter should be removed
+    act(() => {
+      result.current.setQuery(options.initQueryRequest)
+    })
+    expect(mockUpdateUrl).toHaveBeenLastCalledWith('QueryWrapper', 4, null)
   })
 
   it('Updates the query on mount one is found in the URL', () => {


### PR DESCRIPTION
Refactoring / improvements related to PORTALS-2752 - query state management must be overhauled, so I made a few changes to streamline side effects and improve UX
- onChange will be invoked when setState is called internally. Before, it was wrapped in `useEffect` where we had logic to prevent it from running conditionally on the first render. `useEffect` is the wrong mechanism for this kind of behavior
- Deep linking (URL search params) code will always synchronize with the current query.
- If the current query matches the initial query, and is deep linking, then the URL search parameter will be removed
- Remove extraneous query parameters like null values and extra arrays to better match queries for deep linking and cache hits

Also fix PORTALS-2758 - lockedColumn matching should be case-insensitive