### PR TITLE
PORTALS-2634, PORTALS-2636 - SDS for FullTextSearch, SqlEditor, Explore alignment fixes

### DIFF
--- a/packages/synapse-react-client/src/components/FullTextSearch.tsx
+++ b/packages/synapse-react-client/src/components/FullTextSearch.tsx
@@ -1,7 +1,7 @@
-import { Collapse } from '@mui/material'
-import React, { useRef, useState } from 'react'
+import { Collapse, IconButton, TextField } from '@mui/material'
+import React, { ChangeEvent, useRef, useState } from 'react'
 import { TextMatchesQueryFilter } from '@sage-bionetworks/synapse-types'
-import { useQueryContext } from './QueryContext/QueryContext'
+import { useQueryContext } from './QueryContext'
 import { useQueryVisualizationContext } from './QueryVisualizationWrapper'
 import { HelpPopover } from './HelpPopover/HelpPopover'
 import IconSvg from './IconSvg/IconSvg'
@@ -60,50 +60,58 @@ export const FullTextSearch: React.FunctionComponent<FullTextSearchProps> = ({
     }
   }
 
-  const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     searchInputRef.current?.setCustomValidity('')
     setSearchText(event.currentTarget.value)
   }
 
   return (
-    <div className={`QueryWrapperSearchInput`}>
+    <div className={`QueryWrapperFullTextSearchInput`}>
       <Collapse in={showSearchBar} timeout={{ enter: 300, exit: 300 }}>
-        <div className="QueryWrapperSearchInput__helppopoverwrapper">
-          <form
-            className="QueryWrapperSearchInput__searchbar"
-            onSubmit={search}
-          >
-            <span className="QueryWrapperSearchInput__searchbar__searchicon">
-              <IconSvg icon="search" />
-            </span>
-            <input
-              ref={searchInputRef}
-              minLength={MIN_SEARCH_QUERY_LENGTH}
-              onChange={handleChange}
-              placeholder="Enter Search Terms"
-              value={searchText}
-              type="text"
-            />
-            {searchText.length > 0 && (
-              <button
-                className="QueryWrapperSearchInput__searchbar__clearbutton"
-                type="button"
-                onClick={() => {
-                  setSearchText('')
-                }}
-              >
-                <IconSvg icon="close" />
-              </button>
-            )}
-          </form>
-          <div className="QueryWrapperSearchInput__helppopover">
-            <HelpPopover
-              markdownText={helpMessage}
-              helpUrl={helpUrl}
-              placement="left"
-            />
-          </div>
-        </div>
+        <form onSubmit={search}>
+          <TextField
+            sx={{ width: '100%' }}
+            inputProps={{
+              minLength: MIN_SEARCH_QUERY_LENGTH,
+              ref: searchInputRef,
+            }}
+            InputProps={{
+              startAdornment: (
+                <IconSvg
+                  icon="search"
+                  wrap={false}
+                  sx={{
+                    mr: 1,
+                    color: 'grey.600',
+                  }}
+                />
+              ),
+              endAdornment: (
+                <>
+                  {searchText.length > 0 && (
+                    <IconButton
+                      size={'small'}
+                      onClick={() => {
+                        setSearchText('')
+                      }}
+                    >
+                      <IconSvg icon="close" wrap={false} fontSize={'inherit'} />
+                    </IconButton>
+                  )}
+                  <HelpPopover
+                    markdownText={helpMessage}
+                    helpUrl={helpUrl}
+                    placement="left"
+                  />
+                </>
+              ),
+            }}
+            onChange={handleChange}
+            placeholder="Enter Search Terms"
+            value={searchText}
+            type="text"
+          />
+        </form>
       </Collapse>
     </div>
   )

--- a/packages/synapse-react-client/src/components/SynapseTable/SqlEditor.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SqlEditor.tsx
@@ -1,9 +1,9 @@
-import { SearchTwoTone } from '@mui/icons-material'
-import { Collapse } from '@mui/material'
-import React, { useEffect, useRef, useState } from 'react'
+import { Collapse, TextField } from '@mui/material'
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react'
 import { HelpPopover } from '../HelpPopover/HelpPopover'
 import { useQueryVisualizationContext } from '../QueryVisualizationWrapper'
-import { useQueryContext } from '../QueryContext/QueryContext'
+import { useQueryContext } from '../QueryContext'
+import IconSvg from '../IconSvg'
 
 export type SqlEditorProps = {
   helpMessage?: string
@@ -44,7 +44,7 @@ export const SqlEditor: React.FunctionComponent<SqlEditorProps> = ({
     })
   }
 
-  const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     inputRef.current?.setCustomValidity('')
     setSql(event.currentTarget.value)
   }
@@ -52,28 +52,37 @@ export const SqlEditor: React.FunctionComponent<SqlEditorProps> = ({
   return (
     <div className={`QueryWrapperSqlEditorInput`}>
       <Collapse in={showSqlEditor} timeout={{ enter: 300, exit: 300 }}>
-        <div className="QueryWrapperSqlEditorInput__helppopoverwrapper">
-          <form
-            className="QueryWrapperSqlEditorInput__searchbar"
-            onSubmit={search}
-          >
-            <SearchTwoTone className="QueryWrapperSqlEditorInput__searchbar__searchicon" />
-            <input
-              ref={inputRef}
-              onChange={handleChange}
-              placeholder="Enter Query"
-              value={sql}
-              type="text"
-            />
-          </form>
-          <div className="QueryWrapperSqlEditorInput__helppopover">
-            <HelpPopover
-              markdownText={helpMessage}
-              helpUrl={helpUrl}
-              placement="right"
-            />
-          </div>
-        </div>
+        <form onSubmit={search}>
+          <TextField
+            inputProps={{
+              ref: inputRef,
+            }}
+            sx={{ width: '100%' }}
+            InputProps={{
+              startAdornment: (
+                <IconSvg
+                  icon="search"
+                  wrap={false}
+                  sx={{
+                    mr: 1,
+                    color: 'grey.600',
+                  }}
+                />
+              ),
+              endAdornment: (
+                <HelpPopover
+                  markdownText={helpMessage}
+                  helpUrl={helpUrl}
+                  placement="right"
+                />
+              ),
+            }}
+            onChange={handleChange}
+            placeholder="Enter Query"
+            value={sql}
+            type="text"
+          />
+        </form>
       </Collapse>
     </div>
   )

--- a/packages/synapse-react-client/src/style/components/_query-wrapper-plot-nav.scss
+++ b/packages/synapse-react-client/src/style/components/_query-wrapper-plot-nav.scss
@@ -12,6 +12,10 @@
       grid-column: 1 / span 2;
     }
 
+    .ErrorBannerWrapper {
+      grid-column: 1 / span 2;
+    }
+
     // column (depends on if we are showing facet filters)
     &.isShowingFacetFilters {
       .FacetFilterControls {
@@ -20,9 +24,9 @@
       }
       .download-confirmation,
       .FacetNav,
+      .QueryWrapperFullTextSearchInput,
       .QueryWrapperSearchInput,
       .QueryWrapperSqlEditorInput,
-      .ErrorBannerWrapper,
       .FilterAndView {
         grid-column: 2 / span 1;
       }
@@ -48,6 +52,7 @@
   .download-confirmation {
     grid-row: 3 / span 1;
   }
+  .QueryWrapperFullTextSearchInput,
   .QueryWrapperSearchInput {
     grid-row: 4 / span 1;
     .MuiCollapse-entered {
@@ -85,14 +90,23 @@
     .FilterAndView {
       margin-top: 10px;
     }
+    .FacetNav,
+    .FilterAndView,
+    .ErrorBannerWrapper,
+    .QueryWrapperFullTextSearchInput,
+    .QueryWrapperSearchInput,
+    .QueryWrapperSqlEditorInput,
+    .download-confirmation {
+      margin-left: 0px;
+    }
   }
 
   > .FacetFilterControls,
   > .download-confirmation,
   > .FacetNav,
+  > .QueryWrapperFullTextSearchInput,
   > .QueryWrapperSearchInput,
   > .QueryWrapperSqlEditorInput,
-  > .ErrorBannerWrapper,
   > .FilterAndView {
     margin-left: 15px;
   }
@@ -124,6 +138,11 @@
     .direct-download {
       text-align: center;
     }
+  }
+
+  .ErrorBannerWrapper,
+  .download-confirmation {
+    margin-top: 8px;
   }
 }
 

--- a/packages/synapse-react-client/src/style/components/_query-wrapper-text-input.scss
+++ b/packages/synapse-react-client/src/style/components/_query-wrapper-text-input.scss
@@ -1,7 +1,6 @@
 @use '../abstracts/variables' as SRC;
 
-.QueryWrapperSearchInput,
-.QueryWrapperSqlEditorInput {
+.QueryWrapperSearchInput {
   &__helppopoverwrapper {
     display: grid;
     grid-template-columns: auto 25px;


### PR DESCRIPTION
Changed FullTextSearch and SqlEditor components to match SDS style and put info button inside the input. While these changes were not explicitly called out in designs, it supports PORTALS-2636 by having the end of the input align with the right edge of the components

Also updated CSS margins for many components


|Component|Before|After|
|---|---|---|
|FullTextSearch|![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/e4868143-53b7-49d0-831b-13b6335608e0) |![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/89b1bbf6-504c-4269-bfb2-7be1036938ec) |
| SqlEditor | ![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/c4efe8c2-f534-41cf-b7e3-2eb2e368350d)| ![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/c414a581-3b43-472a-a82d-24a651e2520c) |