### PR TITLE
SWC-6618: create list of associated projects for an AR

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementRelatedProjectsList/AccessRequirementRelatedProjectsList.stories.ts
+++ b/packages/synapse-react-client/src/components/AccessRequirementRelatedProjectsList/AccessRequirementRelatedProjectsList.stories.ts
@@ -1,0 +1,22 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { AccessRequirementRelatedProjectsList } from './AccessRequirementRelatedProjectsList'
+
+const meta = {
+  title: 'Governance/AccessRequirementRelatedProjects',
+  component: AccessRequirementRelatedProjectsList,
+} satisfies Meta
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const ManyProjects: Story = {
+  args: {
+    accessRequirementId: 9603055,
+  },
+}
+
+export const OneProject: Story = {
+  args: {
+    accessRequirementId: 9605913,
+  },
+}

--- a/packages/synapse-react-client/src/components/AccessRequirementRelatedProjectsList/AccessRequirementRelatedProjectsList.stories.ts
+++ b/packages/synapse-react-client/src/components/AccessRequirementRelatedProjectsList/AccessRequirementRelatedProjectsList.stories.ts
@@ -1,8 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { AccessRequirementRelatedProjectsList } from './AccessRequirementRelatedProjectsList'
+import { MOCK_REPO_ORIGIN } from '../../utils/functions/getEndpoint'
+import { rest } from 'msw'
+import { ACCESS_REQUIREMENT_SEARCH } from '../../utils/APIConstants'
 
 const meta = {
-  title: 'Governance/AccessRequirementRelatedProjects',
+  title: 'Governance/AccessRequirementRelatedProjectsList',
   component: AccessRequirementRelatedProjectsList,
 } satisfies Meta
 export default meta
@@ -18,5 +21,40 @@ export const ManyProjects: Story = {
 export const OneProject: Story = {
   args: {
     accessRequirementId: 9605913,
+  },
+}
+
+export const ZeroProjectsMock: Story = {
+  args: {
+    accessRequirementId: 1234567,
+  },
+  parameters: {
+    stack: 'mock',
+    msw: {
+      handlers: [
+        // searchAccessRequirements
+        rest.post(
+          `${MOCK_REPO_ORIGIN}${ACCESS_REQUIREMENT_SEARCH}`,
+
+          async (req, res, ctx) => {
+            const zeroRelatedProjects = {
+              results: [
+                {
+                  id: '1234567',
+                  type: 'org.sagebionetworks.repo.model.ManagedACTAccessRequirement',
+                  createdOn: '2017-08-23T18:48:20.892Z',
+                  modifiedOn: '2023-12-14T00:43:41.315Z',
+                  name: 'Team AR without Related Projects',
+                  version: '1',
+                  relatedProjectIds: [],
+                  reviewerIds: [],
+                },
+              ],
+            }
+            return res(ctx.status(200), ctx.json(zeroRelatedProjects))
+          },
+        ),
+      ],
+    },
   },
 }

--- a/packages/synapse-react-client/src/components/AccessRequirementRelatedProjectsList/AccessRequirementRelatedProjectsList.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementRelatedProjectsList/AccessRequirementRelatedProjectsList.tsx
@@ -3,6 +3,7 @@ import { AccessRequirementSearchRequest } from '@sage-bionetworks/synapse-types'
 import { useSearchAccessRequirementsInfinite } from '../../synapse-queries'
 import { EntityLink } from '../EntityLink'
 import { Alert, List, ListItem, Typography } from '@mui/material'
+import pluralize from 'pluralize'
 
 export type AccessRequirementRelatedProjectsListProps = {
   accessRequirementId: number
@@ -20,9 +21,11 @@ export const AccessRequirementRelatedProjectsList = (
   const ar = data?.pages.flatMap(page => page.results)[0] ?? undefined
 
   const nRelatedProjects = ar?.relatedProjectIds.length || 0
-  const relatedProjectsTitle = `${nRelatedProjects} project${
-    nRelatedProjects === 1 ? '' : 's'
-  }${nRelatedProjects > 0 ? ':' : ''}`
+  const relatedProjectsTitle = `${pluralize(
+    'project',
+    nRelatedProjects,
+    true,
+  )}${nRelatedProjects > 0 ? ':' : ''}`
 
   return (
     <>

--- a/packages/synapse-react-client/src/components/AccessRequirementRelatedProjectsList/AccessRequirementRelatedProjectsList.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementRelatedProjectsList/AccessRequirementRelatedProjectsList.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { AccessRequirementSearchRequest } from '@sage-bionetworks/synapse-types'
+import { useSearchAccessRequirementsInfinite } from '../../synapse-queries'
+import { EntityLink } from '../EntityLink'
+import { Alert, List, ListItem, Typography } from '@mui/material'
+
+export type AccessRequirementRelatedProjectsListProps = {
+  accessRequirementId: number
+}
+
+export const AccessRequirementRelatedProjectsList = (
+  props: AccessRequirementRelatedProjectsListProps,
+) => {
+  const searchRequest: Omit<AccessRequirementSearchRequest, 'nextPageToken'> = {
+    ids: [props.accessRequirementId],
+  }
+
+  const { data, isError, error } =
+    useSearchAccessRequirementsInfinite(searchRequest)
+  const ar = data?.pages.flatMap(page => page.results)[0] ?? undefined
+
+  const nRelatedProjects = ar?.relatedProjectIds.length || 0
+  const relatedProjectsTitle = `${nRelatedProjects} project${
+    nRelatedProjects === 1 ? '' : 's'
+  }${nRelatedProjects > 0 ? ':' : ''}`
+
+  return (
+    <>
+      {ar && (
+        <>
+          <Typography variant="body1">{relatedProjectsTitle}</Typography>
+          <List sx={{ listStyleType: 'disc', pl: 4 }}>
+            {ar.relatedProjectIds.map(projectId => (
+              <ListItem
+                sx={{
+                  display: 'list-item',
+                  py: '4px',
+                  // remove extra margin added by type.less to p tags
+                  '.no-margin-y': { my: 0 },
+                }}
+                key={projectId}
+              >
+                <EntityLink
+                  entity={projectId}
+                  link={false}
+                  showIcon={false}
+                  className="no-margin-y"
+                />
+              </ListItem>
+            ))}
+          </List>
+        </>
+      )}
+      {isError && <Alert severity="error">{error.message}</Alert>}
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/components/AccessRequirementRelatedProjectsList/index.ts
+++ b/packages/synapse-react-client/src/components/AccessRequirementRelatedProjectsList/index.ts
@@ -1,0 +1,7 @@
+import { AccessRequirementRelatedProjectsList } from './AccessRequirementRelatedProjectsList'
+import type { AccessRequirementRelatedProjectsListProps } from './AccessRequirementRelatedProjectsList'
+export {
+  AccessRequirementRelatedProjectsList,
+  AccessRequirementRelatedProjectsListProps,
+}
+export default AccessRequirementRelatedProjectsList

--- a/packages/synapse-react-client/src/components/EntityLink.tsx
+++ b/packages/synapse-react-client/src/components/EntityLink.tsx
@@ -84,7 +84,9 @@ export const EntityLink = (props: EntityLinkProps) => {
     } else {
       return (
         <p className={className}>
-          <EntityTypeIcon type={type} style={{ marginRight: '6px' }} />
+          {showIcon && (
+            <EntityTypeIcon type={type} style={{ marginRight: '6px' }} />
+          )}
           {entity[displayTextField as keyof typeof entity]}
         </p>
       )

--- a/packages/synapse-react-client/src/components/index.ts
+++ b/packages/synapse-react-client/src/components/index.ts
@@ -61,6 +61,7 @@ export * from './UserCardList'
 export * from './UserOrTeamBadge'
 export * from './UserProfileLinks'
 export * from './EntityHeaderTable'
+export * from './AccessRequirementRelatedProjectsList'
 
 // TODO: Find a better way to expose Icon components
 export { Project as ProjectIcon } from '../assets/themed_icons/Project'

--- a/packages/synapse-react-client/src/umd.index.ts
+++ b/packages/synapse-react-client/src/umd.index.ts
@@ -71,6 +71,7 @@ import AccessRequirementList from './components/AccessRequirementList/AccessRequ
 import { BackendDestinationEnum } from './utils/functions'
 import TableColumnSchemaForm from './components/TableColumnSchemaEditor/TableColumnSchemaForm'
 import EntityHeaderTable from './components/EntityHeaderTable'
+import AccessRequirementRelatedProjectsList from './components/AccessRequirementRelatedProjectsList'
 
 // Also include scss in the bundle
 import './style/main.scss'
@@ -147,6 +148,7 @@ const SynapseComponents = {
   AccessRequirementList,
   TableColumnSchemaForm,
   EntityHeaderTable,
+  AccessRequirementRelatedProjectsList,
 }
 
 // Include the version in the build

--- a/packages/synapse-types/src/AccessRequirement/AccessRequirementSearch.ts
+++ b/packages/synapse-types/src/AccessRequirement/AccessRequirementSearch.ts
@@ -8,6 +8,8 @@ export type AccessRequirementSearchSort = {
 export interface AccessRequirementSearchRequest {
   /** Optional substring used to filter Access Requirements by name */
   nameContains?: string
+  /** Optional list of ids used to filter access requirements with specific ids. */
+  ids?: number[]
   /** Optional id used to filter Access Requirements to retrieve only those that have been applied within a particular project. */
   relatedProjectId?: string
   /** Optional principal ID used to filter Access Requirements to retrieve only those that can be reviewed by the specific reviewer. */


### PR DESCRIPTION
Will be used in SWC to display a list of associated projects on each AR page. See SWC changes [here](https://github.com/Sage-Bionetworks/SynapseWebClient/pull/5247).