### PR TITLE
SWC-6610 - small tweaks/fixes for TableColumnSchemaForm

### DIFF
--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelForm.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelForm.tsx
@@ -142,8 +142,8 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
         />
       </Box>
       <Box
+        my={isDefaultColumn ? 'auto' : undefined}
         sx={{
-          my: 'auto',
           gridColumn: isJsonSubColumn
             ? /* If this is a JSON Subcolumn, we reduce the width of this grid column to create space to render the visual hierarchical line */
               '3 / span 1'
@@ -181,7 +181,7 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
           />
         )}
       </Box>
-      <Box my={'auto'}>
+      <Box my={isDefaultColumn ? 'auto' : undefined}>
         {isDefaultColumn ? (
           getColumnTypeFriendlyName(columnModel.columnType)
         ) : (
@@ -217,7 +217,7 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
           </FormControl>
         )}
       </Box>
-      <Box>
+      <Box my={isDefaultColumn ? 'auto' : undefined}>
         {isDefaultColumn ? (
           (columnModel as ColumnModelFormData).maximumSize ?? ''
         ) : (
@@ -231,7 +231,7 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
 
               inputProps: {
                 'aria-label': 'Maximum Size',
-                min: 0,
+                min: 1,
                 max: canHaveSize(columnModel.columnType)
                   ? getMaxSizeForType(columnModel.columnType)
                   : undefined,
@@ -253,7 +253,7 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
           />
         )}
       </Box>
-      <Box>
+      <Box my={isDefaultColumn ? 'auto' : undefined}>
         {isDefaultColumn ? (
           (columnModel as ColumnModelFormData).maximumListLength ?? ''
         ) : (
@@ -284,7 +284,7 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
           />
         )}
       </Box>
-      <Box>
+      <Box my={isDefaultColumn ? 'auto' : undefined}>
         {isDefaultColumn ? (
           (columnModel as ColumnModelFormData)?.defaultValue ?? ''
         ) : (

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.test.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.test.ts
@@ -250,8 +250,8 @@ describe('TableColumnSchemaEditorUtils', () => {
   })
   test('getMaxSizeForType', () => {
     const expected: Partial<Record<ColumnTypeEnum, number>> = {
-      [ColumnTypeEnum.STRING]: 50,
-      [ColumnTypeEnum.STRING_LIST]: 50,
+      [ColumnTypeEnum.STRING]: 1000,
+      [ColumnTypeEnum.STRING_LIST]: 1000,
       [ColumnTypeEnum.LINK]: 1000,
     }
     const shouldError = Object.values(ColumnTypeEnum).filter(

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.ts
@@ -201,7 +201,11 @@ export function canHaveDefault(
   isJsonSubColumnFacet: boolean,
 ) {
   // SWC-6333: default types are not allowed in views
-  if (!isView && !isJsonSubColumnFacet) {
+  if (isView) {
+    return false
+  } else if (isJsonSubColumnFacet) {
+    return false
+  } else {
     switch (type) {
       case ColumnTypeEnum.ENTITYID:
       case ColumnTypeEnum.FILEHANDLEID:
@@ -213,12 +217,10 @@ export function canHaveDefault(
       default:
         return true
     }
-  } else {
-    return false
   }
 }
 
-const DEFAULT_STRING_SIZE = 50
+export const DEFAULT_STRING_SIZE = 50
 const MAX_STRING_SIZE = 1000
 
 /**
@@ -231,7 +233,6 @@ export function getMaxSizeForType(type: ColumnType | ColumnTypeEnum): number {
   switch (type) {
     case ColumnTypeEnum.STRING:
     case ColumnTypeEnum.STRING_LIST:
-      return DEFAULT_STRING_SIZE
     case ColumnTypeEnum.LINK:
       return MAX_STRING_SIZE
     default:

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
@@ -495,7 +495,11 @@ function TableColumnSchemaFormRow(props: TableColumnSchemaFormRowProps) {
           >
             {HIERARCHY_END_COMPONENT}
           </Box>
-          <Box>
+          <Box
+            sx={{
+              gridColumn: '3 / span 5',
+            }}
+          >
             <Button
               startIcon={<AddToList />}
               variant={'text'}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
@@ -85,6 +85,8 @@ export type SubmitHandle = {
   submit: () => void
   // Imperative handle to get the data out of the form for SWC compatibility
   getEditedColumnModels: () => SetOptional<ColumnModel, 'id'>[]
+  // Used to check if all form data is valid. Returns the current validity state
+  validate: () => boolean
 }
 
 type TableColumnSchemaFormProps = {
@@ -185,6 +187,10 @@ const TableColumnSchemaForm = React.forwardRef<
         },
         getEditedColumnModels() {
           return transformFormDataToColumnModels(readFormData())
+        },
+        validate() {
+          // TODO: SWC-6612
+          return true
         },
       }
     },

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.test.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.test.ts
@@ -138,6 +138,7 @@ describe('TableColumnSchemaFormReducer', () => {
       name: '',
       isOriginallyDefaultColumn: false,
       columnType: ColumnTypeEnum.STRING,
+      maximumSize: 50,
       isSelected: false,
     })
 

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
@@ -11,6 +11,7 @@ import {
   canHaveRestrictedValues,
   canHaveSize,
   configureFacetsForType,
+  DEFAULT_STRING_SIZE,
 } from './TableColumnSchemaEditorUtils'
 
 export function getIsAllSelected(formData: ColumnModelFormData[]) {
@@ -48,6 +49,7 @@ export function getDefaultColumnModelFormData(): ColumnModelFormData {
   return {
     name: '',
     columnType: ColumnTypeEnum.STRING,
+    maximumSize: DEFAULT_STRING_SIZE,
     isOriginallyDefaultColumn: false,
     isSelected: false,
   }


### PR DESCRIPTION
 - Fix vertical alignment for default column data
 - Expose and stub `validate` handle
 - Improve readability of some logic
 - Minimum specified maximumSize should be 1, not 0
 - For STRING columns, maximum specified maximumSize should be 1000, not 50