### PR TITLE
SWC-6548 - Add utils and reducer for TableColumnSchemaEditor

### DIFF
--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.test.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.test.ts
@@ -1,0 +1,278 @@
+import { ColumnType, ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
+import {
+  canHaveDefault,
+  canHaveMaxListLength,
+  canHaveRestrictedValues,
+  canHaveSize,
+  configureFacetsForType,
+  getAllowedColumnTypes,
+  getMaxSizeForType,
+} from './TableColumnSchemaEditorUtils'
+
+describe('TableColumnSchemaEditorUtils', () => {
+  describe('getAllowedColumnTypes', () => {
+    it('allowed column types for a non-view, regular column model', () => {
+      const expected = [
+        'STRING',
+        'DOUBLE',
+        'BOOLEAN',
+        'INTEGER',
+        'DATE',
+        'FILEHANDLEID',
+        'ENTITYID',
+        'LINK',
+        'MEDIUMTEXT',
+        'LARGETEXT',
+        'USERID',
+        'STRING_LIST',
+        'INTEGER_LIST',
+        'BOOLEAN_LIST',
+        'DATE_LIST',
+        'USERID_LIST',
+        'ENTITYID_LIST',
+        'EVALUATIONID',
+        'JSON',
+      ]
+      const actual = getAllowedColumnTypes(false, false)
+
+      expect(expected.sort()).toEqual(actual.sort())
+    })
+    it('allowed column types for a view, regular column model', () => {
+      const expected = [
+        'STRING',
+        'DOUBLE',
+        'BOOLEAN',
+        'INTEGER',
+        'DATE',
+        'FILEHANDLEID',
+        'ENTITYID',
+        'LINK',
+        // 'MEDIUMTEXT',
+        // 'LARGETEXT',
+        'USERID',
+        'STRING_LIST',
+        'INTEGER_LIST',
+        'BOOLEAN_LIST',
+        'DATE_LIST',
+        'USERID_LIST',
+        'ENTITYID_LIST',
+        'EVALUATIONID',
+        // 'JSON',
+      ]
+      const actual = getAllowedColumnTypes(true, false)
+
+      expect(expected.sort()).toEqual(actual.sort())
+    })
+
+    it('allowed column types for a non-view, jsonSubColumn', () => {
+      const expected = [
+        'STRING',
+        'DOUBLE',
+        'BOOLEAN',
+        'INTEGER',
+        'DATE',
+        'FILEHANDLEID',
+        'ENTITYID',
+        'LINK',
+        'MEDIUMTEXT',
+        'LARGETEXT',
+        'USERID',
+        // 'STRING_LIST',
+        // 'INTEGER_LIST',
+        // 'BOOLEAN_LIST',
+        // 'DATE_LIST',
+        // 'USERID_LIST',
+        // 'ENTITYID_LIST',
+        'EVALUATIONID',
+        // 'JSON',
+      ]
+      const actual = getAllowedColumnTypes(false, true)
+
+      expect(expected.sort()).toEqual(actual.sort())
+    })
+  })
+
+  it('canHaveSize', () => {
+    const expectedTrue = [
+      ColumnTypeEnum.STRING,
+      ColumnTypeEnum.STRING_LIST,
+      ColumnTypeEnum.LINK,
+    ]
+
+    Object.values(ColumnTypeEnum).forEach((key: ColumnType) => {
+      const actual = canHaveSize(key)
+      const expected = expectedTrue.includes(key as ColumnTypeEnum)
+      expect(actual).toBe(expected)
+    })
+  })
+  it('canHaveMaxListLength', () => {
+    const expectedTrue = [
+      ColumnTypeEnum.STRING_LIST,
+      ColumnTypeEnum.BOOLEAN_LIST,
+      ColumnTypeEnum.DATE_LIST,
+      ColumnTypeEnum.INTEGER_LIST,
+    ]
+
+    Object.values(ColumnTypeEnum).forEach((key: ColumnType) => {
+      const actual = canHaveMaxListLength(key)
+      const expected = expectedTrue.includes(key as ColumnTypeEnum)
+      expect(actual).toBe(expected)
+    })
+  })
+
+  describe('configureFacetsForType', () => {
+    it('column types that support both enumeration/range', () => {
+      const types = [ColumnTypeEnum.INTEGER, ColumnTypeEnum.INTEGER_LIST]
+
+      types.forEach(type => {
+        let isJsonSubColumnFacet = false
+        expect(configureFacetsForType(type, isJsonSubColumnFacet)).toEqual([
+          undefined,
+          'enumeration',
+          'range',
+        ])
+
+        isJsonSubColumnFacet = true
+        expect(configureFacetsForType(type, isJsonSubColumnFacet)).toEqual([
+          'enumeration',
+          'range',
+        ])
+      })
+    })
+
+    it('enumeration-only column types', () => {
+      const types = [
+        ColumnTypeEnum.STRING,
+        ColumnTypeEnum.STRING_LIST,
+        ColumnTypeEnum.BOOLEAN,
+        ColumnTypeEnum.BOOLEAN_LIST,
+        ColumnTypeEnum.USERID,
+        ColumnTypeEnum.USERID_LIST,
+        ColumnTypeEnum.ENTITYID,
+        ColumnTypeEnum.ENTITYID_LIST,
+        ColumnTypeEnum.EVALUATIONID,
+      ]
+
+      types.forEach(type => {
+        let isJsonSubColumnFacet = false
+        expect(configureFacetsForType(type, isJsonSubColumnFacet)).toEqual([
+          undefined,
+          'enumeration',
+        ])
+
+        isJsonSubColumnFacet = true
+        expect(configureFacetsForType(type, isJsonSubColumnFacet)).toEqual([
+          'enumeration',
+        ])
+      })
+    })
+
+    it('range-only column types', () => {
+      const types = [
+        ColumnTypeEnum.DOUBLE,
+        ColumnTypeEnum.DATE,
+        ColumnTypeEnum.DATE_LIST,
+      ]
+
+      types.forEach(type => {
+        let isJsonSubColumnFacet = false
+        expect(configureFacetsForType(type, isJsonSubColumnFacet)).toEqual([
+          undefined,
+          'range',
+        ])
+
+        isJsonSubColumnFacet = true
+        expect(configureFacetsForType(type, isJsonSubColumnFacet)).toEqual([
+          'range',
+        ])
+      })
+    })
+
+    it('unfacetable column types', () => {
+      const types = [
+        ColumnTypeEnum.JSON,
+        ColumnTypeEnum.LINK,
+        ColumnTypeEnum.MEDIUMTEXT,
+        ColumnTypeEnum.LARGETEXT,
+        ColumnTypeEnum.FILEHANDLEID,
+      ]
+
+      types.forEach(type => {
+        let isJsonSubColumnFacet = false
+        expect(configureFacetsForType(type, isJsonSubColumnFacet)).toEqual(null)
+
+        isJsonSubColumnFacet = true
+        expect(configureFacetsForType(type, isJsonSubColumnFacet)).toEqual(null)
+      })
+    })
+  })
+  describe('canHaveDefault', () => {
+    it('is always false for view', () => {
+      Object.values(ColumnTypeEnum).forEach((type: ColumnType) => {
+        const actual = canHaveDefault(type, true, false)
+        expect(actual).toBe(false)
+      })
+    })
+    it('is always false for jsonSubColumn', () => {
+      Object.values(ColumnTypeEnum).forEach((type: ColumnType) => {
+        const actual = canHaveDefault(type, false, true)
+        expect(actual).toBe(false)
+      })
+    })
+
+    it('certain column types support default values', () => {
+      const expectedFalse = [
+        ColumnTypeEnum.ENTITYID,
+        ColumnTypeEnum.FILEHANDLEID,
+        ColumnTypeEnum.USERID,
+        ColumnTypeEnum.MEDIUMTEXT,
+        ColumnTypeEnum.LARGETEXT,
+        ColumnTypeEnum.JSON,
+      ]
+      Object.values(ColumnTypeEnum).forEach((type: ColumnType) => {
+        const actual = canHaveDefault(type, false, false)
+        expect(actual).toBe(!expectedFalse.includes(type as ColumnTypeEnum))
+      })
+    })
+  })
+  test('getMaxSizeForType', () => {
+    const expected: Partial<Record<ColumnTypeEnum, number>> = {
+      [ColumnTypeEnum.STRING]: 50,
+      [ColumnTypeEnum.STRING_LIST]: 50,
+      [ColumnTypeEnum.LINK]: 1000,
+    }
+    const shouldError = Object.values(ColumnTypeEnum).filter(
+      type => expected[type] == null,
+    )
+    Object.keys(expected).forEach(columnType => {
+      const expectedMaxSize = expected[columnType as ColumnTypeEnum]
+      const actual = getMaxSizeForType(columnType as ColumnTypeEnum)
+      expect(actual).toBe(expectedMaxSize)
+    })
+    shouldError.forEach((columnType: ColumnType) => {
+      expect(() => {
+        getMaxSizeForType(columnType)
+      }).toThrow()
+    })
+  })
+
+  describe('canHaveRestrictedValues', () => {
+    test('all types for top-level columnModel', () => {
+      const expectedTrue = [
+        ColumnTypeEnum.STRING,
+        ColumnTypeEnum.INTEGER,
+        ColumnTypeEnum.ENTITYID,
+      ]
+      Object.values(ColumnTypeEnum).forEach((type: ColumnType) => {
+        const actual = canHaveRestrictedValues(type, false)
+        expect(actual).toBe(expectedTrue.includes(type as ColumnTypeEnum))
+      })
+    })
+    test('jsonSubColumnFacet', () => {
+      Object.values(ColumnTypeEnum).forEach((key: ColumnType) => {
+        const actual = canHaveRestrictedValues(key, true)
+        expect(actual).toBe(false)
+      })
+    })
+  })
+})

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.ts
@@ -1,0 +1,237 @@
+import {
+  ColumnType,
+  ColumnTypeEnum,
+  FacetType,
+} from '@sage-bionetworks/synapse-types'
+
+/**
+ * These column types can only be used in Tables. They can not be used in views.
+ *  See SWC-6333 - for views, only allow column types that are mapped to annotation types.
+ */
+const unsupportedTypesForViews = [
+  ColumnTypeEnum.LARGETEXT,
+  ColumnTypeEnum.MEDIUMTEXT,
+  ColumnTypeEnum.JSON,
+]
+export function getAllowedColumnTypes(
+  isView: boolean,
+  isJsonSubColumnFacet: boolean,
+) {
+  return Object.values(ColumnTypeEnum)
+    .filter(columnType =>
+      isView ? !unsupportedTypesForViews.includes(columnType) : true,
+    )
+    .filter(columnType => {
+      if (isJsonSubColumnFacet) {
+        switch (columnType) {
+          // JSON Subcolumns cannot be JSON or LIST types
+          case ColumnTypeEnum.JSON:
+          case ColumnTypeEnum.STRING_LIST:
+          case ColumnTypeEnum.INTEGER_LIST:
+          case ColumnTypeEnum.BOOLEAN_LIST:
+          case ColumnTypeEnum.DATE_LIST:
+          case ColumnTypeEnum.USERID_LIST:
+          case ColumnTypeEnum.ENTITYID_LIST:
+            return false
+          default:
+            return true
+        }
+      }
+      return true
+    })
+}
+
+export function getFacetTypeFriendlyName(facetType: FacetType) {
+  switch (facetType) {
+    case 'enumeration':
+      return 'Values'
+    case 'range':
+      return 'Range'
+    default:
+      return facetType
+  }
+}
+export function getColumnTypeFriendlyName(type: ColumnType | ColumnTypeEnum) {
+  switch (type) {
+    case ColumnTypeEnum.STRING:
+      return 'String'
+    case ColumnTypeEnum.DOUBLE:
+      return 'Double'
+    case ColumnTypeEnum.BOOLEAN:
+      return 'Boolean'
+    case ColumnTypeEnum.INTEGER:
+      return 'Integer'
+    case ColumnTypeEnum.DATE:
+      return 'Date'
+    case ColumnTypeEnum.FILEHANDLEID:
+      return 'File'
+    case ColumnTypeEnum.ENTITYID:
+      return 'Entity'
+    case ColumnTypeEnum.LINK:
+      return 'Link'
+    case ColumnTypeEnum.MEDIUMTEXT:
+      return 'MediumText'
+    case ColumnTypeEnum.LARGETEXT:
+      return 'LargeText'
+    case ColumnTypeEnum.USERID:
+      return 'User'
+    case ColumnTypeEnum.STRING_LIST:
+      return 'String List'
+    case ColumnTypeEnum.INTEGER_LIST:
+      return 'Integer List'
+    case ColumnTypeEnum.BOOLEAN_LIST:
+      return 'Boolean List'
+    case ColumnTypeEnum.DATE_LIST:
+      return 'Date List'
+    case ColumnTypeEnum.USERID_LIST:
+      return 'User ID List'
+    case ColumnTypeEnum.ENTITYID_LIST:
+      return 'Entity ID List'
+    case ColumnTypeEnum.EVALUATIONID:
+      return 'Evaluation'
+    case ColumnTypeEnum.JSON:
+      return 'JSON'
+    default:
+      return type
+  }
+}
+
+/**
+ * Can the given type have a size?
+ *
+ * @param type
+ * @return
+ */
+export function canHaveSize(type: ColumnType | ColumnTypeEnum): boolean {
+  switch (type) {
+    case ColumnTypeEnum.STRING:
+    case ColumnTypeEnum.STRING_LIST:
+    case ColumnTypeEnum.LINK:
+      return true
+    default:
+      // all others are false
+      return false
+  }
+}
+
+export function canHaveMaxListLength(
+  type: ColumnType | ColumnTypeEnum,
+): boolean {
+  switch (type) {
+    case ColumnTypeEnum.STRING_LIST:
+    case ColumnTypeEnum.BOOLEAN_LIST:
+    case ColumnTypeEnum.DATE_LIST:
+    case ColumnTypeEnum.INTEGER_LIST:
+      return true
+    default:
+      // all others are false
+      return false
+  }
+}
+
+/**
+ * Configure the facet selection based on the column type
+ *
+ * @param type a ColumnType for which to get the facet selection
+ * @param isJsonSubColumnFacet is this a facet for a json subcolumn?
+ * @return the allowed facetTypes, or null if faceting is not allowed
+ */
+export function configureFacetsForType(
+  type: ColumnType | ColumnTypeEnum,
+  isJsonSubColumnFacet: boolean,
+): (FacetType | undefined)[] | null {
+  let allowedFacetTypes: (FacetType | undefined)[] | null
+  switch (type) {
+    case ColumnTypeEnum.INTEGER:
+    case ColumnTypeEnum.INTEGER_LIST:
+      allowedFacetTypes = ['enumeration', 'range']
+      break
+    case ColumnTypeEnum.STRING:
+    case ColumnTypeEnum.BOOLEAN:
+    case ColumnTypeEnum.USERID:
+    case ColumnTypeEnum.ENTITYID:
+    case ColumnTypeEnum.STRING_LIST:
+    case ColumnTypeEnum.BOOLEAN_LIST:
+    case ColumnTypeEnum.ENTITYID_LIST:
+    case ColumnTypeEnum.USERID_LIST:
+    case ColumnTypeEnum.EVALUATIONID:
+      allowedFacetTypes = ['enumeration']
+      break
+    case ColumnTypeEnum.DOUBLE:
+    case ColumnTypeEnum.DATE:
+    case ColumnTypeEnum.DATE_LIST:
+      allowedFacetTypes = ['range']
+      break
+    default:
+      allowedFacetTypes = null
+  }
+
+  if (allowedFacetTypes && !isJsonSubColumnFacet) {
+    // jsonSubColumn facets MUST have a facet definition, but regular column models do not need one
+    // So allow `undefined` for regular columnModels.
+    allowedFacetTypes = [undefined, ...allowedFacetTypes]
+  }
+  return allowedFacetTypes
+}
+
+export function canHaveDefault(
+  type: ColumnType | ColumnTypeEnum,
+  isView: boolean,
+  isJsonSubColumnFacet: boolean,
+) {
+  // SWC-6333: default types are not allowed in views
+  if (!isView && !isJsonSubColumnFacet) {
+    switch (type) {
+      case ColumnTypeEnum.ENTITYID:
+      case ColumnTypeEnum.FILEHANDLEID:
+      case ColumnTypeEnum.USERID:
+      case ColumnTypeEnum.MEDIUMTEXT:
+      case ColumnTypeEnum.LARGETEXT:
+      case ColumnTypeEnum.JSON:
+        return false
+      default:
+        return true
+    }
+  } else {
+    return false
+  }
+}
+
+const DEFAULT_STRING_SIZE = 50
+const MAX_STRING_SIZE = 1000
+
+/**
+ * Get the default max size for a given type.
+ *
+ * @param type
+ * @return
+ */
+export function getMaxSizeForType(type: ColumnType | ColumnTypeEnum): number {
+  switch (type) {
+    case ColumnTypeEnum.STRING:
+    case ColumnTypeEnum.STRING_LIST:
+      return DEFAULT_STRING_SIZE
+    case ColumnTypeEnum.LINK:
+      return MAX_STRING_SIZE
+    default:
+      throw new Error(`Type is not known to have a max size: ${type}`)
+  }
+}
+
+export function canHaveRestrictedValues(
+  type: ColumnType | ColumnTypeEnum,
+  isJsonSubColumnFacet: boolean,
+): boolean {
+  if (isJsonSubColumnFacet) {
+    return false
+  }
+  switch (type) {
+    case ColumnTypeEnum.STRING:
+    case ColumnTypeEnum.INTEGER:
+    case ColumnTypeEnum.ENTITYID:
+      return true
+    default:
+      // all other are false
+      return false
+  }
+}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.test.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.test.ts
@@ -1,0 +1,924 @@
+import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
+import {
+  ColumnModelFormData,
+  getDefaultColumnModelFormData,
+  getDefaultJsonSubColumnFormData,
+  getNumberOfSelectedItems,
+  reducer,
+} from './TableColumnSchemaFormReducer'
+
+describe('TableColumnSchemaFormReducer', () => {
+  let prevState: ColumnModelFormData[] = []
+  beforeEach(() => {
+    prevState = [
+      {
+        id: '123',
+        name: 'col1',
+        columnType: ColumnTypeEnum.STRING,
+        isSelected: false,
+      },
+      {
+        id: '123',
+        name: 'col2',
+        columnType: ColumnTypeEnum.JSON,
+        jsonSubColumns: [
+          {
+            name: 'subcol1',
+            columnType: ColumnTypeEnum.STRING,
+            isSelected: false,
+            facetType: 'enumeration',
+            jsonPath: '$.x',
+          },
+          {
+            name: 'subcol2',
+            columnType: ColumnTypeEnum.INTEGER,
+            isSelected: false,
+            facetType: 'range',
+            jsonPath: '$.y',
+          },
+        ],
+        isSelected: false,
+      },
+    ]
+  })
+
+  test('setValue', () => {
+    const newValueToPass: ColumnModelFormData[] = [
+      {
+        id: '124',
+        name: 'col2',
+        columnType: ColumnTypeEnum.INTEGER,
+        isSelected: false,
+      },
+    ]
+    const newState = reducer(prevState, {
+      type: 'setValue',
+      value: newValueToPass,
+    })
+    expect(newState).not.toBe(prevState)
+    expect(newState).toEqual(newValueToPass)
+  })
+  test('toggleSelect - top level column', () => {
+    const initialIsSelected = prevState[1].isSelected
+    const newState = reducer(prevState, {
+      type: 'toggleSelect',
+      columnModelIndex: 1,
+    })
+
+    expect(newState).not.toBe(prevState)
+    expect(newState[1].isSelected).toBe(!initialIsSelected)
+  })
+  test('toggleSelect - jsonSubColumn', () => {
+    const initialIsSelected = prevState[1].jsonSubColumns![0].isSelected
+    const newState = reducer(prevState, {
+      type: 'toggleSelect',
+      columnModelIndex: 1,
+      jsonSubColumnModelIndex: 0,
+    })
+
+    expect(newState).not.toBe(prevState)
+    expect(newState[1].jsonSubColumns![0].isSelected).toBe(!initialIsSelected)
+  })
+  test('toggleSelectAll', () => {
+    // First, select one just to test calling toggleSelectAll when there is a partial selection
+    prevState = reducer(prevState, {
+      type: 'toggleSelect',
+      columnModelIndex: 1,
+    })
+
+    let isSelectedExpectedValue = true
+    let newState = reducer(prevState, { type: 'toggleSelectAll' })
+    expect(newState).not.toBe(prevState)
+    expect(newState[0].isSelected).toBe(isSelectedExpectedValue)
+    expect(newState[1].isSelected).toBe(isSelectedExpectedValue)
+    expect(newState[1].jsonSubColumns![0].isSelected).toBe(
+      isSelectedExpectedValue,
+    )
+    expect(newState[1].jsonSubColumns![1].isSelected).toBe(
+      isSelectedExpectedValue,
+    )
+
+    // Now, toggleSelectAll again -- none should be selected
+    isSelectedExpectedValue = false
+    prevState = newState
+    newState = reducer(prevState, { type: 'toggleSelectAll' })
+    expect(newState).not.toBe(prevState)
+    expect(newState[0].isSelected).toBe(isSelectedExpectedValue)
+    expect(newState[1].isSelected).toBe(isSelectedExpectedValue)
+    expect(newState[1].jsonSubColumns![0].isSelected).toBe(
+      isSelectedExpectedValue,
+    )
+    expect(newState[1].jsonSubColumns![1].isSelected).toBe(
+      isSelectedExpectedValue,
+    )
+
+    // Now, toggleSelectAll again -- once again, all should be selected
+    isSelectedExpectedValue = true
+    prevState = newState
+    newState = reducer(prevState, { type: 'toggleSelectAll' })
+    expect(newState).not.toBe(prevState)
+    expect(newState[0].isSelected).toBe(isSelectedExpectedValue)
+    expect(newState[1].isSelected).toBe(isSelectedExpectedValue)
+    expect(newState[1].jsonSubColumns![0].isSelected).toBe(
+      isSelectedExpectedValue,
+    )
+    expect(newState[1].jsonSubColumns![1].isSelected).toBe(
+      isSelectedExpectedValue,
+    )
+  })
+  test('appendColumn', () => {
+    const initialLength = prevState.length
+    const newState = reducer(prevState, {
+      type: 'appendColumn',
+    })
+    expect(newState[newState.length - 1]).toEqual({
+      id: '',
+      name: '',
+      columnType: ColumnTypeEnum.STRING,
+      isSelected: false,
+    })
+
+    expect(newState).not.toBe(prevState)
+    expect(newState.length).toBe(initialLength + 1)
+  })
+  test('appendJsonSubColumn', () => {
+    const initialLength = prevState[1].jsonSubColumns!.length
+    const newState = reducer(prevState, {
+      type: 'appendJsonSubColumn',
+      columnModelIndex: 1,
+    })
+    expect(
+      newState[1].jsonSubColumns![newState[1].jsonSubColumns!.length - 1],
+    ).toEqual({
+      name: '',
+      facetType: 'enumeration',
+      columnType: ColumnTypeEnum.STRING,
+      isSelected: false,
+      jsonPath: '',
+    })
+
+    expect(newState).not.toBe(prevState)
+    expect(newState[1].jsonSubColumns!.length).toBe(initialLength + 1)
+  })
+  test('setColumnModelValue - top level column model', () => {
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'setColumnModelValue',
+      columnModelIndex: 0,
+      value: {
+        ...initialValue,
+        name: 'newName',
+      },
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    // Column models that did not change should be the same object, so React does not need to re-render the component
+    expect(newState[1]).toBe(prevState[1])
+    expect(newState[0].name).toBe('newName')
+  })
+  test('setColumnModelValue - jsonSubColumn', () => {
+    const initalJsonSubColumnToChange = prevState[1].jsonSubColumns![0]
+    const unmodifiedSiblingJsonSubColumn = prevState[1].jsonSubColumns![1]
+    const unmodifiedParentColumnModel = prevState[1]
+    const newState = reducer(prevState, {
+      type: 'setColumnModelValue',
+      columnModelIndex: 1,
+      jsonSubColumnModelIndex: 0,
+      value: {
+        ...initalJsonSubColumnToChange,
+        name: 'newName',
+      },
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed jsonSubColumn should be a different object
+    expect(newState[1].jsonSubColumns![0]).not.toBe(initalJsonSubColumnToChange)
+    // The parent JSON column model and siblings should be the same objects, so React does not need to re-render the entire tree
+    expect(newState[1]).toBe(unmodifiedParentColumnModel)
+    expect(newState[1].jsonSubColumns![1]).toBe(unmodifiedSiblingJsonSubColumn)
+    expect(newState[1].jsonSubColumns![0].name).toBe('newName')
+  })
+  test('changeColumnModelType - both canHaveSize', () => {
+    // STRING -> LINK
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.STRING,
+        maximumSize: 25,
+      },
+    ]
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.LINK,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    expect(newState[0].name).toEqual(initialValue.name)
+    expect(newState[0].columnType).toEqual(ColumnTypeEnum.LINK)
+    // maximumSize should not have changed
+    expect(newState[0].maximumSize).toEqual(initialValue.maximumSize)
+  })
+  test('changeColumnModelType - canHaveSize becomes false', () => {
+    // STRING -> INTEGER
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.STRING,
+        maximumSize: 25,
+      },
+    ]
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.INTEGER,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    expect(newState[0].name).toEqual(initialValue.name)
+    expect(newState[0].columnType).toEqual(ColumnTypeEnum.INTEGER)
+    // maximumSize should not exist on new column model
+    expect(Object.hasOwn(newState[0], 'maximumSize')).toBe(false)
+  })
+
+  test('changeColumnModelType - both canHaveMaxListLength', () => {
+    // STRING_LIST -> INTEGER_LIST
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.STRING_LIST,
+        maximumListLength: 5,
+      },
+    ]
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.INTEGER_LIST,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    expect(newState[0].name).toEqual(initialValue.name)
+    expect(newState[0].columnType).toEqual(ColumnTypeEnum.INTEGER_LIST)
+    // maximumListLength should not have changed
+    expect(newState[0].maximumListLength).toEqual(5)
+  })
+  test('changeColumnModelType - canHaveMaxListLength becomes false', () => {
+    // STRING_LIST -> STRING
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.STRING_LIST,
+        maximumListLength: 5,
+      },
+    ]
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.STRING,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    expect(newState[0].name).toEqual(initialValue.name)
+    expect(newState[0].columnType).toEqual(ColumnTypeEnum.STRING)
+    // maximumListLength should not exist on new column model
+    expect(Object.hasOwn(newState[0], 'maximumListLength')).toBe(false)
+  })
+
+  test('changeColumnModelType - both canHaveRestrictedValues', () => {
+    // STRING -> INTEGER
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.STRING,
+        enumValues: ['1', '2', '3'],
+      },
+    ]
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.INTEGER,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    expect(newState[0].name).toEqual(initialValue.name)
+    expect(newState[0].columnType).toEqual(ColumnTypeEnum.INTEGER)
+    // enumValues should not have changed
+    expect(newState[0].enumValues).toEqual(['1', '2', '3'])
+  })
+  test('changeColumnModelType - canHaveRestrictedValues becomes false', () => {
+    // STRING -> BOOLEAN
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.STRING,
+        enumValues: ['1', '2', '3'],
+      },
+    ]
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.BOOLEAN,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    expect(newState[0].name).toEqual(initialValue.name)
+    expect(newState[0].columnType).toEqual(ColumnTypeEnum.BOOLEAN)
+    // enumValues should not exist on new column model
+    expect(Object.hasOwn(newState[0], 'enumValues')).toBe(false)
+  })
+
+  test('changeColumnModelType - both allow same facet type', () => {
+    // STRING -> BOOLEAN with 'enumeration'
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.STRING,
+        facetType: 'enumeration',
+      },
+    ]
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.BOOLEAN,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    expect(newState[0].name).toEqual(initialValue.name)
+    expect(newState[0].columnType).toEqual(ColumnTypeEnum.BOOLEAN)
+    // facetType should not have changed
+    expect(newState[0].facetType).toEqual('enumeration')
+  })
+  test('changeColumnModelType - new type does not allow same facet type', () => {
+    // STRING -> DOUBLE with 'enumeration'
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.STRING,
+        facetType: 'enumeration',
+      },
+    ]
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.DOUBLE,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    expect(newState[0].name).toEqual(initialValue.name)
+    expect(newState[0].columnType).toEqual(ColumnTypeEnum.DOUBLE)
+    // facetType should not exist on new column model
+    expect(Object.hasOwn(newState[0], 'facetType')).toBe(false)
+  })
+  test('changeColumnModelType - new type does not allow any facets', () => {
+    // STRING -> FILEHANDLEID with 'enumeration'
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.STRING,
+        facetType: 'enumeration',
+      },
+    ]
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.FILEHANDLEID,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    expect(newState[0].name).toEqual(initialValue.name)
+    expect(newState[0].columnType).toEqual(ColumnTypeEnum.FILEHANDLEID)
+    // facetType should not exist on new column model
+    expect(Object.hasOwn(newState[0], 'facetType')).toBe(false)
+  })
+
+  test('changeColumnModelType - both have jsonSubColumns', () => {
+    // JSON -> JSON (technically a no-op, no other column types support jsonSubColumns)
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.JSON,
+        jsonSubColumns: [
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            jsonPath: '$.x',
+          },
+        ],
+      },
+    ]
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.JSON,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    expect(newState[0].name).toEqual(initialValue.name)
+    expect(newState[0].columnType).toEqual(ColumnTypeEnum.JSON)
+    // jsonSubColumns should not have changed
+    expect(newState[0].jsonSubColumns).toEqual(initialValue.jsonSubColumns)
+  })
+  test('changeColumnModelType - new type does not allow jsonSubColumns', () => {
+    // JSON -> STRING
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.JSON,
+        jsonSubColumns: [
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            jsonPath: '$.x',
+          },
+        ],
+      },
+    ]
+    const initialValue = prevState[0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.STRING,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The changed column model should be a different object
+    expect(newState[0]).not.toBe(initialValue)
+    expect(newState[0].name).toEqual(initialValue.name)
+    expect(newState[0].columnType).toEqual(ColumnTypeEnum.STRING)
+    // jsonSubColumns should not exist on new column model
+    expect(Object.hasOwn(newState[0], 'jsonSubColumns')).toBe(false)
+  })
+
+  test('changeColumnModelType - update type for a jsonSubColumn', () => {
+    // STRING -> INTEGER
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'stringToLinkColumn',
+        columnType: ColumnTypeEnum.JSON,
+        jsonSubColumns: [
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            columnType: ColumnTypeEnum.STRING,
+            jsonPath: '$.x',
+          },
+        ],
+      },
+    ]
+    const initialColumnModelObject = prevState[0]
+    const initialJsonSubColumnObject = prevState[0].jsonSubColumns![0]
+    const newState = reducer(prevState, {
+      type: 'changeColumnModelType',
+      columnModelIndex: 0,
+      jsonSubColumnModelIndex: 0,
+      newColumnType: ColumnTypeEnum.INTEGER,
+    })
+
+    expect(newState).not.toBe(prevState)
+    // The column model and array of jsonSubColumns should not have changed
+    expect(newState[0]).toBe(initialColumnModelObject)
+    expect(newState[0].jsonSubColumns).toBe(
+      initialColumnModelObject.jsonSubColumns,
+    )
+    expect(newState[0].jsonSubColumns![0]).not.toBe(initialJsonSubColumnObject)
+    expect(newState[0].jsonSubColumns![0].name).toEqual(
+      initialColumnModelObject.jsonSubColumns![0].name,
+    )
+    expect(newState[0].jsonSubColumns![0].columnType).toEqual(
+      ColumnTypeEnum.INTEGER,
+    )
+    expect(newState[0].jsonSubColumns![0].jsonPath).toEqual(
+      initialColumnModelObject.jsonSubColumns![0].jsonPath,
+    )
+  })
+
+  test('move - ColumnModel', () => {
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col1',
+        isSelected: false,
+      },
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col2',
+        isSelected: false,
+      },
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col3',
+        isSelected: false,
+      },
+    ]
+
+    const column1 = prevState[0]
+    const column2 = prevState[1]
+    const column3 = prevState[2]
+
+    const newState = reducer(prevState, {
+      type: 'move',
+      from: {
+        columnModelIndex: 2,
+      },
+      to: {
+        columnModelIndex: 0,
+      },
+    })
+
+    expect(newState).not.toBe(prevState)
+    // Verify the order changed
+    expect(newState[0].name).toBe('col3')
+    expect(newState[1].name).toBe('col1')
+    expect(newState[2].name).toBe('col2')
+    // Verify that the objects did not change
+    expect(newState[0]).toBe(column3)
+    expect(newState[1]).toBe(column1)
+    expect(newState[2]).toBe(column2)
+  })
+
+  test('move - jsonSubColumn', () => {
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col1',
+        jsonSubColumns: [
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            name: 'subColumn1',
+            isSelected: false,
+            jsonPath: '$.x',
+          },
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            name: 'subColumn2',
+            isSelected: false,
+            jsonPath: '$.y',
+          },
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            name: 'subColumn3',
+            isSelected: false,
+            jsonPath: '$.z',
+          },
+        ],
+        isSelected: false,
+      },
+    ]
+
+    const originalSubColumnArray = prevState[0].jsonSubColumns!
+    const subColumn1 = prevState[0].jsonSubColumns![0]
+    const subColumn2 = prevState[0].jsonSubColumns![1]
+    const subColumn3 = prevState[0].jsonSubColumns![2]
+
+    const newState = reducer(prevState, {
+      type: 'move',
+      from: {
+        columnModelIndex: 0,
+        jsonSubColumnModelIndex: 2,
+      },
+      to: {
+        columnModelIndex: 0,
+        jsonSubColumnModelIndex: 0,
+      },
+    })
+
+    // The top level array should be a new array
+    expect(newState).not.toBe(prevState)
+    // The jsonSubColumns array should be a new array to trigger a re-render
+    expect(newState[0].jsonSubColumns).not.toBe(originalSubColumnArray)
+    // Verify the order changed
+    expect(newState[0].jsonSubColumns![0].name).toBe('subColumn3')
+    expect(newState[0].jsonSubColumns![1].name).toBe('subColumn1')
+    expect(newState[0].jsonSubColumns![2].name).toBe('subColumn2')
+    // Verify that the reordered objects did not change
+    expect(newState[0].jsonSubColumns![0]).toBe(subColumn3)
+    expect(newState[0].jsonSubColumns![1]).toBe(subColumn1)
+    expect(newState[0].jsonSubColumns![2]).toBe(subColumn2)
+  })
+
+  test('moveUp - one item', () => {
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col1',
+        isSelected: false,
+      },
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col2',
+        isSelected: true,
+      },
+    ]
+    let newState = reducer(prevState, {
+      type: 'moveUp',
+    })
+
+    expect(newState).not.toBe(prevState)
+    // Verify the order changed
+    expect(newState[0].name).toBe('col2')
+    expect(newState[1].name).toBe('col1')
+    // Verify that the objects did not change
+    expect(newState[0]).toBe(prevState[1])
+    expect(newState[1]).toBe(prevState[0])
+
+    // Move up once more
+    newState = reducer(prevState, {
+      type: 'moveUp',
+    })
+
+    // Verify that it was a no-op since the selected column is already at the top.
+    expect(newState[0].name).toBe('col2')
+    expect(newState[1].name).toBe('col1')
+  })
+  test('moveUp - two items', () => {
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col1',
+        isSelected: false,
+      },
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col2',
+        isSelected: true,
+      },
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col3',
+        isSelected: true,
+      },
+    ]
+    const newState = reducer(prevState, {
+      type: 'moveUp',
+    })
+
+    expect(newState).not.toBe(prevState)
+    // Verify the order changed - col1 should be moved to the bottom since both 2 and 3 were moved up
+    expect(newState[0].name).toBe('col2')
+    expect(newState[1].name).toBe('col3')
+    expect(newState[2].name).toBe('col1')
+    // Verify that the objects did not change
+    expect(newState[0]).toBe(prevState[1])
+    expect(newState[1]).toBe(prevState[2])
+    expect(newState[2]).toBe(prevState[0])
+  })
+  test('moveUp - jsonSubColumn', () => {
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col1',
+        columnType: ColumnTypeEnum.JSON,
+        isSelected: false,
+
+        jsonSubColumns: [
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            name: 'subColumn1',
+            isSelected: false,
+          },
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            name: 'subColumn2',
+            isSelected: true,
+          },
+        ],
+      },
+    ]
+    const jsonSubColumn1 = prevState[0].jsonSubColumns![0]
+    const jsonSubColumn2 = prevState[0].jsonSubColumns![1]
+    const newState = reducer(prevState, {
+      type: 'moveUp',
+    })
+
+    expect(newState).not.toBe(prevState)
+    // Verify the order changed
+    expect(newState[0].jsonSubColumns![0].name).toBe('subColumn2')
+    expect(newState[0].jsonSubColumns![1].name).toBe('subColumn1')
+    // Verify that the objects did not change
+    expect(newState[0].jsonSubColumns![0]).toBe(jsonSubColumn2)
+    expect(newState[0].jsonSubColumns![1]).toBe(jsonSubColumn1)
+  })
+
+  test('moveDown - one item', () => {
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col1',
+        isSelected: true,
+      },
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col2',
+        isSelected: false,
+      },
+    ]
+    let newState = reducer(prevState, {
+      type: 'moveDown',
+    })
+
+    expect(newState).not.toBe(prevState)
+    // Verify the order changed
+    expect(newState[0].name).toBe('col2')
+    expect(newState[1].name).toBe('col1')
+    // Verify that the objects did not change
+    expect(newState[0]).toBe(prevState[1])
+    expect(newState[1]).toBe(prevState[0])
+
+    // Move down once more
+    newState = reducer(prevState, {
+      type: 'moveDown',
+    })
+
+    // Verify that it was a no-op since the selected column is already at the bottom.
+    expect(newState[0].name).toBe('col2')
+    expect(newState[1].name).toBe('col1')
+  })
+  test('moveDown - two items', () => {
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col1',
+        isSelected: true,
+      },
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col2',
+        isSelected: true,
+      },
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col3',
+        isSelected: false,
+      },
+    ]
+    const newState = reducer(prevState, {
+      type: 'moveDown',
+    })
+
+    expect(newState).not.toBe(prevState)
+    // Verify the order changed - col3 should be moved to the top since both 1 and 2 were moved down
+    expect(newState[0].name).toBe('col3')
+    expect(newState[1].name).toBe('col1')
+    expect(newState[2].name).toBe('col2')
+    // Verify that the objects did not change
+    expect(newState[0]).toBe(prevState[2])
+    expect(newState[1]).toBe(prevState[0])
+    expect(newState[2]).toBe(prevState[1])
+  })
+  test('moveDown - jsonSubColumn', () => {
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col1',
+        columnType: ColumnTypeEnum.JSON,
+        isSelected: false,
+
+        jsonSubColumns: [
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            name: 'subColumn1',
+            isSelected: true,
+          },
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            name: 'subColumn2',
+            isSelected: false,
+          },
+        ],
+      },
+    ]
+    const jsonSubColumn1 = prevState[0].jsonSubColumns![0]
+    const jsonSubColumn2 = prevState[0].jsonSubColumns![1]
+    const newState = reducer(prevState, {
+      type: 'moveDown',
+    })
+
+    expect(newState).not.toBe(prevState)
+    // Verify the order changed
+    expect(newState[0].jsonSubColumns![0].name).toBe('subColumn2')
+    expect(newState[0].jsonSubColumns![1].name).toBe('subColumn1')
+    // Verify that the objects did not change
+    expect(newState[0].jsonSubColumns![0]).toBe(jsonSubColumn2)
+    expect(newState[0].jsonSubColumns![1]).toBe(jsonSubColumn1)
+  })
+
+  test('delete - columnModel', () => {
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col1',
+        isSelected: true,
+      },
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col2',
+        isSelected: false,
+      },
+    ]
+    let newState = reducer(prevState, {
+      type: 'delete',
+    })
+
+    expect(newState).not.toBe(prevState)
+    expect(newState.length).toBe(1)
+    expect(newState[0]).toBe(prevState[1])
+  })
+
+  test('delete - jsonSubColumn', () => {
+    const prevState: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col1',
+        columnType: ColumnTypeEnum.JSON,
+        isSelected: false,
+        jsonSubColumns: [
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            name: 'subColumn1',
+            isSelected: true,
+          },
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            name: 'subColumn2',
+            isSelected: false,
+          },
+        ],
+      },
+    ]
+    const jsonSubColumn2 = prevState[0].jsonSubColumns![1]
+    const newState = reducer(prevState, {
+      type: 'delete',
+    })
+
+    expect(newState).not.toBe(prevState)
+    expect(newState.length).toBe(1)
+    expect(newState[0].jsonSubColumns!.length).toBe(1)
+    expect(newState[0].jsonSubColumns![0]).toBe(jsonSubColumn2)
+  })
+
+  test('getNumberOfSelectedItems', () => {
+    const state: ColumnModelFormData[] = [
+      {
+        ...getDefaultColumnModelFormData(),
+        name: 'col1',
+        columnType: ColumnTypeEnum.JSON,
+        isSelected: true,
+        jsonSubColumns: [
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            name: 'subColumn1',
+            isSelected: true,
+          },
+          {
+            ...getDefaultJsonSubColumnFormData(),
+            name: 'subColumn2',
+            isSelected: false,
+          },
+        ],
+      },
+    ]
+
+    expect(getNumberOfSelectedItems(state)).toBe(2)
+  })
+})

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
@@ -200,17 +200,21 @@ function changeColumnModelType(
   let newColumnModelValue: ColumnModelFormData | JsonSubColumnModelFormData
 
   // Create a copy of the selected column model
-  if (
-    prevState &&
-    prevState[columnModelIndex] &&
-    prevState[columnModelIndex].jsonSubColumns &&
-    jsonSubColumnModelIndex !== undefined
-  ) {
-    newColumnModelValue = cloneDeep(
-      prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex],
-    )
+  if (prevState && prevState[columnModelIndex]) {
+    if (
+      prevState[columnModelIndex].jsonSubColumns &&
+      jsonSubColumnModelIndex !== undefined
+    ) {
+      newColumnModelValue = cloneDeep(
+        prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex],
+      )
+    } else {
+      newColumnModelValue = cloneDeep(prevState[columnModelIndex])
+    }
   } else {
-    newColumnModelValue = cloneDeep(prevState[columnModelIndex])
+    throw new Error(
+      'Cannot change column model type for a column that does not exist',
+    )
   }
 
   // Update the column model. Remove fields that no longer make sense for the new column type
@@ -251,16 +255,16 @@ function changeColumnModelType(
   }
 
   // Replace the value
-  if (
-    prevState &&
-    prevState[columnModelIndex] &&
-    prevState[columnModelIndex].jsonSubColumns &&
-    jsonSubColumnModelIndex !== undefined
-  ) {
-    prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex] =
-      newColumnModelValue as JsonSubColumnModelFormData
-  } else {
-    prevState[columnModelIndex] = newColumnModelValue as ColumnModelFormData
+  if (prevState && prevState[columnModelIndex]) {
+    if (
+      prevState[columnModelIndex].jsonSubColumns &&
+      jsonSubColumnModelIndex !== undefined
+    ) {
+      prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex] =
+        newColumnModelValue as JsonSubColumnModelFormData
+    } else {
+      prevState[columnModelIndex] = newColumnModelValue as ColumnModelFormData
+    }
   }
 }
 
@@ -297,16 +301,16 @@ function setColumnModelValue(
   prevState: ColumnModelFormData[],
 ) {
   const { columnModelIndex, jsonSubColumnModelIndex, value } = action
-  if (
-    prevState &&
-    prevState[columnModelIndex] &&
-    prevState[columnModelIndex].jsonSubColumns &&
-    jsonSubColumnModelIndex !== undefined
-  ) {
-    prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex] =
-      value as JsonSubColumnModelFormData
-  } else {
-    prevState[columnModelIndex] = value as ColumnModelFormData
+  if (prevState && prevState[columnModelIndex]) {
+    if (
+      prevState[columnModelIndex].jsonSubColumns &&
+      jsonSubColumnModelIndex !== undefined
+    ) {
+      prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex] =
+        value as JsonSubColumnModelFormData
+    } else {
+      prevState[columnModelIndex] = value as ColumnModelFormData
+    }
   }
 }
 
@@ -319,21 +323,21 @@ function toggleSelect(
   prevState: ColumnModelFormData[],
 ) {
   const { columnModelIndex, jsonSubColumnModelIndex } = action
-  if (
-    prevState &&
-    prevState[columnModelIndex] &&
-    prevState[columnModelIndex].jsonSubColumns &&
-    jsonSubColumnModelIndex !== undefined
-  ) {
-    const cm =
-      prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex]
-    prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex] = {
-      ...cm,
-      isSelected: !cm.isSelected,
+  if (prevState && prevState[columnModelIndex]) {
+    if (
+      prevState[columnModelIndex].jsonSubColumns &&
+      jsonSubColumnModelIndex !== undefined
+    ) {
+      const cm =
+        prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex]
+      prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex] = {
+        ...cm,
+        isSelected: !cm.isSelected,
+      }
+    } else {
+      const cm = prevState[columnModelIndex]
+      prevState[columnModelIndex] = { ...cm, isSelected: !cm.isSelected }
     }
-  } else {
-    const cm = prevState[columnModelIndex]
-    prevState[columnModelIndex] = { ...cm, isSelected: !cm.isSelected }
   }
 }
 

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
@@ -1,0 +1,500 @@
+import {
+  ColumnModel,
+  ColumnTypeEnum,
+  JsonSubColumnModel,
+} from '@sage-bionetworks/synapse-types'
+import { atomWithReducer } from 'jotai/utils'
+import { SetOptional } from 'type-fest'
+import { cloneDeep } from 'lodash-es'
+import {
+  canHaveMaxListLength,
+  canHaveRestrictedValues,
+  canHaveSize,
+  configureFacetsForType,
+} from './TableColumnSchemaEditorUtils'
+
+export function getIsAllSelected(formData: ColumnModelFormData[]) {
+  return (
+    formData.length > 0 &&
+    formData.every(
+      cm =>
+        // Is selected
+        cm.isSelected &&
+        // And all subcolumns are selected (true if there are no subcolumns)
+        (cm.jsonSubColumns ?? []).every(
+          (jsc: JsonSubColumnModelFormData) => jsc.isSelected,
+        ),
+    )
+  )
+}
+
+export function getNumberOfSelectedItems(formData: ColumnModelFormData[]) {
+  return formData.reduce((acc, curr) => {
+    if (curr.isSelected) {
+      acc += 1
+    }
+    if (curr.jsonSubColumns) {
+      curr.jsonSubColumns.forEach((jsc: JsonSubColumnModelFormData) => {
+        if (jsc.isSelected) {
+          acc += 1
+        }
+      })
+    }
+    return acc
+  }, 0)
+}
+
+export function getDefaultColumnModelFormData(): ColumnModelFormData {
+  return {
+    id: '',
+    name: '',
+    columnType: ColumnTypeEnum.STRING,
+    isSelected: false,
+  }
+}
+
+export function getDefaultJsonSubColumnFormData(): JsonSubColumnModelFormData {
+  return {
+    name: '',
+    jsonPath: '',
+    columnType: ColumnTypeEnum.STRING,
+    facetType: 'enumeration',
+    isSelected: false,
+  }
+}
+
+/**
+ * In the provided array, move items up where the predicate evaluates to true
+ * @param arr the array to reorder
+ * @param predicate a function that returns true if the item should be moved up
+ * @returns - a new array with the reordered items
+ */
+function moveSelectedItemsUp<T = unknown>(
+  arr: T[],
+  predicate: (item: T) => boolean,
+) {
+  const newArr = [...arr]
+  newArr.forEach((item, index) => {
+    // For each item that should move up, swap it with the previous item
+    if (
+      // Cannot move index 0 up
+      index > 0 &&
+      // Only move if the predicate matches
+      predicate(item) &&
+      // If the previous item should also move, skip the swap
+      !predicate(newArr[index - 1])
+    ) {
+      // swap the items
+      const temp = newArr[index - 1]
+      newArr[index - 1] = newArr[index]
+      newArr[index] = temp
+    }
+  })
+  return newArr
+}
+
+/**
+ * In the provided array, move items down where the predicate evaluates to true
+ * @param arr the array to reorder
+ * @param predicate a function that returns true if the item should be moved down
+ * @returns - a new array with the reordered items
+ */
+function moveSelectedItemsDown<T = unknown>(
+  arr: T[],
+  predicate: (item: T) => boolean,
+) {
+  const newArr = [...arr]
+  // Start from the end and work backwards, otherwise items could be moved more than once
+  for (let i = newArr.length - 1; i >= 0; i--) {
+    const item = newArr[i]
+    if (
+      // Cannot move the last item down
+      i < newArr.length - 1 &&
+      // Only move if the predicate matches
+      predicate(item) &&
+      // If the next item should also be moved, don't swap
+      !predicate(newArr[i + 1])
+    ) {
+      // swap the items
+      const temp = newArr[i]
+      newArr[i] = newArr[i + 1]
+      newArr[i + 1] = temp
+    }
+  }
+  return newArr
+}
+
+export type JsonSubColumnModelFormData = JsonSubColumnModel & {
+  // add `isSelected` to the data object
+  isSelected: boolean
+}
+
+export type ColumnModelFormData = Omit<
+  SetOptional<ColumnModel, 'id'>,
+  'jsonSubColumns'
+> & {
+  // add `isSelected` to the data object
+  isSelected: boolean
+  // jsonSubColumns will also include formData (like isSelected)
+  jsonSubColumns?: JsonSubColumnModelFormData[]
+}
+
+type TableColumnSchemaFormReducerAction =
+  | {
+      type: 'setValue'
+      value: ColumnModelFormData[]
+    }
+  | {
+      type: 'toggleSelect'
+      columnModelIndex: number
+      jsonSubColumnModelIndex?: number
+    }
+  | { type: 'toggleSelectAll' }
+  | {
+      type: 'appendColumn'
+    }
+  | {
+      type: 'appendJsonSubColumn'
+      columnModelIndex: number
+    }
+  | {
+      type: 'setColumnModelValue'
+      columnModelIndex: number
+      jsonSubColumnModelIndex?: number
+      value: ColumnModelFormData | JsonSubColumnModelFormData
+    }
+  | {
+      type: 'changeColumnModelType'
+      newColumnType: ColumnTypeEnum
+      columnModelIndex: number
+      jsonSubColumnModelIndex?: number
+    }
+  | {
+      type: 'move'
+      from: {
+        columnModelIndex: number
+        jsonSubColumnModelIndex?: number
+      }
+      to: { columnModelIndex: number; jsonSubColumnModelIndex?: number }
+    }
+  | {
+      type: 'moveUp'
+    }
+  | {
+      type: 'moveDown'
+    }
+  | {
+      type: 'delete'
+    }
+
+function changeColumnModelType(
+  action: {
+    type: 'changeColumnModelType'
+    newColumnType: ColumnTypeEnum
+    columnModelIndex: number
+    jsonSubColumnModelIndex?: number
+  },
+  prevState: ColumnModelFormData[],
+) {
+  const { columnModelIndex, jsonSubColumnModelIndex, newColumnType } = action
+  let newColumnModelValue: ColumnModelFormData | JsonSubColumnModelFormData
+
+  // Create a copy of the selected column model
+  if (
+    prevState &&
+    prevState[columnModelIndex] &&
+    prevState[columnModelIndex].jsonSubColumns &&
+    jsonSubColumnModelIndex !== undefined
+  ) {
+    newColumnModelValue = cloneDeep(
+      prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex],
+    )
+  } else {
+    newColumnModelValue = cloneDeep(prevState[columnModelIndex])
+  }
+
+  // Update the column model. Remove fields that no longer make sense for the new column type
+  newColumnModelValue.columnType = newColumnType
+  if (!canHaveSize(newColumnType) && 'maximumSize' in newColumnModelValue) {
+    delete newColumnModelValue.maximumSize
+  }
+  if (
+    !canHaveMaxListLength(newColumnType) &&
+    'maximumListLength' in newColumnModelValue
+  ) {
+    delete newColumnModelValue.maximumListLength
+  }
+  if (
+    !canHaveRestrictedValues(newColumnType, !!jsonSubColumnModelIndex) &&
+    'enumValues' in newColumnModelValue
+  ) {
+    delete newColumnModelValue.enumValues
+  }
+
+  const allowedFacetTypes = configureFacetsForType(
+    newColumnType,
+    !!jsonSubColumnModelIndex,
+  )
+  if (
+    'facetType' in newColumnModelValue &&
+    (allowedFacetTypes === null ||
+      !allowedFacetTypes.includes(newColumnModelValue.facetType))
+  ) {
+    delete newColumnModelValue.facetType
+  }
+
+  if (
+    'jsonSubColumns' in newColumnModelValue &&
+    newColumnType !== ColumnTypeEnum.JSON
+  ) {
+    delete newColumnModelValue.jsonSubColumns
+  }
+
+  // Replace the value
+  if (
+    prevState &&
+    prevState[columnModelIndex] &&
+    prevState[columnModelIndex].jsonSubColumns &&
+    jsonSubColumnModelIndex !== undefined
+  ) {
+    prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex] =
+      newColumnModelValue as JsonSubColumnModelFormData
+  } else {
+    prevState[columnModelIndex] = newColumnModelValue as ColumnModelFormData
+  }
+}
+
+function toggleSelectAll(prevState: ColumnModelFormData[]) {
+  const allSelected = getIsAllSelected(prevState)
+  if (allSelected) {
+    return prevState.map(cm => ({
+      ...cm,
+      jsonSubColumns: cm.jsonSubColumns?.map(jsc => ({
+        ...jsc,
+        isSelected: false,
+      })),
+      isSelected: false,
+    }))
+  } else {
+    return prevState.map(cm => ({
+      ...cm,
+      jsonSubColumns: cm.jsonSubColumns?.map(jsc => ({
+        ...jsc,
+        isSelected: true,
+      })),
+      isSelected: true,
+    }))
+  }
+}
+
+function setColumnModelValue(
+  action: {
+    type: 'setColumnModelValue'
+    columnModelIndex: number
+    jsonSubColumnModelIndex?: number
+    value: ColumnModelFormData | JsonSubColumnModelFormData
+  },
+  prevState: ColumnModelFormData[],
+) {
+  const { columnModelIndex, jsonSubColumnModelIndex, value } = action
+  if (
+    prevState &&
+    prevState[columnModelIndex] &&
+    prevState[columnModelIndex].jsonSubColumns &&
+    jsonSubColumnModelIndex !== undefined
+  ) {
+    prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex] =
+      value as JsonSubColumnModelFormData
+  } else {
+    prevState[columnModelIndex] = value as ColumnModelFormData
+  }
+}
+
+function toggleSelect(
+  action: {
+    type: 'toggleSelect'
+    columnModelIndex: number
+    jsonSubColumnModelIndex?: number
+  },
+  prevState: ColumnModelFormData[],
+) {
+  const { columnModelIndex, jsonSubColumnModelIndex } = action
+  if (
+    prevState &&
+    prevState[columnModelIndex] &&
+    prevState[columnModelIndex].jsonSubColumns &&
+    jsonSubColumnModelIndex !== undefined
+  ) {
+    const cm =
+      prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex]
+    prevState[columnModelIndex].jsonSubColumns![jsonSubColumnModelIndex] = {
+      ...cm,
+      isSelected: !cm.isSelected,
+    }
+  } else {
+    const cm = prevState[columnModelIndex]
+    prevState[columnModelIndex] = { ...cm, isSelected: !cm.isSelected }
+  }
+}
+
+function deleteColumnModel(prevState: ColumnModelFormData[]) {
+  return prevState
+    .filter(cm => !cm.isSelected)
+    .map(cm => {
+      if (cm.jsonSubColumns) {
+        cm = {
+          ...cm,
+          jsonSubColumns: cm.jsonSubColumns.filter(
+            (jsc: JsonSubColumnModelFormData) => !jsc.isSelected,
+          ),
+        }
+      }
+      return cm
+    })
+}
+
+/**
+ * Returns a new, shallowly-cloned array that moves the object from the `fromIndex` to the `toIndex`.
+ * Derived from https://stackoverflow.com/a/6470794/9723359
+ *
+ * Returns the same array if the `fromIndex` and `toIndex` are the same.
+ * @param arrayToReorder
+ * @param fromIndex
+ * @param toIndex
+ */
+function moveElementInArray<T = unknown>(
+  arrayToReorder: Array<T>,
+  fromIndex: number,
+  toIndex: number,
+): Array<T> {
+  if (fromIndex == toIndex) {
+    return arrayToReorder
+  }
+  const newArray = [...arrayToReorder]
+  const elementToMove = newArray[fromIndex]
+  newArray.splice(fromIndex, 1)
+  newArray.splice(toIndex, 0, elementToMove)
+  return newArray
+}
+
+/**
+ * Moves a column model or jsonSubColumn from the `from` index to the `to` index
+ * @param action
+ * @param prevState
+ */
+function moveColumnModel(
+  action: {
+    type: 'move'
+    from: { columnModelIndex: number; jsonSubColumnModelIndex?: number }
+    to: { columnModelIndex: number; jsonSubColumnModelIndex?: number }
+  },
+  prevState: ColumnModelFormData[],
+) {
+  const { from, to } = action
+  const arrayToReorder =
+    from.jsonSubColumnModelIndex !== undefined
+      ? prevState[from.columnModelIndex].jsonSubColumns!
+      : prevState
+
+  const fromIndex =
+    from.jsonSubColumnModelIndex !== undefined
+      ? from.jsonSubColumnModelIndex
+      : from.columnModelIndex
+
+  const toIndex =
+    to.jsonSubColumnModelIndex !== undefined
+      ? to.jsonSubColumnModelIndex
+      : to.columnModelIndex
+
+  // Move the element
+  const newArray = moveElementInArray(arrayToReorder, fromIndex, toIndex)
+
+  if (from.jsonSubColumnModelIndex !== undefined) {
+    // If we moved a jsonSubColumn, update state to use the new, reordered array
+    prevState[from.columnModelIndex].jsonSubColumns =
+      newArray as JsonSubColumnModelFormData[]
+    return prevState
+  } else {
+    // Otherwise, return the new, reordered array of column models
+    return newArray
+  }
+}
+
+export function reducer(
+  prevState: ColumnModelFormData[],
+  action: TableColumnSchemaFormReducerAction,
+) {
+  switch (action.type) {
+    case 'setValue':
+      prevState = action.value
+      break
+    case 'toggleSelectAll': {
+      prevState = toggleSelectAll(prevState)
+      break
+    }
+    case 'setColumnModelValue': {
+      setColumnModelValue(action, prevState)
+      break
+    }
+    case 'changeColumnModelType': {
+      changeColumnModelType(action, prevState)
+      break
+    }
+
+    case 'appendColumn':
+      prevState.push(getDefaultColumnModelFormData())
+      break
+    case 'appendJsonSubColumn': {
+      const { columnModelIndex } = action
+      prevState[columnModelIndex] = {
+        ...prevState[columnModelIndex],
+        jsonSubColumns: [
+          ...(prevState[columnModelIndex].jsonSubColumns ?? []),
+          getDefaultJsonSubColumnFormData(),
+        ],
+      }
+      break
+    }
+    case 'toggleSelect': {
+      toggleSelect(action, prevState)
+      break
+    }
+    case 'delete':
+      prevState = deleteColumnModel(prevState)
+      break
+    case 'move': {
+      prevState = moveColumnModel(action, prevState)
+      break
+    }
+    case 'moveUp':
+      prevState = moveSelectedItemsUp(prevState, cm => cm.isSelected)
+      prevState.forEach(cm => {
+        if (cm.jsonSubColumns) {
+          cm.jsonSubColumns = moveSelectedItemsUp(
+            cm.jsonSubColumns,
+            jsc => jsc.isSelected,
+          )
+        }
+      })
+      break
+    case 'moveDown':
+      prevState = moveSelectedItemsDown(prevState, cm => cm.isSelected)
+      prevState.forEach(cm => {
+        if (cm.jsonSubColumns) {
+          cm.jsonSubColumns = moveSelectedItemsDown(
+            cm.jsonSubColumns,
+            jsc => jsc.isSelected,
+          )
+        }
+      })
+      break
+    default:
+      throw new Error(`Unexpected action`, action)
+  }
+  return [...prevState]
+}
+
+export const tableColumnSchemaFormDataAtom = atomWithReducer<
+  ColumnModelFormData[],
+  TableColumnSchemaFormReducerAction
+>([], reducer)


### PR DESCRIPTION
This PR contains the bulk of the business logic for managing data in the Table Column Schema form in SWC-6548