### PR TITLE
SWC-6548 - Add TableColumnSchemaEditor

### DIFF
--- a/packages/synapse-react-client/src/components/Skeleton/SkeletonTable.tsx
+++ b/packages/synapse-react-client/src/components/Skeleton/SkeletonTable.tsx
@@ -11,6 +11,7 @@ export type SkeletonTableProps = {
   numCols?: number
   rowHeight?: string
   className?: string
+  fullWidthCells?: boolean
 }
 
 /**
@@ -23,6 +24,7 @@ export const SkeletonTable: React.FC<SkeletonTableProps> = ({
   numCols = 2,
   rowHeight,
   className,
+  fullWidthCells = false,
 }) => {
   const [skeletons, setSkeletons] = useState<JSX.Element[]>([])
 
@@ -33,18 +35,22 @@ export const SkeletonTable: React.FC<SkeletonTableProps> = ({
         <React.Fragment key={i}>
           <Skeleton
             height={rowHeight}
-            width={`${getRandomInt(35, 75)}%`}
+            width={fullWidthCells ? '100%' : `${getRandomInt(35, 75)}%`}
           ></Skeleton>
         </React.Fragment>,
       )
     })
     setSkeletons(elements)
-  }, [numRows, numCols, rowHeight])
+  }, [numRows, numCols, rowHeight, fullWidthCells])
 
   return (
     <div
       className={className}
-      style={{ display: 'grid', gridTemplateColumns: `auto `.repeat(numCols) }}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `auto `.repeat(numCols),
+        gap: '8px',
+      }}
     >
       {skeletons}
     </div>

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelForm.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelForm.tsx
@@ -1,0 +1,392 @@
+import {
+  Box,
+  FormControl,
+  Link,
+  MenuItem,
+  Select,
+  SxProps,
+  TextField,
+  Tooltip,
+} from '@mui/material'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { selectAtom } from 'jotai/utils'
+import {
+  ColumnModelFormData,
+  JsonSubColumnModelFormData,
+  tableColumnSchemaFormDataAtom,
+} from './TableColumnSchemaFormReducer'
+import {
+  ColumnTypeEnum,
+  EntityType,
+  FacetType,
+  VIEW_CONCRETE_TYPE_VALUES,
+} from '@sage-bionetworks/synapse-types'
+import { convertToConcreteEntityType } from '../../utils/functions/EntityTypeUtils'
+import React, { useMemo, useState } from 'react'
+import { isEmpty, isEqual } from 'lodash-es'
+import {
+  canHaveDefault,
+  canHaveMaxListLength,
+  canHaveRestrictedValues,
+  canHaveSize,
+  configureFacetsForType,
+  getAllowedColumnTypes,
+  getColumnTypeFriendlyName,
+  getFacetTypeFriendlyName,
+  getMaxSizeForType,
+} from './TableColumnSchemaEditorUtils'
+import { Checkbox } from '../widgets/Checkbox'
+import JSONArrayEditorModal from '../JSONArrayEditor/JSONArrayEditorModal'
+import { HIERARCHY_VERTICAL_LINE_COMPONENT } from './TableColumnSchemaForm'
+import { InfoTwoTone } from '@mui/icons-material'
+
+type ColumnOrSubcolumnFormProps = {
+  entityType: EntityType
+  columnModelIndex: number
+  jsonSubColumnIndex?: number
+}
+const jsonSubColumnFieldSx: SxProps = {
+  height: '28px',
+  fontSize: '12px',
+}
+const topLevelColumnModelFieldSx: SxProps = {
+  height: '38px',
+  fontSize: '14px',
+}
+
+export default function ColumnModelForm(props: ColumnOrSubcolumnFormProps) {
+  const { columnModelIndex, jsonSubColumnIndex, entityType } = props
+  const isJsonSubColumn = jsonSubColumnIndex != undefined
+  const dispatch = useSetAtom(tableColumnSchemaFormDataAtom)
+  const isView = (VIEW_CONCRETE_TYPE_VALUES as readonly string[]).includes(
+    convertToConcreteEntityType(entityType),
+  )
+
+  const [isShowingRestrictedValuesModal, setIsShowingRestrictedValuesModal] =
+    useState(false)
+
+  const columnModelAtom = useMemo(
+    () =>
+      selectAtom(
+        tableColumnSchemaFormDataAtom,
+        v =>
+          isJsonSubColumn
+            ? v[columnModelIndex].jsonSubColumns![jsonSubColumnIndex]
+            : v[columnModelIndex],
+        isEqual,
+      ),
+    [columnModelIndex, isJsonSubColumn, jsonSubColumnIndex],
+  )
+
+  const columnModel = useAtomValue(columnModelAtom)
+
+  const allowedColumnTypes = useMemo(
+    () => getAllowedColumnTypes(isView, isJsonSubColumn),
+    [isView, isJsonSubColumn],
+  )
+
+  const allowedFacetTypes = useMemo(
+    () => configureFacetsForType(columnModel.columnType, isJsonSubColumn),
+    [columnModel.columnType, isJsonSubColumn],
+  )
+  const fieldSx: SxProps = useMemo(
+    () => (isJsonSubColumn ? jsonSubColumnFieldSx : topLevelColumnModelFieldSx),
+    [isJsonSubColumn],
+  )
+
+  return (
+    <>
+      {isJsonSubColumn && (
+        <Box sx={{ gridColumn: '1 / span 1' }}>
+          {HIERARCHY_VERTICAL_LINE_COMPONENT}
+        </Box>
+      )}
+      <Box
+        display={'flex'}
+        alignItems={'center'}
+        sx={{
+          gridColumn: isJsonSubColumn ? '2 / span 1' : ' 1 / span 1',
+        }}
+      >
+        <Checkbox
+          label={'Select'}
+          hideLabel
+          checked={columnModel.isSelected}
+          onChange={() => {
+            dispatch({
+              type: 'toggleSelect',
+              columnModelIndex,
+              jsonSubColumnModelIndex: jsonSubColumnIndex,
+            })
+          }}
+        />
+      </Box>
+      <Box
+        sx={{
+          gridColumn: isJsonSubColumn
+            ? /* If this is a JSON Subcolumn, we reduce the width of this grid column to create space to render the visual hierarchical line */
+              '3 / span 1'
+            : /* Otherwise, span across both grid columns  */
+              '2 / span 2',
+        }}
+      >
+        <TextField
+          value={columnModel.name}
+          placeholder={isJsonSubColumn ? 'Facet name' : 'Column name'}
+          onChange={e => {
+            dispatch({
+              type: 'setColumnModelValue',
+              columnModelIndex,
+              jsonSubColumnModelIndex: jsonSubColumnIndex,
+              value: {
+                ...columnModel,
+                name: e.target.value,
+              },
+            })
+          }}
+          InputProps={{
+            sx: fieldSx,
+            inputProps: {
+              'aria-label': 'Name',
+            },
+          }}
+          fullWidth
+        />
+      </Box>
+      <Box>
+        <FormControl fullWidth>
+          <Select
+            label="Column Type"
+            value={columnModel.columnType}
+            onChange={e => {
+              dispatch({
+                type: 'changeColumnModelType',
+                columnModelIndex,
+                jsonSubColumnModelIndex: jsonSubColumnIndex,
+                newColumnType: e.target.value as ColumnTypeEnum,
+              })
+            }}
+            sx={fieldSx}
+          >
+            {allowedColumnTypes.map(value => {
+              return (
+                <MenuItem value={value} key={value}>
+                  {getColumnTypeFriendlyName(value)}
+                </MenuItem>
+              )
+            })}
+          </Select>
+        </FormControl>
+      </Box>
+      <Box>
+        <TextField
+          type={'number'}
+          value={(columnModel as ColumnModelFormData).maximumSize ?? ''}
+          disabled={!canHaveSize(columnModel.columnType)}
+          InputProps={{
+            inputProps: {
+              'aria-label': 'Maximum Size',
+              min: 0,
+              max: canHaveSize(columnModel.columnType)
+                ? getMaxSizeForType(columnModel.columnType)
+                : undefined,
+            },
+            sx: fieldSx,
+          }}
+          onChange={e => {
+            dispatch({
+              type: 'setColumnModelValue',
+              columnModelIndex,
+              jsonSubColumnModelIndex: jsonSubColumnIndex,
+              value: {
+                ...columnModel,
+                maximumSize: parseInt(e.target.value),
+              },
+            })
+          }}
+          fullWidth
+        />
+      </Box>
+      <Box>
+        <TextField
+          type={'number'}
+          value={(columnModel as ColumnModelFormData).maximumListLength ?? ''}
+          disabled={!canHaveMaxListLength(columnModel.columnType)}
+          onChange={e => {
+            dispatch({
+              type: 'setColumnModelValue',
+              columnModelIndex,
+              jsonSubColumnModelIndex: jsonSubColumnIndex,
+              value: {
+                ...columnModel,
+                maximumListLength: parseInt(e.target.value),
+              },
+            })
+          }}
+          InputProps={{
+            inputProps: {
+              'aria-label': 'Maximum List Length',
+            },
+            sx: fieldSx,
+          }}
+          fullWidth
+        />
+      </Box>
+      <Box>
+        <TextField
+          fullWidth
+          value={(columnModel as ColumnModelFormData)?.defaultValue ?? ''}
+          disabled={
+            !canHaveDefault(columnModel.columnType, isView, isJsonSubColumn)
+          }
+          onChange={e => {
+            dispatch({
+              type: 'setColumnModelValue',
+              columnModelIndex,
+              jsonSubColumnModelIndex: jsonSubColumnIndex,
+              value: {
+                ...columnModel,
+                defaultValue: e.target.value,
+              },
+            })
+          }}
+          InputProps={{
+            inputProps: {
+              'aria-label': 'Default Value',
+            },
+            sx: fieldSx,
+          }}
+        />
+      </Box>
+      <Box>
+        <JSONArrayEditorModal
+          isShowingModal={isShowingRestrictedValuesModal}
+          onConfirm={newValue => {
+            dispatch({
+              type: 'setColumnModelValue',
+              columnModelIndex,
+              jsonSubColumnModelIndex: jsonSubColumnIndex,
+              value: {
+                ...columnModel,
+                enumValues: isEmpty(newValue) ? undefined : newValue,
+              },
+            })
+            setIsShowingRestrictedValuesModal(false)
+          }}
+          onCancel={() => setIsShowingRestrictedValuesModal(false)}
+        />
+        <TextField
+          fullWidth
+          value={((columnModel as ColumnModelFormData)?.enumValues ?? []).join(
+            ', ',
+          )}
+          onClick={() => {
+            setIsShowingRestrictedValuesModal(true)
+          }}
+          disabled={canHaveRestrictedValues(
+            columnModel.columnType,
+            isJsonSubColumn,
+          )}
+          InputProps={{
+            // Is readOnly because edits are made with the JSONArrayEditorModal
+            readOnly: true,
+            sx: fieldSx,
+            inputProps: {
+              'aria-label': 'Restrict Values',
+            },
+          }}
+        />
+      </Box>
+      <Box>
+        <FormControl fullWidth>
+          <Select
+            label="Facet Type"
+            value={columnModel.facetType}
+            disabled={allowedFacetTypes === null}
+            onChange={e => {
+              dispatch({
+                type: 'setColumnModelValue',
+                columnModelIndex,
+                jsonSubColumnModelIndex: jsonSubColumnIndex,
+                value: {
+                  ...columnModel,
+                  facetType: e.target.value as FacetType,
+                },
+              })
+            }}
+            sx={fieldSx}
+          >
+            {(allowedFacetTypes ?? []).map((value, index) => {
+              return (
+                <MenuItem value={value} key={index}>
+                  {value === undefined ? '' : getFacetTypeFriendlyName(value)}
+                </MenuItem>
+              )
+            })}
+          </Select>
+        </FormControl>
+      </Box>
+      {isJsonSubColumn && (
+        <>
+          <Box>{HIERARCHY_VERTICAL_LINE_COMPONENT}</Box>
+          <Box></Box>
+          <Box
+            sx={{
+              gridColumn: '3 / span 7',
+            }}
+          >
+            <TextField
+              placeholder={'JSON Path'}
+              value={(columnModel as JsonSubColumnModelFormData).jsonPath}
+              onChange={e => {
+                dispatch({
+                  type: 'setColumnModelValue',
+                  columnModelIndex,
+                  jsonSubColumnModelIndex: jsonSubColumnIndex,
+                  value: {
+                    ...(columnModel as JsonSubColumnModelFormData),
+                    jsonPath: e.target.value,
+                  },
+                })
+              }}
+              fullWidth
+              InputProps={{
+                sx: fieldSx,
+                endAdornment: (
+                  <Tooltip
+                    title={
+                      <React.Fragment>
+                        <p>
+                          <Link
+                            href={
+                              'https://dev.mysql.com/doc/refman/8.0/en/json.html#json-path-syntax'
+                            }
+                          >
+                            Please use a valid JSON Path selector, following
+                            this format.
+                          </Link>
+                        </p>
+                        <p>
+                          This field is for linking the sub-column facet to the
+                          corresponding location in the JSON data, so that it
+                          can be used as facet filter. The correct selector will
+                          point to the key referenced in the sub-column JSON
+                          Path.
+                        </p>
+                      </React.Fragment>
+                    }
+                  >
+                    <InfoTwoTone sx={{ color: 'grey.700' }} />
+                  </Tooltip>
+                ),
+                inputProps: {
+                  'aria-label': 'JSON Path',
+                },
+              }}
+            />
+          </Box>
+        </>
+      )}
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.integration.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import TableColumnSchemaEditor, {
+  TableColumnSchemaEditorProps,
+} from './TableColumnSchemaEditor'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import { server } from '../../mocks/msw/server'
+import mockTableEntityData from '../../mocks/entity/mockTableEntity'
+import { getHandlersForTableQuery } from '../../mocks/msw/handlers/tableQueryHandlers'
+import { syn17328596 as mockTableQueryData } from '../../mocks/query/syn17328596'
+
+function renderComponent(props: TableColumnSchemaEditorProps) {
+  return render(<TableColumnSchemaEditor {...props} />, {
+    wrapper: createWrapper(),
+  })
+}
+
+describe('TableColumnSchemaEditor', () => {
+  beforeAll(() => server.listen())
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  it('Renders a form and preloads data', async () => {
+    server.use(...getHandlersForTableQuery(mockTableQueryData))
+    renderComponent({
+      entityId: mockTableEntityData.id,
+    })
+
+    const numColumns = mockTableQueryData.columnModels!.length
+
+    // Fields should be pre-filled with data
+    const nameFields = await screen.findAllByLabelText('Name')
+    expect(nameFields).toHaveLength(numColumns)
+    mockTableQueryData.columnModels!.forEach((cm, index) => {
+      expect(nameFields[index]).toHaveValue(cm.name)
+    })
+
+    // Has a button to add a column
+    await screen.findByRole('button', { name: 'Add Column' })
+  })
+  it.todo('User can update the form and submit the new data')
+  it.todo('User can add default columns')
+  it.todo('User can add annotations columns to a view')
+})

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.stories.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.stories.ts
@@ -1,0 +1,31 @@
+import { Meta, StoryObj } from '@storybook/react'
+import TableColumnSchemaEditor from './TableColumnSchemaEditor'
+import { getHandlersForTableQuery } from '../../mocks/msw/handlers/tableQueryHandlers'
+import {
+  mockQueryBundleRequest,
+  mockQueryResultBundle,
+} from '../../mocks/mockFileViewQuery'
+import { MOCK_REPO_ORIGIN } from '../../utils/functions/getEndpoint'
+import { getEntityHandlers } from '../../mocks/msw/handlers/entityHandlers'
+
+const meta = {
+  title: 'Synapse/Table Column Schema Editor',
+  component: TableColumnSchemaEditor,
+  parameters: { stack: 'mock' },
+} satisfies Meta
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...getEntityHandlers(MOCK_REPO_ORIGIN),
+        ...getHandlersForTableQuery(mockQueryResultBundle, MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
+  args: {
+    entityId: mockQueryBundleRequest.entityId,
+  },
+}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import {
+  useGetEntity,
+  useGetQueryResultBundleWithAsyncStatus,
+} from '../../synapse-queries'
+import { BUNDLE_MASK_QUERY_COLUMN_MODELS } from '../../utils/SynapseConstants'
+import { useDeepCompareMemoize } from 'use-deep-compare-effect'
+import { SkeletonTable } from '../Skeleton'
+import { convertToEntityType } from '../../utils/functions/EntityTypeUtils'
+import TableColumnSchemaForm from './TableColumnSchemaForm'
+
+export type TableColumnSchemaEditorProps = {
+  entityId: string
+}
+
+/**
+ * Fetches column model data for a Synapse Table and renders a form to edit the column models.
+ * @param props
+ * @constructor
+ */
+export default function TableColumnSchemaEditor(
+  props: TableColumnSchemaEditorProps,
+) {
+  const { entityId } = props
+
+  const { data: entity, isLoading: isLoadingEntity } = useGetEntity(entityId)
+  const { data: _queryResultBundle, isLoading: isLoadingColumnModels } =
+    useGetQueryResultBundleWithAsyncStatus(
+      {
+        entityId,
+        query: {
+          sql: 'SELECT * FROM ${entityId}',
+        },
+        partMask: BUNDLE_MASK_QUERY_COLUMN_MODELS,
+        concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+      },
+      {
+        // This data is inserted into a form, so don't refetch it.
+        staleTime: Infinity,
+        useErrorBoundary: true,
+      },
+    )
+
+  const isLoading = isLoadingEntity || isLoadingColumnModels
+
+  // TODO: the hook above is not returning a stable reference. this is unexpected.
+  const queryResultBundle = useDeepCompareMemoize(_queryResultBundle)
+
+  if (isLoading || !entity) {
+    return (
+      <SkeletonTable
+        numRows={8}
+        numCols={7}
+        rowHeight={'50px'}
+        fullWidthCells
+      />
+    )
+  }
+  return (
+    <TableColumnSchemaForm
+      entityType={convertToEntityType(entity.concreteType)}
+      initialData={queryResultBundle?.responseBody?.columnModels}
+    />
+  )
+}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
@@ -1,0 +1,268 @@
+import {
+  ColumnModel,
+  ColumnTypeEnum,
+  EntityType,
+  JsonSubColumnModel,
+} from '@sage-bionetworks/synapse-types'
+import { atom, useAtomValue, useSetAtom } from 'jotai'
+import React, { useEffect, useMemo } from 'react'
+import {
+  ColumnModelFormData,
+  getIsAllSelected,
+  getNumberOfSelectedItems,
+  JsonSubColumnModelFormData,
+  tableColumnSchemaFormDataAtom,
+} from './TableColumnSchemaFormReducer'
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Checkbox as MUICheckbox,
+  Typography,
+} from '@mui/material'
+import { isEqual, times } from 'lodash-es'
+import { selectAtom } from 'jotai/utils'
+import ColumnModelForm from './ColumnModelForm'
+import AddToList from '../../assets/icons/AddToList'
+import { North, South } from '@mui/icons-material'
+import IconSvg from '../IconSvg'
+
+const COLUMN_SCHEMA_FORM_GRID_TEMPLATE_COLUMNS =
+  '18px 18px 2fr 2fr 0.75fr 1fr 1fr 1fr 1fr'
+const GRID_CONTAINER_Y_MARGIN_PX = 6
+export const HIERARCHY_VERTICAL_LINE_COMPONENT = (
+  <Box
+    sx={{
+      width: '1px',
+      height: `calc(100% + 2 * ${GRID_CONTAINER_Y_MARGIN_PX}px)`,
+      backgroundColor: 'grey.400',
+      marginLeft: '8px',
+    }}
+  />
+)
+export const HIERARCHY_END_COMPONENT = (
+  <Box
+    sx={theme => ({
+      width: '50%',
+      height: '60%',
+      borderLeft: `1px solid ${theme.palette.grey[400]}`,
+      borderBottom: `1px solid ${theme.palette.grey[400]}`,
+      marginLeft: '8px',
+      marginBottom: 'auto',
+      marginRight: '0',
+      borderBottomLeftRadius: '5px',
+    })}
+  />
+)
+type TableColumnSchemaFormProps = {
+  /* The type of the Table, which determines various schema restrictions and form functionality */
+  entityType: EntityType
+  initialData?: ColumnModel[]
+}
+
+export default function TableColumnSchemaForm(
+  props: TableColumnSchemaFormProps,
+) {
+  const { initialData, entityType } = props
+
+  const numColumnModels = useAtomValue(
+    useMemo(() => atom(get => get(tableColumnSchemaFormDataAtom).length), []),
+  )
+
+  const dispatch = useSetAtom(tableColumnSchemaFormDataAtom)
+
+  useEffect(() => {
+    if (initialData) {
+      dispatch({
+        type: 'setValue',
+        value: initialData.map(
+          (cm: ColumnModel): ColumnModelFormData => ({
+            ...cm,
+            jsonSubColumns: cm.jsonSubColumns?.map(
+              (jsc: JsonSubColumnModel): JsonSubColumnModelFormData => ({
+                ...jsc,
+                isSelected: false,
+              }),
+            ),
+            isSelected: false,
+          }),
+        ),
+      })
+    }
+  }, [])
+
+  return (
+    <>
+      <TableColumnSchemaFormActions />
+      <Box
+        display={'grid'}
+        sx={{
+          gridTemplateColumns: COLUMN_SCHEMA_FORM_GRID_TEMPLATE_COLUMNS,
+          py: 1.25,
+          fontWeight: 700,
+          borderBottom: '2px solid',
+          borderColor: 'grey.300',
+        }}
+        gap={'8px'}
+      >
+        <Box>{/* Checkbox */}</Box>
+        <Box sx={{ gridColumn: '2 / span 2' }}>Column Name</Box>
+        <Box>Column Type</Box>
+        <Box>Size</Box>
+        <Box>Max List Length</Box>
+        <Box>Default Value</Box>
+        <Box>Restrict Values</Box>
+        <Box>Facet</Box>
+        {times(numColumnModels, index => {
+          return (
+            <TableColumnSchemaFormRow
+              entityType={entityType}
+              columnModelIndex={index}
+              key={index}
+            />
+          )
+        })}
+      </Box>
+
+      <Button
+        onClick={() => {
+          dispatch({ type: 'appendColumn' })
+        }}
+      >
+        Add Column
+      </Button>
+      {/*  Add / import buttons here  */}
+    </>
+  )
+}
+
+function TableColumnSchemaFormActions() {
+  const dispatch = useSetAtom(tableColumnSchemaFormDataAtom)
+
+  const columnModels = useAtomValue(tableColumnSchemaFormDataAtom)
+  const allSelected = getIsAllSelected(columnModels)
+  const numSelected = getNumberOfSelectedItems(columnModels)
+
+  return (
+    <Box display={'flex'} gap={1}>
+      <Button
+        variant={'outlined'}
+        color={'neutral'}
+        onClick={() => {
+          dispatch({ type: 'toggleSelectAll' })
+        }}
+      >
+        {/*
+           MUI Checkbox looks a little different from ours, but it has an indeterminate state
+           TODO: reconcile these differences
+          */}
+        <MUICheckbox
+          size={'small'}
+          checked={allSelected}
+          indeterminate={numSelected > 0 && !allSelected}
+        />
+        <Typography variant="smallText1" color={'text.secondary'}>
+          {numSelected} selected
+        </Typography>
+      </Button>
+      <ButtonGroup>
+        <Button
+          variant={'outlined'}
+          color={'neutral'}
+          onClick={() => {
+            dispatch({ type: 'moveDown' })
+          }}
+          disabled={numSelected == 0}
+        >
+          <South fontSize={'small'} />
+        </Button>
+        <Button
+          variant={'outlined'}
+          color={'neutral'}
+          onClick={() => {
+            dispatch({ type: 'moveUp' })
+          }}
+          disabled={numSelected == 0}
+        >
+          <North fontSize={'small'} />
+        </Button>
+      </ButtonGroup>
+      <Button
+        variant={'outlined'}
+        color={'neutral'}
+        onClick={() => {
+          dispatch({ type: 'delete' })
+        }}
+        disabled={numSelected == 0}
+      >
+        <IconSvg fontSize={'small'} icon={'delete'} wrap={false} />
+      </Button>
+    </Box>
+  )
+}
+
+type TableColumnSchemaFormRowProps = {
+  entityType: EntityType
+  columnModelIndex: number
+}
+
+function TableColumnSchemaFormRow(props: TableColumnSchemaFormRowProps) {
+  const { columnModelIndex, entityType } = props
+  const dispatch = useSetAtom(tableColumnSchemaFormDataAtom)
+  const columnModel = useAtomValue(
+    useMemo(
+      () =>
+        selectAtom(
+          tableColumnSchemaFormDataAtom,
+          v => v[columnModelIndex],
+          isEqual,
+        ),
+      [columnModelIndex],
+    ),
+  )
+
+  if (!columnModel) {
+    return <></>
+  }
+
+  return (
+    <>
+      <ColumnModelForm
+        entityType={entityType}
+        columnModelIndex={columnModelIndex}
+      />
+      {columnModel.columnType === ColumnTypeEnum.JSON &&
+        columnModel.jsonSubColumns &&
+        columnModel.jsonSubColumns.map((subcolumnFacet, index) => (
+          <ColumnModelForm
+            key={index}
+            entityType={entityType}
+            columnModelIndex={columnModelIndex}
+            jsonSubColumnIndex={index}
+          />
+        ))}
+      {columnModel.columnType === ColumnTypeEnum.JSON && (
+        <>
+          <Box
+            sx={{
+              gridColumn: '1 / span 2',
+            }}
+          >
+            {HIERARCHY_END_COMPONENT}
+          </Box>
+          <Box>
+            <Button
+              startIcon={<AddToList />}
+              variant={'text'}
+              onClick={() =>
+                dispatch({ type: 'appendJsonSubColumn', columnModelIndex })
+              }
+            >
+              Add sub-column
+            </Button>
+          </Box>
+        </>
+      )}
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
@@ -24,7 +24,7 @@ import { isEqual, times } from 'lodash-es'
 import { selectAtom } from 'jotai/utils'
 import ColumnModelForm from './ColumnModelForm'
 import AddToList from '../../assets/icons/AddToList'
-import { North, South } from '@mui/icons-material'
+import { AddCircleTwoTone, North, South } from '@mui/icons-material'
 import IconSvg from '../IconSvg'
 
 const COLUMN_SCHEMA_FORM_GRID_TEMPLATE_COLUMNS =
@@ -89,19 +89,25 @@ export default function TableColumnSchemaForm(
         ),
       })
     }
+    // Only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (
-    <>
+    <Box
+      sx={{
+        py: 2.5,
+        borderBottom: '2px solid',
+        borderColor: 'grey.300',
+      }}
+    >
       <TableColumnSchemaFormActions />
       <Box
         display={'grid'}
         sx={{
           gridTemplateColumns: COLUMN_SCHEMA_FORM_GRID_TEMPLATE_COLUMNS,
-          py: 1.25,
+          py: 2.5,
           fontWeight: 700,
-          borderBottom: '2px solid',
-          borderColor: 'grey.300',
         }}
         gap={'8px'}
       >
@@ -125,14 +131,16 @@ export default function TableColumnSchemaForm(
       </Box>
 
       <Button
+        variant={'outlined'}
         onClick={() => {
           dispatch({ type: 'appendColumn' })
         }}
+        startIcon={<AddCircleTwoTone />}
       >
         Add Column
       </Button>
       {/*  Add / import buttons here  */}
-    </>
+    </Box>
   )
 }
 

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
@@ -175,6 +175,7 @@ function TableColumnSchemaFormActions() {
       </Button>
       <ButtonGroup>
         <Button
+          aria-label={'Move Down'}
           variant={'outlined'}
           color={'neutral'}
           onClick={() => {
@@ -185,6 +186,7 @@ function TableColumnSchemaFormActions() {
           <South fontSize={'small'} />
         </Button>
         <Button
+          aria-label={'Move Up'}
           variant={'outlined'}
           color={'neutral'}
           onClick={() => {
@@ -196,6 +198,7 @@ function TableColumnSchemaFormActions() {
         </Button>
       </ButtonGroup>
       <Button
+        aria-label={'Delete'}
         variant={'outlined'}
         color={'neutral'}
         onClick={() => {
@@ -241,7 +244,7 @@ function TableColumnSchemaFormRow(props: TableColumnSchemaFormRowProps) {
       />
       {columnModel.columnType === ColumnTypeEnum.JSON &&
         columnModel.jsonSubColumns &&
-        columnModel.jsonSubColumns.map((subcolumnFacet, index) => (
+        columnModel.jsonSubColumns.map((subColumnFacet, index) => (
           <ColumnModelForm
             key={index}
             entityType={entityType}

--- a/packages/synapse-react-client/src/mocks/entity/mockFileView.ts
+++ b/packages/synapse-react-client/src/mocks/entity/mockFileView.ts
@@ -32,7 +32,7 @@ export const mockFileViewEntity = {
 const mockFileViewEntityHeader: EntityHeader = {
   name: mockFileViewEntity.name,
   id: MOCK_TABLE_ENTITY_ID,
-  type: 'org.sagebionetworks.repo.model.table.TableEntity',
+  type: 'org.sagebionetworks.repo.model.table.EntityView',
   versionNumber: mockFileViewEntity.versionNumber,
   versionLabel: mockFileViewEntity.versionLabel,
   benefactorId: parseInt(mockProject.id),

--- a/packages/synapse-react-client/src/mocks/query/syn17328596.ts
+++ b/packages/synapse-react-client/src/mocks/query/syn17328596.ts
@@ -1,5 +1,7 @@
 // result of querying table syn17328596
-export const syn17328596 = {
+import { QueryResultBundle } from '@sage-bionetworks/synapse-types'
+
+export const syn17328596: QueryResultBundle = {
   concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
   queryResult: {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryResult',

--- a/packages/synapse-react-client/src/theme/DefaultTheme.tsx
+++ b/packages/synapse-react-client/src/theme/DefaultTheme.tsx
@@ -209,6 +209,9 @@ export const defaultMuiThemeOptions: ThemeOptions = {
           outline: ownerState.error
             ? `1px solid ${theme.palette.error.main}`
             : 'none',
+          '&.Mui-disabled': {
+            backgroundColor: theme.palette.grey[100],
+          },
           '&.Mui-focused': {
             boxShadow: `${alpha(
               theme.palette.primary.main,
@@ -279,6 +282,9 @@ export const defaultMuiThemeOptions: ThemeOptions = {
           fontSize: '14px',
           borderRadius: '2px',
           backgroundColor: theme.palette.common.black,
+          '& .MuiLink-root': {
+            color: '#fff',
+          },
         }),
       },
     },

--- a/packages/synapse-react-client/src/theme/palette/Palettes.ts
+++ b/packages/synapse-react-client/src/theme/palette/Palettes.ts
@@ -76,18 +76,8 @@ export const palette: PaletteOptions = {
     200: '#f1f3f5',
     100: '#fbfbfc',
   },
-  neutral: generatePalette('#d0d4d9', {
-    1000: '#22252a',
-    900: '#353a3f',
-    800: '#4a5056',
-    700: '#878e95',
-    600: '#aeb5bc',
-    500: '#d0d4d9',
-    400: '#dfe2e6',
-    300: '#eaecee',
-    200: '#f1f3f5',
-    100: '#fbfbfc',
-  }),
+  // The neutral palette can be used to color components like buttons in grayscale
+  neutral: generatePalette('#878e95'), // grey-700
   darkPrimary: generatePalette('#0b1218'), // primary-900
   light: { ...generatePalette('#f8f9fa'), contrastText: '#22252a' }, // grey-1000
   success: { main: '#32a330' },


### PR DESCRIPTION
 - Add TableColumnSchemaForm component, which allows creating and modifying Synapse Table column schema data
 - Add TableColumnSchemaEditor, which loads column model data and inserts it into TableColumnSchemaForm
 - Update `neutral` palette use gray 700 as a base color, which makes buttons look more interactive
 - Change TextField background color when field is disabled

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/063c7861-5ba5-4ca3-a7ee-f4575161caf9



