### PR TITLE
SWC-6510 - Fix ProjectViewCard styling, use MUI

### DIFF
--- a/packages/synapse-react-client/src/components/ProjectViewCarousel/ProjectViewCard.tsx
+++ b/packages/synapse-react-client/src/components/ProjectViewCarousel/ProjectViewCard.tsx
@@ -1,43 +1,87 @@
 import React from 'react'
-import { Button } from '@mui/material'
+import { Box, Button, Paper, Stack, Typography } from '@mui/material'
 import { PRODUCTION_ENDPOINT_CONFIG } from '../../utils/functions/getEndpoint'
 
 export type ProjectCardProps = {
+  isLoading?: boolean
   projectName: string
   projectDescription: string
   synId: string
-  image?: JSX.Element
-}
+  image?: React.ReactNode
+} & React.HTMLAttributes<HTMLDivElement>
 
-export const ProjectViewCard: React.FunctionComponent<
-  ProjectCardProps & React.HTMLAttributes<HTMLDivElement>
-> = ({ projectName, projectDescription, synId, image, ...domProps }) => {
+export function ProjectViewCard(props: ProjectCardProps) {
+  const { projectName, projectDescription, synId, image, ...domProps } = props
   return (
-    <div
+    <Paper
       {...domProps}
-      className={`cardContainer ProjectViewCard ${domProps.className ?? ''}`}
+      className={`ProjectViewCard ${domProps.className ?? ''}`}
+      sx={{
+        m: 1.5,
+        wordWrap: 'break-word',
+        width: '410px',
+        height: '325px',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
     >
-      {image ? image : <div className={'ProjectViewCard__ImagePlaceholder'} />}
-      <div>
-        <div className="ProjectViewCard__ProjectName">{projectName}</div>
-        <div className="ProjectViewCard__ProjectDescription">
-          {projectDescription}
-        </div>
-      </div>
-      <Button
-        variant="contained"
-        color="primary"
-        className="ProjectViewCard__ViewProjectButton"
-        onClick={() =>
-          window.open(
-            `${PRODUCTION_ENDPOINT_CONFIG.PORTAL}#!Synapse:${synId}`,
-            '_blank',
-            'noopener',
-          )
-        }
+      {image ? (
+        image
+      ) : (
+        <Box
+          sx={{
+            width: '100%',
+            height: '25%',
+            backgroundColor: 'primary.300',
+          }}
+        />
+      )}
+      <Stack
+        justifyContent={'space-between'}
+        sx={{
+          flexGrow: 1,
+          m: 2,
+        }}
       >
-        View Project
-      </Button>
-    </div>
+        <div>
+          <Typography
+            variant={'body1'}
+            sx={{
+              fontWeight: 'bold',
+            }}
+          >
+            {projectName}
+          </Typography>
+          <Typography
+            variant={'smallText1'}
+            sx={{
+              lineHeight: '21px',
+              mt: 1.5,
+            }}
+          >
+            {projectDescription}
+          </Typography>
+        </div>
+        <Button
+          sx={{
+            width: '165px',
+            mb: 1,
+            minHeight: '38px',
+            height: '46px',
+          }}
+          variant="contained"
+          color="primary"
+          onClick={() =>
+            window.open(
+              `${PRODUCTION_ENDPOINT_CONFIG.PORTAL}#!Synapse:${synId}`,
+              '_blank',
+              'noopener',
+            )
+          }
+        >
+          View Project
+        </Button>
+      </Stack>
+    </Paper>
   )
 }

--- a/packages/synapse-react-client/src/components/ProjectViewCarousel/ProjectViewCard.tsx
+++ b/packages/synapse-react-client/src/components/ProjectViewCarousel/ProjectViewCard.tsx
@@ -23,6 +23,7 @@ export function ProjectViewCard(props: ProjectCardProps) {
         height: '325px',
         display: 'flex',
         flexDirection: 'column',
+        overflow: 'hidden',
       }}
     >
       {image ? (

--- a/packages/synapse-react-client/src/components/ProjectViewCarousel/ProjectViewCarousel.tsx
+++ b/packages/synapse-react-client/src/components/ProjectViewCarousel/ProjectViewCarousel.tsx
@@ -1,13 +1,13 @@
 import SynapseClient from '../../synapse-client'
-import { SynapseConstants } from '../../utils'
+import { SynapseConstants, useSynapseContext } from '../../utils'
 import { getFieldIndex } from '../../utils/functions/queryUtils'
 import useGetQueryResultBundle from '../../synapse-queries/entity/useGetQueryResultBundle'
 import { QueryBundleRequest } from '@sage-bionetworks/synapse-types'
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import Carousel from '../Carousel/Carousel'
 import { ProjectViewCard } from './ProjectViewCard'
 import { ErrorBanner } from '../error/ErrorBanner'
-import { useSynapseContext } from '../../utils/context/SynapseContext'
+import { Box } from '@mui/system'
 
 export type ProjectViewCarouselProps = {
   entityId: string
@@ -160,7 +160,15 @@ export const ProjectViewCarousel: React.FunctionComponent<
                   src={project.imageUrl}
                   alt={`Logo for ${project.projectName}`}
                 />
-              ) : undefined
+              ) : (
+                <Box
+                  sx={{
+                    width: '100%',
+                    height: '25%',
+                    backgroundColor: 'primary.300',
+                  }}
+                />
+              )
             }
           />
         )

--- a/packages/synapse-react-client/src/style/components/_project-view-card.scss
+++ b/packages/synapse-react-client/src/style/components/_project-view-card.scss
@@ -2,16 +2,6 @@
 @use 'sass:map';
 
 .ProjectViewCard {
-  word-wrap: break-word;
-  width: 410px;
-  height: 325px;
-  margin: 10px;
-  background: #fff;
-  box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.05);
-  display: flex;
-  flex-direction: column;
-  text-align: left;
-
   img {
     display: block;
     margin-left: auto;
@@ -20,34 +10,5 @@
     min-height: 50px;
     max-height: 33%;
     max-width: 100%;
-  }
-
-  &__ImagePlaceholder {
-    width: 100%;
-    height: 25%;
-    background: map.get(SRC.$primary-color-palette, 300);
-  }
-
-  &__ProjectName {
-    margin: 15px 20px 10px;
-    font-weight: bold;
-    font-size: 16px;
-  }
-
-  &__ProjectDescription {
-    margin: 10px 20px;
-    max-height: 20%;
-    line-height: 21px;
-  }
-
-  &__ViewProjectButton {
-    width: 165px;
-    margin-left: 20px;
-    margin-bottom: 20px;
-    margin-top: auto;
-    padding: 0px 25px;
-    font-size: 14px;
-    min-height: 38px;
-    height: 46px;
   }
 }


### PR DESCRIPTION
It looks ok in SWC because the MUI styles are loaded before the SRC styles, so the correct styles override the bad styles. I reimplemented the components using MUI to prevent this issue from occuring if the load order were to change.

![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/ee5d7add-c151-401e-8854-c53a6adaaa90)
