### PR TITLE
SWC-6594 - Fix grid blowout on review submission page

### DIFF
--- a/packages/synapse-react-client/src/style/components/_submission-page.scss
+++ b/packages/synapse-react-client/src/style/components/_submission-page.scss
@@ -29,7 +29,11 @@
     .SubmissionSummaryGrid {
       display: grid;
       column-gap: 10px;
-      grid-template-columns: auto auto;
+      // Grid column maximum is 50% minus 5px to account for the column gap
+      grid-template-columns: minmax(auto, calc(50% - 5px)) minmax(
+          auto,
+          calc(50% - 5px)
+        );
 
       .Key {
         grid-column: 1;


### PR DESCRIPTION
Fixes SWC-6594


Before change: 

<img width="784" alt="image" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/9eb40164-de0b-4287-80b1-ebbf3c271090">

After change: 

<img width="363" alt="image" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/3b142772-7e78-4410-ac7a-f4e8478e39dd">
