### PR TITLE
SWC-6627 - Extend EntityHeaderTable for use in view scope editor

### DIFF
--- a/packages/synapse-react-client/src/components/EntityHeaderTable/useEntityHeaderTableState.ts
+++ b/packages/synapse-react-client/src/components/EntityHeaderTable/useEntityHeaderTableState.ts
@@ -23,15 +23,18 @@ export function useEntityHeaderTableState(
     [onUpdateEntityIDsTextbox],
   )
 
-  const setRefsInState = useCallback((refs: ReferenceList) => {
-    setRowSelection({})
-    _setRefsInState(refs)
-    if (onUpdate) {
-      onUpdate(refs)
-    }
-    setParseErrors([])
-    setNewEntityIDs('')
-  }, [])
+  const setRefsInState = useCallback(
+    (refs: ReferenceList) => {
+      setRowSelection({})
+      _setRefsInState(refs)
+      if (onUpdate) {
+        onUpdate(refs)
+      }
+      setParseErrors([])
+      setNewEntityIDs('')
+    },
+    [onUpdate, setNewEntityIDs],
+  )
 
   return {
     rowSelection,


### PR DESCRIPTION
 - Allow hiding text field for entering values via prop
 - Allow overriding entity finder config
 - Allow overriding "entity" copy
 - Fix eslint warnings