### PR TITLE
SWC-6627 - Add EntityViewMaskEditor and EntityViewScopeEditor

### DIFF
--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.stories.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.stories.tsx
@@ -1,0 +1,38 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { Paper } from '@mui/material'
+import React, { useState } from 'react'
+import EntityViewMaskEditor from './EntityViewMaskEditor'
+import {
+  ENTITY_VIEW_TYPE_MASK_DOCKER,
+  ENTITY_VIEW_TYPE_MASK_FILE,
+} from '@sage-bionetworks/synapse-types'
+
+const meta: Meta = {
+  title: 'Synapse/EntityView/Mask Editor',
+  component: EntityViewMaskEditor,
+  decorators: [
+    Story => (
+      <Paper sx={{ mx: 'auto', p: 4, maxWidth: '720px' }}>
+        <Story />
+      </Paper>
+    ),
+  ],
+  render: function Render(args) {
+    const [value, setValue] = useState<number>(args.value)
+    return <EntityViewMaskEditor {...args} value={value} onChange={setValue} />
+  },
+} satisfies Meta
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const FileView: Story = {
+  args: {
+    value: ENTITY_VIEW_TYPE_MASK_FILE,
+  },
+}
+
+export const CustomScope: Story = {
+  args: {
+    value: ENTITY_VIEW_TYPE_MASK_FILE | ENTITY_VIEW_TYPE_MASK_DOCKER,
+  },
+}

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.test.tsx
@@ -52,7 +52,7 @@ describe('EntityViewMaskEditor tests', () => {
     )
   })
 
-  it('Disables input if an unsupported mask value is passed', async () => {
+  it('Disables input if an unsupported mask value is passed', () => {
     const value = ENTITY_VIEW_TYPE_MASK_DOCKER
     const onChange = jest.fn()
     renderComponent({ value, onChange })

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.test.tsx
@@ -53,13 +53,18 @@ describe('EntityViewMaskEditor tests', () => {
   })
 
   it('Disables input if an unsupported mask value is passed', () => {
-    const value = ENTITY_VIEW_TYPE_MASK_DOCKER
+    const value = ENTITY_VIEW_TYPE_MASK_FILE | ENTITY_VIEW_TYPE_MASK_DOCKER
     const onChange = jest.fn()
     renderComponent({ value, onChange })
 
     screen
       .getAllByRole('checkbox')
       .forEach(checkbox => expect(checkbox).toBeDisabled())
+
+    expect(screen.getByLabelText('Files')).toBeChecked()
+    expect(screen.getByLabelText('Folders')).not.toBeChecked()
+    expect(screen.getByLabelText('Tables')).not.toBeChecked()
+    expect(screen.getByLabelText('Datasets')).not.toBeChecked()
 
     const alert = screen.getByRole('alert')
     within(alert).getByText(

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import EntityViewMaskEditor, {
+  EntityViewMaskEditorProps,
+  isMaskSupportedInUI,
+} from './EntityViewMaskEditor'
+import { render, screen, within } from '@testing-library/react'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import {
+  ENTITY_VIEW_TYPE_MASK_DOCKER,
+  ENTITY_VIEW_TYPE_MASK_FILE,
+  ENTITY_VIEW_TYPE_MASK_FOLDER,
+  ENTITY_VIEW_TYPE_MASK_TABLE,
+} from '@sage-bionetworks/synapse-types'
+import userEvent from '@testing-library/user-event'
+
+describe('EntityViewMaskEditor tests', () => {
+  function renderComponent(props: EntityViewMaskEditorProps) {
+    return render(<EntityViewMaskEditor {...props} />, {
+      wrapper: createWrapper(),
+    })
+  }
+
+  it('renders mask settings with checked fields matching the passed value', () => {
+    const value = ENTITY_VIEW_TYPE_MASK_FILE | ENTITY_VIEW_TYPE_MASK_FOLDER
+    const onChange = jest.fn()
+    renderComponent({ value, onChange })
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(4)
+
+    expect(screen.getByLabelText('Files')).toBeChecked()
+    expect(screen.getByLabelText('Folders')).toBeChecked()
+    expect(screen.getByLabelText('Tables')).not.toBeChecked()
+    expect(screen.getByLabelText('Datasets')).not.toBeChecked()
+  })
+  it('onChange works', async () => {
+    const value = ENTITY_VIEW_TYPE_MASK_FILE | ENTITY_VIEW_TYPE_MASK_FOLDER
+    const onChange = jest.fn()
+    renderComponent({ value, onChange })
+
+    // Try untoggling 'Files'
+    await userEvent.click(screen.getByLabelText('Files'))
+    expect(onChange).toHaveBeenCalledWith(ENTITY_VIEW_TYPE_MASK_FOLDER)
+
+    // Try adding 'Tables'
+    // Note that we didn't update the prop passed to the component, so both Files and Folders are still checked
+    await userEvent.click(screen.getByLabelText('Tables'))
+    expect(onChange).toHaveBeenCalledWith(
+      ENTITY_VIEW_TYPE_MASK_FILE |
+        ENTITY_VIEW_TYPE_MASK_FOLDER |
+        ENTITY_VIEW_TYPE_MASK_TABLE,
+    )
+  })
+
+  it('Disables input if an unsupported mask value is passed', async () => {
+    const value = ENTITY_VIEW_TYPE_MASK_DOCKER
+    const onChange = jest.fn()
+    renderComponent({ value, onChange })
+
+    screen
+      .getAllByRole('checkbox')
+      .forEach(checkbox => expect(checkbox).toBeDisabled())
+
+    const alert = screen.getByRole('alert')
+    within(alert).getByText(
+      'A custom mask is in use. Changes cannot be made in the UI.',
+    )
+  })
+
+  it('isMaskSupportedInUI', () => {
+    expect(isMaskSupportedInUI(ENTITY_VIEW_TYPE_MASK_FILE)).toBe(true)
+    expect(
+      isMaskSupportedInUI(
+        ENTITY_VIEW_TYPE_MASK_FILE | ENTITY_VIEW_TYPE_MASK_FOLDER,
+      ),
+    ).toBe(true)
+
+    expect(isMaskSupportedInUI(ENTITY_VIEW_TYPE_MASK_DOCKER)).toBe(false)
+    expect(
+      isMaskSupportedInUI(
+        ENTITY_VIEW_TYPE_MASK_FILE | ENTITY_VIEW_TYPE_MASK_DOCKER,
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.tsx
@@ -21,13 +21,14 @@ const maskLabelPairs: [string, number][] = [
 ]
 
 export function isMaskSupportedInUI(value: number) {
-  // Union of all the supported UI mask values
-  const allMasksSupportedInEditor = maskLabelPairs.reduce(
-    (acc, [, mask]) => acc | mask,
-    0,
-  )
-  // Flip the bits and & with the value -- if any bits remain, then an unsupported mask is in use
-  return (~allMasksSupportedInEditor & value) === 0
+  maskLabelPairs.forEach(([, mask]) => {
+    // Remove each supported bit
+    if ((value & mask) !== 0) {
+      value = value - mask
+    }
+  })
+  // If value is not zero, then some unsupported bit remains
+  return value === 0
 }
 
 export default function EntityViewMaskEditor(props: EntityViewMaskEditorProps) {
@@ -45,7 +46,10 @@ export default function EntityViewMaskEditor(props: EntityViewMaskEditorProps) {
           <Checkbox
             key={label}
             label={label}
-            checked={(value & mask) > 0}
+            checked={
+              // Checked if the mask bit is set
+              (value & mask) > 0
+            }
             disabled={customMaskInUse}
             onChange={() => {
               // Toggle the clicked mask value with XOR

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewMaskEditor.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { Alert, FormGroup, Typography } from '@mui/material'
+import {
+  ENTITY_VIEW_TYPE_MASK_DATASET,
+  ENTITY_VIEW_TYPE_MASK_FILE,
+  ENTITY_VIEW_TYPE_MASK_FOLDER,
+  ENTITY_VIEW_TYPE_MASK_TABLE,
+} from '@sage-bionetworks/synapse-types'
+import { Checkbox } from '../widgets/Checkbox'
+
+export type EntityViewMaskEditorProps = {
+  value: number
+  onChange: (mask: number) => void
+}
+
+const maskLabelPairs: [string, number][] = [
+  ['Files', ENTITY_VIEW_TYPE_MASK_FILE],
+  ['Folders', ENTITY_VIEW_TYPE_MASK_FOLDER],
+  ['Tables', ENTITY_VIEW_TYPE_MASK_TABLE],
+  ['Datasets', ENTITY_VIEW_TYPE_MASK_DATASET],
+]
+
+export function isMaskSupportedInUI(value: number) {
+  // Union of all the supported UI mask values
+  const allMasksSupportedInEditor = maskLabelPairs.reduce(
+    (acc, [, mask]) => acc | mask,
+    0,
+  )
+  // Flip the bits and & with the value -- if any bits remain, then an unsupported mask is in use
+  return (~allMasksSupportedInEditor & value) === 0
+}
+
+export default function EntityViewMaskEditor(props: EntityViewMaskEditorProps) {
+  const { value, onChange } = props
+
+  const customMaskInUse = !isMaskSupportedInUI(value)
+
+  return (
+    <>
+      <Typography variant={'body1'} mt={2.5} mb={1.25} sx={{ fontWeight: 700 }}>
+        Include in View
+      </Typography>
+      <FormGroup sx={{ gap: 1 }}>
+        {maskLabelPairs.map(([label, mask]) => (
+          <Checkbox
+            key={label}
+            label={label}
+            checked={(value & mask) > 0}
+            disabled={customMaskInUse}
+            onChange={() => {
+              // Toggle the clicked mask value with XOR
+              onChange(value ^ mask)
+            }}
+          />
+        ))}
+      </FormGroup>
+      {customMaskInUse && (
+        <Alert severity={'warning'} sx={{ my: 2.25 }}>
+          A custom mask is in use. Changes cannot be made in the UI.
+        </Alert>
+      )}
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.stories.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.stories.tsx
@@ -15,6 +15,10 @@ const meta: Meta = {
       </Paper>
     ),
   ],
+  render: function Render(args) {
+    const [ids, setIds] = React.useState<string[]>([])
+    return <EntityViewScopeEditor {...args} scopeIds={ids} onChange={setIds} />
+  },
 } satisfies Meta
 export default meta
 type Story = StoryObj<typeof meta>

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.stories.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from '@storybook/react'
+import EntityViewScopeEditor from './EntityViewScopeEditor'
+import mockProject from '../../mocks/entity/mockProject'
+import { mockFolderEntity } from '../../mocks/entity/mockEntity'
+import { Paper } from '@mui/material'
+import React from 'react'
+
+const meta: Meta = {
+  title: 'Synapse/EntityView/Scope Editor',
+  component: EntityViewScopeEditor,
+  decorators: [
+    Story => (
+      <Paper sx={{ mx: 'auto', p: 4, maxWidth: '720px' }}>
+        <Story />
+      </Paper>
+    ),
+  ],
+} satisfies Meta
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Empty: Story = {
+  args: {
+    scopeIds: [],
+  },
+}
+
+export const HasItems: Story = {
+  args: {
+    scopeIds: [mockProject.id, mockFolderEntity.id!],
+  },
+}

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import EntityViewScopeEditor, {
+  EntityViewScopeEditorProps,
+} from './EntityViewScopeEditor'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import EntityHeaderTable from '../EntityHeaderTable'
+import { VersionSelectionType } from '../EntityFinder/VersionSelectionType'
+import { FinderScope } from '../EntityFinder/tree/EntityTree'
+import { EntityType } from '@sage-bionetworks/synapse-types'
+
+jest.mock('../EntityHeaderTable', () => ({
+  __esModule: true,
+  default: jest.fn(() => <div data-testid={'EntityHeaderTableMocked'} />),
+}))
+
+const mockedEntityHeaderTable = jest.mocked(EntityHeaderTable)
+
+function renderComponent(props: EntityViewScopeEditorProps) {
+  return render(<EntityViewScopeEditor {...props} />, {
+    wrapper: createWrapper(),
+  })
+}
+
+describe('EntityViewScopeEditor tests', () => {
+  it('Renders an EntityHeaderTable which can be used to update scope', async () => {
+    const scopeIds = ['syn123']
+    const onChange = jest.fn()
+    const isProjectView = false
+    renderComponent({
+      scopeIds,
+      onChange,
+      isProjectView,
+    })
+
+    await screen.findByText('Scope')
+    await screen.findByTestId('EntityHeaderTableMocked')
+
+    await waitFor(() =>
+      expect(mockedEntityHeaderTable).toHaveBeenLastCalledWith(
+        {
+          references: [{ targetId: 'syn123' }],
+          isEditable: true,
+          onUpdate: expect.anything(),
+          removeSelectedRowsButtonText: 'Remove Selected Items from View Scope',
+          objectNameCopy: 'container',
+          hideTextFieldToPasteValue: true,
+          entityFinderConfiguration: {
+            selectMultiple: true,
+            versionSelection: VersionSelectionType.DISALLOWED,
+            initialScope: FinderScope.ALL_PROJECTS,
+            initialContainer: 'root',
+            selectableTypes: expect.arrayContaining([
+              EntityType.PROJECT,
+              EntityType.FOLDER,
+            ]),
+          },
+        },
+        expect.anything(),
+      ),
+    )
+
+    const capturedOnUpdate = mockedEntityHeaderTable.mock.lastCall![0].onUpdate!
+
+    act(() => {
+      capturedOnUpdate([{ targetId: 'syn123' }, { targetId: 'syn456' }])
+    })
+
+    expect(onChange).toHaveBeenLastCalledWith(['syn123', 'syn456'])
+  })
+
+  it('Shows text when scope is empty', async () => {
+    const scopeIds: string[] = []
+    const onChange = jest.fn()
+    const isProjectView = false
+    renderComponent({
+      scopeIds,
+      onChange,
+      isProjectView,
+    })
+    await screen.findByText('Empty! Add items to populate your view')
+
+    await waitFor(() =>
+      expect(mockedEntityHeaderTable).toHaveBeenLastCalledWith(
+        {
+          references: [],
+          isEditable: true,
+          onUpdate: expect.anything(),
+          removeSelectedRowsButtonText: 'Remove Selected Items from View Scope',
+          objectNameCopy: 'container',
+          hideTextFieldToPasteValue: true,
+          entityFinderConfiguration: {
+            selectMultiple: true,
+            versionSelection: VersionSelectionType.DISALLOWED,
+            initialScope: FinderScope.ALL_PROJECTS,
+            initialContainer: 'root',
+            selectableTypes: expect.arrayContaining([
+              EntityType.PROJECT,
+              EntityType.FOLDER,
+            ]),
+          },
+        },
+        expect.anything(),
+      ),
+    )
+  })
+
+  it('Restricts the selectable types based on isProjectView', async () => {
+    const scopeIds = ['syn123']
+    const onChange = jest.fn()
+    const isProjectView = true // !
+    renderComponent({
+      scopeIds,
+      onChange,
+      isProjectView,
+    })
+
+    await screen.findByText('Scope')
+    await screen.findByTestId('EntityHeaderTableMocked')
+
+    await waitFor(() =>
+      expect(mockedEntityHeaderTable).toHaveBeenLastCalledWith(
+        {
+          references: [{ targetId: 'syn123' }],
+          isEditable: true,
+          onUpdate: expect.anything(),
+          removeSelectedRowsButtonText: 'Remove Selected Items from View Scope',
+          objectNameCopy: 'container',
+          hideTextFieldToPasteValue: true,
+          entityFinderConfiguration: {
+            selectMultiple: true,
+            versionSelection: VersionSelectionType.DISALLOWED,
+            initialScope: FinderScope.ALL_PROJECTS,
+            initialContainer: 'root',
+            selectableTypes: expect.arrayContaining([
+              EntityType.PROJECT,
+              // Folders cannot be added to a Project View!
+              // EntityType.FOLDER,
+            ]),
+          },
+        },
+        expect.anything(),
+      ),
+    )
+  })
+})

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.test.tsx
@@ -108,7 +108,7 @@ describe('EntityViewScopeEditor tests', () => {
   it('Restricts the selectable types based on isProjectView', async () => {
     const scopeIds = ['syn123']
     const onChange = jest.fn()
-    const isProjectView = true // !
+    const isProjectView = true // Test different UI for project views
     renderComponent({
       scopeIds,
       onChange,
@@ -125,7 +125,7 @@ describe('EntityViewScopeEditor tests', () => {
           isEditable: true,
           onUpdate: expect.anything(),
           removeSelectedRowsButtonText: 'Remove Selected Items from View Scope',
-          objectNameCopy: 'container',
+          objectNameCopy: 'project',
           hideTextFieldToPasteValue: true,
           entityFinderConfiguration: {
             selectMultiple: true,

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.tsx
@@ -18,7 +18,7 @@ export type EntityViewScopeEditorProps = {
 export default function EntityViewScopeEditor(
   props: EntityViewScopeEditorProps,
 ) {
-  const { scopeIds, isProjectView = false } = props
+  const { scopeIds, isProjectView = false, onChange } = props
   const references: ReferenceList = useMemo(
     () => scopeIds.map(scope => ({ targetId: scope })),
     [scopeIds],
@@ -38,10 +38,10 @@ export default function EntityViewScopeEditor(
         references={references}
         isEditable={true}
         onUpdate={newReferences => {
-          props.onChange(newReferences.map(ref => ref.targetId))
+          onChange(newReferences.map(ref => ref.targetId))
         }}
         removeSelectedRowsButtonText={'Remove Selected Items from View Scope'}
-        objectNameCopy={'container'}
+        objectNameCopy={isProjectView ? 'project' : 'container'}
         hideTextFieldToPasteValue={true}
         entityFinderConfiguration={{
           selectMultiple: true,

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.tsx
@@ -1,0 +1,58 @@
+import React, { useMemo } from 'react'
+import EntityHeaderTable from '../EntityHeaderTable'
+import { EntityType, ReferenceList } from '@sage-bionetworks/synapse-types'
+import { VersionSelectionType } from '../EntityFinder/VersionSelectionType'
+import { FinderScope } from '../EntityFinder/tree/EntityTree'
+import { EntityTypeGroup } from '../../utils/functions/EntityTypeUtils'
+import { Typography } from '@mui/material'
+
+const DEFAULT_SELECTABLE_TYPES = EntityTypeGroup.CONTAINER
+const PROJECT_VIEW_SELECTABLE_TYPES = [EntityType.PROJECT]
+
+export type EntityViewScopeEditorProps = {
+  scopeIds: string[]
+  onChange: (scopeIds: string[]) => void
+  isProjectView?: boolean
+}
+
+export default function EntityViewScopeEditor(
+  props: EntityViewScopeEditorProps,
+) {
+  const { scopeIds, isProjectView = false } = props
+  const references: ReferenceList = useMemo(
+    () => scopeIds.map(scope => ({ targetId: scope })),
+    [scopeIds],
+  )
+
+  return (
+    <>
+      <Typography variant={'body1'} mb={1.25} sx={{ fontWeight: 700 }}>
+        Scope
+      </Typography>
+      {scopeIds.length === 0 && (
+        <Typography variant={'smallText1'} color={'grey.600'}>
+          Empty! Add items to populate your view
+        </Typography>
+      )}
+      <EntityHeaderTable
+        references={references}
+        isEditable={true}
+        onUpdate={newReferences => {
+          props.onChange(newReferences.map(ref => ref.targetId))
+        }}
+        removeSelectedRowsButtonText={'Remove Selected Items from View Scope'}
+        objectNameCopy={'container'}
+        hideTextFieldToPasteValue={true}
+        entityFinderConfiguration={{
+          selectMultiple: true,
+          versionSelection: VersionSelectionType.DISALLOWED,
+          initialScope: FinderScope.ALL_PROJECTS,
+          initialContainer: 'root',
+          selectableTypes: isProjectView
+            ? PROJECT_VIEW_SELECTABLE_TYPES
+            : DEFAULT_SELECTABLE_TYPES,
+        }}
+      />
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/utils/functions/EntityTypeUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/EntityTypeUtils.ts
@@ -374,7 +374,7 @@ export const entityJsonKeys: Record<ENTITY_CONCRETE_TYPE, string[]> = {
   [PROJECT_CONCRETE_TYPE_VALUE]: [...allEntityKeys, 'alias'],
 }
 
-type EntityTypeGroupKey = 'ALL_TABLES'
+type EntityTypeGroupKey = 'ALL_TABLES' | 'CONTAINER'
 
 export const EntityTypeGroup: Record<EntityTypeGroupKey, EntityType[]> = {
   ['ALL_TABLES']: [
@@ -386,4 +386,5 @@ export const EntityTypeGroup: Record<EntityTypeGroupKey, EntityType[]> = {
     EntityType.MATERIALIZED_VIEW,
     EntityType.VIRTUAL_TABLE,
   ],
+  ['CONTAINER']: [EntityType.PROJECT, EntityType.FOLDER],
 }


### PR DESCRIPTION
## Mask 

<img width="251" alt="image" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/90ff3e9a-962d-46dc-a196-facf74552546">

<img width="764" alt="image" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/6826b341-0bf9-4508-ba43-b66fdd74208b">

## Scope


https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/ce53dc63-ed51-4463-bf89-ad18173b603e


