### PR TITLE
PORTALS-2771 - primary key equality check to determine row selection

### DIFF
--- a/apps/portals/src/configurations/elportal/synapseConfigs/cohortbuilder.ts
+++ b/apps/portals/src/configurations/elportal/synapseConfigs/cohortbuilder.ts
@@ -20,6 +20,7 @@ export const individualsView: SynapseConfig = {
     visibleColumnCount: 10,
     facetsToPlot: ['Diagnosis'],
     isRowSelectionVisible: true,
+    rowSelectionPrimaryKey: ['individualID'],
     combineRangeFacetConfig: {
       label: 'Age',
       minFacetColumn: 'minAge',
@@ -82,6 +83,7 @@ export const filesView: SynapseConfig = {
     cavaticaHelpURL: '/Limited%20Data%20Commons',
     visibleColumnCount: 10,
     isRowSelectionVisible: true,
+    rowSelectionPrimaryKey: ['fileId'],
     additionalFiltersLocalStorageKey: 'cohort-builder-files-perspective',
     tableConfiguration: {
       showAccessColumn: true,

--- a/packages/synapse-react-client/src/components/QueryContext/QueryContext.tsx
+++ b/packages/synapse-react-client/src/components/QueryContext/QueryContext.tsx
@@ -96,6 +96,8 @@ export type QueryContextType<
   rowSelectionPrimaryKey?: string[]
   /** Whether the user has selected any rows */
   hasSelectedRows: boolean
+  /** Method used to determine if an individual row is selected */
+  getIsRowSelected: (row: Row) => boolean
   /** Combines two faceted columns into a single inclusive range selector */
   combineRangeFacetConfig?: ReadonlyDeep<CombineRangeFacetConfig>
 }

--- a/packages/synapse-react-client/src/components/QueryWrapper/QueryWrapper.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapper/QueryWrapper.tsx
@@ -142,6 +142,7 @@ export function QueryWrapper(props: QueryWrapperProps) {
     hasSelectedRows,
     selectedRows,
     setSelectedRows,
+    getIsRowSelected,
   } = useTableRowSelection({
     entity: entity,
     columnModels: data?.columnModels,
@@ -179,6 +180,7 @@ export function QueryWrapper(props: QueryWrapperProps) {
     hasSelectedRows,
     selectedRows,
     setSelectedRows,
+    getIsRowSelected,
     addValueToSelectedFacet,
     combineRangeFacetConfig,
     ...paginationControls,

--- a/packages/synapse-react-client/src/components/QueryWrapper/useTableRowSelection.test.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapper/useTableRowSelection.test.tsx
@@ -1,0 +1,263 @@
+import useTableRowSelection from './useTableRowSelection'
+import { act, renderHook } from '@testing-library/react'
+import { mockTableEntity } from '../../mocks/entity/mockTableEntity'
+import { mockQueryResultBundle } from '../../mocks/mockFileViewQuery'
+import { mockFileViewEntity } from '../../mocks/entity/mockEntity'
+import { QueryResultBundle, Row } from '@sage-bionetworks/synapse-types'
+import { cloneDeep } from 'lodash-es'
+
+describe('useTableRowSelection tests', () => {
+  it('hides rowSelection by default', () => {
+    const { result } = renderHook(() =>
+      useTableRowSelection({
+        isRowSelectionVisible: undefined, // !
+        entity: mockTableEntity,
+        columnModels: mockQueryResultBundle.columnModels,
+      }),
+    )
+
+    expect(result.current.isRowSelectionVisible).toBe(false)
+    expect(result.current.hasSelectedRows).toBe(false)
+  })
+
+  it('allows selecting and unselecting rows', () => {
+    const { result } = renderHook(() =>
+      useTableRowSelection({
+        isRowSelectionVisible: true,
+        entity: mockTableEntity,
+        columnModels: mockQueryResultBundle.columnModels,
+      }),
+    )
+
+    expect(result.current.isRowSelectionVisible).toBe(true)
+    expect(result.current.selectedRows).toEqual([])
+    expect(result.current.hasSelectedRows).toBe(false)
+
+    // Select a row
+    act(() => {
+      result.current.setSelectedRows([
+        mockQueryResultBundle.queryResult?.queryResults.rows[0]!,
+      ])
+    })
+
+    expect(result.current.selectedRows).toEqual([
+      mockQueryResultBundle.queryResult?.queryResults.rows[0]!,
+    ])
+    expect(result.current.hasSelectedRows).toBe(true)
+    expect(
+      result.current.getIsRowSelected(
+        mockQueryResultBundle.queryResult?.queryResults.rows[0]!,
+      ),
+    ).toBe(true)
+    // Unselect the row / reset the selection
+    act(() => {
+      result.current.setSelectedRows([])
+    })
+
+    expect(result.current.selectedRows).toEqual([])
+    expect(result.current.hasSelectedRows).toBe(false)
+    expect(
+      result.current.getIsRowSelected(
+        mockQueryResultBundle.queryResult?.queryResults.rows[0]!,
+      ),
+    ).toBe(false)
+  })
+
+  it('uses primary key comparison for file views and datasets with `id` column, even when unspecified', () => {
+    // Make sure the mock data has an `id` column
+    expect(
+      mockQueryResultBundle.columnModels!.find(cm => cm.name === 'id'),
+    ).toBeDefined()
+
+    const { result } = renderHook(() =>
+      useTableRowSelection({
+        isRowSelectionVisible: true,
+        entity: mockFileViewEntity,
+        columnModels: mockQueryResultBundle.columnModels,
+      }),
+    )
+
+    expect(result.current.isRowSelectionVisible).toBe(true)
+    expect(result.current.selectedRows).toEqual([])
+    expect(result.current.hasSelectedRows).toBe(false)
+
+    // Select a row
+    act(() => {
+      result.current.setSelectedRows([
+        mockQueryResultBundle.queryResult?.queryResults.rows[0]!,
+      ])
+    })
+
+    expect(result.current.selectedRows).toEqual([
+      mockQueryResultBundle.queryResult?.queryResults.rows[0]!,
+    ])
+    expect(result.current.hasSelectedRows).toBe(true)
+
+    const numColumns = mockQueryResultBundle.columnModels!.length
+    const idColumnIndex = mockQueryResultBundle.columnModels!.findIndex(
+      col => col.name === 'id',
+    )
+    const rowWithMatchingPK: Row = { values: new Array(numColumns) }
+    // Make sure the ID matches
+    rowWithMatchingPK.values[idColumnIndex] =
+      result.current.selectedRows[0].values[idColumnIndex]
+    // The row data ONLY matches on the ID column, but since that's the primary key, getIsRowSelected should be true
+    expect(result.current.getIsRowSelected(rowWithMatchingPK)).toBe(true)
+
+    // Clear the selection
+    act(() => {
+      result.current.setSelectedRows([])
+    })
+
+    expect(result.current.selectedRows).toEqual([])
+    expect(result.current.getIsRowSelected(rowWithMatchingPK)).toBe(false)
+  })
+
+  it('uses primary key comparison when specified', () => {
+    const primaryKey = ['id', 'name']
+    // Make sure the mock data has the primary key columns
+    primaryKey.forEach(k => {
+      expect(
+        mockQueryResultBundle.columnModels!.find(cm => cm.name === k),
+      ).toBeDefined()
+    })
+
+    const { result } = renderHook(() =>
+      useTableRowSelection({
+        isRowSelectionVisible: true,
+        entity: mockFileViewEntity,
+        columnModels: mockQueryResultBundle.columnModels,
+        rowSelectionPrimaryKey: primaryKey,
+      }),
+    )
+
+    expect(result.current.isRowSelectionVisible).toBe(true)
+    expect(result.current.selectedRows).toEqual([])
+    expect(result.current.hasSelectedRows).toBe(false)
+
+    // Select a row
+    act(() => {
+      result.current.setSelectedRows([
+        mockQueryResultBundle.queryResult?.queryResults.rows[0]!,
+      ])
+    })
+
+    expect(result.current.selectedRows).toEqual([
+      mockQueryResultBundle.queryResult?.queryResults.rows[0]!,
+    ])
+    expect(result.current.hasSelectedRows).toBe(true)
+
+    const numColumns = mockQueryResultBundle.columnModels!.length
+    const rowToCompare: Row = { values: new Array(numColumns) }
+    // None of the data matches, so this row is not selected
+    expect(result.current.getIsRowSelected(rowToCompare)).toBe(false)
+
+    // Set the 'id' cell to match. This is only a partial key match, so the row should not be selected
+    const idColumnIndex = mockQueryResultBundle.columnModels!.findIndex(
+      col => col.name === 'id',
+    )
+    rowToCompare.values[idColumnIndex] =
+      result.current.selectedRows[0].values[idColumnIndex]
+    expect(result.current.getIsRowSelected(rowToCompare)).toBe(false)
+
+    // Set the name. Since the full primary key matches, getIsRowSelected should be true
+    const nameColumnIndex = mockQueryResultBundle.columnModels!.findIndex(
+      col => col.name === 'name',
+    )
+    rowToCompare.values[nameColumnIndex] =
+      result.current.selectedRows[0].values[nameColumnIndex]
+    expect(result.current.getIsRowSelected(rowToCompare)).toBe(true)
+
+    // Clear the selection
+    act(() => {
+      result.current.setSelectedRows([])
+    })
+
+    expect(result.current.selectedRows).toEqual([])
+    expect(result.current.getIsRowSelected(rowToCompare)).toBe(false)
+  })
+
+  it('uses rowId comparison if no primary key is specified', () => {
+    // Make sure the mock data has row IDs
+    expect(
+      mockQueryResultBundle.queryResult?.queryResults.rows[0].rowId,
+    ).toBeDefined()
+
+    const { result } = renderHook(() =>
+      useTableRowSelection({
+        isRowSelectionVisible: true,
+        entity: mockTableEntity, // must not use file view or dataset
+        columnModels: mockQueryResultBundle.columnModels,
+      }),
+    )
+
+    expect(result.current.isRowSelectionVisible).toBe(true)
+    expect(result.current.selectedRows).toEqual([])
+    expect(result.current.hasSelectedRows).toBe(false)
+
+    // Select a row
+    act(() => {
+      result.current.setSelectedRows([
+        mockQueryResultBundle.queryResult?.queryResults.rows[0]!,
+      ])
+    })
+
+    const numColumns = mockQueryResultBundle.columnModels!.length
+    const rowWithMatchingRowId: Row = {
+      rowId: mockQueryResultBundle.queryResult?.queryResults.rows[0].rowId,
+      values: new Array(numColumns),
+    }
+    expect(result.current.getIsRowSelected(rowWithMatchingRowId)).toBe(true)
+
+    // Clear the selection
+    act(() => {
+      result.current.setSelectedRows([])
+    })
+
+    expect(result.current.selectedRows).toEqual([])
+    expect(result.current.getIsRowSelected(rowWithMatchingRowId)).toBe(false)
+  })
+
+  it('uses deep equality comparison if no primary key is specified and no rowId exists', () => {
+    // Make sure the mock data does not have row IDs
+    const mockQueryResultBundleWithRowIdsRemoved = cloneDeep(
+      mockQueryResultBundle,
+    ) as QueryResultBundle
+    mockQueryResultBundleWithRowIdsRemoved.queryResult?.queryResults.rows.forEach(
+      row => {
+        delete row.rowId
+      },
+    )
+
+    const { result } = renderHook(() =>
+      useTableRowSelection({
+        isRowSelectionVisible: true,
+        entity: mockTableEntity, // must not use file view or dataset
+        columnModels: mockQueryResultBundleWithRowIdsRemoved.columnModels,
+      }),
+    )
+
+    expect(result.current.isRowSelectionVisible).toBe(true)
+    expect(result.current.selectedRows).toEqual([])
+    expect(result.current.hasSelectedRows).toBe(false)
+
+    // Select a row
+    act(() => {
+      result.current.setSelectedRows([
+        mockQueryResultBundleWithRowIdsRemoved.queryResult?.queryResults
+          .rows[0]!,
+      ])
+    })
+
+    const numColumns =
+      mockQueryResultBundleWithRowIdsRemoved.columnModels!.length
+    // Since we're using deep equality, changing one value will cause the row to not be considered 'selected`
+    const rowWithAllButOneValueMatching = cloneDeep(
+      mockQueryResultBundleWithRowIdsRemoved.queryResult!.queryResults.rows[0],
+    ) as Row
+    rowWithAllButOneValueMatching.values[numColumns - 1] = 'different value'
+    expect(result.current.getIsRowSelected(rowWithAllButOneValueMatching)).toBe(
+      false,
+    )
+  })
+})

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
@@ -529,7 +529,7 @@ export class SynapseTable extends React.Component<
   ) {
     const rowsFormatted: JSX.Element[] = []
     const {
-      queryContext: { data, selectedRows, setSelectedRows },
+      queryContext: { data, selectedRows, setSelectedRows, getIsRowSelected },
       queryVisualizationContext: { columnsToShowInTable },
       columnLinks = [],
     } = this.props
@@ -642,7 +642,7 @@ export class SynapseTable extends React.Component<
           <td key={`(${rowIndex},rowSelectColumn)`}>
             <Checkbox
               label=""
-              checked={!!selectedRows.find(r => r.rowId === row.rowId)}
+              checked={getIsRowSelected(row)}
               onChange={(checked: boolean) => {
                 const cloneSelectedRows = [...selectedRows]
                 if (checked) {


### PR DESCRIPTION
PORTALS-2771 references a case where there is no `rowId`, which breaks 'selected' checkbox state. Add a new helper to determine this state. When defined, we should reference the `rowSelectionPrimaryKey` (so add it for the corresponding EL Portal Cohort Builder case). If there's no specified primary key, gracefully fall back to using rowId or the `id` column when it is appropriate, using deep comparison of Row objects as a last resort.

One goal that is considered, though not yet attained, is to allow users to maintain a cohort selection between sessions. Since data in the portal may change over time, using a primary key is more resilient than using deep equality. However, this is still not perfect; we don't save column models, so this would still break if the index of the primary key column(s) were to change.