### PR TITLE
PORTALS-2634, PORTALS-2636: TopLevelControls/TotalQueryResults appears to be full width in portals

### DIFF
--- a/apps/portals/src/portal-components/RouteControlWrapper.tsx
+++ b/apps/portals/src/portal-components/RouteControlWrapper.tsx
@@ -5,7 +5,10 @@ import { SynapseComponent } from '../SynapseComponent'
 import { ConfigRoute, NestedRoute } from '../types/portal-config'
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material'
 import { Box, Typography, useMediaQuery, useTheme } from '@mui/material'
-import { RESPONSIVE_SIDE_PADDING } from '../utils'
+import {
+  NEGATIVE_RESPONSIVE_SIDE_MARGIN,
+  RESPONSIVE_SIDE_PADDING,
+} from '../utils'
 
 export type RouteControlWrapperProps = NestedRoute & {
   // we have to pass in all the custom routes because unlike the home page the explore buttons configs aren't held in state
@@ -95,7 +98,20 @@ export default function RouteControlWrapper(props: RouteControlWrapperProps) {
           <RouteControl {...routeControlProps} />
         )}
       </Box>
-      <Box sx={RESPONSIVE_SIDE_PADDING}>
+      <Box
+        sx={{
+          ...RESPONSIVE_SIDE_PADDING,
+          ['.TopLevelControls, .TotalQueryResults.hasFilters']: {
+            ...NEGATIVE_RESPONSIVE_SIDE_MARGIN,
+            mt: 0,
+            px: RESPONSIVE_SIDE_PADDING['px'],
+          },
+          '.TopLevelControls > div': {
+            px: 0,
+            py: 2.5,
+          },
+        }}
+      >
         {customRoutes.map((route) => (
           <Route
             key={route.path}

--- a/apps/portals/src/utils.ts
+++ b/apps/portals/src/utils.ts
@@ -14,9 +14,17 @@ export const DESKTOP_VIEWPORT_MIN_WIDTH_MEDIA_QUERY = `(min-width: ${DESKTOP_VIE
 export const useShowDesktop = () =>
   useMediaQuery(DESKTOP_VIEWPORT_MIN_WIDTH_MEDIA_QUERY)
 
-export const RESPONSIVE_SIDE_PADDING: SxProps = {
+export const RESPONSIVE_SIDE_PADDING = {
   px: {
     xs: 2,
     md: 5,
   },
-}
+} satisfies SxProps
+
+// Should stay in sync with RESPONSIVE_SIDE_PADDING
+export const NEGATIVE_RESPONSIVE_SIDE_MARGIN = {
+  mx: {
+    xs: -2,
+    md: -5,
+  },
+} satisfies SxProps


### PR DESCRIPTION
![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/73908d4b-1661-41a7-92e6-2c1c41e2a787)