### PR TITLE
SWC-6612 - Integrate validation with Table Column Schema Form

### DIFF
--- a/packages/synapse-react-client/src/components/JSONArrayEditor/JSONArrayEditorModal.tsx
+++ b/packages/synapse-react-client/src/components/JSONArrayEditor/JSONArrayEditorModal.tsx
@@ -7,17 +7,19 @@ import JSONArrayEditor, { JSONArrayEditorProps } from './JSONArrayEditor'
 import type RJSFForm from '@rjsf/core'
 import { RJSFSchema } from '@rjsf/utils'
 
-export type JSONArrayEditorModalProps = Pick<
-  JSONArrayEditorProps,
+export type JSONArrayEditorModalProps<T = unknown> = Pick<
+  JSONArrayEditorProps<T>,
   'arrayItemDefinition' | 'value'
 > & {
   dialogTitle?: ConfirmationDialogProps['title']
   isShowingModal: boolean
-  onConfirm: (value: string[]) => void
+  onConfirm: (value: T[]) => void
   onCancel: () => void
 }
 
-function JSONArrayEditorModal(props: JSONArrayEditorModalProps) {
+function JSONArrayEditorModal<T = unknown>(
+  props: JSONArrayEditorModalProps<T>,
+) {
   const {
     isShowingModal,
     onConfirm,
@@ -27,7 +29,7 @@ function JSONArrayEditorModal(props: JSONArrayEditorModalProps) {
     ...editorProps
   } = props
   const formRef = useRef<RJSFForm<any, RJSFSchema, any>>(null)
-  const [tempValue, setTempValue] = useState<string[]>(value ?? [])
+  const [tempValue, setTempValue] = useState<T[]>(value ?? [])
 
   useEffect(() => {
     /* If the passed prop changes, reset local component state */
@@ -44,8 +46,8 @@ function JSONArrayEditorModal(props: JSONArrayEditorModalProps) {
       onCancel={onCancel}
       maxWidth="md"
       content={
-        <JSONArrayEditor
-          ref={formRef}
+        <JSONArrayEditor<T>
+          formRef={formRef}
           value={tempValue}
           onChange={newValue => setTempValue(newValue)}
           onSubmit={onConfirm}

--- a/packages/synapse-react-client/src/components/JSONArrayEditor/useParseCsv.ts
+++ b/packages/synapse-react-client/src/components/JSONArrayEditor/useParseCsv.ts
@@ -1,0 +1,53 @@
+import { JSONSchema7Definition } from 'json-schema'
+import { parse as papaparse } from 'papaparse'
+import { useCallback, useMemo } from 'react'
+import { isObject } from 'lodash-es'
+
+export type ParseCsvOptions = {
+  /* If provided, items will be parsed based on the data type prescribed by the schema */
+  jsonSchemaDefinition?: JSONSchema7Definition
+}
+
+export type UseParseCsvReturn = {
+  parse: (dataToParse: string) => Promise<unknown[]>
+}
+
+const DEFAULT_OPTIONS: ParseCsvOptions = {
+  jsonSchemaDefinition: { type: 'string' },
+}
+
+export default function useParseCsv(
+  options: ParseCsvOptions = DEFAULT_OPTIONS,
+): UseParseCsvReturn {
+  const { jsonSchemaDefinition } = options
+  const itemsAreString = useMemo(
+    () =>
+      isObject(jsonSchemaDefinition) &&
+      jsonSchemaDefinition.type &&
+      jsonSchemaDefinition.type === 'string',
+    [jsonSchemaDefinition],
+  )
+
+  const parse = useCallback(
+    (dataToParse: string): Promise<unknown[]> => {
+      return new Promise((resolve, reject) => {
+        papaparse(dataToParse, {
+          // If the items are not strings, let papaparse guess the type. Otherwise, always parse as strings.
+          dynamicTyping: !itemsAreString,
+          complete: result => {
+            if (result.errors.length > 0) {
+              reject(result.errors)
+            } else {
+              resolve(result.data.flat())
+            }
+          },
+        })
+      })
+    },
+    [itemsAreString],
+  )
+
+  return {
+    parse,
+  }
+}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.test.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import DefaultValueField, { DefaultValueFieldProps } from './DefaultValueField'
 import { createWrapper } from '../../../testutils/TestingLibraryUtils'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
 import userEvent from '@testing-library/user-event'
 
@@ -12,27 +12,54 @@ function renderComponent<T>(props: DefaultValueFieldProps<T>) {
 }
 
 describe('DefaultValueField', () => {
-  it('shows a text field for STRING columnType', async () => {
-    const onChange = jest.fn()
-    renderComponent<string>({
-      columnType: ColumnTypeEnum.STRING,
-      onChange,
-      value: 'foo',
+  describe('STRING columnType', () => {
+    it('shows an initial value', () => {
+      const onChange = jest.fn()
+      renderComponent<string>({
+        columnModel: {
+          name: 'foo',
+          columnType: ColumnTypeEnum.STRING,
+          isSelected: false,
+          isOriginallyDefaultColumn: false,
+        },
+        onChange,
+        value: 'bar',
+      })
+
+      const textField = screen.getByRole('textbox')
+      expect(textField).toHaveValue('bar')
+      expect(textField.getAttribute('type')).toBe('text')
     })
+    it('calls onChange', async () => {
+      const onChange = jest.fn()
+      renderComponent<string>({
+        columnModel: {
+          name: 'foo',
+          columnType: ColumnTypeEnum.STRING,
+          isSelected: false,
+          isOriginallyDefaultColumn: false,
+        },
+        onChange,
+        value: undefined,
+      })
 
-    const textField = screen.getByRole('textbox')
-    expect(textField).toHaveValue('foo')
-    expect(textField.getAttribute('type')).toBe('text')
-    await userEvent.click(textField)
-    await userEvent.paste('bar')
+      const textField = screen.getByRole('textbox')
+      expect(textField.getAttribute('type')).toBe('text')
+      await userEvent.type(textField, 'baz')
 
-    expect(onChange).toHaveBeenCalledWith('foobar')
+      expect(onChange).toHaveBeenLastCalledWith('baz')
+    })
   })
 
   it('shows a dropdown select for BOOLEAN columnType', async () => {
     const onChange = jest.fn()
     renderComponent<boolean | undefined>({
-      columnType: ColumnTypeEnum.BOOLEAN,
+      columnModel: {
+        name: 'foo',
+        columnType: ColumnTypeEnum.BOOLEAN,
+        isSelected: false,
+        isOriginallyDefaultColumn: false,
+      },
       onChange,
       value: undefined,
     })
@@ -41,14 +68,70 @@ describe('DefaultValueField', () => {
     expect(booleanField.getAttribute('value')).toBeNull()
     await userEvent.click(booleanField)
     await userEvent.click(await screen.findByRole('option', { name: 'true' }))
-    expect(onChange).toHaveBeenCalledWith(true)
+    expect(onChange).toHaveBeenCalledWith('true')
 
     await userEvent.click(booleanField)
     await userEvent.click(await screen.findByRole('option', { name: 'false' }))
-    expect(onChange).toHaveBeenCalledWith(false)
+    expect(onChange).toHaveBeenCalledWith('false')
 
     await userEvent.click(booleanField)
     await userEvent.click(await screen.findByRole('option', { name: '' }))
     expect(onChange).toHaveBeenCalledWith(undefined)
+  })
+
+  it('shows a date picker for DATE column type', async () => {
+    const onChange = jest.fn()
+    renderComponent<string | undefined>({
+      columnModel: {
+        name: 'foo',
+        columnType: ColumnTypeEnum.DATE,
+        isSelected: false,
+        isOriginallyDefaultColumn: false,
+      },
+      onChange,
+      value: '2021-01-15T00:00:00.000Z',
+    })
+
+    // The actual value shown can vary based on localization
+    // So we will just test for the presence of a value and successful onChange call
+    const datePicker = screen.getByRole('textbox')
+    expect(datePicker.getAttribute('value')).not.toBeNull()
+
+    await userEvent.type(datePicker, '2')
+    expect(onChange).toHaveBeenCalled()
+  })
+
+  it('handles a LIST column type', async () => {
+    const onChange = jest.fn()
+    renderComponent<string | undefined>({
+      columnModel: {
+        name: 'foo',
+        columnType: ColumnTypeEnum.STRING_LIST,
+        isSelected: false,
+        isOriginallyDefaultColumn: false,
+      },
+      onChange,
+      // Default value is a JSON array serialized as a string
+      value: '["bar", "baz"]',
+    })
+
+    const textField = screen.getByRole('textbox')
+    expect(textField.getAttribute('value')).toBe('bar, baz')
+
+    await userEvent.click(textField)
+
+    const multiValueDialog = await screen.findByRole('dialog')
+
+    const itemTextFields = await within(multiValueDialog).findAllByRole(
+      'textbox',
+    )
+    expect(itemTextFields).toHaveLength(2)
+    expect(itemTextFields[0]).toHaveValue('bar')
+    expect(itemTextFields[1]).toHaveValue('baz')
+
+    await userEvent.clear(itemTextFields[0])
+    await userEvent.type(itemTextFields[0], 'qux')
+    await userEvent.click(screen.getByRole('button', { name: 'OK' }))
+    expect(onChange).toHaveBeenCalledWith('["qux","baz"]')
   })
 })

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.tsx
@@ -8,55 +8,169 @@ import {
   TextField,
   TextFieldProps,
 } from '@mui/material'
-import { getTextFieldType } from '../TableColumnSchemaEditorUtils'
+import DateTimePicker from '../../DateTimePicker/DateTimePicker'
+import dayjs, { isDayjs } from 'dayjs'
+import FormHelperText from '@mui/material/FormHelperText'
+import MultiValueField from './MultiValueField'
+import { ColumnModelFormData } from '../Validators/ColumnModelValidator'
 
 export type DefaultValueFieldProps<T> = {
-  columnType: ColumnTypeEnum
-  value: T
-  onChange: (newValue: T) => void
+  columnModel: ColumnModelFormData
+  value: T | undefined
+  onChange: (newValue: T | undefined) => void
   disabled?: boolean
   TextFieldProps?: Omit<TextFieldProps, 'value' | 'onChange' | 'disabled'>
   SelectProps?: Omit<SelectProps, 'value' | 'onChange' | 'disabled'>
+  selectFormHelperText?: React.ReactNode
+}
+
+function DefaultValueBooleanField(props: DefaultValueFieldProps<string>) {
+  const { onChange, value, disabled, SelectProps, selectFormHelperText } = props
+  return (
+    <FormControl fullWidth>
+      <Select
+        {...SelectProps}
+        disabled={disabled}
+        value={value}
+        onChange={e => {
+          if (e.target.value == null) {
+            onChange(undefined)
+          } else {
+            onChange(e.target.value as string)
+          }
+        }}
+      >
+        <MenuItem value={undefined}>{''}</MenuItem>
+        <MenuItem value={'true'}>true</MenuItem>
+        <MenuItem value={'false'}>false</MenuItem>
+      </Select>
+      {selectFormHelperText && (
+        <FormHelperText color={'error.main'}>
+          {selectFormHelperText}
+        </FormHelperText>
+      )}
+    </FormControl>
+  )
+}
+
+function DefaultValueDateField(props: DefaultValueFieldProps<string>) {
+  const { onChange, value = null, disabled, TextFieldProps } = props
+
+  const valueAsDayjs = useMemo(() => {
+    if (value != null) {
+      return dayjs(value)
+    }
+    return value
+  }, [value])
+
+  return (
+    <DateTimePicker
+      value={valueAsDayjs}
+      onChange={newValue => {
+        if (isDayjs(newValue)) {
+          onChange(newValue.toISOString())
+        } else if (newValue == null) {
+          onChange(undefined)
+        } else {
+          onChange(newValue)
+        }
+      }}
+      disabled={disabled}
+      slotProps={{
+        textField: TextFieldProps,
+      }}
+    />
+  )
+}
+
+function DefaultValueListField(props: DefaultValueFieldProps<string>) {
+  const {
+    onChange,
+    value: _value = null,
+    columnModel,
+    TextFieldProps,
+    disabled,
+  } = props
+  // The backend returns the default value as a serialized JSON string
+  // Try to deserialize it
+  const value = useMemo(() => {
+    if (_value == null || _value == '') {
+      return null
+    }
+    try {
+      const parsedValue = JSON.parse(_value) as unknown[]
+      if (columnModel.columnType === ColumnTypeEnum.DATE_LIST) {
+        // if it's a DATE_LIST, then the values are Unix timestamps in milliseconds
+        // divide by 1000 then parse with dayjs
+        return parsedValue.map(v => {
+          if (typeof v === 'number') {
+            return dayjs(v / 1000)
+          }
+          return dayjs(v as string)
+        })
+      }
+      return parsedValue
+    } catch (e) {
+      return null
+    }
+  }, [_value, columnModel.columnType])
+
+  return (
+    <MultiValueField
+      value={value}
+      onChange={arr => {
+        if (arr == null) {
+          onChange(undefined)
+        }
+        onChange(JSON.stringify(arr))
+      }}
+      columnType={columnModel.columnType as ColumnTypeEnum}
+      TextFieldProps={{ ...TextFieldProps, disabled }}
+    />
+  )
 }
 
 export default function DefaultValueField<T>(props: DefaultValueFieldProps<T>) {
-  const { columnType, onChange, value, disabled, TextFieldProps, SelectProps } =
-    props
+  const { columnModel, onChange, value, disabled, TextFieldProps } = props
 
-  const textFieldType: TextFieldProps['type'] = useMemo(
-    () => getTextFieldType(columnType),
-    [columnType],
-  )
+  const { columnType } = columnModel
 
   if (columnType === ColumnTypeEnum.BOOLEAN) {
     return (
-      <FormControl fullWidth>
-        <Select
-          {...SelectProps}
-          disabled={disabled}
-          value={value}
-          onChange={e => {
-            if (e.target.value == undefined) {
-              onChange(undefined as T)
-            } else {
-              onChange((e.target.value === 'true') as T)
-            }
-          }}
-        >
-          <MenuItem value={undefined}>{''}</MenuItem>
-          <MenuItem value={'true'}>true</MenuItem>
-          <MenuItem value={'false'}>false</MenuItem>
-        </Select>
-      </FormControl>
+      <DefaultValueBooleanField
+        {...(props as unknown as DefaultValueFieldProps<string>)}
+      />
+    )
+  }
+
+  if (columnType === ColumnTypeEnum.DATE) {
+    return (
+      <DefaultValueDateField
+        {...(props as unknown as DefaultValueFieldProps<string>)}
+      />
+    )
+  }
+
+  if (columnType.endsWith('_LIST')) {
+    return (
+      <DefaultValueListField
+        {...(props as unknown as DefaultValueFieldProps<string>)}
+      />
     )
   }
 
   return (
     <TextField
       {...TextFieldProps}
-      type={textFieldType}
+      type={'text'}
       value={value}
-      onChange={event => onChange(event.target.value as T)}
+      onChange={event => {
+        if (event.target.value == '') {
+          onChange(undefined as T)
+        } else {
+          onChange(event.target.value as T)
+        }
+      }}
       disabled={disabled}
     />
   )

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/MultiValueField.test.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/MultiValueField.test.tsx
@@ -1,23 +1,19 @@
 import React from 'react'
 import { getJsonSchemaItemDefinitionForColumnType } from '../TableColumnSchemaEditorUtils'
 import { JSONSchema7Definition } from 'json-schema'
-import RestrictedValuesField, {
-  RestrictedValuesFieldProps,
-} from './RestrictedValuesField'
+import MultiValueField, { MultiValueFieldProps } from './MultiValueField'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import { createWrapper } from '../../../testutils/TestingLibraryUtils'
 import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
 import JSONArrayEditorModal from '../../JSONArrayEditor/JSONArrayEditorModal'
 import userEvent from '@testing-library/user-event'
 
-const jsonSchemaItemDefinition: JSONSchema7Definition = {
+const stringDefinition: JSONSchema7Definition = {
   type: 'string',
 }
 jest.mock('../TableColumnSchemaEditorUtils', () => {
   return {
-    getJsonSchemaItemDefinitionForColumnType: jest
-      .fn()
-      .mockReturnValue(jsonSchemaItemDefinition),
+    getJsonSchemaItemDefinitionForColumnType: jest.fn(),
   }
 })
 
@@ -35,14 +31,18 @@ const mockGetJsonSchemaDefinition = jest.mocked(
 )
 const mockJsonArrayEditorModal = jest.mocked(JSONArrayEditorModal)
 
-function renderComponent(props: RestrictedValuesFieldProps) {
-  return render(<RestrictedValuesField {...props} />, {
+function renderComponent(props: MultiValueFieldProps) {
+  return render(<MultiValueField {...props} />, {
     wrapper: createWrapper(),
   })
 }
 
 describe('RestrictedValuesField', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
   test('interactions and calls to dependencies', async () => {
+    mockGetJsonSchemaDefinition.mockReturnValue(stringDefinition)
     const onChange = jest.fn()
     renderComponent({
       columnType: ColumnTypeEnum.STRING,
@@ -57,13 +57,15 @@ describe('RestrictedValuesField', () => {
     expect(mockGetJsonSchemaDefinition).toHaveBeenCalledWith(
       ColumnTypeEnum.STRING,
     )
-    expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        arrayItemDefinition: jsonSchemaItemDefinition,
-        value: ['foo', 'bar'],
-        isShowingModal: false,
-      }),
-      expect.anything(),
+    await waitFor(() =>
+      expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          arrayItemDefinition: stringDefinition,
+          value: ['foo', 'bar'],
+          isShowingModal: false,
+        }),
+        expect.anything(),
+      ),
     )
 
     // Click the text field and the modal will be shown

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/MultiValueField.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/MultiValueField.tsx
@@ -3,16 +3,18 @@ import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
 import JSONArrayEditorModal from '../../JSONArrayEditor/JSONArrayEditorModal'
 import { getJsonSchemaItemDefinitionForColumnType } from '../TableColumnSchemaEditorUtils'
 import { TextField, TextFieldProps } from '@mui/material'
+import { formatDate } from '../../../utils/functions/DateFormatter'
+import dayjs from 'dayjs'
 
-export type RestrictedValuesFieldProps = {
-  value?: string[]
-  onChange: (newValue: string[]) => void
+export type MultiValueFieldProps<T = unknown> = {
+  value?: T[] | null
+  onChange: (newValue: T[] | null) => void
   columnType: ColumnTypeEnum
   TextFieldProps?: Omit<TextFieldProps, 'value' | 'onChange'>
 }
 
-export default function RestrictedValuesField(
-  props: RestrictedValuesFieldProps,
+export default function MultiValueField<T = unknown>(
+  props: MultiValueFieldProps<T>,
 ) {
   const { columnType, onChange, value = [], TextFieldProps } = props
   const [isShowingModal, setIsShowingModal] = useState(false)
@@ -22,11 +24,21 @@ export default function RestrictedValuesField(
     [columnType],
   )
 
+  const textFieldDisplayedValue = useMemo(() => {
+    if (value == null) {
+      return ''
+    }
+    if (columnType === ColumnTypeEnum.DATE_LIST) {
+      return value.map(v => formatDate(dayjs(v as string))).join(', ')
+    }
+    return value.join(', ')
+  }, [value, columnType])
+
   return (
     <>
       <JSONArrayEditorModal
         arrayItemDefinition={arrayItemDefinition}
-        value={value}
+        value={value ?? undefined}
         isShowingModal={isShowingModal}
         onConfirm={values => {
           onChange(values)
@@ -36,7 +48,7 @@ export default function RestrictedValuesField(
       />
       <TextField
         {...TextFieldProps}
-        value={value.join(', ')}
+        value={textFieldDisplayedValue}
         onClick={() => {
           setIsShowingModal(true)
         }}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ImportTableColumnsButton.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ImportTableColumnsButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react'
-import { Button } from '@mui/material'
+import { Button, ButtonProps } from '@mui/material'
 import { DownloadTwoTone } from '@mui/icons-material'
 import { SetOptional } from 'type-fest'
 import {
@@ -15,7 +15,7 @@ import SynapseClient from '../../synapse-client'
 import { useSynapseContext } from '../../utils'
 import { displayToast } from '../ToastMessage'
 
-export type ImportTableColumnsButtonProps = {
+export type ImportTableColumnsButtonProps = Omit<ButtonProps, 'onClick'> & {
   initialFinderProjectId?: string
   onAddColumns: (columnModels: SetOptional<ColumnModel, 'id'>[]) => void
 }
@@ -23,7 +23,7 @@ export type ImportTableColumnsButtonProps = {
 export default function ImportTableColumnsButton(
   props: ImportTableColumnsButtonProps,
 ) {
-  const { initialFinderProjectId, onAddColumns } = props
+  const { initialFinderProjectId, onAddColumns, ...buttonProps } = props
   const [showFinder, setShowFinder] = useState(false)
   const { accessToken } = useSynapseContext()
 
@@ -97,6 +97,7 @@ export default function ImportTableColumnsButton(
           setShowFinder(true)
         }}
         startIcon={<DownloadTwoTone />}
+        {...buttonProps}
       >
         Import Columns
       </Button>

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.stories.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.stories.ts
@@ -10,6 +10,7 @@ import { ColumnTypeEnum, TableBundle } from '@sage-bionetworks/synapse-types'
 import { rest } from 'msw'
 import { ENTITY_BUNDLE_V2 } from '../../utils/APIConstants'
 import mockTableEntityData from '../../mocks/entity/mockTableEntity'
+import mockEntities from '../../mocks/entity'
 
 const meta = {
   title: 'Synapse/Table Column Schema Editor',
@@ -48,10 +49,13 @@ export const Demo: Story = {
         rest.post(
           `${MOCK_REPO_ORIGIN}${ENTITY_BUNDLE_V2(':entityId')}`,
           async (req, res, ctx) => {
+            const entity =
+              mockEntities.find(entity => entity.id === req.params.entityId) ||
+              mockTableEntityData
             return res(
               ctx.status(200),
               ctx.json({
-                entity: mockTableEntityData.entity,
+                entity: entity.entity,
                 tableBundle: mockTableBundle,
               }),
             )

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.tsx
@@ -7,13 +7,10 @@ import { SkeletonTable } from '../Skeleton'
 import { convertToEntityType } from '../../utils/functions/EntityTypeUtils'
 import TableColumnSchemaForm, { SubmitHandle } from './TableColumnSchemaForm'
 import { Alert, Button, Divider } from '@mui/material'
-import { ColumnModelFormData } from './TableColumnSchemaFormReducer'
-import {
-  getViewScopeForEntity,
-  transformFormDataToColumnModels,
-} from './TableColumnSchemaEditorUtils'
-import { ViewScope } from '@sage-bionetworks/synapse-types'
+import { getViewScopeForEntity } from './TableColumnSchemaEditorUtils'
+import { ColumnModel, ViewScope } from '@sage-bionetworks/synapse-types'
 import { Provider } from 'jotai'
+import { SetOptional } from 'type-fest'
 
 export type TableColumnSchemaEditorProps = {
   entityId: string
@@ -48,10 +45,7 @@ function _TableColumnSchemaEditor(props: TableColumnSchemaEditorProps) {
   const { mutate, isLoading: isMutating, error } = useUpdateTableColumns()
 
   const onSubmit = useCallback(
-    (formData: ColumnModelFormData[]) => {
-      // Transform the form data into ColumnModels
-      const newColumnModels = transformFormDataToColumnModels(formData)
-
+    (newColumnModels: SetOptional<ColumnModel, 'id'>[]) => {
       // Update the table schema with the new column models.
       mutate({
         entityId,

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.test.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorUtils.test.ts
@@ -245,10 +245,6 @@ describe('TableColumnSchemaEditorUtils', () => {
         ColumnTypeEnum.JSON,
         ColumnTypeEnum.SUBMISSIONID,
         ColumnTypeEnum.EVALUATIONID,
-        ColumnTypeEnum.STRING_LIST,
-        ColumnTypeEnum.INTEGER_LIST,
-        ColumnTypeEnum.BOOLEAN_LIST,
-        ColumnTypeEnum.DATE_LIST,
         ColumnTypeEnum.USERID_LIST,
         ColumnTypeEnum.ENTITYID_LIST,
       ]

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.test.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.test.ts
@@ -1,6 +1,6 @@
 import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
+import { ColumnModelFormData } from './Validators/ColumnModelValidator'
 import {
-  ColumnModelFormData,
   getDefaultColumnModelFormData,
   getDefaultJsonSubColumnFormData,
   getNumberOfSelectedItems,

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
@@ -1,10 +1,5 @@
-import {
-  ColumnModel,
-  ColumnTypeEnum,
-  JsonSubColumnModel,
-} from '@sage-bionetworks/synapse-types'
+import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
 import { atomWithReducer } from 'jotai/utils'
-import { SetOptional } from 'type-fest'
 import { cloneDeep } from 'lodash-es'
 import {
   canHaveMaxListLength,
@@ -12,6 +7,10 @@ import {
   configureFacetsForType,
   DEFAULT_STRING_SIZE,
 } from './TableColumnSchemaEditorUtils'
+import {
+  ColumnModelFormData,
+  JsonSubColumnModelFormData,
+} from './Validators/ColumnModelValidator'
 
 export function getIsAllSelected(formData: ColumnModelFormData[]) {
   return (
@@ -123,24 +122,6 @@ function moveSelectedItemsDown<T = unknown>(
     }
   }
   return newArr
-}
-
-export type JsonSubColumnModelFormData = JsonSubColumnModel & {
-  // add `isSelected` to the data object
-  isSelected: boolean
-}
-
-export type ColumnModelFormData = Omit<
-  SetOptional<ColumnModel, 'id'>,
-  'jsonSubColumns'
-> & {
-  // add `isSelected` to the data object
-  isSelected: boolean
-  // If the column originates as a default column based on column name, fields other than the facet type are readonly
-  // This field should not be automatically updated, because new columns with the same name should not immediately become readonly.
-  isOriginallyDefaultColumn: boolean
-  // jsonSubColumns will also include formData (like isSelected)
-  jsonSubColumns?: JsonSubColumnModelFormData[]
 }
 
 type TableColumnSchemaFormReducerAction =


### PR DESCRIPTION
 - Validate and parse form data with Zod on submission
 - Render Zod error messages in fields where an error exists after submission
 - Use Zod inferred types to describe input form data (update ColumnModelFormData/JsonSubColumnModelFormData)
 - Rename RestrictedValuesField to MultiValueField and genericize the type value
 - Allow default values for LIST columns
 - Change DefaultValueField to show custom for BOOLEAN and DATE columns. LIST columns will now use MultiValueField
 - Number fields changed to text fields to allow entering any valid value, such as strings like "Infinity" for DOUBLE columns
 - Refactor CSV parsing logic out of JSONArrayEditor and modify functionality to parse the data as non-strings if the passed JSON schema does not specify string items