### PR TITLE
Fix null case for hashCode

### DIFF
--- a/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
+++ b/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
@@ -194,7 +194,7 @@ export class KeyFactory {
    */
   private getKey(...args: any[]): QueryKey {
     return [
-      this.accessToken === undefined
+      this.accessToken == null
         ? this.accessToken
         : btoa(String(hashCode(this.accessToken))),
       ...removeTrailingUndefinedElements(args),

--- a/packages/synapse-react-client/src/utils/functions/StringUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/StringUtils.ts
@@ -23,7 +23,10 @@ export function hex2ascii(inputString: string): string {
  * @return {Number}    A 32bit integer
  * @see https://stackoverflow.com/a/8831937
  */
-export function hashCode(str: string) {
+export function hashCode(str?: string | null) {
+  if (str == null) {
+    str = ''
+  }
   let hash = 0
   for (let i = 0, len = str.length; i < len; i++) {
     const chr = str.charCodeAt(i)


### PR DESCRIPTION
SWC apparently sets `accessToken` to `null`, which is an unhandled case (only `undefined` was handled)