### PR TITLE
Only run CodeQL push action on main branch to fix dependabot PR failures

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,7 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches: [main]
   pull_request:
   schedule:
     - cron: "0 19 * * 0"


### PR DESCRIPTION
Our dependabot PRs all fail because they run CodeQL on the `push` action. These CodeQL jobs fail because write access to the repo is required, and these PRs are granted `readonly` access.

Requiring that the pushed branch is `main` should clean these up.