### PR TITLE
PORTALS-2872: add end-to-end testing for Portals

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -60,6 +60,14 @@ module.exports = {
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-extra-semi": "warn",
   },
+  overrides: [
+    {
+      files: ["apps/portals/e2e/*.ts"],
+      rules: {
+        "@typescript-eslint/no-floating-promises": "error",
+      },
+    },
+  ],
   settings: {
     react: {
       version: "detect",

--- a/.github/workflows/end-to-end-test-portals.yml
+++ b/.github/workflows/end-to-end-test-portals.yml
@@ -1,0 +1,86 @@
+name: End to end testing for Portals
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+env:
+  PW_ALL_BLOBS_DIR: all-blob-reports
+  PORTALS_SUBDIR: apps/portals
+
+jobs:
+  e2e-tests:
+    if: ${{ github.ref_name == 'main' || github.actor == github.repository_owner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        PORTAL:
+          [
+            adknowledgeportal,
+            arkportal,
+            bsmn,
+            cancercomplexity,
+            challengeportal,
+            digitalhealth,
+            elportal,
+            nf,
+            psychencode,
+            stopadportal,
+          ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/pnpm-setup-action
+      - name: Build portal
+        run: |
+          cd "${{ env.PORTALS_SUBDIR }}"
+          chmod +x ./build.sh
+          ./build.sh "${{ matrix.PORTAL }}"
+      - name: Start portal
+        run: pnpm nx run portals:portal:start
+      - name: Install Playwright Browsers
+        run: |
+          cd "${{ env.PORTALS_SUBDIR }}"
+          pnpm playwright install --with-deps
+      # Name report in playwright.config once feature is released:
+      # https://github.com/microsoft/playwright/issues/27284
+      - name: Run e2e tests
+        run: PWTEST_BLOB_REPORT_NAME="${{ matrix.PORTAL }}" pnpm nx run portals:e2e
+        env:
+          PORTAL: ${{ matrix.PORTAL }}
+      - name: Stop portal
+        run: pnpm nx run portals:portal:stop
+      - name: Upload blob report to GitHub Actions Artifacts
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: ${{ env.PW_ALL_BLOBS_DIR }}
+          path: '${{ env.PORTALS_SUBDIR }}/blob-report'
+          retention-days: 1
+  merge-e2e-reports:
+    # Merge reports after e2e-tests, even if some shards have failed
+    # But skip this job if the previous job was cancelled or skipped
+    if: ${{ !cancelled() && needs.e2e-tests.result != 'skipped' }}
+    needs: [e2e-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/pnpm-setup-action
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.PW_ALL_BLOBS_DIR }}
+          path: ${{ env.PORTALS_SUBDIR }}/${{ env.PW_ALL_BLOBS_DIR }}
+      - name: Merge into HTML Report
+        run: cd ${{ env.PORTALS_SUBDIR }}; pnpm exec playwright merge-reports --reporter html ./"${{ env.PW_ALL_BLOBS_DIR }}"
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-report--attempt-${{ github.run_attempt }}
+          path: '${{ env.PORTALS_SUBDIR }}/playwright-report'
+          retention-days: 14

--- a/.github/workflows/end-to-end-test-portals.yml
+++ b/.github/workflows/end-to-end-test-portals.yml
@@ -7,12 +7,16 @@ on:
 env:
   PW_ALL_BLOBS_DIR: all-blob-reports
   PORTALS_SUBDIR: apps/portals
+concurrency:
+  group: '${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   e2e-tests:
-    if: ${{ github.ref_name == 'main' || github.actor == github.repository_owner }}
+    if: ${{ (github.event_name == 'push' && (github.ref_name == 'main' || github.actor == github.repository_owner)) || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
+      max-parallel: ${{ github.repository_owner == 'Sage-Bionetworks' && 5 || 10 }}
       matrix:
         PORTAL:
           [

--- a/apps/portals/.gitignore
+++ b/apps/portals/.gitignore
@@ -11,3 +11,10 @@ public/deploy_date.txt
 public/favicon.svg
 public/logo.svg
 public/socialmedia.png
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+.env

--- a/apps/portals/e2e/README.md
+++ b/apps/portals/e2e/README.md
@@ -1,0 +1,30 @@
+# Portals End-to-End Testing Workflow
+
+## Dev Setup
+
+### Local
+
+1. Create a `.env` file with the following environment variables: `PORTAL`. The value should match one of the Portal directory names in `src/configurations/`, e.g. 'adknowledgeportal'.
+2. Build the Portal: `pnpm portal:build`.
+3. Start the Portal: `pnpm portal:start`. The Portal will be available at `http://localhost:3000`.
+4. Run tests: `pnpm e2e`. Tests can be run multiple times against the running Portal.
+5. Stop the Portal: `pnpm portal:stop`.
+
+### CI
+
+In your forked repository, ensure that [Actions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository) are enabled.
+
+In your forked repository, tests will run on each push to your forked repository. In the Sage-Bionetworks repo, tests will run on each PR or push to main. In both cases, the Playwright report will be saved as a GitHub Artifact.
+
+The GitHub UI or CLI can be used to view the reports:
+
+- GitHub UI
+  - Navigate to the Action run summary page.
+  - Download the report named "html-report--attempt-{number}". _Note:_ only the report from the latest attempt will be available.
+  - Unzip and move the files into the `playwright-report` directory in SWC.
+  - Run `yarn e2e:report` to view the HTML report in the browser.
+- GitHub CLI
+  - Install [GitHub CLI](https://cli.github.com/), if necessary.
+  - Install [jq](https://jqlang.github.io/jq/download/), if necessary.
+  - [Authenticate](https://cli.github.com/manual/gh_auth_login) with a GitHub host, if necessary.
+  - Run `e2e/view_github_report.sh` with the following arguments: GitHub repo owner name and the GitHub run ID of the report to view. The HTML report will open in the browser.

--- a/apps/portals/e2e/configs/bannersConfig.ts
+++ b/apps/portals/e2e/configs/bannersConfig.ts
@@ -1,0 +1,19 @@
+import { Portal } from './routesConfig'
+
+export type BannerType = 'beta' | 'cookies' | 'survey'
+
+type BannerConfig = Record<Portal, BannerType[]>
+const bannerConfig: BannerConfig = {
+  adknowledgeportal: ['cookies'],
+  arkportal: ['cookies'],
+  bsmn: ['cookies'],
+  cancercomplexity: ['cookies'],
+  challengeportal: ['cookies'],
+  digitalhealth: ['cookies'],
+  elportal: ['beta', 'cookies'],
+  nf: ['survey', 'cookies'],
+  psychencode: ['cookies'],
+  stopadportal: ['cookies'],
+}
+
+export default bannerConfig

--- a/apps/portals/e2e/configs/exploreConfig.ts
+++ b/apps/portals/e2e/configs/exploreConfig.ts
@@ -1,0 +1,73 @@
+import { Portal } from './routesConfig'
+
+type ExploreTabTypes = {
+  table?: string[]
+  table_charts?: string[]
+  cards?: string[]
+  cards_charts?: string[]
+  people_charts?: string[]
+}
+
+type ExploreConfig = Record<Portal, ExploreTabTypes>
+
+const exploreConfig: ExploreConfig = {
+  adknowledgeportal: {
+    table_charts: ['Data', 'Experimental Models', 'Target Enabling Resources'],
+    cards: ['Programs'],
+    cards_charts: [
+      'Projects',
+      'Studies',
+      'Publications',
+      'Computational Tools',
+    ],
+    people_charts: ['People'],
+  },
+  arkportal: {
+    table: ['Datasets', 'All Data'],
+    cards: ['Programs', 'Projects', 'Collections'],
+  },
+  bsmn: {
+    cards_charts: ['Projects', 'Data', 'Tools', 'Publications'],
+    people_charts: ['People'],
+  },
+  cancercomplexity: {
+    cards_charts: [
+      'Grants',
+      'People',
+      'Publications',
+      'Datasets',
+      'Tools',
+      'Educational Resources',
+    ],
+  },
+  challengeportal: {},
+  digitalhealth: {
+    cards_charts: ['Collections', 'Tools', 'Publications'],
+    table_charts: ['Data'],
+  },
+  elportal: {
+    table_charts: ['Data By Files'],
+    cards: ['Species'],
+    cards_charts: [
+      'Projects',
+      'Studies',
+      'Publications',
+      'Computational Tools',
+    ],
+    people_charts: ['People'],
+  },
+  nf: {
+    table_charts: ['Files'],
+    cards: ['Initiatives'],
+    cards_charts: ['Studies', 'Datasets', 'Publications', 'Tools', 'Hackathon'],
+  },
+  psychencode: {
+    table_charts: ['Data'],
+    cards: ['Publications'],
+    cards_charts: ['Studies', 'Grants'],
+    people_charts: ['People'],
+  },
+  stopadportal: {},
+}
+
+export default exploreConfig

--- a/apps/portals/e2e/configs/routesConfig.ts
+++ b/apps/portals/e2e/configs/routesConfig.ts
@@ -1,0 +1,72 @@
+export type Portal =
+  | 'adknowledgeportal'
+  | 'arkportal'
+  | 'bsmn'
+  | 'cancercomplexity'
+  | 'challengeportal'
+  | 'digitalhealth'
+  | 'elportal'
+  | 'nf'
+  | 'psychencode'
+  | 'stopadportal'
+
+type RouteButtonsLinks = { buttons: string[]; links: string[] }
+type RouteConfig = Record<Portal, RouteButtonsLinks>
+
+const routesConfig: RouteConfig = {
+  adknowledgeportal: {
+    buttons: ['Home', 'Explore', 'Sign In'],
+    links: [
+      'Analytical Workspace',
+      'Data Access',
+      'Contribute',
+      'News',
+      'Help',
+    ],
+  },
+  arkportal: {
+    buttons: ['Explore', 'Sign In'],
+    links: ['Home', 'About', 'Data Access', 'News', 'Help'],
+  },
+  bsmn: {
+    buttons: ['Home', 'Explore'],
+    links: ['About'],
+  },
+  cancercomplexity: {
+    buttons: ['Home', 'Explore', 'Sign In'],
+    links: ['Intranet', 'News', 'Help'],
+  },
+  challengeportal: {
+    buttons: ['Home'],
+    links: [],
+  },
+  digitalhealth: {
+    buttons: ['Home', 'Explore', 'Sign In'],
+    links: ['About', 'Help'],
+  },
+  elportal: {
+    buttons: ['Explore', 'Sign In'],
+    links: [
+      'Home',
+      'Limited Data Commons',
+      'Data Access',
+      'Contribute',
+      'News',
+      'Help',
+    ],
+  },
+  nf: {
+    buttons: ['Explore', 'Organizations', 'Sign In'],
+    links: ['Browse Tools', 'About', 'Contribute Data', 'News', 'Help'],
+  },
+  psychencode: {
+    buttons: ['Home', 'Explore', 'Sign In'],
+    links: ['Data Access', 'News', 'About', 'Help'],
+  },
+  stopadportal: {
+    buttons: ['Help', 'Sign In'],
+    links: ['Home', 'Apply'],
+  },
+}
+
+export default routesConfig

--- a/apps/portals/e2e/explore.spec.ts
+++ b/apps/portals/e2e/explore.spec.ts
@@ -1,0 +1,361 @@
+import { Locator, Page, expect, test } from '@playwright/test'
+import { defaultExpectTimeout } from '../playwright.config'
+import exploreConfig from './configs/exploreConfig'
+import { dismissBanners } from './helpers/banners'
+import { getPortal } from './helpers/portalInfo'
+
+const portalExploreConfig = exploreConfig[getPortal()]
+
+const goToExploreTab = async (page: Page, exploreTab: string) => {
+  await test.step(`go to Explore/${exploreTab}`, async () => {
+    await test.step('navigate to explore page', async () => {
+      await page.goto(`/Explore/${exploreTab}`)
+    })
+
+    await test.step('explore page has loaded', async () => {
+      await expect(
+        page.getByRole('main').getByText('Explore', { exact: true }),
+      ).toBeVisible()
+      await expect(page.getByLabel('Explore Sections')).toBeVisible()
+      await expect(page.getByRole('tab', { name: exploreTab })).toBeVisible()
+    })
+
+    await dismissBanners(page)
+  })
+}
+
+const expectCards = async (page: Page) => {
+  await test.step('expect cards', async () => {
+    const { cards, nCards } = await test.step('expect cards list', async () => {
+      const cards = page.locator('.SRC-portalCard')
+      await expect.poll(() => cards.count()).toBeGreaterThanOrEqual(1)
+      const nCards = await cards.count()
+      return { cards, nCards }
+    })
+
+    for (let i = 0; i < nCards; i++) {
+      await test.step(`confirm card ${i}`, async () => {
+        const card = cards.nth(i)
+        const mainCard = card.locator('.SRC-portalCardMain')
+        await expect(mainCard, 'card has main div').toBeVisible()
+
+        const cardContent = mainCard.locator('.SRC-cardContent')
+        await expect(cardContent, 'main card has card content').toBeVisible()
+
+        const cardType = cardContent.locator('.SRC-type')
+        if (await cardType.isVisible()) {
+          expect(await cardType.textContent()).not.toBeNull()
+        }
+      })
+    }
+  })
+}
+
+const expectButtons = async (locator: Locator, buttonNames: string[]) => {
+  for (const buttonName of buttonNames) {
+    await expect(
+      locator.getByRole('button', { name: buttonName }),
+    ).toBeVisible()
+  }
+}
+
+const expectTopLevelControls = async (
+  page: Page,
+  exploreTab: string,
+  isTableTab: boolean,
+) => {
+  await test.step('expect top level controls', async () => {
+    const header = page.getByTestId('TopLevelControls')
+
+    await test.step('confirm heading', async () => {
+      let exploreTabHeading = exploreTab
+      if (
+        (getPortal() === 'arkportal' && exploreTab === 'All Data') ||
+        (getPortal() === 'elportal' && exploreTab === 'Data By Files')
+      ) {
+        exploreTabHeading = 'Data'
+      }
+      await expect(header.getByRole('heading')).toContainText(exploreTabHeading)
+    })
+
+    await test.step('confirm header buttons', async () => {
+      const buttonNames = [
+        'Hide filters',
+        'Show / Hide Search Bar',
+        'Copy this search to the clipboard',
+        'Show / Hide Visualizations',
+        // 'Download Options', - hidden in some portal tabs
+      ]
+      if (isTableTab) buttonNames.push('Show/Hide Columns')
+      await expectButtons(header, buttonNames)
+    })
+  })
+}
+
+const getFacetFilterControlsPanel = (page: Page) => {
+  return page.locator('.FacetFilterControls')
+}
+
+const getFacetFilterControls = (page: Page) => {
+  return getFacetFilterControlsPanel(page).locator(
+    '.FacetFilterControls__facet',
+  )
+}
+
+const getAvailableFacetsDiv = (page: Page) => {
+  return getFacetFilterControlsPanel(page)
+    .locator('> div')
+    .filter({ hasText: 'Available Facets' })
+}
+
+const expectFacetControls = async (page: Page) => {
+  await test.step('expect facet controls', async () => {
+    const facetControls = getFacetFilterControls(page)
+
+    await test.step('wait for facets to finish loading', async () => {
+      await expect(
+        facetControls.filter({ has: page.locator('.MuiSkeleton-root') }),
+      ).toHaveCount(0)
+    })
+
+    await test.step('confirm facet controls', async () => {
+      await expect.poll(() => facetControls.count()).toBeGreaterThanOrEqual(1)
+
+      const nFacetControls = await facetControls.count()
+      for (let i = 0; i < Math.min(nFacetControls, 3); i++) {
+        await test.step(`confirm facet control ${i}`, async () => {
+          const facetControl = facetControls.nth(i)
+          const facetControlHeader = facetControl.locator('.FacetFilterHeader')
+          await expect(facetControlHeader).toBeVisible()
+          expect(await facetControlHeader.textContent()).not.toBeNull()
+
+          const checkboxes = facetControl.getByRole('checkbox')
+          const radioButtons = facetControl
+            .getByRole('radiogroup')
+            .getByRole('radio')
+          await expect
+            .poll(() => checkboxes.or(radioButtons).count())
+            .toBeGreaterThanOrEqual(1)
+        })
+      }
+    })
+
+    await test.step('confirm available facets control', async () => {
+      const availableFacets = getAvailableFacetsDiv(page)
+      await expect(availableFacets).toBeVisible()
+      await expect
+        .poll(() => availableFacets.getByRole('button').count())
+        .toBeGreaterThanOrEqual(1)
+    })
+  })
+}
+
+const expectFacetCharts = async (page: Page) => {
+  await test.step('confirm facet charts', async () => {
+    const chartsPanel = page.locator('.FacetNav')
+    const chartCells = chartsPanel.locator('.FacetNavPanel:visible')
+
+    const nChartCells = await chartCells.count()
+    expect(nChartCells).toBeGreaterThanOrEqual(1)
+    expect(nChartCells).toBeLessThanOrEqual(2)
+
+    const availableFacetNames =
+      await test.step('get available facets', async () => {
+        const availableFacetButtons =
+          getAvailableFacetsDiv(page).getByRole('button')
+        const nAvailableFacets = await availableFacetButtons.count()
+        const availableFacetNames: string[] = []
+        for (let i = 0; i < nAvailableFacets; i++) {
+          const buttonText = await availableFacetButtons.nth(i).textContent()
+          buttonText && availableFacetNames.push(buttonText)
+        }
+        return availableFacetNames
+      })
+
+    for (let i = 0; i < nChartCells; i++) {
+      await test.step(`confirm chart ${i}`, async () => {
+        const chartCell = chartCells.nth(i)
+        await expect(chartCell).toBeVisible()
+
+        await test.step('confirm chart title', async () => {
+          const chartTitle = chartCell.locator('.FacetNavPanel__title')
+          const chartTitleText = await chartTitle.textContent()
+          expect(availableFacetNames).toContain(chartTitleText)
+          await expectButtons(chartTitle, [
+            'Filter by specific facet',
+            'Expand to large graph',
+            'Hide graph under Show More',
+          ])
+        })
+
+        await test.step('confirm chart body', async () => {
+          const chartBody = chartCell.locator('.FacetNavPanel__body')
+          await expect(chartBody.locator('.js-plotly-plot')).toBeVisible()
+          await expect(
+            chartBody.locator('.FacetNavPanel__body__legend'),
+          ).toBeVisible()
+        })
+      })
+    }
+
+    await test.step('confirm view all charts button', async () => {
+      const button = chartsPanel.getByRole('button', {
+        name: 'View All Charts',
+      })
+
+      const nFacetControlLabels = await getFacetFilterControls(page)
+        .locator('.FacetFilterHeader__label')
+        .count()
+      if (nFacetControlLabels <= 2) {
+        await expect(button).not.toBeVisible()
+      }
+      if (await button.isVisible()) {
+        expect(nFacetControlLabels).toBeGreaterThan(2)
+      }
+    })
+  })
+}
+
+const expectCharts = async (
+  page: Page,
+  exploreTab: string,
+  isTableTab: boolean,
+) => {
+  await test.step('confirm charts', async () => {
+    await expectTopLevelControls(page, exploreTab, isTableTab)
+    await expectFacetControls(page)
+    await expectFacetCharts(page)
+  })
+}
+
+const expectSynapseProfileHref = (href: string) => {
+  expect(href).toMatch(/^https:\/\/www\.synapse\.org\/#!Profile:\d{6,}$/)
+}
+
+const expectPeopleCards = async (page: Page) => {
+  await test.step('confirm people cards', async () => {
+    const cards = await test.step('expect people card list', async () => {
+      const cards = page.locator('.SRC-userCard')
+      await expect.poll(() => cards.count()).toBeGreaterThanOrEqual(1)
+      return cards
+    })
+
+    await test.step('expect people cards have subcomponents', async () => {
+      const nCards = await cards.count()
+      for (let i = 0; i < nCards; i++) {
+        await test.step(`confirm card ${i}`, async () => {
+          const card = cards.nth(i)
+
+          const isSynapseUser = await card
+            .filter({ has: cards.getByText('synapse') })
+            .isVisible()
+
+          if (isSynapseUser) {
+            await test.step('confirm profile pic link', async () => {
+              const profilePicLink = await card
+                .locator('> a')
+                .getAttribute('href')
+              expectSynapseProfileHref(profilePicLink || '')
+            })
+          }
+
+          await test.step('confirm card content', async () => {
+            const cardContent = card.locator('.SRC-cardContent')
+            await expect(cardContent).toBeVisible()
+
+            const userCardName = cardContent.locator('.SRC-userCardName')
+            await expect(userCardName).toBeVisible()
+            expect(await userCardName.textContent()).not.toBeNull()
+
+            if (isSynapseUser) {
+              const userCardNameLink = await userCardName
+                .getByRole('link')
+                .getAttribute('href')
+              expectSynapseProfileHref(userCardNameLink || '')
+
+              const emailText = await cardContent
+                .locator('.SRC-emailText')
+                .locator('a')
+                .textContent()
+              expect(emailText).toContain('@synapse.org')
+            }
+          })
+        })
+      }
+    })
+  })
+}
+
+const expectTable = async (page: Page, exploreTab: string) => {
+  await test.step('confirm table', async () => {
+    await expectTopLevelControls(page, exploreTab, true)
+
+    await test.step('table has loaded', async () => {
+      const progressBar = page.getByRole('progressbar').locator(':visible')
+      await expect(progressBar).toHaveCount(0, {
+        timeout: defaultExpectTimeout * 3,
+      })
+    })
+
+    await expectFacetControls(page)
+
+    await test.step('expect table body', async () => {
+      const table = page.getByRole('table')
+      await expect(table).toBeVisible()
+
+      const rows = table.getByRole('row')
+      const totalRowsText = await page.getByText('total rows').textContent()
+      const totalRows = Number(totalRowsText?.replace(/\D/g, ''))
+
+      await test.step('confirm total row count in heading', async () => {
+        const tabHeading = await page.getByRole('heading').textContent()
+        const totalRowsHeading = Number(tabHeading?.replace(/\D/g, '')) || 0
+        expect(totalRows).toEqual(totalRowsHeading)
+      })
+
+      await test.step('confirm rows shown matches page count or total rows', async () => {
+        const rowsPerPage = await page.getByRole('combobox').inputValue()
+        await expect(rows).toHaveCount(
+          // add one for the header row
+          Math.min(Number(rowsPerPage), totalRows) + 1,
+        )
+      })
+
+      await test.step('confirm column headers include buttons', async () => {
+        const colHeaders = rows.first()
+        expect(
+          await colHeaders.getByLabel('sort').count(),
+        ).toBeGreaterThanOrEqual(1)
+        expect(
+          await colHeaders.getByLabel('Filter by specific facet').count(),
+        ).toBeGreaterThanOrEqual(1)
+      })
+    })
+  })
+}
+
+test.describe('Explore', () => {
+  for (const [exploreTabType, exploreTabs] of Object.entries(
+    portalExploreConfig,
+  )) {
+    const exploreTabTypes = exploreTabType.split('_')
+
+    for (const exploreTab of exploreTabs) {
+      test(exploreTab, async ({ page }) => {
+        await goToExploreTab(page, exploreTab)
+
+        if (exploreTabTypes.includes('cards')) await expectCards(page)
+        if (exploreTabTypes.includes('charts')) {
+          await expectCharts(
+            page,
+            exploreTab,
+            exploreTabTypes.includes('table'),
+          )
+        }
+        if (exploreTabTypes.includes('people')) await expectPeopleCards(page)
+        if (exploreTabTypes.includes('table'))
+          await expectTable(page, exploreTab)
+      })
+    }
+  }
+})

--- a/apps/portals/e2e/helpers/banners.ts
+++ b/apps/portals/e2e/helpers/banners.ts
@@ -1,0 +1,38 @@
+import { Page, expect, test } from '@playwright/test'
+import bannerConfig, { BannerType } from '../configs/bannersConfig'
+import { getPortal } from '../helpers/portalInfo'
+
+type DismissBannerConfig = {
+  bodyText: string
+  closeButtonText?: string
+  closeButtonLabel?: string
+}
+const dismissBannerConfig: Record<BannerType, DismissBannerConfig> = {
+  beta: { bodyText: 'beta version', closeButtonLabel: 'Close' },
+  cookies: {
+    bodyText: 'Our site uses cookies',
+    closeButtonText: 'Accept and Continue',
+  },
+  survey: { bodyText: 'survey', closeButtonLabel: 'Close' },
+}
+const dismissBanner = async (page: Page, bannerType: BannerType) => {
+  await test.step(`dismiss ${bannerType} banner`, async () => {
+    const bannerConfig = dismissBannerConfig[bannerType]
+    const banner = page
+      .getByRole('alert')
+      .filter({ hasText: bannerConfig.bodyText })
+    const button = bannerConfig.closeButtonLabel
+      ? banner.getByLabel(bannerConfig.closeButtonLabel)
+      : banner.getByRole('button', { name: bannerConfig.closeButtonText })
+    await button.click()
+    await expect(banner).not.toBeVisible()
+  })
+}
+
+export const dismissBanners = async (page: Page) => {
+  const portal = getPortal()
+  const portalBanners = bannerConfig[portal]
+  for (const portalBanner of portalBanners) {
+    await dismissBanner(page, portalBanner)
+  }
+}

--- a/apps/portals/e2e/helpers/portalInfo.ts
+++ b/apps/portals/e2e/helpers/portalInfo.ts
@@ -1,0 +1,17 @@
+import { expect } from '@playwright/test'
+import { Portal } from '../configs/routesConfig'
+
+export const getPortal = () => {
+  expect(process.env.PORTAL).not.toBeUndefined()
+  return process.env.PORTAL! as Portal
+}
+
+export const getPortalTitle = () => {
+  expect(process.env.VITE_PORTAL_NAME).not.toBeUndefined()
+  return process.env.VITE_PORTAL_NAME!
+}
+
+export const getPortalDescription = () => {
+  expect(process.env.VITE_PORTAL_DESCRIPTION).not.toBeUndefined()
+  return process.env.VITE_PORTAL_DESCRIPTION!
+}

--- a/apps/portals/e2e/homepage.spec.ts
+++ b/apps/portals/e2e/homepage.spec.ts
@@ -1,0 +1,46 @@
+import { Page, expect, test } from '@playwright/test'
+import { viewports } from '../playwright.config'
+import routesConfig from './configs/routesConfig'
+import { getPortal, getPortalTitle } from './helpers/portalInfo'
+
+const expectNavRoutesAreVisible = async (page: Page) => {
+  const portalRouteConfig = routesConfig[getPortal()]
+  const nav = page.locator('.nav')
+
+  await test.step('nav buttons are visible', async () => {
+    for (const button of portalRouteConfig.buttons) {
+      await expect(nav.getByRole('button', { name: button })).toBeVisible()
+    }
+  })
+
+  await test.step('nav links are visible', async () => {
+    for (const link of portalRouteConfig.links) {
+      await expect(nav.getByRole('link', { name: link })).toBeVisible()
+    }
+  })
+}
+
+test.describe('Homepage', () => {
+  test('has title', async ({ page }) => {
+    await page.goto('/')
+    await expect(page).toHaveTitle(getPortalTitle())
+  })
+
+  test('has expanded nav', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('MENU')).not.toBeVisible()
+    await expectNavRoutesAreVisible(page)
+  })
+
+  test.describe('Smaller viewport', () => {
+    test.use({ viewport: viewports.collapsed })
+
+    test('has collapsed nav', async ({ page }) => {
+      await page.goto('/')
+      const menu = page.getByText('MENU')
+      await expect(menu).toBeVisible()
+      await menu.click()
+      await expectNavRoutesAreVisible(page)
+    })
+  })
+})

--- a/apps/portals/e2e/view_github_report.sh
+++ b/apps/portals/e2e/view_github_report.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# View Playwright report stored in GitHub
+#   ./view_github_report.sh [github-repo-owner] [github-run-id]
+#  
+
+# Abort script on errors and unbound variables
+# https://bertvv.github.io/cheat-sheets/Bash.html
+set -o errexit   # abort on nonzero exitstatus
+set -o nounset   # abort on unbound variable
+set -o pipefail  # don't hide errors within pipes
+
+# Set variables
+SCRIPT_PATH="$(cd "$(dirname "${0}")"; echo $(pwd))"
+PROJECT_PATH="$(dirname ${SCRIPT_PATH})"
+REPO_NAME="$(basename "$(dirname "$(dirname "$PROJECT_PATH")")")" # handle monorepo structure
+BLOB_DIR="${PROJECT_PATH}/blob-report/"
+REPORT_DIR="${PROJECT_PATH}/playwright-report/"
+
+# Get parameters from user
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 [github-repo-owner] [github-run-id]"
+  echo "* github-repo-owner: GitHub repo owner"
+  echo "* github-run-id: GitHub Run ID of report to view"
+  exit
+fi
+REPO_OWNER="${1}"
+RUN_ID="${2}"
+
+# Create directories, if necessary
+mkdir -p "${BLOB_DIR}"
+mkdir -p "${REPORT_DIR}"
+
+# Delete previous report files
+for file in $(find "${BLOB_DIR}" -type f) $(find "${REPORT_DIR}" -type f); do 
+  [ -f "${file}" ] && echo "delete: ${file}" && rm "${file}"
+done
+
+# Get workflow artifact id and name
+ARTIFACT=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "/repos/${REPO_OWNER}/${REPO_NAME}/actions/runs/${RUN_ID}/artifacts" \
+  | jq '.artifacts[] | select(.name | contains("html-report")) | {id, name}')
+ARTIFACT_ID=$(echo "${ARTIFACT}" | jq '.id')
+ARTIFACT_NAME=$(echo "${ARTIFACT}" | jq -r '.name')
+
+# Download workflow artifact
+ARTIFACT_ENDPOINT="/repos/${REPO_OWNER}/${REPO_NAME}/actions/artifacts/${ARTIFACT_ID}/zip"
+ARTIFACT_ZIP="${BLOB_DIR}/${ARTIFACT_NAME}.zip"
+echo "download: ${ARTIFACT_ENDPOINT} to ${ARTIFACT_ZIP}"
+gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "${ARTIFACT_ENDPOINT}" > "${ARTIFACT_ZIP}"
+
+# Unzip file
+unzip "${ARTIFACT_ZIP}" -d "${REPORT_DIR}"
+
+# Show report
+pnpm nx run portals:e2e:report

--- a/apps/portals/package.json
+++ b/apps/portals/package.json
@@ -38,9 +38,18 @@
     "test": "pnpm run copy-test-configuration && vitest",
     "test:ci": "pnpm run copy-test-configuration && vitest run --coverage",
     "generate-sitemap": "node sitemap/generate-sitemap.cjs",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "portal:build": "export $(grep -v '^#' .env | xargs); chmod +x ./build.sh; ./build.sh ${PORTAL}",
+    "portal:start": "pnpm run start >/dev/null 2>&1 &",
+    "portal:stop": "pid=$(lsof -i :3000 -t) && kill ${pid}",
+    "e2e": "playwright test",
+    "e2e:chromium": "playwright test --project=chromium",
+    "e2e:report": "pnpm exec playwright show-report",
+    "e2e:report:blob": "pnpm exec playwright merge-reports --reporter html ./blob-report && pnpm e2e:report",
+    "playwright:update": "pnpm add -D @playwright/test@latest; pnpm playwright install"
   },
   "devDependencies": {
+    "@playwright/test": "^1.40.1",
     "@sage-bionetworks/synapse-types": "workspace:*",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^13.4.0",
@@ -58,6 +67,7 @@
     "@vitest/utils": "^0.34.6",
     "assert": "^2.0.0",
     "buffer": "^6.0.3",
+    "dotenv": "^16.3.1",
     "https-browserify": "^1.0.0",
     "identity-obj-proxy": "^3.0.0",
     "jsdom": "^21.1.2",

--- a/apps/portals/playwright.config.ts
+++ b/apps/portals/playwright.config.ts
@@ -1,0 +1,93 @@
+import { defineConfig, devices } from '@playwright/test'
+import dotenv from 'dotenv'
+import path from 'path'
+
+const baseURL = 'http://localhost:3000'
+export const viewports = {
+  expanded: { width: 1600, height: 1200 },
+  collapsed: { width: 1280, height: 720 },
+}
+export const defaultExpectTimeout = 10 * 1000
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+dotenv.config()
+dotenv.config({
+  path: path.resolve(`src/configurations/${process.env.PORTAL!}/.env`),
+})
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  /* Timeouts */
+  expect: {
+    timeout: defaultExpectTimeout,
+  },
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 1 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : 2,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: process.env.CI ? [['list'], ['blob']] : 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: baseURL,
+
+    /* Collect traces. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], viewport: viewports.expanded },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'], viewport: viewports.expanded },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'], viewport: viewports.expanded },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'pnpm portal:start',
+    url: baseURL,
+    reuseExistingServer: true,
+  },
+})

--- a/apps/portals/tsconfig.json
+++ b/apps/portals/tsconfig.json
@@ -10,6 +10,12 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": false
   },
-  "include": ["src/**/*.tsx", "src/**/*.ts"],
+  "include": [
+    "src/**/*.tsx",
+    "src/**/*.ts",
+    "e2e/**.ts",
+    "e2e/**/**.ts",
+    "playwright.config.ts"
+  ],
   "files": ["src/types.d.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/synapse-react-client
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.40.1
+        version: 1.40.1
       '@sage-bionetworks/synapse-types':
         specifier: workspace:*
         version: link:../../packages/synapse-types
@@ -401,6 +404,9 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
       https-browserify:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4511,6 +4517,14 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@playwright/test@1.40.1:
+    resolution: {integrity: sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright: 1.40.1
+    dev: true
 
   /@plotly/d3-sankey-circular@0.33.1:
     resolution: {integrity: sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==}
@@ -15070,6 +15084,22 @@ packages:
       jsonc-parser: 3.2.0
       mlly: 1.4.0
       pathe: 1.1.1
+
+  /playwright-core@1.40.1:
+    resolution: {integrity: sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dev: true
+
+  /playwright@1.40.1:
+    resolution: {integrity: sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.40.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
 
   /plotly.js-basic-dist@2.24.3:
     resolution: {integrity: sha512-fiVn3XTl7acMUp/Th9QDflmaK/EtId28U8SF1kmPgpwQaiTvP7M5u1XLeXIsEsSbDOmtWfr5hEpKYwcc2TcjEA==}


### PR DESCRIPTION
- Use Playwright for e2e testing of Portals 
- Add general e2e tests for all Portals for Homepage links and Explore tabs 
- Run e2e tests on push/PR to main Sage branch and on all pushes to forked repos. See example workflow [here](https://github.com/Sage-Bionetworks/synapse-web-monorepo/actions/runs/7252816010)
- Download and review e2e report with traces by following [these steps](https://github.com/hallieswan/synapse-web-monorepo/tree/PORTALS-2872/apps/portals/e2e#ci)