### PR TITLE
PORTALS-2639 - QueryWrapperPlotNav/SynapseTable style updates

### DIFF
--- a/apps/portals/src/configurations/arkportal/style/_style_overrides.scss
+++ b/apps/portals/src/configurations/arkportal/style/_style_overrides.scss
@@ -20,7 +20,7 @@
 // targets all columns that are 4 from the beginning
 // https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child
 // relying on having specified the order in the studies sql
-td.SRC_noBorderTop:nth-child(n + 4) {
+.SynapseTable td:nth-child(n + 4) {
   .markdown.markdown-inline {
     a {
       font-size: 0px;

--- a/apps/portals/src/configurations/crc-researcher/style/_style_overrides.scss
+++ b/apps/portals/src/configurations/crc-researcher/style/_style_overrides.scss
@@ -5,11 +5,12 @@
   background-blend-mode: multiply;
 }
 
-td.SRC_noBorderTop {
+.SynapseTable td {
   .markdown.markdown-inline {
     a {
       white-space: nowrap;
     }
+
     a::after {
       font-family: 'Font Awesome 5 Free';
       content: '\f35d';

--- a/apps/portals/src/configurations/digitalhealth/style/_style_overrides.scss
+++ b/apps/portals/src/configurations/digitalhealth/style/_style_overrides.scss
@@ -36,7 +36,7 @@
 // targets all columns that are 4 from the beginning
 // https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child
 // relying on having specified the order in the studies sql
-td.SRC_noBorderTop:nth-child(n + 4) {
+.SynapseTable td:nth-child(n + 4) {
   .markdown.markdown-inline {
     a {
       font-size: 0px;

--- a/apps/portals/src/portal-components/RouteControlWrapper.tsx
+++ b/apps/portals/src/portal-components/RouteControlWrapper.tsx
@@ -5,7 +5,10 @@ import { SynapseComponent } from '../SynapseComponent'
 import { ConfigRoute, NestedRoute } from '../types/portal-config'
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material'
 import { Box, Typography, useMediaQuery, useTheme } from '@mui/material'
-import { RESPONSIVE_SIDE_PADDING } from '../utils'
+import {
+  NEGATIVE_RESPONSIVE_SIDE_MARGIN,
+  RESPONSIVE_SIDE_PADDING,
+} from '../utils'
 
 export type RouteControlWrapperProps = NestedRoute & {
   // we have to pass in all the custom routes because unlike the home page the explore buttons configs aren't held in state
@@ -95,7 +98,20 @@ export default function RouteControlWrapper(props: RouteControlWrapperProps) {
           <RouteControl {...routeControlProps} />
         )}
       </Box>
-      <Box sx={RESPONSIVE_SIDE_PADDING}>
+      <Box
+        sx={{
+          ...RESPONSIVE_SIDE_PADDING,
+          ['.TopLevelControls, .TotalQueryResults.hasFilters']: {
+            ...NEGATIVE_RESPONSIVE_SIDE_MARGIN,
+            mt: 0,
+            px: RESPONSIVE_SIDE_PADDING['px'],
+          },
+          '.TopLevelControls > div': {
+            px: 0,
+            py: 2.5,
+          },
+        }}
+      >
         {customRoutes.map((route) => (
           <Route
             key={route.path}

--- a/apps/portals/src/utils.ts
+++ b/apps/portals/src/utils.ts
@@ -14,9 +14,17 @@ export const DESKTOP_VIEWPORT_MIN_WIDTH_MEDIA_QUERY = `(min-width: ${DESKTOP_VIE
 export const useShowDesktop = () =>
   useMediaQuery(DESKTOP_VIEWPORT_MIN_WIDTH_MEDIA_QUERY)
 
-export const RESPONSIVE_SIDE_PADDING: SxProps = {
+export const RESPONSIVE_SIDE_PADDING = {
   px: {
     xs: 2,
     md: 5,
   },
-}
+} satisfies SxProps
+
+// Should stay in sync with RESPONSIVE_SIDE_PADDING
+export const NEGATIVE_RESPONSIVE_SIDE_MARGIN = {
+  mx: {
+    xs: -2,
+    md: -5,
+  },
+} satisfies SxProps

--- a/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
@@ -22,7 +22,7 @@ import {
   Row,
   SelectColumn,
 } from '@sage-bionetworks/synapse-types'
-import { Tooltip } from '@mui/material'
+import { Box, Link, Tooltip } from '@mui/material'
 import {
   CardLink,
   ColumnIconConfigs,
@@ -286,14 +286,14 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
     if (str.match(SYNAPSE_ENTITY_ID_REGEX)) {
       // its a synId
       return (
-        <a
+        <Link
           target={TargetEnum.NEW_WINDOW}
           rel="noopener noreferrer"
           href={`${PRODUCTION_ENDPOINT_CONFIG.PORTAL}#!Synapse:${str}`}
           className={newClassName}
         >
           {str}
-        </a>
+        </Link>
       )
     } else {
       // they don't need a link
@@ -348,7 +348,7 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
               {split.map((el, index) => {
                 return (
                   <React.Fragment key={el}>
-                    <a
+                    <Link
                       href={href ?? undefined}
                       target={linkTarget ?? TargetEnum.NEW_WINDOW}
                       rel="noopener noreferrer"
@@ -357,7 +357,7 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
                       style={style}
                     >
                       {el}
-                    </a>
+                    </Link>
                     {index < split.length - 1 && (
                       <span style={{ marginRight: 4 }}>, </span>
                     )}
@@ -381,7 +381,7 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
 
             return (
               <React.Fragment key={el}>
-                <a
+                <Link
                   href={href}
                   key={el}
                   className={newClassName}
@@ -389,7 +389,7 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
                   target={linkTarget ?? TargetEnum.CURRENT_WINDOW}
                 >
                   {el}
-                </a>
+                </Link>
                 {index < split.length - 1 && (
                   <span style={{ marginRight: 4 }}>, </span>
                 )}
@@ -548,17 +548,16 @@ export function ShortDescription(props: {
         {getCutoff(description).previewText}
       </span>
       {description.length >= CHAR_COUNT_CUTOFF && (
-        <a
+        <Link
           style={{
             fontSize: '16px',
             cursor: 'pointer',
             marginLeft: '5px',
           }}
-          className="highlight-link"
           onClick={toggleShowMore}
         >
           ...Show More
-        </a>
+        </Link>
       )}
     </div>
   )
@@ -612,14 +611,13 @@ export default class GenericCard extends React.Component<
   }) => {
     if (href) {
       return (
-        <a
+        <Link
           data-search-handle={titleSearchHandle}
           target={target}
           href={href}
-          className="highlight-link"
         >
           {title}
-        </a>
+        </Link>
       )
     } else {
       return <span data-search-handle={titleSearchHandle}> {title} </span>
@@ -900,11 +898,15 @@ export default class GenericCard extends React.Component<
               />
             )}
             {ctaLinkConfig && ctaHref && ctaTarget && (
-              <div className="SRC-portalCardCTALink bootstrap-4-backport">
-                <a target={ctaTarget} rel="noopener noreferrer" href={ctaHref}>
+              <Box sx={{ mt: '20px' }}>
+                <Link
+                  target={ctaTarget}
+                  rel="noopener noreferrer"
+                  href={ctaHref}
+                >
                   {ctaLinkConfig.text}
-                </a>
-              </div>
+                </Link>
+              </Box>
             )}
           </div>
         </div>

--- a/packages/synapse-react-client/src/components/IconSvg/IconSvg.tsx
+++ b/packages/synapse-react-client/src/components/IconSvg/IconSvg.tsx
@@ -34,6 +34,7 @@ import {
   ExpandLess,
   ExpandMore,
   FactCheckTwoTone,
+  FilterAltTwoTone,
   FlagTwoTone,
   FolderTwoTone,
   FormatBold,
@@ -58,6 +59,7 @@ import {
   Login,
   MailOutlineTwoTone,
   MoreVertTwoTone,
+  OpenInFull,
   OpenInNewTwoTone,
   PeopleTwoTone,
   PhoneTwoTone,
@@ -73,6 +75,7 @@ import {
   SearchOutlined,
   SearchTwoTone,
   ShoppingCartOutlined,
+  Sort,
   Star,
   StarOutline,
   StarTwoTone,
@@ -117,7 +120,6 @@ import { EntityType } from '@sage-bionetworks/synapse-types'
 import { Tooltip } from '@mui/material'
 import CreateVersion from '../../assets/icons/CreateVersion'
 import { SvgIconProps } from '@mui/material/SvgIcon/SvgIcon'
-import { SortDown, SortUp } from '../../assets/themed_icons'
 import { GoogleIcon24 } from '../../assets/GoogleIcon24'
 
 export const IconStrings = [
@@ -139,6 +141,7 @@ export const IconStrings = [
   'dashboard',
   'delete',
   'deleteSweep',
+  'filter',
   'addToCart',
   'addCircleOutline',
   'addCircleTwoTone',
@@ -241,6 +244,7 @@ export const IconStrings = [
   'sortUp',
   'sortDown',
   'google24',
+  'openInFull',
 ] as const
 
 export type IconName = (typeof IconStrings)[number]
@@ -496,11 +500,23 @@ function IconMapping(props: { icon: string } & SvgIconProps) {
     case 'email':
       return <MailOutlineTwoTone {...otherProps} />
     case 'sortUp':
-      return <SortUp {...otherProps} />
+      return (
+        <Sort
+          {...otherProps}
+          sx={{
+            transform: 'scale(1, -1)',
+            ...otherProps.sx,
+          }}
+        />
+      )
     case 'sortDown':
-      return <SortDown {...otherProps} />
+      return <Sort {...otherProps} />
     case 'google24':
       return <GoogleIcon24 {...otherProps} />
+    case 'filter':
+      return <FilterAltTwoTone {...otherProps} />
+    case 'openInFull':
+      return <OpenInFull {...otherProps} />
     default:
       return <></>
   }

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/FilterAndView.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/FilterAndView.tsx
@@ -6,6 +6,7 @@ import { useQueryContext } from '../QueryContext'
 import { useSynapseContext } from '../../utils'
 import { useQueryVisualizationContext } from '../QueryVisualizationWrapper'
 import LastUpdatedOn from './LastUpdatedOn'
+import { Box, LinearProgress, Typography } from '@mui/material'
 
 export type FilterAndViewProps = {
   tableConfiguration:
@@ -22,9 +23,28 @@ const FilterAndView = (props: FilterAndViewProps) => {
   const { tableConfiguration, cardConfiguration, hideDownload } = props
   const synapseContext = useSynapseContext()
   const queryContext = useQueryContext()
+  const { data, isLoadingNewBundle, asyncJobStatus } = queryContext
   const queryVisualizationContext = useQueryVisualizationContext()
   return (
     <div className={`FilterAndView`}>
+      {!data && isLoadingNewBundle && (
+        <Box sx={{ mt: 15, mx: 15 }}>
+          <LinearProgress />
+          {asyncJobStatus?.progressMessage && (
+            <Typography
+              variant={'smallText1'}
+              sx={{
+                color: 'grey.600',
+                fontSize: '10px',
+                textAlign: 'center',
+                my: 1,
+              }}
+            >
+              {asyncJobStatus?.progressMessage}
+            </Typography>
+          )}
+        </Box>
+      )}
       {tableConfiguration ? (
         <SynapseTable
           {...tableConfiguration}

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/JSON/JSONArrayRenderer.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/JSON/JSONArrayRenderer.tsx
@@ -24,7 +24,11 @@ export function JSONArrayRenderer(props: JSONArrayRendererProps) {
     )
   }
   if (value.length === 1) {
-    return <JSONPrimitiveRenderer value={value[0]} />
+    return (
+      <Typography variant={'smallText1'}>
+        <JSONPrimitiveRenderer value={value[0]} />
+      </Typography>
+    )
   }
   return (
     <>

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/JSON/JSONTableCellRenderer.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/JSON/JSONTableCellRenderer.tsx
@@ -7,6 +7,7 @@ import { JSONPrimitiveRenderer } from './JSONPrimitiveRenderer'
 import { JSONArrayRenderer } from './JSONArrayRenderer'
 import { JSONObjectRenderer } from './JSONObjectRenderer'
 import { ComplexJSONRenderer } from './ComplexJSONRenderer'
+import { Typography } from '@mui/material'
 
 export type JSONTableCellRendererProps = {
   value: string | null
@@ -25,7 +26,11 @@ export default function JSONTableCellRenderer(
   }
 
   if (isJSONPrimitive(value) || value === null) {
-    return <JSONPrimitiveRenderer value={value} />
+    return (
+      <Typography variant="smallText1">
+        <JSONPrimitiveRenderer value={value} />
+      </Typography>
+    )
   } else if (Array.isArray(value) && value.every(isJSONPrimitive)) {
     return <JSONArrayRenderer value={value} />
   } else if (

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/JSON/__snapshots__/JSONTableCellRenderer.test.tsx.snap
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/JSON/__snapshots__/JSONTableCellRenderer.test.tsx.snap
@@ -471,25 +471,37 @@ exports[`JSONTableCellRenderer handles "complex object" case 1`] = `
 exports[`JSONTableCellRenderer handles "null" case 1`] = `
 <div>
   <span
-    class="MuiTypography-root MuiTypography-smallText1 SRC-inactive css-37jdci-MuiTypography-root"
+    class="MuiTypography-root MuiTypography-smallText1 css-37jdci-MuiTypography-root"
   >
-    &lt;null value&gt;
+    <span
+      class="MuiTypography-root MuiTypography-smallText1 SRC-inactive css-37jdci-MuiTypography-root"
+    >
+      &lt;null value&gt;
+    </span>
   </span>
 </div>
 `;
 
 exports[`JSONTableCellRenderer handles "one item" case 1`] = `
 <div>
-  foo
+  <span
+    class="MuiTypography-root MuiTypography-smallText1 css-37jdci-MuiTypography-root"
+  >
+    foo
+  </span>
 </div>
 `;
 
 exports[`JSONTableCellRenderer handles "one null item" case 1`] = `
 <div>
   <span
-    class="MuiTypography-root MuiTypography-smallText1 SRC-inactive css-37jdci-MuiTypography-root"
+    class="MuiTypography-root MuiTypography-smallText1 css-37jdci-MuiTypography-root"
   >
-    &lt;null value&gt;
+    <span
+      class="MuiTypography-root MuiTypography-smallText1 SRC-inactive css-37jdci-MuiTypography-root"
+    >
+      &lt;null value&gt;
+    </span>
   </span>
 </div>
 `;

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/SynapseTableCell.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/SynapseTableCell.tsx
@@ -30,12 +30,12 @@ import { EntityLink } from '../../EntityLink'
 import EvaluationIdRenderer from './EvaluationIdRenderer'
 import { SynapseCardLabel } from '../../GenericCard'
 import IconSvg, { IconName } from '../../IconSvg/IconSvg'
-import { useQueryContext } from '../../QueryContext/QueryContext'
+import { useQueryContext } from '../../QueryContext'
 import { NOT_SET_DISPLAY_VALUE } from '../SynapseTableConstants'
 import UserCard from '../../UserCard/UserCard'
 import UserIdList from './UserIdList'
 import JSONTableCellRenderer from './JSON/JSONTableCellRenderer'
-import { Typography } from '@mui/material'
+import { Link, Typography } from '@mui/material'
 
 export type SynapseTableCellProps = {
   columnType: ColumnType
@@ -161,12 +161,15 @@ export function SynapseTableCell(props: SynapseTableCellProps) {
       return (
         <>
           {entity && (
-            <DirectDownload
-              associatedObjectId={entity.id!}
-              associatedObjectType={FileHandleAssociateType.TableEntity}
-              fileHandleId={columnValue}
-              displayFileName={true}
-            />
+            <p>
+              <DirectDownload
+                iconSvgPropOverrides={{ sx: { color: 'primary.main' } }}
+                associatedObjectId={entity.id!}
+                associatedObjectType={FileHandleAssociateType.TableEntity}
+                fileHandleId={columnValue}
+                displayFileName={true}
+              />
+            </p>
           )}
         </>
       )
@@ -224,13 +227,13 @@ export function SynapseTableCell(props: SynapseTableCellProps) {
             )
           }
           return (
-            <a
+            <Link
               target="_blank"
               rel="noopener noreferrer"
               href={`${PRODUCTION_ENDPOINT_CONFIG.PORTAL}#!Team:${ownerId}`}
             >
               <IconSvg icon={icon} /> {userName}
-            </a>
+            </Link>
           )
         } else {
           // isUserCard
@@ -246,13 +249,11 @@ export function SynapseTableCell(props: SynapseTableCellProps) {
       break
     case ColumnTypeEnum.LINK:
       return (
-        <a target="_blank" rel="noopener noreferrer" href={columnValue}>
+        <Link target="_blank" rel="noopener noreferrer" href={columnValue}>
           {columnValue}
-        </a>
+        </Link>
       )
     case ColumnTypeEnum.STRING:
-    case ColumnTypeEnum.DOUBLE:
-    case ColumnTypeEnum.INTEGER:
     case ColumnTypeEnum.BOOLEAN:
     case ColumnTypeEnum.MEDIUMTEXT:
     case ColumnTypeEnum.LARGETEXT: {
@@ -262,6 +263,26 @@ export function SynapseTableCell(props: SynapseTableCellProps) {
         </Typography>
       )
     }
+    case ColumnTypeEnum.INTEGER:
+      return (
+        <Typography
+          variant={'smallText1'}
+          sx={{ textAlign: 'right' }}
+          className={isBold}
+        >
+          {parseInt(columnValue).toLocaleString()}
+        </Typography>
+      )
+    case ColumnTypeEnum.DOUBLE:
+      return (
+        <Typography
+          variant={'smallText1'}
+          sx={{ textAlign: 'right' }}
+          className={isBold}
+        >
+          {parseFloat(columnValue).toLocaleString()}
+        </Typography>
+      )
     case ColumnTypeEnum.JSON:
       return <JSONTableCellRenderer value={columnValue} />
     default:

--- a/packages/synapse-react-client/src/components/SynapseTable/TablePagination.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/TablePagination.tsx
@@ -30,7 +30,12 @@ export const TablePagination = () => {
         count={Math.ceil(queryCount! / pageSize)}
         color="secondary"
         onChange={handlePage}
-        style={{ display: 'inline-block', float: 'left' }}
+        shape={'rounded'}
+        sx={{
+          display: 'inline-block',
+          float: 'left',
+          '.MuiPaginationItem-root': { fontSize: '14px' },
+        }}
       />
       <Typography variant="body1" style={{ display: 'inline-block' }}>
         {`${queryCount?.toLocaleString()} total rows /`}

--- a/packages/synapse-react-client/src/components/SynapseTable/TopLevelControls/TopLevelControls.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/TopLevelControls/TopLevelControls.tsx
@@ -13,7 +13,6 @@ import { ElementWithTooltip } from '../../widgets/ElementWithTooltip'
 import { ColumnSelection, DownloadOptions } from '../table-top'
 import { Button, Divider, Tooltip, Typography } from '@mui/material'
 import QueryCount from '../../QueryCount/QueryCount'
-import { Icon } from '../../row_renderers/utils'
 import MissingQueryResultsWarning from '../../MissingQueryResultsWarning/MissingQueryResultsWarning'
 import { Cavatica } from '../../../assets/icons/Cavatica'
 import { RowSelectionControls } from '../RowSelection/RowSelectionControls'
@@ -22,6 +21,7 @@ import {
   getNumberOfResultsToInvokeAction,
   getNumberOfResultsToInvokeActionCopy,
 } from './TopLevelControlsUtils'
+import IconSvg from '../../IconSvg'
 
 export type TopLevelControlsProps = {
   name?: string
@@ -182,15 +182,24 @@ const TopLevelControls = (props: TopLevelControlsProps) => {
             </>
           )}
           {!hideFacetFilterControl && (
-            <a
+            <Button
+              variant={'text'}
               onClick={() => setShowFacetFilter(value => !value)}
-              className="TopLevelControls__querycount__facetFilterLink SRC-no-underline-on-hover"
+              startIcon={
+                <IconSvg
+                  icon={showFacetFilter ? 'close' : 'filter'}
+                  wrap={false}
+                />
+              }
+              sx={{
+                ml: 2,
+                fontWeight: 400,
+                fontSize: '14px',
+                textDecoration: 'none !important',
+              }}
             >
-              <Icon type={showFacetFilter ? 'close' : 'filter'}></Icon>
-              <span className="TopLevelControls__querycount__facetFilterLink__text">
-                {showFacetFilter ? 'Hide' : 'Show'} filters
-              </span>
-            </a>
+              {showFacetFilter ? 'Hide' : 'Show'} filters
+            </Button>
           )}
         </div>
         <div className="TopLevelControls__actions">

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNav.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNav.tsx
@@ -63,7 +63,6 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
     isLoadingNewBundle,
     executeQueryRequest,
     error,
-    asyncJobStatus,
   } = useQueryContext()
 
   const { showFacetVisualization } = useQueryVisualizationContext()
@@ -178,19 +177,8 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
       lastQueryRequest.query.selectedFacets.length > 0) ||
     (lastQueryRequest?.query.additionalFilters !== undefined &&
       lastQueryRequest?.query.additionalFilters.length > 0)
-  if (error) {
+  if (error || (!data && isLoadingNewBundle)) {
     return <></>
-  } else if (!data && isLoadingNewBundle) {
-    return (
-      <div className="SRC-loadingContainer SRC-centerContentColumn">
-        {asyncJobStatus?.progressMessage && (
-          <div>
-            <span className="spinner" />
-            {asyncJobStatus.progressMessage}
-          </div>
-        )}
-      </div>
-    )
   } else {
     return (
       <>
@@ -209,8 +197,6 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
               {facets.map(facet => (
                 <div
                   style={{
-                    paddingLeft: '20px',
-                    paddingRight: '20px',
                     minWidth: '435px',
                     display: isFacetHiddenInGrid(facet.columnName)
                       ? 'none'

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNav.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNav.tsx
@@ -12,7 +12,7 @@ import { useQueryContext } from '../../QueryContext/QueryContext'
 import { applyChangesToValuesColumn } from '../query-filter/FacetFilterControls'
 import FacetNavPanel, { PlotType } from './FacetNavPanel'
 import TotalQueryResults from '../../TotalQueryResults'
-import WideButton from '../../styled/WideButton'
+import { Box, Button } from '@mui/material'
 
 /*
 TODO: This component has a few bugs when its props are updated with new data, this should be handled
@@ -254,20 +254,28 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
               ))}
             </div>
             {showMoreButtonState !== 'NONE' && (
-              <div className="FacetNav__showMoreContainer">
-                <WideButton
+              <Box
+                display="flex"
+                justifyContent="center"
+                sx={{
+                  backgroundColor: 'grey.100',
+                  p: 2,
+                  mt: 2,
+                }}
+              >
+                <Button
                   variant="contained"
                   color="secondary"
                   onClick={() =>
                     onShowMoreClick(showMoreButtonState === 'MORE')
                   }
-                  sx={{ width: '250px' }}
+                  sx={{ width: '150px' }}
                 >
                   {showMoreButtonState === 'LESS'
                     ? 'Hide Charts'
                     : 'View All Charts'}
-                </WideButton>
-              </div>
+                </Button>
+              </Box>
             )}
           </div>
         )}

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNavPanel.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNavPanel.tsx
@@ -6,7 +6,6 @@ import createPlotlyComponent from 'react-plotly.js/factory'
 import { SizeMe } from 'react-sizeme'
 import { SkeletonInlineBlock } from '../../Skeleton/SkeletonInlineBlock'
 import getColorPalette from '../../ColorGradient/ColorGradient'
-import { ElementWithTooltip } from '../ElementWithTooltip'
 import { SynapseConstants } from '../../../utils'
 import SynapseClient from '../../../synapse-client'
 import { useSynapseContext } from '../../../utils/context/SynapseContext'
@@ -20,12 +19,12 @@ import loadingScreen from '../../LoadingScreen/LoadingScreen'
 import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
 import { useQueryContext } from '../../QueryContext/QueryContext'
 import { EnumFacetFilter } from '../query-filter/EnumFacetFilter'
-import { Tooltip } from '@mui/material'
+import { Box, IconButton, Tooltip } from '@mui/material'
 import { useQuery } from 'react-query'
 import { ConfirmationDialog } from '../../ConfirmationDialog/ConfirmationDialog'
 import { FacetPlotLegendList } from './FacetPlotLegendList'
 import { FacetWithLabel, truncate } from './FacetPlotLegendUtils'
-import { Box } from '@mui/material'
+import IconSvg from '../../IconSvg'
 
 const Plot = createPlotlyComponent(Plotly)
 
@@ -366,22 +365,20 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
                   }
                   containerAs="Dropdown"
                 />
-                <ElementWithTooltip
-                  tooltipText="Expand to large graph"
-                  key="expandGraph"
-                  callbackFn={() => setShowModal(true)}
-                  className="SRC-primary-color"
-                  darkTheme={false}
-                  icon={'expand'}
-                />
-                <ElementWithTooltip
-                  tooltipText="Hide graph under Show More"
-                  key="hideGraph"
-                  callbackFn={() => onHide()}
-                  className="SRC-primary-color"
-                  darkTheme={false}
-                  icon={'close'}
-                />
+                <Tooltip title={'Expand to large graph'}>
+                  <IconButton onClick={() => setShowModal(true)} size={'small'}>
+                    <IconSvg
+                      icon={'openInFull'}
+                      wrap={false}
+                      fontSize={'inherit'}
+                    />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title={'Hide graph under Show More'}>
+                  <IconButton onClick={() => onHide()} size={'small'}>
+                    <IconSvg icon={'close'} wrap={false} fontSize={'inherit'} />
+                  </IconButton>
+                </Tooltip>
               </div>
             </div>
           )}

--- a/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter.tsx
@@ -1,8 +1,7 @@
-import { Collapse } from '@mui/material'
+import { Collapse, IconButton, Menu } from '@mui/material'
 import React, { useMemo, useState } from 'react'
 import { Dropdown } from 'react-bootstrap'
 import useDeepCompareEffect from 'use-deep-compare-effect'
-import { ElementWithTooltip } from '../ElementWithTooltip'
 import { SynapseConstants } from '../../../utils'
 import useGetInfoFromIds from '../../../utils/hooks/useGetInfoFromIds'
 import {
@@ -126,6 +125,15 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
   const [searchTerm, setSearchText] = useState<string>('')
   const [filteredSet, setFilteredSet] =
     useState<FacetColumnResultValueCount[]>(facetValues)
+
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const open = Boolean(anchorEl)
+  const handleClickDropdownIcon = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
 
   useDeepCompareEffect(() => {
     setFilteredSet(facetValues)
@@ -391,19 +399,28 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
       )
     } else {
       return (
-        <Dropdown
-          className="EnumFacetFilter"
-          show={isShowDropdown}
-          onToggle={onToggle}
-        >
-          <ElementWithTooltip
-            tooltipText="Filter by specific facet"
-            key="facetFilterTooltip"
-            darkTheme={false}
-            icon={'filter'}
-          />
-          <Dropdown.Menu>{content}</Dropdown.Menu>
-        </Dropdown>
+        <div className="EnumFacetFilter">
+          <IconButton onClick={handleClickDropdownIcon} size={'small'}>
+            <IconSvg
+              icon={'filter'}
+              wrap={false}
+              label={'Filter by specific facet'}
+              sx={{
+                color: allIsSelected ? 'grey.700' : 'primary.main',
+                fontSize: '20px',
+              }}
+            />
+          </IconButton>
+          <Menu
+            anchorEl={anchorEl}
+            open={open}
+            onClose={handleClose}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+          >
+            {content}
+          </Menu>
+        </div>
       )
     }
   } else {

--- a/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter.tsx
@@ -1,4 +1,4 @@
-import { Collapse, Fade, IconButton, Menu } from '@mui/material'
+import { Collapse, Fade, IconButton, Menu, Tooltip } from '@mui/material'
 import React, { useMemo, useState } from 'react'
 import { Dropdown } from 'react-bootstrap'
 import useDeepCompareEffect from 'use-deep-compare-effect'
@@ -400,17 +400,18 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
     } else {
       return (
         <div className="EnumFacetFilter">
-          <IconButton onClick={handleClickDropdownIcon} size={'small'}>
-            <IconSvg
-              icon={'filter'}
-              wrap={false}
-              label={'Filter by specific facet'}
-              sx={{
-                color: allIsSelected ? 'grey.700' : 'primary.main',
-                fontSize: '20px',
-              }}
-            />
-          </IconButton>
+          <Tooltip title={'Filter by specific facet'}>
+            <IconButton onClick={handleClickDropdownIcon} size={'small'}>
+              <IconSvg
+                icon={'filter'}
+                wrap={false}
+                sx={{
+                  color: allIsSelected ? 'grey.700' : 'primary.main',
+                  fontSize: '20px',
+                }}
+              />
+            </IconButton>
+          </Tooltip>
           <Menu
             anchorEl={anchorEl}
             open={open}

--- a/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter.tsx
@@ -1,4 +1,4 @@
-import { Collapse, IconButton, Menu } from '@mui/material'
+import { Collapse, Fade, IconButton, Menu } from '@mui/material'
 import React, { useMemo, useState } from 'react'
 import { Dropdown } from 'react-bootstrap'
 import useDeepCompareEffect from 'use-deep-compare-effect'
@@ -417,6 +417,7 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
             onClose={handleClose}
             anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
             transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+            TransitionComponent={Fade}
           >
             {content}
           </Menu>

--- a/packages/synapse-react-client/src/style/base/_core.scss
+++ b/packages/synapse-react-client/src/style/base/_core.scss
@@ -79,18 +79,6 @@ svg.SRC-hoverBox {
   overflow: auto;
 }
 
-.table > tbody > tr > td.SRC_noBorderTop {
-  border-top: none;
-}
-
-.table > thead.SRC_borderTop {
-  border-top: 1px solid #dddddd;
-}
-
-.table > thead.SRC_bordered th {
-  border: 1px solid #dddddd !important;
-}
-
 .table {
   .SRC-primary-text-color {
     svg {
@@ -1147,6 +1135,24 @@ hr ~ .QueryWrapperPlotNav {
 
 .SynapseTable {
   min-height: 400px;
+  th {
+    background-color: map.get(SRC.$colors, 'gray-100');
+    border-right: 1px solid map.get(SRC.$colors, 'gray-400');
+  }
+  td,
+  th {
+    & > * {
+      padding: 8px 10px;
+    }
+  }
+
+  tr:nth-of-type(2n) {
+    background-color: #fbfbfc;
+  }
+
+  tbody > tr > td {
+    vertical-align: top;
+  }
 }
 
 .table > tbody > tr > td {

--- a/packages/synapse-react-client/src/style/components/_cards.scss
+++ b/packages/synapse-react-client/src/style/components/_cards.scss
@@ -105,9 +105,6 @@ $text-color-lighter: #898989;
     display: flex;
     margin-left: 15px;
   }
-  .SRC-portalCardCTALink {
-    margin-top: 20px;
-  }
 
   .SRC-downloadData {
     border-radius: 20px;

--- a/packages/synapse-react-client/src/style/components/_expandable_table_data.scss
+++ b/packages/synapse-react-client/src/style/components/_expandable_table_data.scss
@@ -3,7 +3,6 @@
 
   p {
     text-overflow: ellipsis;
-    margin: 0px 5px;
   }
 
   &[aria-expanded='true'] {

--- a/packages/synapse-react-client/src/style/components/_query-wrapper-plot-nav.scss
+++ b/packages/synapse-react-client/src/style/components/_query-wrapper-plot-nav.scss
@@ -163,23 +163,6 @@
   &__querycount {
     display: inline-flex;
     align-items: center;
-    &__facetFilterLink {
-      height: 100%;
-      display: flex;
-      flex-wrap: nowrap;
-      justify-content: flex-start;
-      align-items: center;
-      margin-left: 15px;
-      font-weight: 400 !important;
-      &__text {
-        font-size: 14px;
-        margin-top: 4px;
-      }
-      svg {
-        margin-right: 7px;
-        margin-top: 8px;
-      }
-    }
   }
   &__actions {
     display: inline-flex;

--- a/packages/synapse-react-client/src/style/components/_query-wrapper-plot-nav.scss
+++ b/packages/synapse-react-client/src/style/components/_query-wrapper-plot-nav.scss
@@ -5,7 +5,8 @@
   display: grid;
 
   @media (min-width: map-get(SRC.$breakpoints, 'medium')) {
-    grid-template-columns: 25% 75%;
+    grid-template-columns: 23% 75%;
+    grid-column-gap: 2%;
 
     // by default, children take up the full row
     > * {
@@ -90,25 +91,6 @@
     .FilterAndView {
       margin-top: 10px;
     }
-    .FacetNav,
-    .FilterAndView,
-    .ErrorBannerWrapper,
-    .QueryWrapperFullTextSearchInput,
-    .QueryWrapperSearchInput,
-    .QueryWrapperSqlEditorInput,
-    .download-confirmation {
-      margin-left: 0px;
-    }
-  }
-
-  > .FacetFilterControls,
-  > .download-confirmation,
-  > .FacetNav,
-  > .QueryWrapperFullTextSearchInput,
-  > .QueryWrapperSearchInput,
-  > .QueryWrapperSqlEditorInput,
-  > .FilterAndView {
-    margin-left: 15px;
   }
 
   .QueryWrapperTextInput {

--- a/packages/synapse-react-client/src/style/components/facet_nav/_facet-nav-panel.scss
+++ b/packages/synapse-react-client/src/style/components/facet_nav/_facet-nav-panel.scss
@@ -27,6 +27,7 @@ $facetNavPanel-btn-margin: 0 1px;
       text-align: right;
       align-items: center;
       display: flex;
+      gap: 2px;
       line-height: 16px;
 
       .ElementWithTooltip {

--- a/packages/synapse-react-client/src/style/components/facet_nav/_facet-nav.scss
+++ b/packages/synapse-react-client/src/style/components/facet_nav/_facet-nav.scss
@@ -9,19 +9,11 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
+    gap: 4%;
 
     > div {
-      margin: 3px;
       flex-grow: 1;
-      flex-basis: 49%;
+      flex-basis: 45%;
     }
-  }
-
-  &__showMoreContainer {
-    background-color: SRC.$gray-light;
-    display: flex;
-    justify-content: center;
-    padding: 10px;
-    margin-top: 10px;
   }
 }

--- a/packages/synapse-react-client/src/style/components/facet_nav/_facet-nav.scss
+++ b/packages/synapse-react-client/src/style/components/facet_nav/_facet-nav.scss
@@ -2,7 +2,6 @@
 
 .FacetNav {
   padding-top: 5px;
-  border: 1px solid SRC.$gray-dark;
 
   &__row {
     background-color: #fff;

--- a/packages/synapse-react-client/src/style/components/query_filter/_enum-facet-filter.scss
+++ b/packages/synapse-react-client/src/style/components/query_filter/_enum-facet-filter.scss
@@ -16,12 +16,15 @@
     .EnumFacetFilter__checkboxContainer {
       cursor: pointer;
     }
+    .EnumFacetFilter__noMatch,
+    .EnumFacetFilter__checkboxContainer,
+    .EnumFacetFilter__checkboxContainer--forAll {
+      padding: 2px 16px;
+    }
 
     .EnumFacetFilter__checkboxContainer,
     .EnumFacetFilter__checkboxContainer--forAll {
       transition: background-color 200ms ease-in-out;
-
-      padding: 0px 5px;
       margin: 0px;
       .checkbox,
       .checkbox-focused {

--- a/packages/synapse-react-client/test/containers/widgets/facet-nav/FacetNavPanel.test.tsx
+++ b/packages/synapse-react-client/test/containers/widgets/facet-nav/FacetNavPanel.test.tsx
@@ -96,15 +96,9 @@ describe('FacetNavPanel tests', () => {
 
     const buttons = await screen.findAllByRole<HTMLButtonElement>('button')
     expect(buttons.length).toBe(3)
-    expect(buttons[0].querySelector('svg')!.getAttribute('data-icon')).toBe(
-      'filter',
-    )
-    expect(buttons[1].querySelector('svg')!.getAttribute('data-icon')).toBe(
-      'expand',
-    )
-    expect(buttons[2].querySelector('svg')!.getAttribute('data-icon')).toBe(
-      'close',
-    )
+    await screen.findByRole('button', { name: 'Filter by specific facet' })
+    await screen.findByRole('button', { name: 'Expand to large graph' })
+    await screen.findByRole('button', { name: 'Hide graph under Show More' })
 
     const panelBody = await within(panel).findByRole('graphics-object')
     expect(panelBody).toHaveClass('FacetNavPanel__body')


### PR DESCRIPTION
QueryWrapperPlotNav:
- Remove old FacetNav loading spinner and replace with a cleaner one in FilterAndView
- Use grid column gap instead of margin to set space between QueryWrapperPlotNav components

SynapseTable:
- Update many table styles
- Use MUI icons as in design
- Remove bootstrap `.table` classes
- Remove SRC_noBorderTop class and adjust portals custom styles to accomodate
- Separate table pagination component from overflow wrapper

FacetNavPanel:
- Use MUI icons

EnumFacetFilter:
- Use MUI icon for dropdown mode
- Replace bootstrap dropdown with MUI implementation

SynapseTableCell
- JSON cells should always be wrapped in a `Typography` (`p`)
- Wrap `DirectDownload` in `p` and style with primary color
- USERID and Links should use `Link` instead of `a`
- Numerics aligned right and with `toLocaleString` for easy comparison


GenericCard
- Use MUI `Link` instead of `a`