### PR TITLE
SWC-6627 - Add WizardChoiceButton, TableTypeSelection, ViewTypeSelection, SqlDefinedTableEditor

### DIFF
--- a/packages/synapse-react-client/src/components/CreateTableViewWizard/TableTypeSelection.test.tsx
+++ b/packages/synapse-react-client/src/components/CreateTableViewWizard/TableTypeSelection.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { render, screen, within } from '@testing-library/react'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import TableTypeSelection, {
+  TableTypeSelectionProps,
+} from './TableTypeSelection'
+import userEvent from '@testing-library/user-event'
+
+describe('TableTypeSelection', () => {
+  function renderComponent(props: TableTypeSelectionProps) {
+    return render(<TableTypeSelection {...props} />, {
+      wrapper: createWrapper(),
+    })
+  }
+
+  test('Table type selection menu is shown and callbacks work', async () => {
+    const onTableSelected = jest.fn()
+    const onViewSelected = jest.fn()
+    renderComponent({
+      onTableSelected,
+      onViewSelected,
+    })
+
+    const menu = screen.getByRole('menu')
+    const menuItems = within(menu).getAllByRole('menuitem')
+    expect(menuItems).toHaveLength(2)
+    within(menuItems[0]).getByText(/^Table$/)
+    within(menuItems[1]).getByText(/^View$/)
+
+    await userEvent.click(menuItems[0])
+    expect(onTableSelected).toHaveBeenCalled()
+
+    await userEvent.click(menuItems[1])
+    expect(onViewSelected).toHaveBeenCalled()
+  })
+})

--- a/packages/synapse-react-client/src/components/CreateTableViewWizard/TableTypeSelection.tsx
+++ b/packages/synapse-react-client/src/components/CreateTableViewWizard/TableTypeSelection.tsx
@@ -6,7 +6,7 @@ import { Link } from '@mui/material'
 
 const TABLE_DESCRIPTION = (
   <>
-    <WizardChoiceButtonDescription my={1.25}>
+    <WizardChoiceButtonDescription>
       Synapse tables are used to organize web-accessible, sharable, and
       queryable data. Tables may be queried and edited with the Synapse UI, as
       well as with the Synapse programmatic clients.
@@ -27,7 +27,7 @@ const TABLE_DESCRIPTION = (
 
 const VIEW_DESCRIPTION = (
   <>
-    <WizardChoiceButtonDescription my={1.25}>
+    <WizardChoiceButtonDescription>
       Views allow you to see and query groups of other objects in Synapse, such
       as files, tables, projects, or submissions and any associated annotations
       about those items.
@@ -45,7 +45,7 @@ const VIEW_DESCRIPTION = (
 )
 
 export type TableTypeSelectionProps = {
-  /* Callback including the chosen type, and optional viewTypeMask if included in the choice (e.g. Project Views) */
+  /* Callback invoked if the user selects "Table" */
   onTableSelected: () => void
   /* Callback invoked if the user selects the "View" group, which will show more options */
   onViewSelected: () => void

--- a/packages/synapse-react-client/src/components/CreateTableViewWizard/TableTypeSelection.tsx
+++ b/packages/synapse-react-client/src/components/CreateTableViewWizard/TableTypeSelection.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import WizardChoiceButtonGroup from '../WizardChoiceButton/WizardChoiceButtonGroup'
+import WizardChoiceButton from '../WizardChoiceButton/WizardChoiceButton'
+import WizardChoiceButtonDescription from '../WizardChoiceButton/WizardChoiceButtonDescription'
+import { Link } from '@mui/material'
+
+const TABLE_DESCRIPTION = (
+  <>
+    <WizardChoiceButtonDescription my={1.25}>
+      Synapse tables are used to organize web-accessible, sharable, and
+      queryable data. Tables may be queried and edited with the Synapse UI, as
+      well as with the Synapse programmatic clients.
+    </WizardChoiceButtonDescription>
+    <Link
+      href={
+        'https://help.synapse.org/docs/Organizing-Data-With-Tables.2011038095.html'
+      }
+      target="_blank"
+      onClick={e => {
+        e.stopPropagation()
+      }}
+    >
+      More about Tables
+    </Link>
+  </>
+)
+
+const VIEW_DESCRIPTION = (
+  <>
+    <WizardChoiceButtonDescription my={1.25}>
+      Views allow you to see and query groups of other objects in Synapse, such
+      as files, tables, projects, or submissions and any associated annotations
+      about those items.
+    </WizardChoiceButtonDescription>
+    <Link
+      href={'https://help.synapse.org/docs/Views.2011070739.html'}
+      target="_blank"
+      onClick={e => {
+        e.stopPropagation()
+      }}
+    >
+      More about Views
+    </Link>
+  </>
+)
+
+export type TableTypeSelectionProps = {
+  /* Callback including the chosen type, and optional viewTypeMask if included in the choice (e.g. Project Views) */
+  onTableSelected: () => void
+  /* Callback invoked if the user selects the "View" group, which will show more options */
+  onViewSelected: () => void
+}
+
+/**
+ * React component for the first step of creating a new table or view.
+ * The user will decide if they want to create a Table or a View
+ */
+export default function TableTypeSelection(props: TableTypeSelectionProps) {
+  const { onTableSelected, onViewSelected } = props
+  return (
+    <WizardChoiceButtonGroup>
+      <WizardChoiceButton
+        title={'Table'}
+        description={TABLE_DESCRIPTION}
+        onClick={() => {
+          onTableSelected()
+        }}
+      />
+      <WizardChoiceButton
+        title={'View'}
+        description={VIEW_DESCRIPTION}
+        onClick={onViewSelected}
+      />
+    </WizardChoiceButtonGroup>
+  )
+}

--- a/packages/synapse-react-client/src/components/CreateTableViewWizard/ViewTypeSelection.test.tsx
+++ b/packages/synapse-react-client/src/components/CreateTableViewWizard/ViewTypeSelection.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { render, screen, within } from '@testing-library/react'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import userEvent from '@testing-library/user-event'
+import ViewTypeSelection, { ViewTypeSelectionProps } from './ViewTypeSelection'
+import {
+  ENTITY_VIEW_TYPE_MASK_PROJECT,
+  EntityType,
+} from '@sage-bionetworks/synapse-types'
+
+describe('ViewTypeSelection', () => {
+  function renderComponent(
+    props: ViewTypeSelectionProps,
+    isInExperimentalMode: boolean,
+  ) {
+    return render(<ViewTypeSelection {...props} />, {
+      wrapper: createWrapper({ isInExperimentalMode }),
+    })
+  }
+
+  test('View type selection menu is shown and callbacks work', async () => {
+    const onTypeSelected = jest.fn()
+    renderComponent(
+      {
+        onTypeSelected,
+      },
+      true,
+    )
+
+    const menu = screen.getByRole('menu')
+    const menuItems = within(menu).getAllByRole('menuitem')
+    expect(menuItems).toHaveLength(5)
+
+    within(menuItems[0]).getByText(/^Files, Folders, and Other Objects$/)
+    within(menuItems[1]).getByText(/^Projects$/)
+    within(menuItems[2]).getByText(/^Challenge Submissions$/)
+    within(menuItems[3]).getByText(/^Materialized View$/)
+    within(menuItems[4]).getByText(/^Virtual Table$/)
+
+    await userEvent.click(menuItems[0])
+    expect(onTypeSelected).toHaveBeenCalledWith(EntityType.ENTITY_VIEW)
+
+    await userEvent.click(menuItems[1])
+    expect(onTypeSelected).toHaveBeenCalledWith(
+      EntityType.ENTITY_VIEW,
+      ENTITY_VIEW_TYPE_MASK_PROJECT,
+    )
+
+    await userEvent.click(menuItems[2])
+    expect(onTypeSelected).toHaveBeenCalledWith(EntityType.SUBMISSION_VIEW)
+
+    await userEvent.click(menuItems[3])
+    expect(onTypeSelected).toHaveBeenCalledWith(EntityType.MATERIALIZED_VIEW)
+
+    await userEvent.click(menuItems[4])
+    expect(onTypeSelected).toHaveBeenCalledWith(EntityType.VIRTUAL_TABLE)
+  })
+
+  it('hides virtual table out of experimental mode', () => {
+    const onTypeSelected = jest.fn()
+    renderComponent(
+      {
+        onTypeSelected,
+      },
+      false,
+    )
+
+    const menu = screen.getByRole('menu')
+    const menuItems = within(menu).getAllByRole('menuitem')
+    expect(menuItems).toHaveLength(4)
+
+    expect(within(menu).queryByText(/^Virtual Table$/)).not.toBeInTheDocument()
+  })
+})

--- a/packages/synapse-react-client/src/components/CreateTableViewWizard/ViewTypeSelection.tsx
+++ b/packages/synapse-react-client/src/components/CreateTableViewWizard/ViewTypeSelection.tsx
@@ -11,7 +11,7 @@ import { useSynapseContext } from '../../utils'
 
 const FILE_VIEW_DESCRIPTION = (
   <>
-    <WizardChoiceButtonDescription my={1.25}>
+    <WizardChoiceButtonDescription>
       This view lists all files, folders, and/or tables in the selected folders
       or projects.
     </WizardChoiceButtonDescription>
@@ -31,7 +31,7 @@ const FILE_VIEW_DESCRIPTION = (
 
 const PROJECT_VIEW_DESCRIPTION = (
   <>
-    <WizardChoiceButtonDescription my={1.25}>
+    <WizardChoiceButtonDescription>
       This view lists all (and only) your selected projects.
     </WizardChoiceButtonDescription>
     <Link
@@ -50,7 +50,7 @@ const PROJECT_VIEW_DESCRIPTION = (
 
 const SUBMISSION_VIEW_DESCRIPTION = (
   <>
-    <WizardChoiceButtonDescription my={1.25}>
+    <WizardChoiceButtonDescription>
       This view lists all submissions within one or more evaluation queues.
     </WizardChoiceButtonDescription>
     <Link
@@ -69,7 +69,7 @@ const SUBMISSION_VIEW_DESCRIPTION = (
 
 const MATERIALIZED_VIEW_DESCRIPTION = (
   <>
-    <WizardChoiceButtonDescription my={1.25}>
+    <WizardChoiceButtonDescription>
       The results of a query across multiple sources, defined by a SQL
       statement.
     </WizardChoiceButtonDescription>
@@ -88,7 +88,7 @@ const MATERIALIZED_VIEW_DESCRIPTION = (
 )
 
 const VIRTUAL_TABLE_DESCRIPTION = (
-  <WizardChoiceButtonDescription my={1.25}>
+  <WizardChoiceButtonDescription>
     A saved query on another table or view where complex filters can be applied
     to aggregated results.
   </WizardChoiceButtonDescription>

--- a/packages/synapse-react-client/src/components/CreateTableViewWizard/ViewTypeSelection.tsx
+++ b/packages/synapse-react-client/src/components/CreateTableViewWizard/ViewTypeSelection.tsx
@@ -1,0 +1,152 @@
+import React from 'react'
+import {
+  ENTITY_VIEW_TYPE_MASK_PROJECT,
+  EntityType,
+} from '@sage-bionetworks/synapse-types'
+import WizardChoiceButtonGroup from '../WizardChoiceButton/WizardChoiceButtonGroup'
+import WizardChoiceButton from '../WizardChoiceButton/WizardChoiceButton'
+import { Link } from '@mui/material'
+import WizardChoiceButtonDescription from '../WizardChoiceButton/WizardChoiceButtonDescription'
+import { useSynapseContext } from '../../utils'
+
+const FILE_VIEW_DESCRIPTION = (
+  <>
+    <WizardChoiceButtonDescription my={1.25}>
+      This view lists all files, folders, and/or tables in the selected folders
+      or projects.
+    </WizardChoiceButtonDescription>
+    <Link
+      href={
+        'https://help.synapse.org/docs/Views.2011070739.html#Views-CreatingaFileView'
+      }
+      target="_blank"
+      onClick={e => {
+        e.stopPropagation()
+      }}
+    >
+      More about File Views
+    </Link>
+  </>
+)
+
+const PROJECT_VIEW_DESCRIPTION = (
+  <>
+    <WizardChoiceButtonDescription my={1.25}>
+      This view lists all (and only) your selected projects.
+    </WizardChoiceButtonDescription>
+    <Link
+      href={
+        'https://help.synapse.org/docs/Views.2011070739.html#Views-CreatingaProjectView'
+      }
+      target="_blank"
+      onClick={e => {
+        e.stopPropagation()
+      }}
+    >
+      More about Project Views
+    </Link>
+  </>
+)
+
+const SUBMISSION_VIEW_DESCRIPTION = (
+  <>
+    <WizardChoiceButtonDescription my={1.25}>
+      This view lists all submissions within one or more evaluation queues.
+    </WizardChoiceButtonDescription>
+    <Link
+      href={
+        'https://help.synapse.org/docs/Views.2011070739.html#Views-CreatingaSubmissionView'
+      }
+      target="_blank"
+      onClick={e => {
+        e.stopPropagation()
+      }}
+    >
+      More about Submission Views
+    </Link>
+  </>
+)
+
+const MATERIALIZED_VIEW_DESCRIPTION = (
+  <>
+    <WizardChoiceButtonDescription my={1.25}>
+      The results of a query across multiple sources, defined by a SQL
+      statement.
+    </WizardChoiceButtonDescription>
+    <Link
+      href={
+        'https://help.synapse.org/docs/Combining-Data-from-Multiple-Table-Sources.2973270158.html'
+      }
+      target="_blank"
+      onClick={e => {
+        e.stopPropagation()
+      }}
+    >
+      More about Materialized Views
+    </Link>
+  </>
+)
+
+const VIRTUAL_TABLE_DESCRIPTION = (
+  <WizardChoiceButtonDescription my={1.25}>
+    A saved query on another table or view where complex filters can be applied
+    to aggregated results.
+  </WizardChoiceButtonDescription>
+)
+
+export type ViewTypeSelectionProps = {
+  /* Callback including the chosen type, and optional viewTypeMask if included in the choice (e.g. Project Views) */
+  onTypeSelected: (type: EntityType, viewTypeMask?: number) => void
+}
+
+/**
+ * React component for selecting a View type in the View creation wizard.
+ * Renders UI to show all view types where the user must choose one to continue.
+ */
+export default function ViewTypeSelection(props: ViewTypeSelectionProps) {
+  const { onTypeSelected } = props
+
+  const { isInExperimentalMode } = useSynapseContext()
+
+  return (
+    <WizardChoiceButtonGroup>
+      <WizardChoiceButton
+        title={'Files, Folders, and Other Objects'}
+        description={FILE_VIEW_DESCRIPTION}
+        onClick={() => {
+          onTypeSelected(EntityType.ENTITY_VIEW)
+        }}
+      />
+      <WizardChoiceButton
+        title={'Projects'}
+        description={PROJECT_VIEW_DESCRIPTION}
+        onClick={() => {
+          onTypeSelected(EntityType.ENTITY_VIEW, ENTITY_VIEW_TYPE_MASK_PROJECT)
+        }}
+      />
+      <WizardChoiceButton
+        title={'Challenge Submissions'}
+        description={SUBMISSION_VIEW_DESCRIPTION}
+        onClick={() => {
+          onTypeSelected(EntityType.SUBMISSION_VIEW)
+        }}
+      />
+      <WizardChoiceButton
+        title={'Materialized View'}
+        description={MATERIALIZED_VIEW_DESCRIPTION}
+        onClick={() => {
+          onTypeSelected(EntityType.MATERIALIZED_VIEW)
+        }}
+      />
+      {isInExperimentalMode && (
+        <WizardChoiceButton
+          title={'Virtual Table'}
+          description={VIRTUAL_TABLE_DESCRIPTION}
+          onClick={() => {
+            onTypeSelected(EntityType.VIRTUAL_TABLE)
+          }}
+        />
+      )}
+    </WizardChoiceButtonGroup>
+  )
+}

--- a/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTable.tsx
+++ b/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTable.tsx
@@ -305,11 +305,13 @@ export const EntityHeaderTable = (props: EntityHeaderTableProps) => {
         table.setColumnFilters([])
       }
     },
-    [showFilterControls],
+    [table, showFilterControls],
   )
 
   if (isLoading) {
-    return <SkeletonTable numCols={3} numRows={10} />
+    return (
+      <SkeletonTable numCols={3} numRows={Math.min(10, refsInState.length)} />
+    )
   } else if (!isSuccess) {
     return <></>
   }

--- a/packages/synapse-react-client/src/components/SqlDefinedTableEditor/SqlDefinedTableEditor.test.tsx
+++ b/packages/synapse-react-client/src/components/SqlDefinedTableEditor/SqlDefinedTableEditor.test.tsx
@@ -1,0 +1,34 @@
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import React from 'react'
+import SqlDefinedTableEditor, {
+  SqlDefinedTableEditorProps,
+} from './SqlDefinedTableEditor'
+import { render, screen } from '@testing-library/react'
+import { EntityType } from '@sage-bionetworks/synapse-types'
+
+describe('SqlDefinedTableEditor tests', () => {
+  function renderComponent(props: SqlDefinedTableEditorProps) {
+    return render(<SqlDefinedTableEditor {...props} />, {
+      wrapper: createWrapper(),
+    })
+  }
+
+  it('shows MaterializedView help text when entityType is MATERIALIZED_VIEW', () => {
+    renderComponent({ entityType: EntityType.MATERIALIZED_VIEW })
+
+    screen.getByText(
+      'A materialized view is a type of Synapse table that is defined using a Synapse SQL statement',
+      { exact: false },
+    )
+  })
+  it('does not show help for virtual table', () => {
+    renderComponent({ entityType: EntityType.VIRTUAL_TABLE })
+
+    expect(
+      screen.queryByText(
+        'A materialized view is a type of Synapse table that is defined using a Synapse SQL statement',
+        { exact: false },
+      ),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/packages/synapse-react-client/src/components/SqlDefinedTableEditor/SqlDefinedTableEditor.tsx
+++ b/packages/synapse-react-client/src/components/SqlDefinedTableEditor/SqlDefinedTableEditor.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { Box, Link, TextField, Typography } from '@mui/material'
+import { TextFieldProps } from '@mui/material/TextField'
+import { EntityType } from '@sage-bionetworks/synapse-types'
+
+const MATERIALIZED_VIEW_HELP = (
+  <Box mb={2.5}>
+    <Typography variant={'body1'} color={'grey.700'} mb={1.25}>
+      If you store normalized data in Synapse tables, views, or datasets, you
+      can combine separate data sources using Materialized Views. A materialized
+      view is a type of Synapse table that is defined using a Synapse SQL
+      statement, which can contain SQL keywords such as JOIN and UNION to
+      combine existing Synapse tables.
+    </Typography>
+    <Link
+      href={
+        'https://help.synapse.org/docs/Combining-Data-from-Multiple-Table-Sources.2973270158.html'
+      }
+      target="_blank"
+      onClick={e => {
+        e.stopPropagation()
+      }}
+    >
+      More about Materialized Views
+    </Link>
+  </Box>
+)
+
+export type SqlDefinedTableEditorProps = TextFieldProps & {
+  /* Optional entity type for showing help documentation */
+  entityType?: EntityType
+}
+
+/**
+ * Component used to edit the SQL of a Synapse entity defined by SQL, such as a MaterializedView or VirtualTable
+ * @param props
+ * @constructor
+ */
+export default function SqlDefinedTableEditor(
+  props: SqlDefinedTableEditorProps,
+) {
+  const { entityType, ...textFieldProps } = props
+  return (
+    <>
+      {entityType === EntityType.MATERIALIZED_VIEW && MATERIALIZED_VIEW_HELP}
+      <TextField
+        label={'Defining SQL'}
+        placeholder={'SELECT * FROM syn123'}
+        fullWidth
+        multiline
+        required
+        minRows={6}
+        {...textFieldProps}
+      />
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.tsx
@@ -163,7 +163,7 @@ export default function DefaultValueField<T>(props: DefaultValueFieldProps<T>) {
     <TextField
       {...TextFieldProps}
       type={'text'}
-      value={value}
+      value={value || undefined}
       onChange={event => {
         if (event.target.value == '') {
           onChange(undefined as T)

--- a/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButton.tsx
+++ b/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButton.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Box, Typography } from '@mui/material'
+import IconSvg from '../IconSvg'
+import WizardChoiceButtonDescription from './WizardChoiceButtonDescription'
+
+export default function WizardChoiceButton(props: {
+  title: string
+  description?: React.ReactNode
+  onClick?: () => void
+}) {
+  const { title, description, onClick } = props
+
+  const descriptionNode =
+    typeof description === 'string' ? (
+      <WizardChoiceButtonDescription>
+        {description}
+      </WizardChoiceButtonDescription>
+    ) : (
+      description
+    )
+  return (
+    <Box
+      component={'button'}
+      role={'menuitem'}
+      aria-label={title}
+      display={'flex'}
+      p={'20px'}
+      sx={{
+        width: '100%',
+        border: '1px solid',
+        borderColor: 'grey.200',
+        borderRadius: '5px',
+        '&:hover': {
+          backgroundColor: 'grey.100',
+        },
+      }}
+      onClick={onClick}
+      justifyContent={'space-between'}
+      alignItems={'center'}
+      gap={'10px'}
+    >
+      <Box sx={{ textAlign: 'left' }}>
+        <Typography variant={'headline2'} mb={'10px'}>
+          {title}
+        </Typography>
+        {descriptionNode}
+      </Box>
+      <Box>
+        <IconSvg
+          icon={'chevronRight'}
+          fontSize={'large'}
+          sx={{
+            color: 'primary.light',
+          }}
+        />
+      </Box>
+    </Box>
+  )
+}

--- a/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButtonDescription.tsx
+++ b/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButtonDescription.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Typography, TypographyProps } from '@mui/material'
+
+export default function WizardChoiceButtonDescription(
+  props: Omit<TypographyProps, 'variant'>,
+) {
+  return <Typography variant={'body1'} color={'grey.700'} {...props} />
+}

--- a/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButtonDescription.tsx
+++ b/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButtonDescription.tsx
@@ -4,5 +4,15 @@ import { Typography, TypographyProps } from '@mui/material'
 export default function WizardChoiceButtonDescription(
   props: Omit<TypographyProps, 'variant'>,
 ) {
-  return <Typography variant={'body1'} color={'grey.700'} {...props} />
+  return (
+    <Typography
+      variant={'body1'}
+      color={'grey.700'}
+      {...props}
+      sx={{
+        my: 1.25,
+        ...(Array.isArray(props.sx) ? props.sx : [props.sx]),
+      }}
+    />
+  )
 }

--- a/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButtonGroup.stories.tsx
+++ b/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButtonGroup.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Meta, StoryObj } from '@storybook/react'
+import WizardChoiceButton from './WizardChoiceButton'
+import WizardChoiceButtonGroup from './WizardChoiceButtonGroup'
+
+const meta = {
+  title: 'UI/WizardChoiceButtonGroup',
+  component: WizardChoiceButtonGroup,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/vLusb6uSfhx45OyFx5IHwy/(XDM)-Extensible-Data-Management-Comps?type=design&node-id=2955-29513&mode=design&t=Dhbz59ySu37vSy4e-4',
+    },
+  },
+} satisfies Meta
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  args: {
+    children: (
+      <>
+        <WizardChoiceButton
+          title={"'Classic' Access Requirement"}
+          description={
+            'These access requirements use proprietary a proprietary model for describing access conditions. If you need to maintain compatibility with a legacy access requirement, or cannot use DUO, choose this option.'
+          }
+        />
+        <WizardChoiceButton
+          title={'DUO Access Requirement'}
+          description={
+            'The Data Use Ontology (DUO) is an open standard for describing access requirement conditions. Access Requirements managed under DUO support additional automation features.'
+          }
+        />
+      </>
+    ),
+  },
+}

--- a/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButtonGroup.tsx
+++ b/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButtonGroup.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
-import { Box } from '@mui/material'
+import { Box, BoxProps } from '@mui/material'
 
-export type WizardChoiceButtonGroupProps = React.PropsWithChildren<{}>
-
-export default function WizardChoiceButtonGroup(
-  props: WizardChoiceButtonGroupProps,
-) {
-  const { children } = props
+export default function WizardChoiceButtonGroup(props: BoxProps) {
+  const { sx } = props
   return (
     <Box
       role={'menu'}
+      {...props}
       sx={{
         '& > button': {
           '&:first-of-type': {
@@ -26,9 +23,8 @@ export default function WizardChoiceButtonGroup(
             borderTop: 'none',
           },
         },
+        ...(Array.isArray(sx) ? sx : [sx]),
       }}
-    >
-      {children}
-    </Box>
+    />
   )
 }

--- a/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButtonGroup.tsx
+++ b/packages/synapse-react-client/src/components/WizardChoiceButton/WizardChoiceButtonGroup.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Box } from '@mui/material'
+
+export type WizardChoiceButtonGroupProps = React.PropsWithChildren<{}>
+
+export default function WizardChoiceButtonGroup(
+  props: WizardChoiceButtonGroupProps,
+) {
+  const { children } = props
+  return (
+    <Box
+      role={'menu'}
+      sx={{
+        '& > button': {
+          '&:first-of-type': {
+            borderBottomLeftRadius: 0,
+            borderBottomRightRadius: 0,
+          },
+          '&:not(:first-of-type):not(:last-child)': {
+            borderRadius: 0,
+            borderTop: 'none',
+          },
+          '&:last-child': {
+            borderTopLeftRadius: 0,
+            borderTopRightRadius: 0,
+            borderTop: 'none',
+          },
+        },
+      }}
+    >
+      {children}
+    </Box>
+  )
+}


### PR DESCRIPTION
 - Add WizardChoiceButton
 - Add TableTypeSelection, ViewTypeSelection
 - Add SqlDefinedTableEditor
 - DefaultValueField: fallback to `undefined` in case `value` is null, which is not a valid input value
 - EntityHeaderTable: Number of skeleton/loading rows should match number of refs passed


## Screenshots

|Feature|Screenshot|
|---|---|
|TableTypeSelection (WizardChoiceButton)| <img width="825" alt="image" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/2a44f1f5-c49c-4a40-8245-d2a1f5ecad54"> |
|ViewTypeSelection (WizardChoiceButton)| <img width="825" alt="image" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/344cbfaf-3b64-4d88-9345-6ed3843382e9"> |
|SqlDefinedTableEditor| <img width="831" alt="image" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/477fdcfb-e6f5-4d42-b173-063839a5ef57"> |
