### PR TITLE
SWC-6611 - ColumnType-aware fields in TableColumnSchemaForm 

### DIFF
--- a/.github/actions/pnpm-setup-action/action.yml
+++ b/.github/actions/pnpm-setup-action/action.yml
@@ -26,13 +26,15 @@ runs:
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
-    - name: Set up Nx build cache
-      uses: actions/cache@v3
-      with:
-        path: .nx/cache
-        key: ${{ runner.os }}-nx-cache
-        restore-keys: |
-          ${{ runner.os }}-nx-cache
+    #    TODO: Storing the Nx cache is failing builds because the cache is not meant to be shared between machines.
+    #    This check can be disabled, but may present security risks. See: https://nx.dev/recipes/troubleshooting/unknown-local-cache#you-share-cache-with-another-machine-using-a-network-drive
+    #    - name: Set up Nx build cache
+    #      uses: actions/cache@v3
+    #      with:
+    #        path: .nx/cache
+    #        key: ${{ runner.os }}-nx-cache
+    #        restore-keys: |
+    #          ${{ runner.os }}-nx-cache
     - name: Install dependencies (use frozen lockfile)
       run: pnpm install --frozen-lockfile
       shell: bash

--- a/packages/synapse-react-client/src/components/JSONArrayEditor/JSONArrayEditorModal.test.tsx
+++ b/packages/synapse-react-client/src/components/JSONArrayEditor/JSONArrayEditorModal.test.tsx
@@ -15,6 +15,7 @@ function renderComponent(props: JSONArrayEditorModalProps) {
 async function setUp(props: JSONArrayEditorModalProps) {
   const user = userEvent.setup()
   const component = renderComponent(props)
+
   const showPasteValuesButton = await screen.findByRole<HTMLButtonElement>(
     'button',
     {
@@ -36,12 +37,16 @@ async function setUp(props: JSONArrayEditorModalProps) {
     },
   )
 
+  // This button only appears if there are no items in the array
+  const addFirstItemButton = screen.queryByRole('button', { name: 'Add item' })
+
   return {
     component,
     user,
     showPasteValuesButton,
     confirmModalButton,
     cancelModalButton,
+    addFirstItemButton,
   }
 }
 
@@ -52,11 +57,14 @@ describe('JSONArrayEditorModal', () => {
     jest.clearAllMocks()
   })
   it('Can enter values', async () => {
-    const { user, confirmModalButton } = await setUp({
+    const { user, addFirstItemButton, confirmModalButton } = await setUp({
       isShowingModal: true,
       onConfirm,
       onCancel,
     })
+
+    expect(addFirstItemButton).toBeInTheDocument()
+    await user.click(addFirstItemButton!)
 
     const firstInput = await screen.findByRole('textbox')
     await user.type(firstInput, 'first value')
@@ -74,11 +82,19 @@ describe('JSONArrayEditorModal', () => {
   })
   it('Can append by entering CSV', async () => {
     const textToPaste = 'second value,third value,fourth value'
-    const { user, showPasteValuesButton, confirmModalButton } = await setUp({
+    const {
+      user,
+      addFirstItemButton,
+      showPasteValuesButton,
+      confirmModalButton,
+    } = await setUp({
       isShowingModal: true,
       onConfirm,
       onCancel,
     })
+
+    expect(addFirstItemButton).toBeInTheDocument()
+    await user.click(addFirstItemButton!)
 
     const firstInput = await screen.findByRole('textbox')
     await user.type(firstInput, 'first value')
@@ -112,11 +128,19 @@ describe('JSONArrayEditorModal', () => {
   })
   it('Can append by entering TSV', async () => {
     const textToPaste = 'second value\tthird value\tfourth value'
-    const { user, showPasteValuesButton, confirmModalButton } = await setUp({
+    const {
+      user,
+      addFirstItemButton,
+      showPasteValuesButton,
+      confirmModalButton,
+    } = await setUp({
       isShowingModal: true,
       onConfirm,
       onCancel,
     })
+
+    expect(addFirstItemButton).toBeInTheDocument()
+    await user.click(addFirstItemButton!)
 
     const firstInput = await screen.findByRole('textbox')
     await user.type(firstInput, 'first value')
@@ -150,11 +174,19 @@ describe('JSONArrayEditorModal', () => {
   })
   it('Does not append pasted values when paste is cancelled', async () => {
     const textToPaste = 'second value,third value,fourth value'
-    const { user, showPasteValuesButton, confirmModalButton } = await setUp({
+    const {
+      user,
+      addFirstItemButton,
+      showPasteValuesButton,
+      confirmModalButton,
+    } = await setUp({
       isShowingModal: true,
       onConfirm,
       onCancel,
     })
+
+    expect(addFirstItemButton).toBeInTheDocument()
+    await user.click(addFirstItemButton!)
 
     const firstInput = await screen.findByRole('textbox')
     await user.type(firstInput, 'first value')
@@ -186,11 +218,14 @@ describe('JSONArrayEditorModal', () => {
     expect(onConfirm).toHaveBeenCalledWith(['first value'])
   })
   it('Handles cancelling the modal', async () => {
-    const { user, cancelModalButton } = await setUp({
+    const { user, addFirstItemButton, cancelModalButton } = await setUp({
       isShowingModal: true,
       onConfirm,
       onCancel,
     })
+
+    expect(addFirstItemButton).toBeInTheDocument()
+    await user.click(addFirstItemButton!)
 
     const firstInput = await screen.findByRole('textbox')
     await user.type(firstInput, 'first value')
@@ -206,5 +241,27 @@ describe('JSONArrayEditorModal', () => {
 
     expect(onCancel).toHaveBeenCalled()
     expect(onConfirm).not.toHaveBeenCalled()
+  })
+  it('Shows initial values', async () => {
+    const initialValues = ['foo', 'bar']
+    const { user, addFirstItemButton, confirmModalButton } = await setUp({
+      isShowingModal: true,
+      onConfirm,
+      onCancel,
+      value: initialValues,
+    })
+
+    expect(addFirstItemButton).not.toBeInTheDocument()
+
+    const inputs = await screen.findAllByRole('textbox')
+
+    const firstInput = inputs[0]
+    expect(firstInput).toHaveValue('foo')
+
+    const secondInput = inputs[1]
+    expect(secondInput).toHaveValue('bar')
+
+    await user.click(confirmModalButton)
+    expect(onConfirm).toHaveBeenCalledWith(['foo', 'bar'])
   })
 })

--- a/packages/synapse-react-client/src/components/JSONArrayEditor/JSONArrayEditorModal.tsx
+++ b/packages/synapse-react-client/src/components/JSONArrayEditor/JSONArrayEditorModal.tsx
@@ -1,37 +1,60 @@
-import React, { useRef, useState } from 'react'
-import { ConfirmationDialog } from '../ConfirmationDialog'
-import JSONArrayEditor from './JSONArrayEditor'
+import React, { useEffect, useRef, useState } from 'react'
+import {
+  ConfirmationDialog,
+  ConfirmationDialogProps,
+} from '../ConfirmationDialog'
+import JSONArrayEditor, { JSONArrayEditorProps } from './JSONArrayEditor'
 import type RJSFForm from '@rjsf/core'
 import { RJSFSchema } from '@rjsf/utils'
 
-export type JSONArrayEditorModalProps = {
+export type JSONArrayEditorModalProps = Pick<
+  JSONArrayEditorProps,
+  'arrayItemDefinition' | 'value'
+> & {
+  dialogTitle?: ConfirmationDialogProps['title']
   isShowingModal: boolean
   onConfirm: (value: string[]) => void
   onCancel: () => void
 }
 
 function JSONArrayEditorModal(props: JSONArrayEditorModalProps) {
-  const { isShowingModal, onConfirm, onCancel } = props
+  const {
+    isShowingModal,
+    onConfirm,
+    onCancel,
+    dialogTitle = 'Edit Values',
+    value,
+    ...editorProps
+  } = props
   const formRef = useRef<RJSFForm<any, RJSFSchema, any>>(null)
-  const [value, setValue] = useState<string[]>([])
+  const [tempValue, setTempValue] = useState<string[]>(value ?? [])
+
+  useEffect(() => {
+    /* If the passed prop changes, reset local component state */
+    if (value) {
+      setTempValue(value)
+    }
+  }, [value])
+
   return (
     <ConfirmationDialog
       open={isShowingModal}
-      title="Edit Values"
+      title={dialogTitle}
       confirmButtonText="OK"
       onCancel={onCancel}
       maxWidth="md"
       content={
         <JSONArrayEditor
           ref={formRef}
-          value={value}
-          onChange={newValue => setValue(newValue)}
+          value={tempValue}
+          onChange={newValue => setTempValue(newValue)}
           onSubmit={onConfirm}
+          {...editorProps}
         />
       }
       onConfirm={() => {
         // Workaround for https://github.com/rjsf-team/react-jsonschema-form/issues/3121
-        ;(formRef.current as any).formElement.current.requestSubmit()
+        formRef.current!.formElement.current.requestSubmit()
       }}
     ></ConfirmationDialog>
   )

--- a/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/CustomFormContext.ts
+++ b/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/CustomFormContext.ts
@@ -1,0 +1,14 @@
+import { FormContextType } from '@rjsf/utils'
+
+export interface CustomFormContext extends FormContextType {
+  /**
+   * If true, non-additionalProperty arrays show controls that allow the user to make the array empty.
+   * This is useful for the annotations editor because we always want to show fields for array items, even if the
+   * array is empty. We don't want users to be able to remove the field for the last item in the array.
+   *
+   * This is not desirable in other places where we would want to use a JSON Schema form.
+   *
+   * Default is undefined/falsy
+   */
+  allowRemovingLastItemInArray?: boolean
+}

--- a/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/SchemaDrivenAnnotationEditor.tsx
+++ b/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/SchemaDrivenAnnotationEditor.tsx
@@ -51,6 +51,7 @@ import ArrayFieldDescriptionTemplate from './template/ArrayFieldDescriptionTempl
 import BaseInputTemplate from './template/BaseInputTemplate'
 import RJSF from '@rjsf/core'
 import FieldErrorTemplate from './template/FieldErrorTemplate'
+import ErrorListTemplate from './template/ErrorListTemplate'
 
 export type SchemaDrivenAnnotationEditorProps = {
   /** The entity whose annotations should be edited with the form */
@@ -282,8 +283,7 @@ export function SchemaDrivenAnnotationEditor(
                 WrapIfAdditionalTemplate: WrapIfAdditionalTemplate,
                 ButtonTemplates: ButtonTemplate,
                 DescriptionFieldTemplate: DescriptionFieldTemplate,
-                /* Errors are displayed by an Alert component below, so we don't show the builtin ErrorList */
-                ErrorListTemplate: () => null,
+                ErrorListTemplate: ErrorListTemplate,
               }}
               ref={ref}
               disabled={mutation.isLoading}
@@ -350,24 +350,6 @@ export function SchemaDrivenAnnotationEditor(
                 CheckboxWidget: BooleanWidget,
               }}
             >
-              {validationError && (
-                <Alert severity="error" sx={{ my: 2 }}>
-                  <b>Validation errors found:</b>
-                  <ul>
-                    {validationError.map(
-                      (e: RJSFValidationError, index: number) => {
-                        return (
-                          <li key={index}>
-                            <b>{`${getFriendlyPropertyName(e)}: `}</b>{' '}
-                            {`${e.message}`}
-                          </li>
-                        )
-                      },
-                    )}
-                  </ul>
-                </Alert>
-              )}
-
               {submissionError && showSubmissionError && (
                 <Alert severity="error" sx={{ my: 2 }}>
                   Annotations could not be updated: {submissionError.reason}

--- a/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/template/ButtonTemplate.tsx
+++ b/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/template/ButtonTemplate.tsx
@@ -55,7 +55,7 @@ function IconButtonTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: IconButtonProps<T, S, F> & IconButtonTemplateProps) {
-  const { iconType, buttonType, ...otherProps } = props
+  const { iconType, buttonType, uiSchema, ...otherProps } = props
 
   return (
     <IconButton {...otherProps} color={'default'} sx={buttonSx}>

--- a/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/template/ErrorListTemplate.tsx
+++ b/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/template/ErrorListTemplate.tsx
@@ -1,0 +1,32 @@
+import { Alert } from '@mui/material'
+import {
+  ErrorListProps,
+  FormContextType,
+  RJSFSchema,
+  RJSFValidationError,
+  StrictRJSFSchema,
+} from '@rjsf/utils'
+import { getFriendlyPropertyName } from '../AnnotationEditorUtils'
+import React from 'react'
+
+export default function ErrorListTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>(props: ErrorListProps<T, S, F>) {
+  const { errors } = props
+  return (
+    <Alert severity="error" sx={{ my: 2 }}>
+      <b>Validation errors found:</b>
+      <ul>
+        {errors.map((e: RJSFValidationError, index: number) => {
+          return (
+            <li key={index}>
+              <b>{`${getFriendlyPropertyName(e)}: `}</b> {`${e.message}`}
+            </li>
+          )
+        })}
+      </ul>
+    </Alert>
+  )
+}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelForm.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelForm.tsx
@@ -284,13 +284,6 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
         ) : (
           <DefaultValueField
             TextFieldProps={{
-              disabled:
-                disabled ||
-                !canHaveDefault(
-                  columnModel.columnType,
-                  isView,
-                  isJsonSubColumn,
-                ),
               InputProps: {
                 disableInjectingGlobalStyles:
                   DISABLE_INJECTING_GLOBAL_STYLES_VALUE,
@@ -303,14 +296,6 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
             }}
             SelectProps={{
               label: 'Default Value',
-              disabled:
-                disabled ||
-                !canHaveDefault(
-                  columnModel.columnType,
-                  isView,
-                  isJsonSubColumn,
-                ),
-
               sx: fieldSx,
               inputProps: {
                 'aria-label': 'Default Value',
@@ -329,6 +314,10 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
                 },
               })
             }}
+            disabled={
+              disabled ||
+              !canHaveDefault(columnModel.columnType, isView, isJsonSubColumn)
+            }
           />
         )}
       </Box>

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelForm.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelForm.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Fade,
   FormControl,
   Link,
   MenuItem,
@@ -23,7 +22,7 @@ import {
   VIEW_CONCRETE_TYPE_VALUES,
 } from '@sage-bionetworks/synapse-types'
 import { convertToConcreteEntityType } from '../../utils/functions/EntityTypeUtils'
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { isEmpty, isEqual } from 'lodash-es'
 import {
   canHaveDefault,
@@ -37,9 +36,10 @@ import {
   getMaxSizeForType,
 } from './TableColumnSchemaEditorUtils'
 import { Checkbox } from '../widgets/Checkbox'
-import JSONArrayEditorModal from '../JSONArrayEditor/JSONArrayEditorModal'
 import { HIERARCHY_VERTICAL_LINE_COMPONENT } from './TableColumnSchemaForm'
 import { InfoTwoTone } from '@mui/icons-material'
+import DefaultValueField from './ColumnModelFormFields/DefaultValueField'
+import RestrictedValuesField from './ColumnModelFormFields/RestrictedValuesField'
 
 type ColumnModelFormProps = {
   entityType: EntityType
@@ -77,9 +77,6 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
   const isView = (VIEW_CONCRETE_TYPE_VALUES as readonly string[]).includes(
     convertToConcreteEntityType(entityType),
   )
-
-  const [isShowingRestrictedValuesModal, setIsShowingRestrictedValuesModal] =
-    useState(false)
 
   const columnModelAtom = useMemo(
     () =>
@@ -201,9 +198,6 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
                 'aria-label': 'Column Type',
               }}
               sx={fieldSx}
-              MenuProps={{
-                TransitionComponent: Fade,
-              }}
               disabled={disabled}
             >
               {allowedColumnTypes.map(value => {
@@ -288,39 +282,60 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
         {isDefaultColumn ? (
           (columnModel as ColumnModelFormData)?.defaultValue ?? ''
         ) : (
-          <TextField
-            fullWidth
+          <DefaultValueField
+            TextFieldProps={{
+              disabled:
+                disabled ||
+                !canHaveDefault(
+                  columnModel.columnType,
+                  isView,
+                  isJsonSubColumn,
+                ),
+              InputProps: {
+                disableInjectingGlobalStyles:
+                  DISABLE_INJECTING_GLOBAL_STYLES_VALUE,
+                inputProps: {
+                  'aria-label': 'Default Value',
+                },
+                sx: fieldSx,
+              },
+              fullWidth: true,
+            }}
+            SelectProps={{
+              label: 'Default Value',
+              disabled:
+                disabled ||
+                !canHaveDefault(
+                  columnModel.columnType,
+                  isView,
+                  isJsonSubColumn,
+                ),
+
+              sx: fieldSx,
+              inputProps: {
+                'aria-label': 'Default Value',
+              },
+            }}
+            columnType={columnModel.columnType as ColumnTypeEnum}
             value={(columnModel as ColumnModelFormData)?.defaultValue ?? ''}
-            disabled={
-              disabled ||
-              !canHaveDefault(columnModel.columnType, isView, isJsonSubColumn)
-            }
-            onChange={e => {
+            onChange={value => {
               dispatch({
                 type: 'setColumnModelValue',
                 columnModelIndex,
                 jsonSubColumnModelIndex: jsonSubColumnIndex,
                 value: {
                   ...columnModel,
-                  defaultValue: e.target.value,
+                  defaultValue: value,
                 },
               })
-            }}
-            InputProps={{
-              disableInjectingGlobalStyles:
-                DISABLE_INJECTING_GLOBAL_STYLES_VALUE,
-              inputProps: {
-                'aria-label': 'Default Value',
-              },
-              sx: fieldSx,
             }}
           />
         )}
       </Box>
       <Box>
-        <JSONArrayEditorModal
-          isShowingModal={isShowingRestrictedValuesModal}
-          onConfirm={newValue => {
+        <RestrictedValuesField
+          value={(columnModel as ColumnModelFormData)?.enumValues}
+          onChange={newValue => {
             dispatch({
               type: 'setColumnModelValue',
               columnModelIndex,
@@ -330,29 +345,22 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
                 enumValues: isEmpty(newValue) ? undefined : newValue,
               },
             })
-            setIsShowingRestrictedValuesModal(false)
           }}
-          onCancel={() => setIsShowingRestrictedValuesModal(false)}
-        />
-        <TextField
-          fullWidth
-          value={((columnModel as ColumnModelFormData)?.enumValues ?? []).join(
-            ', ',
-          )}
-          onClick={() => {
-            setIsShowingRestrictedValuesModal(true)
-          }}
-          disabled={
-            disabled ||
-            !canHaveRestrictedValues(columnModel.columnType, isJsonSubColumn)
-          }
-          InputProps={{
-            disableInjectingGlobalStyles: DISABLE_INJECTING_GLOBAL_STYLES_VALUE,
-            // Is readOnly because edits are made with the JSONArrayEditorModal
-            readOnly: true,
-            sx: fieldSx,
-            inputProps: {
-              'aria-label': 'Restrict Values',
+          columnType={columnModel.columnType as ColumnTypeEnum}
+          TextFieldProps={{
+            fullWidth: true,
+            disabled:
+              disabled ||
+              !canHaveRestrictedValues(columnModel.columnType, isJsonSubColumn),
+            InputProps: {
+              disableInjectingGlobalStyles:
+                DISABLE_INJECTING_GLOBAL_STYLES_VALUE,
+              // Is readOnly because edits are made with the JSONArrayEditorModal
+              readOnly: true,
+              sx: fieldSx,
+              inputProps: {
+                'aria-label': 'Restrict Values',
+              },
             },
           }}
         />
@@ -363,9 +371,6 @@ export default function ColumnModelForm(props: ColumnModelFormProps) {
             label="Facet Type"
             value={columnModel.facetType}
             disabled={disabled || allowedFacetTypes === null}
-            MenuProps={{
-              TransitionComponent: Fade,
-            }}
             onChange={e => {
               dispatch({
                 type: 'setColumnModelValue',

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.test.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import DefaultValueField, { DefaultValueFieldProps } from './DefaultValueField'
+import { createWrapper } from '../../../testutils/TestingLibraryUtils'
+import { render, screen } from '@testing-library/react'
+import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
+import userEvent from '@testing-library/user-event'
+
+function renderComponent<T>(props: DefaultValueFieldProps<T>) {
+  return render(<DefaultValueField<T> {...props} />, {
+    wrapper: createWrapper(),
+  })
+}
+
+describe('DefaultValueField', () => {
+  it('shows a text field for STRING columnType', async () => {
+    const onChange = jest.fn()
+    renderComponent<string>({
+      columnType: ColumnTypeEnum.STRING,
+      onChange,
+      value: 'foo',
+    })
+
+    const textField = screen.getByRole('textbox')
+    expect(textField).toHaveValue('foo')
+    expect(textField.getAttribute('type')).toBe('text')
+    await userEvent.click(textField)
+    await userEvent.paste('bar')
+
+    expect(onChange).toHaveBeenCalledWith('foobar')
+  })
+
+  it('shows a dropdown select for BOOLEAN columnType', async () => {
+    const onChange = jest.fn()
+    renderComponent<boolean | undefined>({
+      columnType: ColumnTypeEnum.BOOLEAN,
+      onChange,
+      value: undefined,
+    })
+
+    const booleanField = screen.getByRole('combobox')
+    expect(booleanField.getAttribute('value')).toBeNull()
+    await userEvent.click(booleanField)
+    await userEvent.click(await screen.findByRole('option', { name: 'true' }))
+    expect(onChange).toHaveBeenCalledWith(true)
+
+    await userEvent.click(booleanField)
+    await userEvent.click(await screen.findByRole('option', { name: 'false' }))
+    expect(onChange).toHaveBeenCalledWith(false)
+
+    await userEvent.click(booleanField)
+    await userEvent.click(await screen.findByRole('option', { name: '' }))
+    expect(onChange).toHaveBeenCalledWith(undefined)
+  })
+})

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.tsx
@@ -14,12 +14,14 @@ export type DefaultValueFieldProps<T> = {
   columnType: ColumnTypeEnum
   value: T
   onChange: (newValue: T) => void
-  TextFieldProps?: Omit<TextFieldProps, 'value' | 'onChange'>
-  SelectProps?: Omit<SelectProps, 'value' | 'onChange'>
+  disabled?: boolean
+  TextFieldProps?: Omit<TextFieldProps, 'value' | 'onChange' | 'disabled'>
+  SelectProps?: Omit<SelectProps, 'value' | 'onChange' | 'disabled'>
 }
 
 export default function DefaultValueField<T>(props: DefaultValueFieldProps<T>) {
-  const { columnType, onChange, value, TextFieldProps, SelectProps } = props
+  const { columnType, onChange, value, disabled, TextFieldProps, SelectProps } =
+    props
 
   const textFieldType: TextFieldProps['type'] = useMemo(
     () => getTextFieldType(columnType),
@@ -31,6 +33,7 @@ export default function DefaultValueField<T>(props: DefaultValueFieldProps<T>) {
       <FormControl fullWidth>
         <Select
           {...SelectProps}
+          disabled={disabled}
           value={value}
           onChange={e => {
             if (e.target.value == undefined) {
@@ -54,6 +57,7 @@ export default function DefaultValueField<T>(props: DefaultValueFieldProps<T>) {
       type={textFieldType}
       value={value}
       onChange={event => onChange(event.target.value as T)}
+      disabled={disabled}
     />
   )
 }

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.tsx
@@ -1,0 +1,59 @@
+import React, { useMemo } from 'react'
+import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
+import {
+  FormControl,
+  MenuItem,
+  Select,
+  SelectProps,
+  TextField,
+  TextFieldProps,
+} from '@mui/material'
+import { getTextFieldType } from '../TableColumnSchemaEditorUtils'
+
+export type DefaultValueFieldProps<T> = {
+  columnType: ColumnTypeEnum
+  value: T
+  onChange: (newValue: T) => void
+  TextFieldProps?: Omit<TextFieldProps, 'value' | 'onChange'>
+  SelectProps?: Omit<SelectProps, 'value' | 'onChange'>
+}
+
+export default function DefaultValueField<T>(props: DefaultValueFieldProps<T>) {
+  const { columnType, onChange, value, TextFieldProps, SelectProps } = props
+
+  const textFieldType: TextFieldProps['type'] = useMemo(
+    () => getTextFieldType(columnType),
+    [columnType],
+  )
+
+  if (columnType === ColumnTypeEnum.BOOLEAN) {
+    return (
+      <FormControl fullWidth>
+        <Select
+          {...SelectProps}
+          value={value}
+          onChange={e => {
+            if (e.target.value == undefined) {
+              onChange(undefined as T)
+            } else {
+              onChange((e.target.value === 'true') as T)
+            }
+          }}
+        >
+          <MenuItem value={undefined}>{''}</MenuItem>
+          <MenuItem value={'true'}>true</MenuItem>
+          <MenuItem value={'false'}>false</MenuItem>
+        </Select>
+      </FormControl>
+    )
+  }
+
+  return (
+    <TextField
+      {...TextFieldProps}
+      type={textFieldType}
+      value={value}
+      onChange={event => onChange(event.target.value as T)}
+    />
+  )
+}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/RestrictedValuesField.test.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/RestrictedValuesField.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react'
+import { getJsonSchemaItemDefinitionForColumnType } from '../TableColumnSchemaEditorUtils'
+import { JSONSchema7Definition } from 'json-schema'
+import RestrictedValuesField, {
+  RestrictedValuesFieldProps,
+} from './RestrictedValuesField'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { createWrapper } from '../../../testutils/TestingLibraryUtils'
+import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
+import JSONArrayEditorModal from '../../JSONArrayEditor/JSONArrayEditorModal'
+import userEvent from '@testing-library/user-event'
+
+const jsonSchemaItemDefinition: JSONSchema7Definition = {
+  type: 'string',
+}
+jest.mock('../TableColumnSchemaEditorUtils', () => {
+  return {
+    getJsonSchemaItemDefinitionForColumnType: jest
+      .fn()
+      .mockReturnValue(jsonSchemaItemDefinition),
+  }
+})
+
+jest.mock('../../JSONArrayEditor/JSONArrayEditorModal', () => {
+  return {
+    __esModule: true,
+    default: jest
+      .fn()
+      .mockReturnValue(<div data-testid={'JSONArrayEditorModal'} />),
+  }
+})
+
+const mockGetJsonSchemaDefinition = jest.mocked(
+  getJsonSchemaItemDefinitionForColumnType,
+)
+const mockJsonArrayEditorModal = jest.mocked(JSONArrayEditorModal)
+
+function renderComponent(props: RestrictedValuesFieldProps) {
+  return render(<RestrictedValuesField {...props} />, {
+    wrapper: createWrapper(),
+  })
+}
+
+describe('RestrictedValuesField', () => {
+  test('interactions and calls to dependencies', async () => {
+    const onChange = jest.fn()
+    renderComponent({
+      columnType: ColumnTypeEnum.STRING,
+      onChange,
+      value: ['foo', 'bar'],
+    })
+
+    await screen.findByTestId('JSONArrayEditorModal')
+    const textField = await screen.findByRole('textbox')
+    expect(textField).toHaveValue('foo, bar')
+
+    expect(mockGetJsonSchemaDefinition).toHaveBeenCalledWith(
+      ColumnTypeEnum.STRING,
+    )
+    expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        arrayItemDefinition: jsonSchemaItemDefinition,
+        value: ['foo', 'bar'],
+        isShowingModal: false,
+      }),
+      expect.anything(),
+    )
+
+    // Click the text field and the modal will be shown
+    await userEvent.click(textField)
+
+    await waitFor(() =>
+      expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isShowingModal: true,
+        }),
+        expect.anything(),
+      ),
+    )
+
+    // Invoke the modal's onCancel and the modal will be hidden
+    act(() => {
+      mockJsonArrayEditorModal.mock.lastCall![0].onCancel()
+    })
+    await waitFor(() =>
+      expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isShowingModal: false,
+        }),
+        expect.anything(),
+      ),
+    )
+
+    // Show the modal one more time so we can call onChange
+    await userEvent.click(textField)
+
+    await waitFor(() =>
+      expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isShowingModal: true,
+        }),
+        expect.anything(),
+      ),
+    )
+
+    // Invoke onConfirm. Verify the callback is called and the modal is hidden
+    act(() => {
+      mockJsonArrayEditorModal.mock.lastCall![0].onConfirm(['baz', 'qux'])
+    })
+    await waitFor(() => {
+      expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isShowingModal: false,
+        }),
+        expect.anything(),
+      )
+
+      expect(onChange).toHaveBeenCalledWith(['baz', 'qux'])
+    })
+  })
+})

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/RestrictedValuesField.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/RestrictedValuesField.tsx
@@ -1,0 +1,46 @@
+import React, { useMemo, useState } from 'react'
+import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
+import JSONArrayEditorModal from '../../JSONArrayEditor/JSONArrayEditorModal'
+import { getJsonSchemaItemDefinitionForColumnType } from '../TableColumnSchemaEditorUtils'
+import { TextField, TextFieldProps } from '@mui/material'
+
+export type RestrictedValuesFieldProps = {
+  value?: string[]
+  onChange: (newValue: string[]) => void
+  columnType: ColumnTypeEnum
+  TextFieldProps?: Omit<TextFieldProps, 'value' | 'onChange'>
+}
+
+export default function RestrictedValuesField(
+  props: RestrictedValuesFieldProps,
+) {
+  const { columnType, onChange, value = [], TextFieldProps } = props
+  const [isShowingModal, setIsShowingModal] = useState(false)
+
+  const arrayItemDefinition = useMemo(
+    () => getJsonSchemaItemDefinitionForColumnType(columnType),
+    [columnType],
+  )
+
+  return (
+    <>
+      <JSONArrayEditorModal
+        arrayItemDefinition={arrayItemDefinition}
+        value={value}
+        isShowingModal={isShowingModal}
+        onConfirm={values => {
+          onChange(values)
+          setIsShowingModal(false)
+        }}
+        onCancel={() => setIsShowingModal(false)}
+      />
+      <TextField
+        {...TextFieldProps}
+        value={value.join(', ')}
+        onClick={() => {
+          setIsShowingModal(true)
+        }}
+      />
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.stories.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.stories.ts
@@ -3,15 +3,13 @@ import TableColumnSchemaEditor from './TableColumnSchemaEditor'
 import {
   getAnnotationColumnHandlers,
   getDefaultColumnHandlers,
-  getHandlersForTableQuery,
 } from '../../mocks/msw/handlers/tableQueryHandlers'
-import {
-  mockQueryBundleRequest,
-  mockQueryResultBundle,
-} from '../../mocks/mockFileViewQuery'
+import { mockQueryResultBundle } from '../../mocks/mockFileViewQuery'
 import { MOCK_REPO_ORIGIN } from '../../utils/functions/getEndpoint'
-import { getEntityHandlers } from '../../mocks/msw/handlers/entityHandlers'
-import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
+import { ColumnTypeEnum, TableBundle } from '@sage-bionetworks/synapse-types'
+import { rest } from 'msw'
+import { ENTITY_BUNDLE_V2 } from '../../utils/APIConstants'
+import mockTableEntityData from '../../mocks/entity/mockTableEntity'
 
 const meta = {
   title: 'Synapse/Table Column Schema Editor',
@@ -21,12 +19,15 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+const mockTableBundle: TableBundle = {
+  columnModels: mockQueryResultBundle.columnModels!,
+  maxRowsPerPage: 25,
+}
+
 export const Demo: Story = {
   parameters: {
     msw: {
       handlers: [
-        ...getEntityHandlers(MOCK_REPO_ORIGIN),
-        ...getHandlersForTableQuery(mockQueryResultBundle, MOCK_REPO_ORIGIN),
         ...getDefaultColumnHandlers(MOCK_REPO_ORIGIN),
         ...getAnnotationColumnHandlers(
           {
@@ -43,10 +44,22 @@ export const Demo: Story = {
           },
           MOCK_REPO_ORIGIN,
         ),
+        rest.post(
+          `${MOCK_REPO_ORIGIN}${ENTITY_BUNDLE_V2(':entityId')}`,
+          async (req, res, ctx) => {
+            return res(
+              ctx.status(200),
+              ctx.json({
+                ...mockTableEntityData.bundle,
+                tableBundle: mockTableBundle,
+              }),
+            )
+          },
+        ),
       ],
     },
   },
   args: {
-    entityId: mockQueryBundleRequest.entityId,
+    entityId: mockTableEntityData.id,
   },
 }

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.stories.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.stories.ts
@@ -25,6 +25,7 @@ const mockTableBundle: TableBundle = {
 }
 
 export const Demo: Story = {
+  name: 'Table Column Schema Editor',
   parameters: {
     msw: {
       handlers: [
@@ -50,7 +51,7 @@ export const Demo: Story = {
             return res(
               ctx.status(200),
               ctx.json({
-                ...mockTableEntityData.bundle,
+                entity: mockTableEntityData.entity,
                 tableBundle: mockTableBundle,
               }),
             )

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.test.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.test.ts
@@ -243,6 +243,14 @@ describe('TableColumnSchemaEditorUtils', () => {
         ColumnTypeEnum.MEDIUMTEXT,
         ColumnTypeEnum.LARGETEXT,
         ColumnTypeEnum.JSON,
+        ColumnTypeEnum.SUBMISSIONID,
+        ColumnTypeEnum.EVALUATIONID,
+        ColumnTypeEnum.STRING_LIST,
+        ColumnTypeEnum.INTEGER_LIST,
+        ColumnTypeEnum.BOOLEAN_LIST,
+        ColumnTypeEnum.DATE_LIST,
+        ColumnTypeEnum.USERID_LIST,
+        ColumnTypeEnum.ENTITYID_LIST,
       ]
       Object.values(ColumnTypeEnum).forEach((type: ColumnType) => {
         const actual = canHaveDefault(type, false, false)

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.test.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.test.ts
@@ -15,9 +15,11 @@ import {
   canHaveSize,
   configureFacetsForType,
   getAllowedColumnTypes,
+  getJsonSchemaItemDefinitionForColumnType,
   getMaxSizeForType,
   getViewScopeForEntity,
 } from './TableColumnSchemaEditorUtils'
+import { JSONSchema7Definition } from 'json-schema'
 
 describe('TableColumnSchemaEditorUtils', () => {
   describe('getAllowedColumnTypes', () => {
@@ -370,6 +372,24 @@ describe('TableColumnSchemaEditorUtils', () => {
         viewTypeMask: undefined,
         viewEntityType: 'submissionview',
       })
+    })
+  })
+  describe('getJsonSchemaItemDefinitionForColumnType', () => {
+    test.each<[ColumnTypeEnum, JSONSchema7Definition]>([
+      [ColumnTypeEnum.STRING, { type: 'string', minLength: 1 }],
+      [ColumnTypeEnum.STRING_LIST, { type: 'string', minLength: 1 }],
+      [ColumnTypeEnum.INTEGER, { type: 'integer' }],
+      [ColumnTypeEnum.INTEGER_LIST, { type: 'integer' }],
+      [ColumnTypeEnum.DOUBLE, { type: 'number' }],
+      [ColumnTypeEnum.BOOLEAN, { type: 'boolean' }],
+      [ColumnTypeEnum.BOOLEAN_LIST, { type: 'boolean' }],
+      [ColumnTypeEnum.DATE, { type: 'string', format: 'datetime' }],
+      [ColumnTypeEnum.DATE_LIST, { type: 'string', format: 'datetime' }],
+      [ColumnTypeEnum.USERID, { type: 'string', minLength: 1 }],
+      [ColumnTypeEnum.ENTITYID, { type: 'string', minLength: 1 }],
+    ])(`%s`, (columnType, expected) => {
+      const actual = getJsonSchemaItemDefinitionForColumnType(columnType)
+      expect(actual).toEqual(expected)
     })
   })
 })

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.ts
@@ -227,7 +227,6 @@ export function canHaveDefault(
 
 export const DEFAULT_STRING_SIZE = 50
 const MAX_STRING_SIZE = 1000
-// const MAX_LIST_LENGTH = 100
 
 /**
  * Get the default max size for a given type.
@@ -357,50 +356,6 @@ export function getViewScopeForEntity(entity: Entity): ViewScope | undefined {
   }
   return undefined
 }
-//
-// function validateName(name: string) {
-//   return !(name == null || name == '')
-// }
-//
-// function validateSize(maximumSize: number) {
-//   return maximumSize > 0 && maximumSize <= MAX_STRING_SIZE
-// }
-//
-// function validateMaxListLength(maxListLength: number) {
-//   return maxListLength > 0 && maxListLength <= MAX_LIST_LENGTH
-// }
-//
-// function validateDefault() {}
-//
-// function validateColumnModel(cm: ColumnModelFormData) {
-//   if (!validateName()) {
-//     isValid = false
-//   }
-//   if (!validateSize()) {
-//     isValid = false
-//   }
-//   if (!validateMaxListLength()) {
-//     isValid = false
-//   }
-//   if (!view.validateDefault()) {
-//     isValid = false
-//   }
-// }
-//
-// export function validate(formData: ColumnModelFormData[]): boolean {
-//   if (!validateName()) {
-//     isValid = false
-//   }
-//   if (!validateSize()) {
-//     isValid = false
-//   }
-//   if (!validateMaxListLength()) {
-//     isValid = false
-//   }
-//   if (!view.validateDefault()) {
-//     isValid = false
-//   }
-// }
 
 export function getJsonSchemaItemDefinitionForColumnType(
   columnType: ColumnTypeEnum,

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.ts
@@ -22,6 +22,7 @@ import {
   isEntityView,
   isSubmissionView,
 } from '../../utils/functions/EntityTypeUtils'
+import { JSONSchema7Definition } from 'json-schema'
 
 /**
  * These column types can only be used in Tables. They can not be used in views.
@@ -205,6 +206,8 @@ export function canHaveDefault(
     return false
   } else if (isJsonSubColumnFacet) {
     return false
+  } else if (type.endsWith('_LIST')) {
+    return false
   } else {
     switch (type) {
       case ColumnTypeEnum.ENTITYID:
@@ -213,6 +216,8 @@ export function canHaveDefault(
       case ColumnTypeEnum.MEDIUMTEXT:
       case ColumnTypeEnum.LARGETEXT:
       case ColumnTypeEnum.JSON:
+      case ColumnTypeEnum.SUBMISSIONID:
+      case ColumnTypeEnum.EVALUATIONID:
         return false
       default:
         return true
@@ -222,6 +227,7 @@ export function canHaveDefault(
 
 export const DEFAULT_STRING_SIZE = 50
 const MAX_STRING_SIZE = 1000
+// const MAX_LIST_LENGTH = 100
 
 /**
  * Get the default max size for a given type.
@@ -350,4 +356,94 @@ export function getViewScopeForEntity(entity: Entity): ViewScope | undefined {
     }
   }
   return undefined
+}
+//
+// function validateName(name: string) {
+//   return !(name == null || name == '')
+// }
+//
+// function validateSize(maximumSize: number) {
+//   return maximumSize > 0 && maximumSize <= MAX_STRING_SIZE
+// }
+//
+// function validateMaxListLength(maxListLength: number) {
+//   return maxListLength > 0 && maxListLength <= MAX_LIST_LENGTH
+// }
+//
+// function validateDefault() {}
+//
+// function validateColumnModel(cm: ColumnModelFormData) {
+//   if (!validateName()) {
+//     isValid = false
+//   }
+//   if (!validateSize()) {
+//     isValid = false
+//   }
+//   if (!validateMaxListLength()) {
+//     isValid = false
+//   }
+//   if (!view.validateDefault()) {
+//     isValid = false
+//   }
+// }
+//
+// export function validate(formData: ColumnModelFormData[]): boolean {
+//   if (!validateName()) {
+//     isValid = false
+//   }
+//   if (!validateSize()) {
+//     isValid = false
+//   }
+//   if (!validateMaxListLength()) {
+//     isValid = false
+//   }
+//   if (!view.validateDefault()) {
+//     isValid = false
+//   }
+// }
+
+export function getJsonSchemaItemDefinitionForColumnType(
+  columnType: ColumnTypeEnum,
+): JSONSchema7Definition {
+  switch (columnType) {
+    case ColumnTypeEnum.STRING:
+    case ColumnTypeEnum.STRING_LIST:
+      return { type: 'string', minLength: 1 }
+    case ColumnTypeEnum.DOUBLE:
+      return { type: 'number' }
+    case ColumnTypeEnum.BOOLEAN:
+    case ColumnTypeEnum.BOOLEAN_LIST:
+      return { type: 'boolean' }
+    case ColumnTypeEnum.INTEGER:
+    case ColumnTypeEnum.INTEGER_LIST:
+      return { type: 'integer' }
+    case ColumnTypeEnum.DATE:
+    case ColumnTypeEnum.DATE_LIST:
+      return { type: 'string', format: 'datetime' }
+    case ColumnTypeEnum.FILEHANDLEID:
+    case ColumnTypeEnum.ENTITYID:
+    case ColumnTypeEnum.ENTITYID_LIST:
+    case ColumnTypeEnum.LINK:
+    case ColumnTypeEnum.MEDIUMTEXT:
+    case ColumnTypeEnum.LARGETEXT:
+    case ColumnTypeEnum.USERID:
+    case ColumnTypeEnum.USERID_LIST:
+    case ColumnTypeEnum.SUBMISSIONID:
+    case ColumnTypeEnum.JSON:
+    case ColumnTypeEnum.EVALUATIONID:
+    default:
+      return { type: 'string', minLength: 1 }
+  }
+}
+
+export function getTextFieldType(columnType: ColumnTypeEnum) {
+  switch (columnType) {
+    case ColumnTypeEnum.DOUBLE:
+    case ColumnTypeEnum.INTEGER:
+      return 'number'
+    case ColumnTypeEnum.DATE:
+      return 'datetime'
+    default:
+      return 'text'
+  }
 }

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.ts
@@ -397,7 +397,7 @@ export function getTextFieldType(columnType: ColumnTypeEnum) {
     case ColumnTypeEnum.INTEGER:
       return 'number'
     case ColumnTypeEnum.DATE:
-      return 'datetime'
+      return 'date'
     default:
       return 'text'
   }

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.test.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.test.ts
@@ -328,8 +328,8 @@ describe('TableColumnSchemaFormReducer', () => {
     expect(newState[0]).not.toBe(initialValue)
     expect(newState[0].name).toEqual(initialValue.name)
     expect(newState[0].columnType).toEqual(ColumnTypeEnum.INTEGER)
-    // enumValues should not have changed
-    expect(newState[0].enumValues).toEqual(['1', '2', '3'])
+    // enumValues should have been removed
+    expect(newState[0].enumValues).toBeUndefined()
   })
   test('changeColumnModelType - canHaveRestrictedValues becomes false', () => {
     // STRING -> BOOLEAN

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
@@ -8,7 +8,6 @@ import { SetOptional } from 'type-fest'
 import { cloneDeep } from 'lodash-es'
 import {
   canHaveMaxListLength,
-  canHaveRestrictedValues,
   canHaveSize,
   configureFacetsForType,
   DEFAULT_STRING_SIZE,
@@ -233,11 +232,13 @@ function changeColumnModelType(
   ) {
     delete newColumnModelValue.maximumListLength
   }
-  if (
-    !canHaveRestrictedValues(newColumnType, !!jsonSubColumnModelIndex) &&
-    'enumValues' in newColumnModelValue
-  ) {
+
+  // Remove default and restricted values unconditionally since they may not adhere to the new column type
+  if ('enumValues' in newColumnModelValue) {
     delete newColumnModelValue.enumValues
+  }
+  if ('defaultValue' in newColumnModelValue) {
+    delete newColumnModelValue.defaultValue
   }
 
   const allowedFacetTypes = configureFacetsForType(

--- a/packages/synapse-react-client/src/components/entity/metadata/EntityModal.tsx
+++ b/packages/synapse-react-client/src/components/entity/metadata/EntityModal.tsx
@@ -92,9 +92,7 @@ export function EntityModal(props: EntityModalProps) {
       variant={'contained'}
       onClick={() => {
         // Workaround for https://github.com/rjsf-team/react-jsonschema-form/issues/3121
-        ;(
-          annotationEditorFormRef.current as any
-        ).formElement.current.requestSubmit()
+        annotationEditorFormRef.current!.formElement.current.requestSubmit()
       }}
     >
       Save Annotations

--- a/packages/synapse-react-client/src/theme/DefaultTheme.tsx
+++ b/packages/synapse-react-client/src/theme/DefaultTheme.tsx
@@ -18,6 +18,9 @@ import {
 
 const DIALOG_INNER_PADDING = '2px'
 
+// The default TransitionComponent, Grow, causes click event interception issues, especially in SWC's gwtbootstrap modals.
+const TRANSITION_COMPONENT_OVERRIDE = Fade
+
 export const defaultMuiThemeOptions: ThemeOptions = {
   typography: typographyOptions,
   palette: palette,
@@ -252,6 +255,11 @@ export const defaultMuiThemeOptions: ThemeOptions = {
         }),
       },
     },
+    MuiMenu: {
+      defaultProps: {
+        TransitionComponent: TRANSITION_COMPONENT_OVERRIDE,
+      },
+    },
     MuiMenuItem: {
       styleOverrides: {
         root: {
@@ -272,7 +280,7 @@ export const defaultMuiThemeOptions: ThemeOptions = {
     MuiTooltip: {
       defaultProps: {
         arrow: true,
-        TransitionComponent: Fade,
+        TransitionComponent: TRANSITION_COMPONENT_OVERRIDE,
       },
       styleOverrides: {
         arrow: ({ theme }) => ({


### PR DESCRIPTION
SWC-6611

 - Add `DefaultValueField` and `RestrictedValuesField` components where the form field varies on column type
 - Move custom animation props to theme for consistency/simplicity
 - Use columnModels from table bundle instead of query in (unused) editor component
 - Reset restricted/default value on column type change
 - Disallow default values for _LIST types since they don't work on the backend
 - Changes to RJSF custom ArrayFieldTemplate to allow empty arrays



https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/d5acad29-d91d-4031-99c8-65f215f5796d

