### PR TITLE
SWC-6627 - EntityHeaderTable style updates + small fixes

### DIFF
--- a/packages/synapse-react-client/src/components/EntityHeaderTable/DebouncedInput.tsx
+++ b/packages/synapse-react-client/src/components/EntityHeaderTable/DebouncedInput.tsx
@@ -16,20 +16,21 @@ export function DebouncedInput({
   options: string[]
   delay?: number
 } & Pick<
-  React.InputHTMLAttributes<TextFieldProps>,
-  'type' | 'min' | 'max' | 'value' | 'placeholder' | 'className' | 'list'
+  TextFieldProps,
+  'type' | 'value' | 'placeholder' | 'className' | 'label'
 >) {
   const [value, setValue] = useState(initialValue)
   useDebouncedEffect(
     () => {
       onChange(value)
     },
-    [value],
+    [onChange, value],
     delay,
   )
 
   return (
     <Autocomplete
+      freeSolo
       disablePortal
       isOptionEqualToValue={(option, value) =>
         value.length == 0 || option === value

--- a/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTable.stories.ts
+++ b/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTable.stories.ts
@@ -9,6 +9,12 @@ import { ReferenceList } from '@sage-bionetworks/synapse-types'
 const meta = {
   title: 'Governance/EntityHeaderTable',
   component: EntityHeaderTable,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/vLusb6uSfhx45OyFx5IHwy/(XDM)-Extensible-Data-Management-Comps?type=design&node-id=6546-11978',
+    },
+  },
 } satisfies Meta
 export default meta
 

--- a/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTable.tsx
+++ b/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, MouseEventHandler, useCallback } from 'react'
+import React, { useState, useMemo, useCallback, useEffect } from 'react'
 import {
   useReactTable,
   ColumnFiltersState,
@@ -23,7 +23,10 @@ import {
   Tooltip,
 } from '@mui/material'
 import { EntityHeader, ReferenceList } from '@sage-bionetworks/synapse-types'
-import { getEntityTypeFromHeader } from '../../utils/functions/EntityTypeUtils'
+import {
+  entityTypeToFriendlyName,
+  getEntityTypeFromHeader,
+} from '../../utils/functions/EntityTypeUtils'
 import { useGetEntityHeaders } from '../../synapse-queries'
 import IconSvg from '../IconSvg'
 import { SkeletonTable } from '../Skeleton'
@@ -192,7 +195,9 @@ export const EntityHeaderTable = (props: EntityHeaderTableProps) => {
       },
       {
         accessorFn: (row: EntityHeaderOrDummy) =>
-          row.isDummy ? '-' : getEntityTypeFromHeader(row),
+          row.isDummy
+            ? '-'
+            : entityTypeToFriendlyName(getEntityTypeFromHeader(row)),
         id: 'type',
         header: 'Type',
         cell: EntityHeaderTypeCell,
@@ -241,7 +246,7 @@ export const EntityHeaderTable = (props: EntityHeaderTableProps) => {
       }
     })
     return newData.concat(dummyEntityHeaders)
-  }, [results])
+  }, [refsInState, results])
   const table = useReactTable({
     data,
     columns,
@@ -264,12 +269,7 @@ export const EntityHeaderTable = (props: EntityHeaderTableProps) => {
     columnResizeMode: 'onChange',
   })
 
-  if (isLoading) {
-    return <SkeletonTable numCols={3} numRows={10} />
-  } else if (!isSuccess) {
-    return <></>
-  }
-  const onRemoveFromAR: MouseEventHandler<HTMLButtonElement> = e => {
+  const onRemove = useCallback(() => {
     // rowSelection looks like {3: true. 5: true} where the key is the row index.
     // Create a new ReferenceList based on the entityHeaders in the current table.
     const updatedData = data.filter(
@@ -281,54 +281,94 @@ export const EntityHeaderTable = (props: EntityHeaderTableProps) => {
       }
     })
     setRefsInState(newRowRefs)
-  }
+  }, [data, rowSelection, setRefsInState])
 
   const isSelection = selectionCount > 0
   const totalRowCount = data.length
   const filteredRowCount = table.getPrePaginationRowModel().rows.length
+  const showFilterControls = totalRowCount > UNMANAGEABLE_SUBJECT_COUNT
+
+  /**
+   * Reset the column filters when the filter controls are hidden.
+   * This handles the following edge case:
+   *      1. List contains 100 items of type "A" and 1 of type "B"
+   *      2. User filters to show just "A" items
+   *      3. User removes all "A" items
+   *      4. Only the single "B" item remains, but the filter is still present on type "A".
+   *         The filter controls are hidden, so the user cannot see the "B" item.
+   *
+   * This effect will clear the filters when the filter controls are hidden, preventing this scenario.
+   */
+  useEffect(
+    function resetFiltersWhenFilterControlsAreHidden() {
+      if (!showFilterControls) {
+        table.setColumnFilters([])
+      }
+    },
+    [showFilterControls],
+  )
+
+  if (isLoading) {
+    return <SkeletonTable numCols={3} numRows={10} />
+  } else if (!isSuccess) {
+    return <></>
+  }
   return (
     <div>
       <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          padding: '12px 10px 10px 5px',
-        }}
+        display={'flex'}
+        justifyContent={'space-between'}
+        p={'12px 10px 10px 5px'}
       >
-        <div>
-          {totalRowCount > UNMANAGEABLE_SUBJECT_COUNT && (
-            <Typography variant="body1" sx={{ marginBottom: '10px' }}>
-              {totalRowCount} {pluralObjectName}{' '}
-              {filteredRowCount < totalRowCount
-                ? `(${filteredRowCount} visible)`
-                : ''}
-              {isSelection && <span>{` (${selectionCount} selected)`}</span>}
-            </Typography>
-          )}
-        </div>
-        <div>
-          {isEditable && refsInState.length > 0 && (
-            <Button
-              variant="contained"
-              disabled={!isSelection}
-              onClick={onRemoveFromAR}
-            >
-              {removeSelectedRowsButtonText}
-            </Button>
-          )}
-        </div>
+        {showFilterControls && (
+          <Typography variant="body1" sx={{ marginBottom: '10px' }}>
+            {totalRowCount} {pluralObjectName}{' '}
+            {filteredRowCount < totalRowCount
+              ? `(${filteredRowCount} visible)`
+              : ''}
+            {isSelection && <span>{` (${selectionCount} selected)`}</span>}
+          </Typography>
+        )}
+        {isEditable && refsInState.length > 0 && (
+          <Button
+            variant="contained"
+            disabled={!isSelection}
+            onClick={onRemove}
+          >
+            {removeSelectedRowsButtonText}
+          </Button>
+        )}
+      </Box>
+      <Box display={'flex'} pb={2}>
+        {table.getHeaderGroups().map(headerGroup =>
+          headerGroup.headers.map(header => {
+            return header.isPlaceholder ? null : (
+              <React.Fragment key={header.column.id}>
+                {header.column.getCanFilter() && showFilterControls ? (
+                  <Box sx={{ flexGrow: 1 }}>
+                    <Filter column={header.column} table={table} />
+                  </Box>
+                ) : null}
+              </React.Fragment>
+            )
+          }),
+        )}
       </Box>
       {totalRowCount > 0 && (
         <Box
-          sx={{
+          sx={theme => ({
             overflow: 'auto',
             maxHeight: '250px',
             paddingLeft: '2px',
             th: {
-              backgroundColor: '#eee',
+              height: '38px',
+              backgroundColor: theme.palette.grey[200],
               zIndex: 100,
             },
-          }}
+            ['tr:nth-of-type(2n)']: {
+              backgroundColor: theme.palette.grey[100],
+            },
+          })}
         >
           <table style={{ borderCollapse: 'collapse', width: '100%' }}>
             <thead>
@@ -357,58 +397,42 @@ export const EntityHeaderTable = (props: EntityHeaderTableProps) => {
                           width: columnSize,
                           position: 'sticky',
                           top: '0px',
-                          background: '#fff',
                         }}
                       >
                         {header.isPlaceholder ? null : (
-                          <>
-                            <div
-                              {...{
-                                className: header.column.getCanSort()
-                                  ? 'SRC-hand-cursor'
-                                  : '',
-                                onClick:
-                                  header.column.getToggleSortingHandler(),
-                              }}
-                            >
-                              {flexRender(
-                                header.column.columnDef.header,
-                                header.getContext(),
-                              )}
-                              {{
-                                asc: (
-                                  <IconSvg
-                                    icon={'sortUp'}
-                                    wrap={false}
-                                    sx={{
-                                      color: 'primary.main',
-                                      backgroundColor: 'none',
-                                      float: 'right',
-                                      marginRight: '5px',
-                                    }}
-                                  />
-                                ),
-                                desc: (
-                                  <IconSvg
-                                    icon={'sortDown'}
-                                    wrap={false}
-                                    sx={{
-                                      color: 'primary.main',
-                                      backgroundColor: 'none',
-                                      float: 'right',
-                                      marginRight: '5px',
-                                    }}
-                                  />
-                                ),
-                              }[header.column.getIsSorted() as string] ?? null}
-                            </div>
-                            {header.column.getCanFilter() &&
-                            totalRowCount > UNMANAGEABLE_SUBJECT_COUNT ? (
-                              <div>
-                                <Filter column={header.column} table={table} />
-                              </div>
-                            ) : null}
-                          </>
+                          <Box display={'flex'} alignItems={'center'}>
+                            {flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                            <Box mx={'auto'} />
+                            {header.column.getCanSort() && (
+                              <IconButton
+                                onClick={header.column.getToggleSortingHandler()}
+                                size={'small'}
+                                sx={{
+                                  marginLeft: 'auto',
+                                  marginRight: '16px',
+                                }}
+                              >
+                                <IconSvg
+                                  icon={
+                                    header.column.getIsSorted() === 'asc'
+                                      ? 'sortUp'
+                                      : 'sortDown'
+                                  }
+                                  wrap={false}
+                                  fontSize={'inherit'}
+                                  sx={{
+                                    color: header.column.getIsSorted()
+                                      ? 'primary.main'
+                                      : 'grey.700',
+                                    backgroundColor: 'none',
+                                  }}
+                                />
+                              </IconButton>
+                            )}
+                          </Box>
                         )}
                         {header.column.getCanResize() && (
                           <div
@@ -459,7 +483,9 @@ export const EntityHeaderTable = (props: EntityHeaderTableProps) => {
         confirmButtonCopy={`Add ${pluralObjectName}`}
         onConfirm={items => {
           if (hideTextFieldToPasteValue) {
-            onUpdate([...refsInState, ...items])
+            const newRefs = [...refsInState, ...items]
+            setRefsInState(newRefs)
+            onUpdate(newRefs)
           } else {
             const newEntityIDsArray = items.map(ref => ref.targetId)
             const newEntityIDsString =

--- a/packages/synapse-react-client/src/components/EntityHeaderTable/Filter.tsx
+++ b/packages/synapse-react-client/src/components/EntityHeaderTable/Filter.tsx
@@ -28,10 +28,9 @@ export function Filter({
       options={sortedUniqueValues}
       initialValue={columnFilterValue}
       onChange={value => column.setFilterValue(value)}
-      placeholder={`Filter by ${column.id}... (${
+      label={`Filter by ${column.columnDef.header} (${
         column.getFacetedUniqueValues().size
       })`}
-      list={column.id + 'list'}
     />
   )
 }

--- a/packages/synapse-react-client/src/mocks/entity/index.ts
+++ b/packages/synapse-react-client/src/mocks/entity/index.ts
@@ -1,14 +1,14 @@
 import mockDatasetData from './mockDataset'
 import mockDatasetCollectionData from './mockDatasetCollection'
 import { MockEntityData } from './MockEntityData'
-import mockFileEntityData from './mockFileEntity'
+import { mockFileEntities } from './mockFileEntity'
 import { mockProjectsEntityData } from './mockProject'
 import mockTableEntityData from './mockTableEntity'
 import { mockFileViewData } from './mockFileView'
 import { mockProjectViewData } from './mockProjectView'
 
 const mockEntities: MockEntityData[] = [
-  mockFileEntityData,
+  ...mockFileEntities,
   ...mockProjectsEntityData,
   mockDatasetData,
   mockDatasetCollectionData,

--- a/packages/synapse-react-client/src/mocks/entity/mockFileEntity.ts
+++ b/packages/synapse-react-client/src/mocks/entity/mockFileEntity.ts
@@ -18,6 +18,8 @@ import {
 import { MOCK_USER_ID, MOCK_USER_ID_2 } from '../user/mock_user_profile'
 import { MockEntityData } from './MockEntityData'
 import mockProject from './mockProject'
+import { times } from 'lodash-es'
+import { generateBaseEntity } from '../faker/generateFakeEntity'
 
 const parentId = mockProject.id
 const projectName = mockProject.name
@@ -234,6 +236,17 @@ const mockFileEntityHeader: EntityHeader = {
   isLatestVersion: true,
 }
 
+const generatedFileEntityData: MockEntityData<FileEntity>[] = times(50).map(
+  i =>
+    generateBaseEntity(
+      {
+        concreteType: 'org.sagebionetworks.repo.model.FileEntity',
+        parentId: mockProject.id,
+      },
+      30000 + i + 1,
+    ) as MockEntityData<FileEntity>,
+)
+
 const mockFileEntityData = {
   id: MOCK_FILE_ENTITY_ID,
   name: MOCK_FILE_NAME,
@@ -245,5 +258,10 @@ const mockFileEntityData = {
   entityHeader: mockFileEntityHeader,
   path: filePath,
 } satisfies MockEntityData<FileEntity>
+
+export const mockFileEntities = [
+  mockFileEntityData,
+  ...generatedFileEntityData,
+] satisfies MockEntityData<FileEntity>[]
 
 export default mockFileEntityData

--- a/packages/synapse-react-client/src/mocks/entity/mockProject.ts
+++ b/packages/synapse-react-client/src/mocks/entity/mockProject.ts
@@ -209,23 +209,20 @@ const mockProjectEntityData = {
   json: mockProjectJson,
 } satisfies MockEntityData<Project>
 
-export const mockProjects: Project[] = mockProjectIds.map(id => {
+const generatedProjectsEntityData = mockProjectIds.map(id => {
   if (`syn${id}` === MOCK_PROJECT_ID) {
-    return mockProjectEntity
+    return mockProjectEntityData
   }
-  return generateProject({ id: `syn${id}` })
+  return generateProject(undefined, id)
 })
 
-export const mockProjectsEntityData: MockEntityData<Project>[] =
-  mockProjects.map((p: Project): MockEntityData<Project> => {
-    if (p.id === MOCK_PROJECT_ID) {
-      return mockProjectEntityData
-    }
-    return {
-      id: p.id!,
-      name: p.name,
-      entity: p,
-    }
-  })
+export const mockProjects: Project[] = generatedProjectsEntityData.map(
+  projectData => projectData.entity,
+)
+
+export const mockProjectsEntityData: MockEntityData<Project>[] = [
+  mockProjectEntityData,
+  ...generatedProjectsEntityData,
+]
 
 export default mockProjectEntityData

--- a/packages/synapse-react-client/src/mocks/faker/generateFakeEntity.ts
+++ b/packages/synapse-react-client/src/mocks/faker/generateFakeEntity.ts
@@ -44,11 +44,15 @@ export function generateBaseEntity(
 }
 
 export function generateProject(
-  overrides?: Partial<Project>,
+  entityDataOverrides?: Partial<Project>,
+  idOverride?: number,
 ): MockEntityData<Project> {
-  return generateBaseEntity({
-    name: faker.lorem.words({ min: 1, max: 4 }),
-    concreteType: 'org.sagebionetworks.repo.model.Project',
-    ...overrides,
-  }) as MockEntityData<Project>
+  return generateBaseEntity(
+    {
+      name: faker.lorem.words({ min: 1, max: 4 }),
+      concreteType: 'org.sagebionetworks.repo.model.Project',
+      ...entityDataOverrides,
+    },
+    idOverride,
+  ) as MockEntityData<Project>
 }

--- a/packages/synapse-react-client/src/mocks/faker/generateFakeEntity.ts
+++ b/packages/synapse-react-client/src/mocks/faker/generateFakeEntity.ts
@@ -1,10 +1,15 @@
 import { faker } from '@faker-js/faker'
-import { Entity, Project } from '@sage-bionetworks/synapse-types'
+import { Entity, EntityHeader, Project } from '@sage-bionetworks/synapse-types'
 import { pickRandomMockUser } from './fakerUtils'
+import { MockEntityData } from '../entity/MockEntityData'
 
-function generateBaseEntity(overrides?: Partial<Entity>): Entity {
-  return {
-    id: `syn${faker.number.int({ min: 10000, max: 99999 })}`,
+export function generateBaseEntity(
+  entityDataOverrides?: Partial<Entity>,
+  idOverride?: number,
+): MockEntityData {
+  const id = idOverride ?? faker.number.int({ min: 10000, max: 99999 })
+  const entity = {
+    id: `syn${id}`,
     createdBy: String(pickRandomMockUser().id),
     createdOn: faker.date.anytime().toISOString(),
     etag: faker.string.uuid(),
@@ -12,15 +17,38 @@ function generateBaseEntity(overrides?: Partial<Entity>): Entity {
     modifiedOn: faker.date.anytime().toISOString(),
     name: faker.lorem.words({ min: 1, max: 4 }),
     concreteType: 'org.sagebionetworks.repo.model.FileEntity',
-    ...overrides,
+    ...entityDataOverrides,
+  } satisfies Entity
+  const header: EntityHeader = {
+    id: entity.id,
+    name: entity.name,
+    type: entity.concreteType,
+    createdBy: entity.createdBy,
+    createdOn: entity.createdOn,
+    modifiedBy: entity.modifiedBy,
+    modifiedOn: entity.modifiedOn,
+    benefactorId: id,
+    isLatestVersion: true,
+    versionLabel:
+      'versionLabel' in entity ? (entity.versionLabel as string) : undefined,
+    versionNumber:
+      'versionNumber' in entity ? (entity.versionNumber as number) : undefined,
+  }
+
+  return {
+    id: entity.id!,
+    entity: entity,
+    name: entity.name,
+    entityHeader: header,
   }
 }
 
-export function generateProject(overrides?: Partial<Project>): Project {
-  return {
-    ...generateBaseEntity(overrides),
+export function generateProject(
+  overrides?: Partial<Project>,
+): MockEntityData<Project> {
+  return generateBaseEntity({
     name: faker.lorem.words({ min: 1, max: 4 }),
     concreteType: 'org.sagebionetworks.repo.model.Project',
     ...overrides,
-  }
+  }) as MockEntityData<Project>
 }


### PR DESCRIPTION
 - Move filter inputs above table
 - Change sort icon to always be visible if table can be sorted
 - Handle case where filters would not be cleared if items were removed to cause the filter controls to be hidden
 - Update styling to get closer to design
 - Fix prop signature for DebouncedInput to accept `label`

|Before|After|
|---|---|
| <img width="939" alt="image" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/7cd6c2d5-afc3-43cd-9300-25e6695a1a0f"> | <img width="939" alt="image" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/f72bd0c1-40a8-4249-bf63-7d49387d8c13"> |



