### PR TITLE
SWC-6531: expose HttpClient and BackendDestinationEnum in UMD, allow BackendDestinationEnum to be used as value

### DIFF
--- a/packages/synapse-react-client/src/umd.index.ts
+++ b/packages/synapse-react-client/src/umd.index.ts
@@ -52,7 +52,7 @@ import EntityPageBreadcrumbs from './components/entity/page/breadcrumbs/EntityPa
 import EntityActionMenu from './components/entity/page/action_menu/EntityActionMenu'
 import EntityPageTitleBar from './components/entity/page/title_bar/EntityPageTitleBar'
 import { CreatedByModifiedBy } from './components/entity/page/CreatedByModifiedBy'
-import SynapseClient from './synapse-client'
+import SynapseClient, { HttpClient } from './synapse-client'
 import * as SynapseQueries from './synapse-queries'
 import { SynapseConstants } from './utils'
 import Palettes from './theme/palette/Palettes'
@@ -68,9 +68,14 @@ import { FullContextProvider } from './utils/context/FullContextProvider'
 import SubscriptionPage from './components/SubscriptionPage'
 import OrientationBanner from './components/OrientationBanner/OrientationBanner'
 import AccessRequirementList from './components/AccessRequirementList/AccessRequirementList'
+import { BackendDestinationEnum } from './utils/functions'
 
 // Also include scss in the bundle
 import './style/main.scss'
+
+const SynapseEnums = {
+  BackendDestinationEnum,
+}
 
 const SynapseContext = {
   FullContextProvider,
@@ -145,11 +150,13 @@ const SynapseComponents = {
 const SynapseReactClientVersion = require('../package.json').version
 
 export {
+  HttpClient,
   SynapseReactClientVersion,
   SynapseComponents,
   SynapseConstants,
   SynapseClient,
   SynapseContext,
+  SynapseEnums,
   SynapseQueries,
   Palettes,
 }

--- a/packages/synapse-react-client/src/utils/functions/index.ts
+++ b/packages/synapse-react-client/src/utils/functions/index.ts
@@ -8,7 +8,7 @@ import {
 } from './SqlFunctions'
 import { hex2ascii } from './StringUtils'
 import type { SQLOperator } from './SqlFunctions'
-import type { BackendDestinationEnum } from './getEndpoint'
+import { BackendDestinationEnum } from './getEndpoint'
 
 export {
   getNextPageOfData,


### PR DESCRIPTION
Allows HttpClient and BackendDestinationEnum to be called when evaluating JS in the browser page in a Playwright test, e.g. `window.SRC.HttpClient.doGet(...)`