### PR TITLE
SWC-6627 - Add EvaluationFinder

### DIFF
--- a/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.stories.tsx
+++ b/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.stories.tsx
@@ -1,0 +1,28 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { Paper } from '@mui/material'
+import React, { useState } from 'react'
+import EvaluationFinder from './EvaluationFinder'
+
+const meta: Meta = {
+  title: 'Synapse/Evaluation Finder',
+  component: EvaluationFinder,
+  decorators: [
+    Story => (
+      <Paper sx={{ mx: 'auto', p: 4, maxWidth: '720px' }}>
+        <Story />
+      </Paper>
+    ),
+  ],
+  render: function Render(args) {
+    const [ids, setIds] = useState<string[]>([])
+    return <EvaluationFinder {...args} selectedIds={ids} onChange={setIds} />
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  name: 'Evaluation Finder',
+  args: {},
+}

--- a/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.test.tsx
+++ b/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.test.tsx
@@ -38,7 +38,7 @@ describe('EvaluationFinder', () => {
     renderComponent({ onChange, selectedIds })
 
     // The first page is visible
-    const evaluationsToSelect = await screen.findAllByRole('checkbox')
+    let evaluationsToSelect = await screen.findAllByRole('checkbox')
     expect(evaluationsToSelect).toHaveLength(2)
 
     // Verify that the selection is correct
@@ -53,7 +53,8 @@ describe('EvaluationFinder', () => {
     await userEvent.click(nextPageButton)
 
     // Page 2 will be shown
-    await waitFor(() => expect(screen.getAllByRole('checkbox')).toHaveLength(1))
+    evaluationsToSelect = await screen.findAllByRole('checkbox')
+    expect(evaluationsToSelect).toHaveLength(1)
     expect(nextPageButton).toBeDisabled()
 
     // Go back to page 1
@@ -62,6 +63,12 @@ describe('EvaluationFinder', () => {
     })
     await userEvent.click(previousPageButton)
     await waitFor(() => expect(screen.getAllByRole('checkbox')).toHaveLength(2))
+
+    evaluationsToSelect = await screen.findAllByRole('checkbox')
+    expect(evaluationsToSelect).toHaveLength(2)
+
+    // Click the first evaluation and verify that the onChange callback is called
+    await userEvent.click(evaluationsToSelect[0])
+    expect(onChange).toHaveBeenCalledWith(expect.arrayContaining(['1', '2']))
   })
-  it('shows selection and calls onChange', () => {})
 })

--- a/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.test.tsx
+++ b/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import EvaluationFinder, { EvaluationFinderProps } from './EvaluationFinder'
+import { Evaluation, PaginatedResults } from '@sage-bionetworks/synapse-types'
+import SynapseClient from '../../synapse-client'
+import userEvent from '@testing-library/user-event'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+
+function renderComponent(props: EvaluationFinderProps) {
+  return render(<EvaluationFinder {...props} />, { wrapper: createWrapper() })
+}
+
+const onChange = jest.fn()
+const selectedIds = ['2']
+
+const mockPage1: PaginatedResults<Evaluation> = {
+  results: [
+    { id: '1', name: 'Eval 1', submissionInstructionsMessage: '_Markdown_' },
+    { id: '2', name: 'Eval 2' },
+  ],
+  totalNumberOfResults: 3,
+}
+const mockPage2: PaginatedResults<Evaluation> = {
+  results: [{ id: '3', name: 'Eval 3' }],
+  totalNumberOfResults: 3,
+}
+
+jest.spyOn(SynapseClient, 'getEvaluations').mockImplementation(params => {
+  if (params == null || params.offset == null || params.offset === 0) {
+    return Promise.resolve(mockPage1)
+  } else {
+    return Promise.resolve(mockPage2)
+  }
+})
+
+describe('EvaluationFinder', () => {
+  it('fetches and shows pages of evaluations', async () => {
+    renderComponent({ onChange, selectedIds })
+
+    // The first page is visible
+    const evaluationsToSelect = await screen.findAllByRole('checkbox')
+    expect(evaluationsToSelect).toHaveLength(2)
+
+    // Verify that the selection is correct
+    expect(evaluationsToSelect[0]).not.toBeChecked()
+    expect(evaluationsToSelect[1]).toBeChecked()
+
+    const nextPageButton = await screen.findByRole('button', {
+      name: 'Next',
+    })
+
+    await waitFor(() => expect(nextPageButton).not.toBeDisabled())
+    await userEvent.click(nextPageButton)
+
+    // Page 2 will be shown
+    await waitFor(() => expect(screen.getAllByRole('checkbox')).toHaveLength(1))
+    expect(nextPageButton).toBeDisabled()
+
+    // Go back to page 1
+    const previousPageButton = await screen.findByRole('button', {
+      name: 'Previous',
+    })
+    await userEvent.click(previousPageButton)
+    await waitFor(() => expect(screen.getAllByRole('checkbox')).toHaveLength(2))
+  })
+  it('shows selection and calls onChange', () => {})
+})

--- a/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.tsx
+++ b/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react'
+import { useGetEvaluationsInfinite } from '../../synapse-queries/evaluation/useEvaluation'
+import { HelpPopover } from '../HelpPopover/HelpPopover'
+import {
+  Box,
+  Button,
+  FormControl,
+  FormGroup,
+  LinearProgress,
+  Typography,
+} from '@mui/material'
+import { GetEvaluationParameters } from '@sage-bionetworks/synapse-types'
+import { Checkbox } from '../widgets/Checkbox'
+
+export type EvaluationFinderProps = Pick<
+  GetEvaluationParameters,
+  'accessType' | 'activeOnly'
+> & {
+  selectedIds: string[]
+  onChange: (newSelectedIds: string[]) => void
+}
+
+export default function EvaluationFinder(props: EvaluationFinderProps) {
+  const { accessType, activeOnly, selectedIds = [], onChange } = props
+  const [currentPage, setCurrentPage] = useState(0)
+  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useGetEvaluationsInfinite(
+      {
+        accessType,
+        activeOnly,
+      },
+      { keepPreviousData: true },
+    )
+
+  if (isLoading) {
+    return <LinearProgress />
+  }
+  if (!data?.pages) {
+    return <></>
+  }
+
+  const canGoToNextPage =
+    (data.pages.length - 1 > currentPage || hasNextPage) && !isFetchingNextPage
+
+  return (
+    <>
+      <FormControl>
+        <FormGroup sx={{ gap: 1 }}>
+          {data.pages[currentPage]?.results.map(evaluation => (
+            <Checkbox
+              key={evaluation.id}
+              label={
+                <Typography variant={'smallText1'} component={'span'}>
+                  {evaluation.name}{' '}
+                  {evaluation.submissionInstructionsMessage &&
+                    evaluation.submissionInstructionsMessage.length > 0 && (
+                      <HelpPopover
+                        markdownText={evaluation.submissionInstructionsMessage}
+                        placement={'right'}
+                      />
+                    )}
+                </Typography>
+              }
+              checked={selectedIds.includes(evaluation.id!)}
+              onChange={() => {
+                if (selectedIds.includes(evaluation.id!)) {
+                  onChange(selectedIds.filter(id => id !== evaluation.id))
+                } else {
+                  onChange([...selectedIds, evaluation.id!])
+                }
+              }}
+            />
+          ))}
+        </FormGroup>
+      </FormControl>
+      <Box display={'flex'} my={2} gap={1}>
+        {currentPage > 0 && (
+          <Button
+            variant={'outlined'}
+            onClick={() => setCurrentPage(page => page - 1)}
+          >
+            Previous
+          </Button>
+        )}
+        <Button
+          variant={'outlined'}
+          disabled={!canGoToNextPage}
+          onClick={() => {
+            if (data.pages[currentPage + 1]) {
+              setCurrentPage(page => page + 1)
+            } else {
+              fetchNextPage().then(() => setCurrentPage(page => page + 1))
+            }
+          }}
+        >
+          Next
+        </Button>
+      </Box>
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.tsx
+++ b/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.tsx
@@ -61,6 +61,7 @@ export default function EvaluationFinder(props: EvaluationFinderProps) {
                     )}
                 </Typography>
               }
+              aria-label={evaluation.name!}
               checked={selectedIds.includes(evaluation.id!)}
               onChange={() => {
                 if (selectedIds.includes(evaluation.id!)) {

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownPopover.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownPopover.tsx
@@ -93,9 +93,6 @@ export const MarkdownPopover: React.FunctionComponent<MarkdownPopoverProps> = ({
     <LightTooltip
       title={content}
       placement={placement}
-      onClick={() =>
-        setOpenMarkdownPopoverId(currentId => (currentId == id ? null : id))
-      }
       open={show}
       sx={{
         ...sx,
@@ -108,6 +105,14 @@ export const MarkdownPopover: React.FunctionComponent<MarkdownPopoverProps> = ({
       <Box
         role="button"
         className={'PopoverContainer'}
+        onClick={e => {
+          // Prevent the default action of the click event -- for example, if this is in a `label` tag for a checkbox,
+          // prevent the click from toggling the checkbox value
+          e.preventDefault()
+          // Prevent the click from propagating to the parent container
+          e.stopPropagation()
+          setOpenMarkdownPopoverId(currentId => (currentId == id ? null : id))
+        }}
         sx={{ display: 'inline-block', cursor: 'pointer' }}
       >
         {children}

--- a/packages/synapse-react-client/src/components/styled/LightTooltip.tsx
+++ b/packages/synapse-react-client/src/components/styled/LightTooltip.tsx
@@ -26,8 +26,8 @@ export const LightTooltip: StyledComponent<TooltipProps> = styled(
     },
     color: theme.palette.background.paper,
   },
-  [`& .${linkClasses.root}`]: {
-    color: theme.palette.primary.main,
+  [`& .${tooltipClasses.tooltip} .${linkClasses.root}`]: {
+    color: `${theme.palette.primary.main}`,
   },
 }))
 

--- a/packages/synapse-react-client/src/components/widgets/Checkbox.test.tsx
+++ b/packages/synapse-react-client/src/components/widgets/Checkbox.test.tsx
@@ -5,12 +5,12 @@ import userEvent from '@testing-library/user-event'
 
 const mockCallback = jest.fn()
 
-const props: CheckboxProps = {
+const props = {
   label: 'checkboxLabel',
   checked: true,
   className: 'checkboxClass',
   onChange: mockCallback,
-}
+} satisfies CheckboxProps
 
 describe('basic function', () => {
   beforeEach(() => {

--- a/packages/synapse-react-client/src/components/widgets/Checkbox.tsx
+++ b/packages/synapse-react-client/src/components/widgets/Checkbox.tsx
@@ -1,8 +1,9 @@
+import Typography from '@mui/material/Typography'
 import { uniqueId as _uniqueId } from 'lodash-es'
 import React, { useState } from 'react'
 
 export type CheckboxProps = React.PropsWithChildren<{
-  label: string
+  label: React.ReactNode
   hideLabel?: boolean
   checked?: boolean
   className?: string
@@ -45,7 +46,6 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
   return (
     <div className={className} onClick={props.onClick}>
       <input
-        aria-label={props.label}
         type="checkbox"
         checked={checked}
         id={uniqueId}
@@ -53,11 +53,14 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
         disabled={disabled}
         data-testid={props['data-testid']}
       />
-      {
-        <label htmlFor={uniqueId} aria-hidden={hideLabel}>
-          {hideLabel ? <></> : props.label}
-        </label>
-      }
+      <Typography
+        component={'label'}
+        variant={'smallText1'}
+        htmlFor={uniqueId}
+        aria-hidden={hideLabel}
+      >
+        {hideLabel ? <></> : props.label}
+      </Typography>
       {props.children ?? <></>}
     </div>
   )

--- a/packages/synapse-react-client/src/components/widgets/Checkbox.tsx
+++ b/packages/synapse-react-client/src/components/widgets/Checkbox.tsx
@@ -2,17 +2,26 @@ import Typography from '@mui/material/Typography'
 import { uniqueId as _uniqueId } from 'lodash-es'
 import React, { useState } from 'react'
 
-export type CheckboxProps = React.PropsWithChildren<{
-  label: React.ReactNode
-  hideLabel?: boolean
-  checked?: boolean
-  className?: string
-  onChange: (newValue: boolean) => void
-  isSelectAll?: boolean
-  onClick?: (event: React.SyntheticEvent<HTMLDivElement>) => void
-  disabled?: boolean
-  'data-testid'?: string
-}>
+export type CheckboxProps = React.PropsWithChildren<
+  {
+    hideLabel?: boolean
+    checked?: boolean
+    className?: string
+    onChange: (newValue: boolean) => void
+    isSelectAll?: boolean
+    onClick?: (event: React.SyntheticEvent<HTMLDivElement>) => void
+    disabled?: boolean
+    'data-testid'?: string
+    'aria-label'?: string
+  } & (
+    | {
+        label?: React.ReactNode
+        /* If the label is not a string, then we require an aria-label */
+        'aria-label': string
+      }
+    | { label: string }
+  )
+>
 
 export const Checkbox: React.FunctionComponent<CheckboxProps> = (
   props: CheckboxProps,
@@ -46,6 +55,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
   return (
     <div className={className} onClick={props.onClick}>
       <input
+        aria-label={props['aria-label']}
         type="checkbox"
         checked={checked}
         id={uniqueId}
@@ -57,9 +67,9 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
         component={'label'}
         variant={'smallText1'}
         htmlFor={uniqueId}
-        aria-hidden={hideLabel}
+        sx={hideLabel ? { display: 'none' } : {}}
       >
-        {hideLabel ? <></> : props.label}
+        {props.label}
       </Typography>
       {props.children ?? <></>}
     </div>

--- a/packages/synapse-react-client/src/components/widgets/Checkbox.tsx
+++ b/packages/synapse-react-client/src/components/widgets/Checkbox.tsx
@@ -55,7 +55,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
   return (
     <div className={className} onClick={props.onClick}>
       <input
-        aria-label={props['aria-label']}
+        aria-label={'aria-label' in props ? props['aria-label'] : props.label}
         type="checkbox"
         checked={checked}
         id={uniqueId}

--- a/packages/synapse-react-client/src/synapse-queries/InfiniteQueryUtils.test.ts
+++ b/packages/synapse-react-client/src/synapse-queries/InfiniteQueryUtils.test.ts
@@ -1,0 +1,106 @@
+import { PaginatedResults } from '@sage-bionetworks/synapse-types'
+import { getNextPageParamForPaginatedResults } from './InfiniteQueryUtils'
+
+describe('InfiniteQueryUtils', () => {
+  describe('getNextPageParamForPaginatedResults', () => {
+    test('totalNumberOfResults is 1 more than fetched, not last page', () => {
+      const pages: PaginatedResults<unknown>[] = [
+        {
+          totalNumberOfResults: 3,
+          results: [1, 2],
+        },
+        {
+          totalNumberOfResults: 5,
+          results: [3, 4],
+        },
+      ]
+
+      const nextPageParam = getNextPageParamForPaginatedResults(
+        pages[pages.length - 1],
+        pages,
+      )
+      expect(nextPageParam).toBe(4)
+    })
+    test('totalNumberOfResults is 1 more than fetched, on last page', () => {
+      const pages: PaginatedResults<unknown>[] = [
+        {
+          totalNumberOfResults: 3,
+          results: [1, 2],
+        },
+        {
+          // Note that totalNumberOfResults is 4 and we fetched 4 results
+          totalNumberOfResults: 4,
+          results: [3, 4],
+        },
+      ]
+
+      const nextPageParam = getNextPageParamForPaginatedResults(
+        pages[pages.length - 1],
+        pages,
+      )
+      expect(nextPageParam).toBe(undefined)
+    })
+    test('totalNumberOfResults is always correct more than fetched, not last page', () => {
+      const pages: PaginatedResults<unknown>[] = [
+        {
+          totalNumberOfResults: 4,
+          results: [1, 2],
+        },
+      ]
+
+      const nextPageParam = getNextPageParamForPaginatedResults(
+        pages[pages.length - 1],
+        pages,
+      )
+      expect(nextPageParam).toBe(2)
+    })
+    test('totalNumberOfResults is always correct more than fetched, on last page', () => {
+      const pages: PaginatedResults<unknown>[] = [
+        {
+          totalNumberOfResults: 4,
+          results: [1, 2],
+        },
+        {
+          totalNumberOfResults: 4,
+          results: [3, 4],
+        },
+      ]
+
+      const nextPageParam = getNextPageParamForPaginatedResults(
+        pages[pages.length - 1],
+        pages,
+      )
+      expect(nextPageParam).toBe(undefined)
+    })
+    test('totalNumberOfResults is undefined, not last page', () => {
+      const pages: PaginatedResults<unknown>[] = [
+        {
+          results: [1, 2],
+        },
+      ]
+
+      const nextPageParam = getNextPageParamForPaginatedResults(
+        pages[pages.length - 1],
+        pages,
+      )
+      expect(nextPageParam).toBe(2)
+    })
+
+    test('totalNumberOfResults is undefined, on last page', () => {
+      const pages: PaginatedResults<unknown>[] = [
+        {
+          results: [1, 2],
+        },
+        {
+          results: [],
+        },
+      ]
+
+      const nextPageParam = getNextPageParamForPaginatedResults(
+        pages[pages.length - 1],
+        pages,
+      )
+      expect(nextPageParam).toBe(undefined)
+    })
+  })
+})

--- a/packages/synapse-react-client/src/synapse-queries/InfiniteQueryUtils.ts
+++ b/packages/synapse-react-client/src/synapse-queries/InfiniteQueryUtils.ts
@@ -1,0 +1,39 @@
+import { PaginatedResults } from '@sage-bionetworks/synapse-types'
+
+/**
+ * Returns a function that can be used for `getNextPageParam` in `useInfiniteQuery` when the results are
+ * Synapse PaginatedResults
+ * @param limit
+ */
+export function getNextPageParamForPaginatedResults(
+  lastPage: PaginatedResults<unknown>,
+  pages: PaginatedResults<unknown>[],
+) {
+  // totalNumberOfResults is deprecated, it may not be the correct value
+  // For a given service, one of the following is true about totalNumberOfResults
+  //   1. If this is not the last page, it's offset + page.results.length + 1
+  //   2. If this is the last page, it's the correct total number of results
+  //   3. It is always the correct value, regardless of the page
+  //   4. It is not present
+  // We need to handle all of those cases
+  const totalFetchedResults = pages.reduce((acc, page) => {
+    return acc + page.results.length
+  }, 0)
+  if (lastPage.totalNumberOfResults) {
+    if (lastPage.totalNumberOfResults > totalFetchedResults) {
+      // If the total is present and is greater than everything we've fetched so far, make the new limit the total fetched
+      return totalFetchedResults
+    } else {
+      // There are no more pages to fetch
+      return undefined
+    }
+  } else {
+    // If totalNumberOfResults is not present, the limit for the next page will be the total number of fetched results
+    if (lastPage.results.length > 0) {
+      return totalFetchedResults
+    }
+    // If the last page has no items, we've hit the end. No more pages to fetch
+    // We will end up with an empty last page, but that's ok
+    else return undefined
+  }
+}

--- a/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
+++ b/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
@@ -12,6 +12,7 @@ import {
   FavoriteSortDirection,
   FileHandle,
   FileHandleAssociation,
+  GetEvaluationParameters,
   GetProjectsParameters,
   PrincipalAliasRequest,
   QueryBundleRequest,
@@ -718,5 +719,9 @@ export class KeyFactory {
     request: Omit<ViewColumnModelRequest, 'nextPageToken'>,
   ) {
     return this.getKey('annotationColumnModels', request)
+  }
+
+  public getEvaluationsQueryKey(request: GetEvaluationParameters) {
+    return this.getKey('evaluation', request)
   }
 }

--- a/packages/synapse-react-client/src/synapse-queries/entity/useEntity.ts
+++ b/packages/synapse-react-client/src/synapse-queries/entity/useEntity.ts
@@ -37,6 +37,7 @@ import {
 import { invalidateAllQueriesForEntity } from '../QueryClientUtils'
 import { createTableUpdateTransactionRequest } from '../../utils'
 import { SetOptional } from 'type-fest'
+import { getNextPageParamForPaginatedResults } from '../InfiniteQueryUtils'
 
 export function useGetEntity<T extends Entity>(
   entityId: string,
@@ -178,11 +179,7 @@ export function useGetVersionsInfinite(
     },
     {
       ...options,
-      getNextPageParam: (lastPage, pages) => {
-        if (lastPage.results.length > 0) return pages.length * LIMIT
-        //set the new offset to (page * limit)
-        else return undefined
-      },
+      getNextPageParam: getNextPageParamForPaginatedResults,
     },
   )
 }

--- a/packages/synapse-react-client/src/synapse-queries/evaluation/useEvaluation.ts
+++ b/packages/synapse-react-client/src/synapse-queries/evaluation/useEvaluation.ts
@@ -1,0 +1,34 @@
+import {
+  Evaluation,
+  GetEvaluationParameters,
+  PaginatedResults,
+} from '@sage-bionetworks/synapse-types'
+import { useInfiniteQuery, UseInfiniteQueryOptions } from 'react-query'
+import { SynapseClientError, useSynapseContext } from '../../utils'
+import SynapseClient from '../../synapse-client'
+import { getNextPageParamForPaginatedResults } from '../InfiniteQueryUtils'
+
+export function useGetEvaluationsInfinite(
+  request: GetEvaluationParameters = {},
+  options?: UseInfiniteQueryOptions<
+    PaginatedResults<Evaluation>,
+    SynapseClientError
+  >,
+) {
+  const LIMIT = 20
+  const { accessToken, keyFactory } = useSynapseContext()
+
+  return useInfiniteQuery<PaginatedResults<Evaluation>, SynapseClientError>(
+    keyFactory.getEvaluationsQueryKey(request),
+    async context =>
+      SynapseClient.getEvaluations(
+        { ...request, limit: LIMIT, offset: context.pageParam },
+        accessToken,
+      ),
+
+    {
+      ...options,
+      getNextPageParam: getNextPageParamForPaginatedResults,
+    },
+  )
+}

--- a/packages/synapse-react-client/src/synapse-queries/trash/useTrashCan.ts
+++ b/packages/synapse-react-client/src/synapse-queries/trash/useTrashCan.ts
@@ -12,6 +12,7 @@ import {
   PaginatedResults,
   TrashedEntity,
 } from '@sage-bionetworks/synapse-types'
+import { getNextPageParamForPaginatedResults } from '../InfiniteQueryUtils'
 
 export function useGetItemsInTrashCanInfinite(
   options?: UseInfiniteQueryOptions<
@@ -28,16 +29,7 @@ export function useGetItemsInTrashCanInfinite(
     },
     {
       ...options,
-      getNextPageParam: (page, pages) => {
-        const numberOfFetchedResults = pages.flatMap(
-          page => page.results,
-        ).length
-        if (page.totalNumberOfResults! > numberOfFetchedResults) {
-          return numberOfFetchedResults
-        } else {
-          return undefined
-        }
-      },
+      getNextPageParam: getNextPageParamForPaginatedResults,
     },
   )
 }

--- a/packages/synapse-react-client/src/synapse-queries/user/useFavorites.ts
+++ b/packages/synapse-react-client/src/synapse-queries/user/useFavorites.ts
@@ -15,6 +15,7 @@ import {
   FavoriteSortBy,
   FavoriteSortDirection,
 } from '@sage-bionetworks/synapse-types'
+import { getNextPageParamForPaginatedResults } from '../InfiniteQueryUtils'
 
 export function useIsFavorite(entityId: string) {
   // TODO: Handle pagination - the default limit is 200
@@ -119,11 +120,7 @@ export function useGetFavoritesInfinite(
     },
     {
       ...options,
-      getNextPageParam: (lastPage, pages) => {
-        if (lastPage.results.length > 0) return pages.length * LIMIT
-        //set the new offset to (page * limit)
-        else return undefined
-      },
+      getNextPageParam: getNextPageParamForPaginatedResults,
     },
   )
 }

--- a/packages/synapse-react-client/src/synapse-queries/user/useGetUserTeams.ts
+++ b/packages/synapse-react-client/src/synapse-queries/user/useGetUserTeams.ts
@@ -9,6 +9,7 @@ import { SynapseClientError } from '../../utils/SynapseClientError'
 import { useSynapseContext } from '../../utils/context/SynapseContext'
 import { PaginatedIds, PaginatedResults } from '@sage-bionetworks/synapse-types'
 import { Team } from '@sage-bionetworks/synapse-types'
+import { getNextPageParamForPaginatedResults } from '../InfiniteQueryUtils'
 
 export function useGetUserSubmissionTeamsInfinite(
   challengeId: string,
@@ -47,7 +48,7 @@ export function useGetUserTeamsInfinite(
   >,
 ) {
   const { accessToken, keyFactory } = useSynapseContext()
-
+  const LIMIT = 10
   return useInfiniteQuery<PaginatedResults<Team>, SynapseClientError>(
     keyFactory.getUserTeamsQueryKey(userId),
     async context => {
@@ -55,16 +56,12 @@ export function useGetUserTeamsInfinite(
         accessToken,
         userId,
         context.pageParam, // pass the context.pageParam for the new offset
-        10, // limit
+        LIMIT, // limit
       )
     },
     {
       ...options,
-      getNextPageParam: (lastPage, pages) => {
-        if (lastPage.results.length > 0)
-          return pages.length * 10 //set the new offset to (page * limit)
-        else return undefined
-      },
+      getNextPageParam: getNextPageParamForPaginatedResults,
     },
   )
 }

--- a/packages/synapse-react-client/src/utils/APIConstants.ts
+++ b/packages/synapse-react-client/src/utils/APIConstants.ts
@@ -132,8 +132,6 @@ export const APPROVED_SUBMISSION_INFO = (
 
 export const EVALUATION = `${REPO}/evaluation`
 export const EVALUATION_BY_ID = (id: string | number) => EVALUATION + `/${id}`
-export const EVALUATIONS_BY_ID = (ids: string[] | number[]) =>
-  EVALUATION + `/?evaluationIds=${ids.join(',')}&limit=${ids.length}`
 
 export const ACTIVITY_FOR_ENTITY = (entityId: string, versionNumber?: string) =>
   versionNumber

--- a/packages/synapse-react-client/src/utils/hooks/useGetInfoFromIds.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useGetInfoFromIds.ts
@@ -103,7 +103,7 @@ const getEvaluationItems = async (
   lookupList: string[],
   token: string | undefined,
 ): Promise<Evaluation[]> => {
-  const newData = await getEvaluations(lookupList, token)
+  const newData = await getEvaluations({ evaluationIds: lookupList }, token)
   const notFound = lookupList.filter(
     item => newData.results.map(item => item.id).indexOf(item) === -1,
   )

--- a/packages/synapse-types/src/Evaluation/GetEvaluationParameters.ts
+++ b/packages/synapse-types/src/Evaluation/GetEvaluationParameters.ts
@@ -1,3 +1,5 @@
+// https://rest-docs.synapse.org/rest/GET/evaluation.html
+// and
 // https://rest-docs.synapse.org/rest/GET/entity/id/evaluation.html
 
 import ACCESS_TYPE from '../ACCESS_TYPE'
@@ -6,5 +8,6 @@ export type GetEvaluationParameters = {
   accessType?: ACCESS_TYPE
   activeOnly?: boolean
   evaluationIds?: string[]
-  nextPageToken?: string | null
+  limit?: number
+  offset?: number
 }


### PR DESCRIPTION
 - Add EvaluationFinder, which will be used to choose evaluations for a SubmissionView
 - Update MarkdownPopover to not propagate click and prevent default behavior, fixing a case where opening a popover would toggle the checkbox in the EvaluationFinder
 - Update Checkbox to allow passing any ReactNode as a label
 - Update and reuse logic for `getNextPageParam` for infinite queries where the response is a PaginatedResults object
 - Change SynapseClient.getEvaluations signature to allow passing any parameters

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/6de1bd04-a55f-47b6-abfb-9e085061481c

