### PR TITLE
PORTALS-2773 - fix cohort builder applied filters

### DIFF
--- a/apps/portals/src/configurations/elportal/synapseConfigs/cohortbuilder.ts
+++ b/apps/portals/src/configurations/elportal/synapseConfigs/cohortbuilder.ts
@@ -46,12 +46,12 @@ export const individualsView: SynapseConfig = {
         onClick: (event) => {
           // add filter for files perspective, to show files associated to the selected participants only.
           const idColIndex = event.data?.columnModels?.findIndex(
-            (cm) => cm.name === 'Individual ID',
+            (cm) => cm.name === 'individualID',
           )
           const localStorageFilter: ColumnSingleValueQueryFilter = {
             concreteType:
               'org.sagebionetworks.repo.model.table.ColumnSingleValueQueryFilter',
-            columnName: 'Individual ID',
+            columnName: 'individualID',
             operator: ColumnSingleValueFilterOperator.IN,
             isDefiningCondition: true,
             values: event.selectedRows!.map((row) => row.values[idColIndex!]!),
@@ -110,7 +110,7 @@ export const filesView: SynapseConfig = {
           const localStorageFilter: ColumnSingleValueQueryFilter = {
             concreteType:
               'org.sagebionetworks.repo.model.table.ColumnSingleValueQueryFilter',
-            columnName: 'fileIds',
+            columnName: 'fileId',
             operator: ColumnSingleValueFilterOperator.IN,
             isDefiningCondition: true,
             values: event.selectedRows!.map((row) => row.values[idColIndex!]!),

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/SelectionCriteriaPills.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/SelectionCriteriaPills.tsx
@@ -35,10 +35,13 @@ function getPillPropsFromColumnQueryFilter(
   queryVisualizationContext: QueryVisualizationContextType,
 ): SelectionCriteriaPillProps[] {
   const { getColumnDisplayName } = queryVisualizationContext
-  const columnModel = queryContext.getColumnModel(queryFilter.columnName)!
+  const columnModel = queryContext.getColumnModel(queryFilter.columnName)
   // ColumnSingleValueQueryFilter and ColumnMultiValueQueryFilter both allow for a list of values
   // If there are more than _n_ values, consolidate to one pill
-  if (queryFilter.values.length > MAX_VALUES_IN_FILTER_FOR_INDIVIDUAL_PILLS) {
+  if (
+    queryFilter.values.length > MAX_VALUES_IN_FILTER_FOR_INDIVIDUAL_PILLS ||
+    !columnModel
+  ) {
     const text = `${pluralize(
       getColumnDisplayName(queryFilter.columnName),
     )} (${queryFilter.values.length.toLocaleString()})`
@@ -137,13 +140,14 @@ function getPillPropsFromFacetFilters(
     ) {
       return []
     }
-    const columnModel = queryContext.getColumnModel(selectedFacet.columnName)!
+    const columnModel = queryContext.getColumnModel(selectedFacet.columnName)
     const { getColumnDisplayName, getDisplayValue } = queryVisualizationContext
     if (isFacetColumnValuesRequest(selectedFacet)) {
       // If there are more than _n_ values, consolidate to one pill
       if (
         selectedFacet.facetValues.length >
-        MAX_VALUES_IN_FILTER_FOR_INDIVIDUAL_PILLS
+          MAX_VALUES_IN_FILTER_FOR_INDIVIDUAL_PILLS ||
+        !columnModel
       ) {
         const text = `${pluralize(
           getColumnDisplayName(selectedFacet.columnName),


### PR DESCRIPTION
PORTALS-2773

Also needed to modify SelectionCriteriaPills to handle cases where we have a filter where a column model is not present, since these filters are applied to columns on the table/view referenced in the definingSql.