### PR TITLE
Bump synapse-react-client to v3.1.63

### DIFF
--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "3.1.62",
+  "version": "3.1.63",
   "private": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Release of 3.1.62 failed, but was fixed by #557 