### PR TITLE
SWC-6520 - Extract new component QueryWrapperLoadingScreen and re-use in StandaloneQueryWrapper

### DIFF
--- a/packages/synapse-react-client/src/components/QueryWrapper/QueryWrapperLoadingScreen.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapper/QueryWrapperLoadingScreen.tsx
@@ -1,0 +1,32 @@
+import { useQueryContext } from '../QueryContext'
+import { useAtomValue } from 'jotai'
+import { isLoadingNewBundleAtom, tableQueryDataAtom } from './QueryWrapper'
+import { Box, LinearProgress, Typography } from '@mui/material'
+import React from 'react'
+
+export default function QueryWrapperLoadingScreen() {
+  const { asyncJobStatus } = useQueryContext()
+  const isLoadingNewBundle = useAtomValue(isLoadingNewBundleAtom)
+  const data = useAtomValue(tableQueryDataAtom)
+  if (data || !isLoadingNewBundle) {
+    return <></>
+  }
+  return (
+    <Box sx={{ mt: 15, mx: 15 }}>
+      <LinearProgress />
+      {asyncJobStatus?.progressMessage && (
+        <Typography
+          variant={'smallText1'}
+          sx={{
+            color: 'grey.600',
+            fontSize: '10px',
+            textAlign: 'center',
+            my: 1,
+          }}
+        >
+          {asyncJobStatus?.progressMessage}
+        </Typography>
+      )}
+    </Box>
+  )
+}

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/FilterAndView.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/FilterAndView.tsx
@@ -2,15 +2,9 @@ import React from 'react'
 import CardContainer from '../CardContainer'
 import SynapseTable, { SynapseTableProps } from '../SynapseTable'
 import { CardConfiguration } from '../CardContainerLogic'
-import { useQueryContext } from '../QueryContext'
 import LastUpdatedOn from './LastUpdatedOn'
-import { Box, LinearProgress, Typography } from '@mui/material'
 import { useDeepCompareMemoize } from 'use-deep-compare-effect'
-import { useAtomValue } from 'jotai'
-import {
-  isLoadingNewBundleAtom,
-  tableQueryDataAtom,
-} from '../QueryWrapper/QueryWrapper'
+import QueryWrapperLoadingScreen from '../QueryWrapper/QueryWrapperLoadingScreen'
 
 export type FilterAndViewProps = {
   tableConfiguration?: SynapseTableProps
@@ -28,30 +22,10 @@ const FilterAndView = (props: FilterAndViewProps) => {
         }
       : undefined,
   )
-  const queryContext = useQueryContext()
-  const { asyncJobStatus } = queryContext
-  const isLoadingNewBundle = useAtomValue(isLoadingNewBundleAtom)
-  const data = useAtomValue(tableQueryDataAtom)
+
   return (
     <div className={`FilterAndView`}>
-      {!data && isLoadingNewBundle && (
-        <Box sx={{ mt: 15, mx: 15 }}>
-          <LinearProgress />
-          {asyncJobStatus?.progressMessage && (
-            <Typography
-              variant={'smallText1'}
-              sx={{
-                color: 'grey.600',
-                fontSize: '10px',
-                textAlign: 'center',
-                my: 1,
-              }}
-            >
-              {asyncJobStatus?.progressMessage}
-            </Typography>
-          )}
-        </Box>
-      )}
+      <QueryWrapperLoadingScreen />
       {tableConfiguration ? <SynapseTable {...tableConfiguration} /> : <></>}
       {cardConfiguration ? <CardContainer {...cardConfiguration} /> : <></>}
       <LastUpdatedOn />

--- a/packages/synapse-react-client/src/components/StandaloneQueryWrapper/StandaloneQueryWrapper.tsx
+++ b/packages/synapse-react-client/src/components/StandaloneQueryWrapper/StandaloneQueryWrapper.tsx
@@ -29,6 +29,7 @@ import {
   Operator,
   SearchParams,
 } from '../QueryWrapperPlotNav/QueryWrapperPlotNav'
+import QueryWrapperLoadingScreen from '../QueryWrapper/QueryWrapperLoadingScreen'
 
 type StandaloneQueryWrapperOwnProps = {
   sql: string
@@ -172,6 +173,7 @@ const StandaloneQueryWrapper: React.FunctionComponent<
                       {showTopLevelControls && (
                         <TotalQueryResults frontText={''} />
                       )}
+                      <QueryWrapperLoadingScreen />
                       <SynapseTable
                         showAccessColumn={showAccessColumn}
                         data-testid="SynapseTable"


### PR DESCRIPTION
Depends on #429 

[Screencast from 08-28-2023 05:07:59 PM.webm](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/d8c36bcd-4016-4237-af10-d6d9fbebf928)
