### PR TITLE
SWC-6617: add AR type column to AR table in ACT dashboard

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
@@ -4,11 +4,15 @@ import useGetInfoFromIds, {
   UseGetInfoFromIdsProps,
 } from '../../utils/hooks/useGetInfoFromIds'
 import {
+  ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   AccessRequirement,
   EntityHeader,
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   ManagedACTAccessRequirement,
   Renewal,
   Request,
+  SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
 } from '@sage-bionetworks/synapse-types'
 import IconSvg from '../IconSvg/IconSvg'
 import StandaloneLoginForm from '../Authentication/StandaloneLoginForm'
@@ -58,10 +62,10 @@ export type AccessRequirementListProps = {
 const SUPPORTED_ACCESS_REQUIREMENTS = new Set<
   AccessRequirement['concreteType']
 >([
-  'org.sagebionetworks.repo.model.SelfSignAccessRequirement',
-  'org.sagebionetworks.repo.model.TermsOfUseAccessRequirement',
-  'org.sagebionetworks.repo.model.ManagedACTAccessRequirement',
-  'org.sagebionetworks.repo.model.ACTAccessRequirement',
+  SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
 ])
 
 const DialogSubsectionHeader: StyledComponent<TypographyProps> = styled(
@@ -207,25 +211,25 @@ export default function AccessRequirementList(
   const anyARsRequireTwoFactorAuth = accessRequirements?.some(
     accessRequirement =>
       accessRequirement.concreteType ===
-        'org.sagebionetworks.repo.model.ManagedACTAccessRequirement' &&
+        MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE &&
       accessRequirement.isTwoFaRequired,
   )
 
   const anyARsRequireCertification = accessRequirements?.some(
     accessRequirement =>
       (accessRequirement.concreteType ===
-        'org.sagebionetworks.repo.model.ManagedACTAccessRequirement' ||
+        MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE ||
         accessRequirement.concreteType ===
-          'org.sagebionetworks.repo.model.SelfSignAccessRequirement') &&
+          SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE) &&
       accessRequirement.isCertifiedUserRequired,
   )
 
   const anyARsRequireProfileValidation = accessRequirements?.some(
     accessRequirement =>
       (accessRequirement.concreteType ===
-        'org.sagebionetworks.repo.model.ManagedACTAccessRequirement' ||
+        MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE ||
         accessRequirement.concreteType ===
-          'org.sagebionetworks.repo.model.SelfSignAccessRequirement') &&
+          SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE) &&
       accessRequirement.isValidatedProfileRequired,
   )
 

--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementListItem.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementListItem.tsx
@@ -1,6 +1,10 @@
 import {
+  ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   AccessRequirement,
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   ManagedACTAccessRequirement,
+  SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
 } from '@sage-bionetworks/synapse-types'
 import UnmanagedACTAccessRequirementItem from './RequirementItem/UnmanagedACTAccessRequirementItem'
 import ManagedACTAccessRequirementItem from './ManagedACTAccessRequirementRequestFlow/ManagedACTAccessRequirementItem'
@@ -22,15 +26,15 @@ export function AccessRequirementListItem(
 ) {
   const { accessRequirement, entityId, onHide, onRequestAccess } = props
   switch (accessRequirement.concreteType) {
-    case 'org.sagebionetworks.repo.model.SelfSignAccessRequirement':
-    case 'org.sagebionetworks.repo.model.TermsOfUseAccessRequirement':
+    case SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+    case TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
       return (
         <SelfSignAccessRequirementItem
           accessRequirement={accessRequirement}
           onHide={onHide}
         />
       )
-    case 'org.sagebionetworks.repo.model.ACTAccessRequirement':
+    case ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
       return (
         <UnmanagedACTAccessRequirementItem
           accessRequirement={accessRequirement}
@@ -38,7 +42,7 @@ export function AccessRequirementListItem(
           entityId={entityId}
         />
       )
-    case 'org.sagebionetworks.repo.model.ManagedACTAccessRequirement':
+    case MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
       return (
         <ManagedACTAccessRequirementItem
           accessRequirement={accessRequirement}

--- a/packages/synapse-react-client/src/components/DownloadCart/MeetAccessRequirementCard.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/DownloadCart/MeetAccessRequirementCard.integration.test.tsx
@@ -22,6 +22,7 @@ import {
   BackendDestinationEnum,
   getEndpoint,
 } from '../../utils/functions/getEndpoint'
+import { AccessRequirement } from '@sage-bionetworks/synapse-types'
 
 const ACCESS_REQUIREMENT_ID = 1111
 const defaultProps: MeetAccessRequirementCardProps = {
@@ -29,7 +30,9 @@ const defaultProps: MeetAccessRequirementCardProps = {
   count: 10,
 }
 
-const setupAccessRequirementResponse = (accessRequirement: any) => {
+const setupAccessRequirementResponse = (
+  accessRequirement: AccessRequirement,
+) => {
   server.use(
     rest.get(
       `${getEndpoint(

--- a/packages/synapse-react-client/src/components/DownloadCart/MeetAccessRequirementCard.tsx
+++ b/packages/synapse-react-client/src/components/DownloadCart/MeetAccessRequirementCard.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react'
 import { useGetAccessRequirements } from '../../synapse-queries/dataaccess/useAccessRequirements'
-import { SelfSignAccessRequirement } from '@sage-bionetworks/synapse-types'
+import {
+  ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  SelfSignAccessRequirement,
+  TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+} from '@sage-bionetworks/synapse-types'
 import {
   EASY_DIFFICULTY,
   MEDIUM_DIFFICULTY,
@@ -37,12 +44,12 @@ export const MeetAccessRequirementCard: React.FunctionComponent<
 
   if (!isLoading && ar) {
     switch (ar.concreteType) {
-      case 'org.sagebionetworks.repo.model.TermsOfUseAccessRequirement':
+      case TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
         title = TERMS_OF_USE_TITLE
         iconType = EASY_DIFFICULTY
         description = ar.name ?? ''
         break
-      case 'org.sagebionetworks.repo.model.SelfSignAccessRequirement': {
+      case SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE: {
         title = SELF_SIGN_TITLE
         const selfSignAR: SelfSignAccessRequirement = ar
         if (selfSignAR.isValidatedProfileRequired) {
@@ -55,13 +62,13 @@ export const MeetAccessRequirementCard: React.FunctionComponent<
         description = ar.name ?? ''
         break
       }
-      case 'org.sagebionetworks.repo.model.ManagedACTAccessRequirement':
-      case 'org.sagebionetworks.repo.model.ACTAccessRequirement':
+      case MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+      case ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
         title = ACT_TITLE
         iconType = VARIABLE_DIFFICULTY
         description = ar.name ?? ''
         break
-      case 'org.sagebionetworks.repo.model.LockAccessRequirement':
+      case LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
         title = LOCK_TITLE
         iconType = VARIABLE_DIFFICULTY
         description =

--- a/packages/synapse-react-client/src/components/dataaccess/AccessRequirementTable.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/AccessRequirementTable.tsx
@@ -6,7 +6,20 @@ import { formatDate } from '../../utils/functions/DateFormatter'
 import { PRODUCTION_ENDPOINT_CONFIG } from '../../utils/functions/getEndpoint'
 import { useSearchAccessRequirementsInfinite } from '../../synapse-queries/dataaccess/useAccessRequirements'
 import { ACT_TEAM_ID } from '../../utils/SynapseConstants'
-import { ACCESS_TYPE } from '@sage-bionetworks/synapse-types'
+import {
+  ACCESS_REQUIREMENT_CONCRETE_TYPE,
+  ACCESS_TYPE,
+  ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE,
+  LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE,
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE,
+  SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE,
+  TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE,
+} from '@sage-bionetworks/synapse-types'
 import {
   AccessRequirementSearchRequest,
   AccessRequirementSearchSort,
@@ -23,6 +36,26 @@ export type AccessRequirementTableProps = {
   reviewerId?: string
   accessType?: ACCESS_TYPE
   onCreateNewAccessRequirementClicked?: () => void
+}
+
+export function accessRequirementConcreteTypeValueToDisplayValue(
+  accessRequirementConcreteTypeValue: ACCESS_REQUIREMENT_CONCRETE_TYPE,
+) {
+  switch (accessRequirementConcreteTypeValue) {
+    case TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+      return TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE
+    case SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE: {
+      return SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE
+    }
+    case MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+      return MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE
+    case ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+      return ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE
+    case LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+      return LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE
+    default:
+      return 'Unknown'
+  }
 }
 
 export function AccessRequirementTable(props: AccessRequirementTableProps) {
@@ -98,6 +131,7 @@ export function AccessRequirementTable(props: AccessRequirementTableProps) {
                   />
                 </span>
               </th>
+              <th>Type</th>
               <th>Related to Projects</th>
               <th>Reviewer</th>
               <th>Last Modified</th>
@@ -129,6 +163,9 @@ export function AccessRequirementTable(props: AccessRequirementTableProps) {
                     </a>
                   </td>
                   <td>{ar.name}</td>
+                  <td>
+                    {accessRequirementConcreteTypeValueToDisplayValue(ar.type)}
+                  </td>
                   <td>
                     {ar.relatedProjectIds.map(projectId => (
                       <React.Fragment key={projectId}>

--- a/packages/synapse-react-client/src/mocks/mockAccessRequirements.ts
+++ b/packages/synapse-react-client/src/mocks/mockAccessRequirements.ts
@@ -1,16 +1,21 @@
 import {
   ACCESS_TYPE,
   AccessRequirement,
+  AccessRequirementSearchResponse,
+  ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   ACTAccessRequirement,
+  LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   LockAccessRequirement,
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   ManagedACTAccessRequirement,
   ObjectType,
   RestrictableObjectType,
+  SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   SelfSignAccessRequirement,
+  TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   TermsOfUseAccessRequirement,
   WikiPageKey,
 } from '@sage-bionetworks/synapse-types'
-import { AccessRequirementSearchResponse } from '@sage-bionetworks/synapse-types'
 import mockProjectData from './entity/mockProject'
 import { MOCK_USER_ID } from './user/mock_user_profile'
 import {
@@ -44,7 +49,7 @@ const defaultAccessRequirement = {
 export const mockManagedACTAccessRequirement: ManagedACTAccessRequirement = {
   ...defaultAccessRequirement,
   id: 1,
-  concreteType: 'org.sagebionetworks.repo.model.ManagedACTAccessRequirement',
+  concreteType: MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   areOtherAttachmentsRequired: true,
   isCertifiedUserRequired: true,
   isDUCRequired: true,
@@ -68,7 +73,7 @@ export const mockManagedACTAccessRequirementWikiPageKey: WikiPageKey = {
 export const mockToUAccessRequirement: TermsOfUseAccessRequirement = {
   ...defaultAccessRequirement,
   id: 2,
-  concreteType: 'org.sagebionetworks.repo.model.TermsOfUseAccessRequirement',
+  concreteType: TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   termsOfUse:
     'These are the termsOfUse for a TermsOfUseAccessRequirement. The content is inlined in the object, but **markdown** is supported.',
   description: '',
@@ -78,7 +83,7 @@ export const mockToUAccessRequirement: TermsOfUseAccessRequirement = {
 export const mockSelfSignAccessRequirement: SelfSignAccessRequirement = {
   ...defaultAccessRequirement,
   id: 3,
-  concreteType: 'org.sagebionetworks.repo.model.SelfSignAccessRequirement',
+  concreteType: SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   isCertifiedUserRequired: true,
   isValidatedProfileRequired: true,
   description: '',
@@ -94,7 +99,7 @@ export const mockSelfSignAccessRequirementWikiPageKey: WikiPageKey = {
 export const mockACTAccessRequirement: ACTAccessRequirement = {
   ...defaultAccessRequirement,
   id: 4,
-  concreteType: 'org.sagebionetworks.repo.model.ACTAccessRequirement',
+  concreteType: ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   actContactInfo:
     'This is the actContactInfo for the ACTAccessRequirement. You would probably email some documentation to act@sagebase.org, or something like that. **Markdown is supported**.',
   openJiraIssue: true,
@@ -105,7 +110,7 @@ export const mockACTAccessRequirement: ACTAccessRequirement = {
 export const mockLockAccessRequirement: LockAccessRequirement = {
   ...defaultAccessRequirement,
   id: 5,
-  concreteType: 'org.sagebionetworks.repo.model.LockAccessRequirement',
+  concreteType: LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   description: '',
   subjectsDefinedByAnnotations: false,
   jiraKey: '',
@@ -114,7 +119,7 @@ export const mockLockAccessRequirement: LockAccessRequirement = {
 export const mockToUAccessRequirementWithWiki: TermsOfUseAccessRequirement = {
   ...defaultAccessRequirement,
   id: 6,
-  concreteType: 'org.sagebionetworks.repo.model.TermsOfUseAccessRequirement',
+  concreteType: TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   // termsOfUse:
   //   'These are the terms of use for a TermsOfUseAccessRequirement. The content is inlined in the object, but **markdown** is supported.',
   description: '',
@@ -130,7 +135,7 @@ export const mockToUAccessRequirementWithWikiPageKey: WikiPageKey = {
 export const mockACTAccessRequirementWithWiki: ACTAccessRequirement = {
   ...defaultAccessRequirement,
   id: 7,
-  concreteType: 'org.sagebionetworks.repo.model.ACTAccessRequirement',
+  concreteType: ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   // actContactInfo:
   //   'This is the contact info for the ACTAccessRequirement. You would probably email some documentation to act@sagebase.org, or something like that. **Markdown is supported**.',
   openJiraIssue: true,
@@ -149,6 +154,7 @@ export const mockSearchResults: AccessRequirementSearchResponse = {
     {
       id: mockManagedACTAccessRequirement.id.toString(),
       createdOn: mockManagedACTAccessRequirement.createdOn,
+      type: mockManagedACTAccessRequirement.concreteType,
       modifiedOn: mockManagedACTAccessRequirement.modifiedOn,
       name: mockManagedACTAccessRequirement.name,
       version: mockManagedACTAccessRequirement.versionNumber.toString(),
@@ -158,6 +164,7 @@ export const mockSearchResults: AccessRequirementSearchResponse = {
     {
       id: '9603055',
       createdOn: '2017-08-23T18:48:20.892Z',
+      type: ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
       modifiedOn: '2022-05-20T22:26:44.406Z',
       name: 'Access Requiremnent 2',
       version: '269',
@@ -167,6 +174,7 @@ export const mockSearchResults: AccessRequirementSearchResponse = {
     {
       id: '9605257',
       createdOn: '2021-01-15T17:05:10.544Z',
+      type: ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
       modifiedOn: '2021-01-15T17:13:06.767Z',
       name: 'Another AR',
       version: '3',
@@ -176,6 +184,7 @@ export const mockSearchResults: AccessRequirementSearchResponse = {
     {
       id: '9605529',
       createdOn: '2021-12-20T17:42:32.822Z',
+      type: ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
       modifiedOn: '2021-12-20T18:17:46.904Z',
       name: 'Some mock ARs',
       version: '5',

--- a/packages/synapse-react-client/src/mocks/msw/handlers/accessRequirementHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/accessRequirementHandlers.ts
@@ -9,6 +9,7 @@ import { MOCK_REPO_ORIGIN } from '../../../utils/functions/getEndpoint'
 import {
   AccessRequirement,
   AccessRequirementStatus,
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   ObjectType,
   PaginatedResults,
   SubmissionState,
@@ -101,7 +102,7 @@ export const getAccessRequirementStatusHandlers = (
       if (!response && accessRequirement) {
         const isManagedACTAR =
           accessRequirement.concreteType ===
-          'org.sagebionetworks.repo.model.ManagedACTAccessRequirement'
+          MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
         response = {
           accessRequirementId: req.params.id as string,
           concreteType: isManagedACTAR

--- a/packages/synapse-react-client/src/utils/types/IsType.ts
+++ b/packages/synapse-react-client/src/utils/types/IsType.ts
@@ -28,6 +28,7 @@ import {
   PROXY_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   S3FileHandle,
+  TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   TermsOfUseAccessRequirement,
   TEXT_MATCHES_QUERY_FILTER_CONCRETE_TYPE_VALUE,
   TextMatchesQueryFilter,
@@ -106,7 +107,7 @@ export const isFileEntity = isTypeViaConcreteTypeFactory<FileEntity>(
 )
 export const isTermsOfUseAccessRequirement =
   isTypeViaConcreteTypeFactory<TermsOfUseAccessRequirement>(
-    'org.sagebionetworks.repo.model.TermsOfUseAccessRequirement',
+    TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
   )
 export const isInviteeVerificationSignedToken =
   isTypeViaConcreteTypeFactory<InviteeVerificationSignedToken>(

--- a/packages/synapse-types/src/AccessRequirement/ACTAccessRequirement.ts
+++ b/packages/synapse-types/src/AccessRequirement/ACTAccessRequirement.ts
@@ -1,6 +1,12 @@
 import ACCESS_TYPE from '../ACCESS_TYPE'
 import { RestrictableObjectDescriptor } from './RestrictableObjectDescriptor'
 
+export const ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE = 'Basic'
+export const ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE =
+  'org.sagebionetworks.repo.model.ACTAccessRequirement'
+export type ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE =
+  typeof ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+
 //https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/ACTAccessRequirement.html
 export interface ACTAccessRequirement {
   /* The version number issued to this version on the object. */
@@ -28,7 +34,7 @@ export interface ACTAccessRequirement {
   /* The enumeration of possible permission. */
   accessType: ACCESS_TYPE
   /* Indicates which type of AccessRequirement this object represents. Provided by the system, the user may not set this field. */
-  concreteType: 'org.sagebionetworks.repo.model.ACTAccessRequirement'
+  concreteType: ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE
   /* Information on how to contact the Synapse ACT for access approval (external to Synapse). */
   actContactInfo?: string
   /* If true, then in addition to following directions in the 'actContactInfo' the client should open a JIRA issue to notify the ACT. If omitted, default is 'true'. */

--- a/packages/synapse-types/src/AccessRequirement/ACTAccessRequirementInterface.ts
+++ b/packages/synapse-types/src/AccessRequirement/ACTAccessRequirementInterface.ts
@@ -1,5 +1,15 @@
-import { ACTAccessRequirement } from './ACTAccessRequirement'
-import { ManagedACTAccessRequirement } from './ManagedACTAccessRequirement'
+import {
+  ACTAccessRequirement,
+  ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE,
+} from './ACTAccessRequirement'
+import {
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE,
+  ManagedACTAccessRequirement,
+} from './ManagedACTAccessRequirement'
+
+export type ACT_ACCESS_REQUIREMENT_INTERFACE_CONCRETE_TYPE =
+  | ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE
+  | MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE
 
 export type ACTAccessRequirementInterface =
   | ACTAccessRequirement

--- a/packages/synapse-types/src/AccessRequirement/AccessRequirement.ts
+++ b/packages/synapse-types/src/AccessRequirement/AccessRequirement.ts
@@ -1,6 +1,20 @@
-import { SelfSignAccessRequirementInterface } from './SelfSignAccessRequirementInterface'
-import { ACTAccessRequirementInterface } from './ACTAccessRequirementInterface'
-import { LockAccessRequirement } from './LockAccessRequirement'
+import {
+  ACT_ACCESS_REQUIREMENT_INTERFACE_CONCRETE_TYPE,
+  ACTAccessRequirementInterface,
+} from './ACTAccessRequirementInterface'
+import {
+  LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE,
+  LockAccessRequirement,
+} from './LockAccessRequirement'
+import {
+  SELF_SIGN_ACCESS_REQUIREMENT_INTERFACE_CONCRETE_TYPE,
+  SelfSignAccessRequirementInterface,
+} from './SelfSignAccessRequirementInterface'
+
+export type ACCESS_REQUIREMENT_CONCRETE_TYPE =
+  | LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE
+  | SELF_SIGN_ACCESS_REQUIREMENT_INTERFACE_CONCRETE_TYPE
+  | ACT_ACCESS_REQUIREMENT_INTERFACE_CONCRETE_TYPE
 
 export type AccessRequirement =
   | LockAccessRequirement

--- a/packages/synapse-types/src/AccessRequirement/AccessRequirementSearch.ts
+++ b/packages/synapse-types/src/AccessRequirement/AccessRequirementSearch.ts
@@ -1,4 +1,5 @@
 import ACCESS_TYPE from '../ACCESS_TYPE'
+import { ACCESS_REQUIREMENT_CONCRETE_TYPE } from './AccessRequirement'
 
 export type AccessRequirementSearchSort = {
   field: 'CREATED_ON' | 'NAME'
@@ -22,6 +23,8 @@ export interface AccessRequirementSearchRequest {
 export type AccessRequirementSearchResult = {
   /** The id of the AR */
   id: string
+  /** The concrete type of the AR */
+  type: ACCESS_REQUIREMENT_CONCRETE_TYPE
   /** The creation date of the AR */
   createdOn: string
   /** The last modification date of the AR */

--- a/packages/synapse-types/src/AccessRequirement/LockAccessRequirement.ts
+++ b/packages/synapse-types/src/AccessRequirement/LockAccessRequirement.ts
@@ -1,6 +1,12 @@
 import { RestrictableObjectDescriptor } from './RestrictableObjectDescriptor'
 import ACCESS_TYPE from '../ACCESS_TYPE'
 
+export const LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE = 'Lock'
+export const LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE =
+  'org.sagebionetworks.repo.model.LockAccessRequirement'
+export type LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE =
+  typeof LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+
 /**
  * JSON schema for Lock Access Requirement, used to lock down the entity while waiting for ACT to review.
  * https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/LockAccessRequirement.html
@@ -31,7 +37,7 @@ export type LockAccessRequirement = {
   /* 	The enumeration of possible permission. */
   accessType: ACCESS_TYPE
   /* 	Indicates which type of AccessRequirement this object represents. Provided by the system, the user may not set this field. */
-  concreteType: 'org.sagebionetworks.repo.model.LockAccessRequirement'
+  concreteType: LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE
   /* 	The key of the jira issue created for this Access Requirement. */
   jiraKey: string
 }

--- a/packages/synapse-types/src/AccessRequirement/ManagedACTAccessRequirement.ts
+++ b/packages/synapse-types/src/AccessRequirement/ManagedACTAccessRequirement.ts
@@ -1,6 +1,13 @@
 import { RestrictableObjectDescriptor } from './RestrictableObjectDescriptor'
 import ACCESS_TYPE from '../ACCESS_TYPE'
 
+export const MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE =
+  'Managed'
+export const MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE =
+  'org.sagebionetworks.repo.model.ManagedACTAccessRequirement'
+export type MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE =
+  typeof MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+
 export type ManagedACTAccessRequirement = {
   /* The version number issued to this version on the object. */
   versionNumber: number
@@ -26,7 +33,7 @@ export type ManagedACTAccessRequirement = {
   subjectIds: Array<RestrictableObjectDescriptor>
   /* The enumeration of possible permission. */
   accessType: ACCESS_TYPE /* Indicates which type of AccessRequirement this object represents. Provided by the system, the user may not set this field. */
-  concreteType: 'org.sagebionetworks.repo.model.ManagedACTAccessRequirement'
+  concreteType: MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE
   /* If true, then accessor needs to be a Synapse Certified User to gain access. */
   isCertifiedUserRequired: boolean
   /* If true, then accessor needs to have their Synapse Profile validated to gain access. */

--- a/packages/synapse-types/src/AccessRequirement/SelfSignAccessRequirement.ts
+++ b/packages/synapse-types/src/AccessRequirement/SelfSignAccessRequirement.ts
@@ -1,6 +1,13 @@
 import { RestrictableObjectDescriptor } from './RestrictableObjectDescriptor'
 import ACCESS_TYPE from '../ACCESS_TYPE'
 
+export const SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE =
+  'Click-Wrap'
+export const SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE =
+  'org.sagebionetworks.repo.model.SelfSignAccessRequirement'
+export type SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE =
+  typeof SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+
 export interface SelfSignAccessRequirement {
   /* The version number issued to this version on the object. */
   versionNumber: number
@@ -27,7 +34,7 @@ export interface SelfSignAccessRequirement {
   /* The enumeration of possible permission. */
   accessType: ACCESS_TYPE
   /* Indicates which type of AccessRequirement this object represents. Provided by the system, the user may not set this field. */
-  concreteType: 'org.sagebionetworks.repo.model.SelfSignAccessRequirement'
+  concreteType: SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE
   /* If true, then accessor needs to be a Synapse Certified User to gain access. */
   isCertifiedUserRequired: boolean
   /* If true, then accessor needs to have their Synapse Profile validated to gain access. */

--- a/packages/synapse-types/src/AccessRequirement/SelfSignAccessRequirementInterface.ts
+++ b/packages/synapse-types/src/AccessRequirement/SelfSignAccessRequirementInterface.ts
@@ -1,5 +1,15 @@
-import { TermsOfUseAccessRequirement } from './TermsOfUseAccessRequirement'
-import { SelfSignAccessRequirement } from './SelfSignAccessRequirement'
+import {
+  SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE,
+  SelfSignAccessRequirement,
+} from './SelfSignAccessRequirement'
+import {
+  TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE,
+  TermsOfUseAccessRequirement,
+} from './TermsOfUseAccessRequirement'
+
+export type SELF_SIGN_ACCESS_REQUIREMENT_INTERFACE_CONCRETE_TYPE =
+  | SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE
+  | TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE
 
 // This interface is not needed, but exists on synapse, keeping to maintain
 // parity

--- a/packages/synapse-types/src/AccessRequirement/TermsOfUseAccessRequirement.ts
+++ b/packages/synapse-types/src/AccessRequirement/TermsOfUseAccessRequirement.ts
@@ -1,6 +1,13 @@
 import { RestrictableObjectDescriptor } from './RestrictableObjectDescriptor'
 import ACCESS_TYPE from '../ACCESS_TYPE'
 
+export const TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_DISPLAY_VALUE =
+  'Terms of Use'
+export const TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE =
+  'org.sagebionetworks.repo.model.TermsOfUseAccessRequirement'
+export type TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE =
+  typeof TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+
 export interface TermsOfUseAccessRequirement {
   /* The version number issued to this version on the object. */
   versionNumber: number
@@ -27,7 +34,7 @@ export interface TermsOfUseAccessRequirement {
   /* The enumeration of possible permission. */
   accessType: ACCESS_TYPE
   /* Indicates which type of AccessRequirement this object represents. Provided by the system, the user may not set this field. */
-  concreteType: 'org.sagebionetworks.repo.model.TermsOfUseAccessRequirement'
+  concreteType: TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE
   /* Terms Of Use for Access, stored directly in the document (versus in a referenced Location)*/
   termsOfUse?: string
 }


### PR DESCRIPTION
I mapped the AR concrete type to a display value, which is shown in the AR table. If there is an established mapping or a better approach, happy to use that instead! 

- org.sagebionetworks.repo.model.SelfSignAccessRequirement -> Click-Wrap
- org.sagebionetworks.repo.model.ManagedACTAccessRequirement -> Managed
- org.sagebionetworks.repo.model.ACTAccessRequirement -> Basic
- org.sagebionetworks.repo.model.LockAccessRequirement -> Lock
- org.sagebionetworks.repo.model.TermsOfUseAccessRequirement -> Terms of Use

<img width="1604" alt="SWC-6617" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/85c6de2b-7e90-4b77-9080-ebd2b3bb3d47">
