### PR TITLE
SWC-6552 - Fix UserOrTeamBadge showing stale data

### DIFF
--- a/packages/synapse-react-client/src/components/UserOrTeamBadge/UserOrTeamBadge.tsx
+++ b/packages/synapse-react-client/src/components/UserOrTeamBadge/UserOrTeamBadge.tsx
@@ -1,7 +1,6 @@
 import { Skeleton } from '@mui/material'
-import React, { useEffect, useState } from 'react'
-import { useGetUserGroupHeader } from '../../synapse-queries/user/useUserGroupHeader'
-import { useSynapseContext } from '../../utils/context/SynapseContext'
+import React from 'react'
+import { useGetUserGroupHeader } from '../../synapse-queries'
 import { UserGroupHeader } from '@sage-bionetworks/synapse-types'
 import TeamBadge from '../TeamBadge'
 import { UserBadge } from '../UserCard/UserBadge'
@@ -29,11 +28,6 @@ export default function UserOrTeamBadge(props: UserOrTeamBadgeProps) {
     principalId = providedUserGroupHeader?.ownerId
   }
 
-  const { accessToken } = useSynapseContext()
-  const [userGroupHeader, setUserGroupHeader] = useState<
-    UserGroupHeader | undefined
-  >(providedUserGroupHeader)
-
   const { data: fetchedUserGroupHeader } = useGetUserGroupHeader(
     (principalId ?? '').toString(),
     {
@@ -41,11 +35,7 @@ export default function UserOrTeamBadge(props: UserOrTeamBadgeProps) {
     },
   )
 
-  useEffect(() => {
-    if (principalId && userGroupHeader == undefined && fetchedUserGroupHeader) {
-      setUserGroupHeader(fetchedUserGroupHeader)
-    }
-  }, [accessToken, principalId, userGroupHeader, fetchedUserGroupHeader])
+  const userGroupHeader = providedUserGroupHeader ?? fetchedUserGroupHeader
 
   if (principalId == null && providedUserGroupHeader == null) {
     console.error(


### PR DESCRIPTION
`UserOrTeamBadge` provides two 'interfaces' so the userGroupHeader data can be either provided or fetched (via react-query) using a principalId. This bug only occurred when data was fetched, but the faulty logic existed to manage both scenarios.

The data was stored in `useState`. Due to incorrect logic in an effect, the data was NOT updated when the fetched data changed due to the `principalId` changing.

We can remove the effect and just pick the correct object inline and the bug is resolved.