### PR TITLE
SWC-6628: left align ProjectViewCarousel text on home page

### DIFF
--- a/packages/synapse-react-client/src/style/components/_synapse-homepage.scss
+++ b/packages/synapse-react-client/src/style/components/_synapse-homepage.scss
@@ -21,6 +21,8 @@
       p {
         text-align: center;
       }
+
+      .BrainhubCarouselItem p,
       p.text-align-left {
         text-align: left;
       }


### PR DESCRIPTION
main | feature
:---:|:---:
<img width="1617" alt="main_carousel" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/27d04f1d-ecc1-4063-9769-d6a242632cff"> | <img width="1621" alt="feature_carousel" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/caebc399-7d2f-4ed2-9087-b93d7a323a6d">
