### PR TITLE
SWC-6549 - New utilities for getting subcolumn information

### DIFF
--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.integration.test.tsx
@@ -494,4 +494,66 @@ describe('SynapseTable tests', () => {
     within(column).getByText('Number of Studies')
     screen.getByText('123')
   })
+
+  it('does not contain facet controls for JSON subcolumn facets', async () => {
+    const queryResultBundleWithFacetedJsonSubcolumn: QueryResultBundle = {
+      concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
+      queryCount: 1,
+      selectColumns: [{ name: 'study', columnType: 'JSON' }],
+      columnModels: [
+        {
+          id: '1',
+          name: 'study',
+          columnType: 'JSON',
+          jsonSubColumns: [
+            {
+              name: 'studyName',
+              jsonPath: '$.name',
+              columnType: 'STRING',
+              facetType: 'enumeration',
+            },
+          ],
+        },
+      ],
+      facets: [
+        {
+          columnName: 'study',
+          facetType: 'enumeration',
+          jsonPath: '$.name',
+          concreteType:
+            'org.sagebionetworks.repo.model.table.FacetColumnResultValues',
+          facetValues: [{ value: 'foo', count: 1, isSelected: false }],
+        },
+      ],
+      lastUpdatedOn: '2023-08-28T07:27:00.667Z',
+      queryResult: {
+        concreteType: 'org.sagebionetworks.repo.model.table.QueryResult',
+        queryResults: {
+          concreteType: 'org.sagebionetworks.repo.model.table.RowSet',
+          tableId: MOCK_TABLE_ENTITY_ID,
+          etag: '53e1e27a-dbf3-4db3-acd1-dafca30b894c',
+          headers: [{ name: 'study', columnType: 'JSON' }],
+          rows: [{ values: ['{"name": "foo"}'] }],
+        },
+      },
+    }
+
+    server.use(
+      ...getHandlersForTableQuery(queryResultBundleWithFacetedJsonSubcolumn),
+    )
+
+    renderTable({ showDirectDownloadColumn: true })
+    mockAllIsIntersecting(true)
+
+    // The study column should be visible
+    const column = await screen.findByRole('columnheader')
+    within(column).getByText('Study')
+
+    // No facet filter controls should be visible, since the only facet on the study column is a JSON subcolumn facet
+    expect(
+      screen.queryByRole('button', {
+        name: 'Filter by specific facet',
+      }),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableRenderers.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableRenderers.tsx
@@ -172,7 +172,11 @@ export function TableDataColumnHeader(
   // we have to figure out if the current column is a facet selection
   const facetIndex: number = facets.findIndex(
     (facetColumnResult: FacetColumnResult) => {
-      return facetColumnResult.columnName === columnModel?.name
+      return (
+        facetColumnResult.columnName === columnModel?.name &&
+        // Exclude JSON subcolumn facets, since there may be more than one on a given column
+        facetColumnResult.jsonPath == undefined
+      )
     },
   )
   // the header must be included in the facets and it has to be enumerable for current rendering capabilities

--- a/packages/synapse-react-client/src/utils/types/UniqueFacetIdentifier.ts
+++ b/packages/synapse-react-client/src/utils/types/UniqueFacetIdentifier.ts
@@ -1,0 +1,9 @@
+/**
+ * A facet in a SynapseTable can be uniquely identified with the columnName and optional jsonPath.
+ *
+ * This type is used for cases where we need to pass just enough data around to identify/look up a facet request or result.
+ */
+export type UniqueFacetIdentifier = {
+  columnName: string
+  jsonPath?: string
+}


### PR DESCRIPTION
* don't show JSON subcolumn facet controls in SynapseTable
* Add new utilities getCorrespondingColumnForFacet, getCorrespondingSelectedFacet
* Allow supplying a JSONPath in QueryVisualizationContext.getColumnDisplayName