### PR TITLE
PORTALS-2793 - Use a larger runner, add a 1hr timeout, and remove the existing parallel job limit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ubuntu-22.04-4core-16GBRAM-150GBSSD
+    # Job should not last longer than 60 minutes--and the larger runner is billed per-minute ;)
+    timeout-minutes: 60
     # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     # We should test all active LTS releases, but not until our test suite is less flaky
     strategy:
@@ -25,7 +28,7 @@ jobs:
         # Portals won't build without a configuration. For now, copy the test configuration.
         # We may want to invert the model and give each portal its own project in the workspace, so we can build the portals in parallel.
       - run: pnpm nx run portals:copy-test-configuration
-      - run: pnpm nx affected --target=build --parallel=2 --base=remotes/origin/main
+      - run: pnpm nx affected --target=build --base=remotes/origin/main
   test:
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +38,7 @@ jobs:
       - uses: ./.github/actions/pnpm-setup-action
       - run: pnpm nx run portals:copy-test-configuration
       - id: test
-        run: pnpm nx affected --target test --parallel=2 --base=remotes/origin/main
+        run: pnpm nx affected --target test --base=remotes/origin/main
       - name: Upload test report
         if: success() || steps.test.conclusion == 'failure'
         uses: actions/upload-artifact@v3
@@ -51,7 +54,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/pnpm-setup-action
-      - run: pnpm nx affected --target=lint --parallel=2 --base=remotes/origin/main
+      - run: pnpm nx affected --target=lint --base=remotes/origin/main
   typecheck:
     runs-on: ubuntu-latest
     steps:
@@ -61,4 +64,4 @@ jobs:
       - uses: ./.github/actions/pnpm-setup-action
       # Portals test configuration must be loaded for a successful type check
       - run: pnpm nx run portals:copy-test-configuration
-      - run: pnpm nx affected --target=type-check --parallel=2 --base=remotes/origin/main
+      - run: pnpm nx affected --target=type-check --base=remotes/origin/main

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ jobs:
         # Portals won't build without a configuration. For now, copy the test configuration.
         # We may want to invert the model and give each portal its own project in the workspace, so we can build the portals in parallel.
       - run: pnpm nx run portals:copy-test-configuration
-      - run: pnpm nx run-many --target=build --base=remotes/origin/main
+      - run: pnpm nx run-many --target=build
   test:
     runs-on:
       labels: ubuntu-22.04-4core-16GBRAM-150GBSSD
@@ -38,7 +38,7 @@ jobs:
       - uses: ./.github/actions/pnpm-setup-action
       - run: pnpm nx run portals:copy-test-configuration
       - id: test
-        run: pnpm nx run-many --target test --base=remotes/origin/main
+        run: pnpm nx run-many --target test
       - name: Upload test report
         if: success() || steps.test.conclusion == 'failure'
         uses: actions/upload-artifact@v3
@@ -54,7 +54,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/pnpm-setup-action
-      - run: pnpm nx run-many --target=lint --base=remotes/origin/main
+      - run: pnpm nx run-many --target=lint
   typecheck:
     runs-on: ubuntu-latest
     steps:
@@ -64,4 +64,4 @@ jobs:
       - uses: ./.github/actions/pnpm-setup-action
       # Portals test configuration must be loaded for a successful type check
       - run: pnpm nx run portals:copy-test-configuration
-      - run: pnpm nx run-many --target=type-check --base=remotes/origin/main
+      - run: pnpm nx run-many --target=type-check

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,7 +28,7 @@ jobs:
         # Portals won't build without a configuration. For now, copy the test configuration.
         # We may want to invert the model and give each portal its own project in the workspace, so we can build the portals in parallel.
       - run: pnpm nx run portals:copy-test-configuration
-      - run: pnpm nx affected --target=build --base=remotes/origin/main
+      - run: pnpm nx run-many --target=build --base=remotes/origin/main
   test:
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +38,7 @@ jobs:
       - uses: ./.github/actions/pnpm-setup-action
       - run: pnpm nx run portals:copy-test-configuration
       - id: test
-        run: pnpm nx affected --target test --base=remotes/origin/main
+        run: pnpm nx run-many --target test --base=remotes/origin/main
       - name: Upload test report
         if: success() || steps.test.conclusion == 'failure'
         uses: actions/upload-artifact@v3
@@ -54,7 +54,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/pnpm-setup-action
-      - run: pnpm nx affected --target=lint --base=remotes/origin/main
+      - run: pnpm nx run-many --target=lint --base=remotes/origin/main
   typecheck:
     runs-on: ubuntu-latest
     steps:
@@ -64,4 +64,4 @@ jobs:
       - uses: ./.github/actions/pnpm-setup-action
       # Portals test configuration must be loaded for a successful type check
       - run: pnpm nx run portals:copy-test-configuration
-      - run: pnpm nx affected --target=type-check --base=remotes/origin/main
+      - run: pnpm nx run-many --target=type-check --base=remotes/origin/main

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ jobs:
         # Portals won't build without a configuration. For now, copy the test configuration.
         # We may want to invert the model and give each portal its own project in the workspace, so we can build the portals in parallel.
       - run: pnpm nx run portals:copy-test-configuration
-      - run: pnpm nx run-many --target=build
+      - run: pnpm nx affected --target=build --base=remotes/origin/main
   test:
     runs-on:
       labels: ubuntu-22.04-4core-16GBRAM-150GBSSD
@@ -38,7 +38,7 @@ jobs:
       - uses: ./.github/actions/pnpm-setup-action
       - run: pnpm nx run portals:copy-test-configuration
       - id: test
-        run: pnpm nx run-many --target test
+        run: pnpm nx affected --target test --base=remotes/origin/main
       - name: Upload test report
         if: success() || steps.test.conclusion == 'failure'
         uses: actions/upload-artifact@v3
@@ -54,7 +54,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/pnpm-setup-action
-      - run: pnpm nx run-many --target=lint
+      - run: pnpm nx affected --target=lint --base=remotes/origin/main
   typecheck:
     runs-on: ubuntu-latest
     steps:
@@ -64,4 +64,4 @@ jobs:
       - uses: ./.github/actions/pnpm-setup-action
       # Portals test configuration must be loaded for a successful type check
       - run: pnpm nx run portals:copy-test-configuration
-      - run: pnpm nx run-many --target=type-check
+      - run: pnpm nx affected --target=type-check --base=remotes/origin/main

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,10 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on:
-      labels: ubuntu-22.04-4core-16GBRAM-150GBSSD
-    # Job should not last longer than 60 minutes--and the larger runner is billed per-minute ;)
-    timeout-minutes: 60
+    runs-on: ubuntu-latest
     # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     # We should test all active LTS releases, but not until our test suite is less flaky
     strategy:
@@ -30,7 +27,10 @@ jobs:
       - run: pnpm nx run portals:copy-test-configuration
       - run: pnpm nx run-many --target=build --base=remotes/origin/main
   test:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ubuntu-22.04-4core-16GBRAM-150GBSSD
+    # Job should not last longer than 60 minutes--and the larger runner is billed per-minute ;)
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3.1.0
         with:


### PR DESCRIPTION
Using a larger runner brings our `test` job worst-case time to around 17m: https://github.com/Sage-Bionetworks/synapse-web-monorepo/actions/runs/6030039839/job/16360992278?pr=455

With the regular runner we were consistently seeing times >30min
