### PR TITLE
SWC-6627 - Improvements for custom RadioGroup

### DIFF
--- a/packages/synapse-react-client/demo/containers/playground/ToastDemo.tsx
+++ b/packages/synapse-react-client/demo/containers/playground/ToastDemo.tsx
@@ -50,7 +50,6 @@ export const ToastDemo = () => {
         Alert Variant
       </Typography>
       <RadioGroup
-        id="toast-demo-variant"
         options={[
           { label: 'Info', value: 'info' },
           { label: 'Success', value: 'success' },

--- a/packages/synapse-react-client/demo/containers/playground/WidgetDemo.tsx
+++ b/packages/synapse-react-client/demo/containers/playground/WidgetDemo.tsx
@@ -112,7 +112,6 @@ export const WidgetDemo: React.FunctionComponent = () => {
       Option Value is: {optionValue}
       <br />
       <RadioGroup
-        id="radioGroup1"
         options={options}
         value={optionValue}
         onChange={(value: string) => setOptionValue(value)}

--- a/packages/synapse-react-client/src/components/AccessRequirement/ImposeRestrictionDialog/ImposeRestrictionDialog.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirement/ImposeRestrictionDialog/ImposeRestrictionDialog.tsx
@@ -100,7 +100,6 @@ export default function ImposeRestrictionDialog(
             Is this sensitive human data that must be protected?
           </FormLabel>
           <RadioGroup<boolean>
-            id={`impose-restriction-${entityId}`}
             value={isSensitiveHumanData}
             options={[
               {

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsEditor.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsEditor.tsx
@@ -134,7 +134,6 @@ export default function DataAccessRequestAccessorsEditor(
                     ac.type !== AccessType.GAIN_ACCESS && (
                       <>
                         <RadioGroup
-                          id={`accessor-renewal-${ac.userId}`}
                           value={ac.type}
                           options={[
                             {

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/EvaluationQueueList.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/EvaluationQueueList.tsx
@@ -42,7 +42,6 @@ function EvaluationQueueList({
             currentValue={selectedEvaluation}
             onChange={onEvaluationChange}
             label=""
-            groupId="radiogroup"
             style={{ marginBottom: '16px' }}
           />
         )

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/SubmissionCommitList.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/SubmissionCommitList.tsx
@@ -63,7 +63,6 @@ function SubmissionCommitList({
             currentValue={selectedCommit?.digest}
             onChange={commitChangeHandler}
             label=""
-            groupId="radiogroup"
             style={{ marginBottom: '16px' }}
           />
         )

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/SubmissionDirectoryList.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/SubmissionDirectoryList.tsx
@@ -173,7 +173,6 @@ function SubmissionDirectoryList({
               entityChangeHandler(selectedItemId as string)
             }}
             label=""
-            groupId="radiogroup"
             style={{ marginBottom: '16px' }}
           />
         )

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamTable.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamTable.tsx
@@ -111,7 +111,6 @@ export default function ChallengeTeamTable({
             currentValue={selectedTeam}
             onChange={teamChangeHandler}
             label=""
-            groupId="radiogroup"
             style={{ marginBottom: '16px' }}
           />
         )

--- a/packages/synapse-react-client/src/components/widgets/RadioGroup.test.tsx
+++ b/packages/synapse-react-client/src/components/widgets/RadioGroup.test.tsx
@@ -35,7 +35,7 @@ describe('basic function', () => {
     const radioOptions = screen.getAllByRole<HTMLInputElement>('radio')
     expect(radioOptions).toHaveLength(props.options.length)
     expect(radioGroup.className.includes('radioGroupClass')).toBe(true)
-    screen.getByLabelText(props.options[0].label)
+    screen.getByLabelText(props.options[0].label as string)
 
     expect(radioOptions[0]).not.toBeChecked()
     expect(radioOptions[1]).toBeChecked()
@@ -62,5 +62,16 @@ describe('basic function', () => {
     expect(radioOptions[0]).not.toBeChecked()
     expect(radioOptions[1]).not.toBeChecked()
     expect(radioOptions[2]).not.toBeChecked()
+  })
+
+  it('should disable the input values when disabled is true', () => {
+    init({ ...props, disabled: true })
+    screen.getByRole<HTMLDivElement>('radiogroup')
+    const radioOptions = screen.getAllByRole<HTMLInputElement>('radio')
+    expect(radioOptions).toHaveLength(props.options.length)
+
+    expect(radioOptions[0]).toBeDisabled()
+    expect(radioOptions[1]).toBeDisabled()
+    expect(radioOptions[2]).toBeDisabled()
   })
 })

--- a/packages/synapse-react-client/src/components/widgets/RadioGroup.test.tsx
+++ b/packages/synapse-react-client/src/components/widgets/RadioGroup.test.tsx
@@ -12,7 +12,6 @@ function createTestProps(overrides?: RadioGroupProps): RadioGroupProps {
       { label: 'Label1', value: 'value1' },
       { label: 'Label2', value: 'value2' },
     ],
-    id: 'radioGroup1',
     className: 'radioGroupClass',
     value: 'value1',
     onChange: mockCallback,

--- a/packages/synapse-react-client/src/components/widgets/RadioGroup.tsx
+++ b/packages/synapse-react-client/src/components/widgets/RadioGroup.tsx
@@ -17,7 +17,7 @@ export function RadioGroup<T extends string | boolean | number = string>(
     : `radiogroup`
 
   return (
-    <div id={props.id} className={className} role="radiogroup">
+    <div className={className} role="radiogroup">
       {props.options.map((option, index) => (
         <RadioOption<T>
           key={index.toString()}

--- a/packages/synapse-react-client/src/components/widgets/RadioGroup.tsx
+++ b/packages/synapse-react-client/src/components/widgets/RadioGroup.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from 'react'
-import { uniqueId as _uniqueId } from 'lodash-es'
+import React, { useId } from 'react'
 
 export type RadioGroupProps<T extends string | boolean | number = string> = {
-  options: { label: string; value: T }[]
-  id: string
+  options: { label: React.ReactNode; value: T }[]
+  id?: string
   className?: string
   value?: T
   onChange: (value: T) => void
+  disabled?: boolean
 }
 
 export function RadioGroup<T extends string | boolean | number = string>(
@@ -17,15 +17,15 @@ export function RadioGroup<T extends string | boolean | number = string>(
     : `radiogroup`
 
   return (
-    <div className={className} role="radiogroup">
+    <div id={props.id} className={className} role="radiogroup">
       {props.options.map((option, index) => (
         <RadioOption<T>
           key={index.toString()}
-          groupId={props.id}
           label={option.label}
           value={option.value}
           currentValue={props.value}
           onChange={props.onChange}
+          disabled={props.disabled}
         />
       ))}
     </div>
@@ -33,18 +33,18 @@ export function RadioGroup<T extends string | boolean | number = string>(
 }
 
 export type RadioOptionProps<T extends string | boolean | number = string> = {
-  groupId: string
-  label: string
+  label: React.ReactNode
   value: T
   currentValue?: T
   style?: React.CSSProperties
   onChange: (value: T) => void
+  disabled?: boolean
 }
 
 export function RadioOption<T extends string | boolean | number = string>(
   props: RadioOptionProps<T>,
 ) {
-  const [uniqueId] = useState(_uniqueId('src-radio-'))
+  const uniqueId = useId()
   return (
     <div className={'radio'} onClick={() => props.onChange(props.value)}>
       <input
@@ -55,6 +55,7 @@ export function RadioOption<T extends string | boolean | number = string>(
         }}
         checked={props.currentValue === props.value}
         value={props.value.toString()}
+        disabled={props.disabled}
       />
       <label htmlFor={uniqueId} style={props.style}>
         {props.label}

--- a/packages/synapse-react-client/src/components/widgets/RadioGroup.tsx
+++ b/packages/synapse-react-client/src/components/widgets/RadioGroup.tsx
@@ -2,7 +2,6 @@ import React, { useId } from 'react'
 
 export type RadioGroupProps<T extends string | boolean | number = string> = {
   options: { label: React.ReactNode; value: T }[]
-  id?: string
   className?: string
   value?: T
   onChange: (value: T) => void

--- a/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilterUI.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilterUI.tsx
@@ -100,12 +100,11 @@ export function RangeFacetFilterUI(props: RangeFacetFilterProps) {
       <Collapse in={!isCollapsed}>
         <RadioGroup
           value={radioValue}
-          id="rangeSelector"
           options={options}
           onChange={(radioValue: string) =>
             handleRadioGroupChange(radioValue as RadioValuesEnum)
           }
-        ></RadioGroup>
+        />
         {radioValue === RadioValuesEnum.RANGE &&
           (columnMin === columnMax ? (
             <label>{columnMax}</label>


### PR DESCRIPTION
 - Allow passing a ReactNode label
 - Allow disabling the group
 - Make `id` optional, and use `useId` to generate a unique ID when one is not provided

In SWC-6627 we will be reimplementing the ability to add evaluations to a SubmissionView. The existing UI uses a radio group. We will want to disable the radio group inputs while the data changes, e.g. loading new pages