### PR TITLE
SWC-6627 - Update TableColumnSchemaEditor to be used in SWC

### DIFF
--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.integration.test.tsx
@@ -8,13 +8,14 @@ import { server } from '../../mocks/msw/server'
 import mockTableEntityData from '../../mocks/entity/mockTableEntity'
 import {
   getAnnotationColumnHandlers,
+  getCreateColumnModelBatchHandler,
   getDefaultColumnHandlers,
+  getTableTransactionHandlers,
 } from '../../mocks/msw/handlers/tableQueryHandlers'
 import { syn17328596 as mockTableQueryData } from '../../mocks/query/syn17328596'
 import userEvent from '@testing-library/user-event'
 import { SynapseClient } from '../../index'
 import { rest } from 'msw'
-import { uniqueId } from 'lodash-es'
 import {
   ColumnModel,
   ColumnTypeEnum,
@@ -28,8 +29,13 @@ import { mockFileViewEntity } from '../../mocks/entity/mockFileView'
 import { ImportTableColumnsButtonProps } from './ImportTableColumnsButton'
 import { SetOptional } from 'type-fest'
 import { ENTITY_BUNDLE_V2 } from '../../utils/APIConstants'
-import { addColumnModelToForm } from './TableColumnSchemaEditorTestUtils'
+import {
+  addColumnModelToForm,
+  modifyColumnModelInForm,
+} from './TableColumnSchemaEditorTestUtils'
 import { MOCK_ANNOTATION_COLUMNS } from '../../mocks/mockAnnotationColumns'
+import defaultFileViewColumnModels from '../../mocks/query/defaultFileViewColumnModels'
+import { MOCK_ACCESS_TOKEN } from '../../mocks/MockSynapseContext'
 
 const mockedImportedColumns: SetOptional<ColumnModel, 'id'>[] = [
   {
@@ -77,10 +83,18 @@ async function setUp(props: TableColumnSchemaEditorProps) {
   const user = userEvent.setup()
   const component = renderComponent(props)
   const saveButton = await screen.findByRole('button', { name: 'Save' })
-  return { user, component, saveButton }
+  const cancelButton = await screen.findByRole('button', { name: 'Cancel' })
+  const moveDownButton = await screen.findByRole('button', {
+    name: 'Move Down',
+  })
+  return { user, component, saveButton, cancelButton, moveDownButton }
 }
 
 describe('TableColumnSchemaEditor', () => {
+  const mockOnColumnsUpdated = jest.fn()
+  const mockOnCancel = jest.fn()
+  const updateTableSpy = jest.spyOn(SynapseClient, 'updateTable')
+
   beforeAll(() => {
     server.listen()
   })
@@ -91,23 +105,20 @@ describe('TableColumnSchemaEditor', () => {
       /* Each test in this suite should register its own table query handler */
       ...getDefaultColumnHandlers(),
       ...getAnnotationColumnHandlers(MOCK_ANNOTATION_COLUMNS),
-      rest.post(
-        `${getEndpoint(
-          BackendDestinationEnum.REPO_ENDPOINT,
-        )}/repo/v1/column/batch`,
-        async (req, res, ctx) => {
-          const response: { list: ColumnModel[] } = await req.json()
-          response.list.forEach(cm => {
-            if (cm.id == null) {
-              cm.id = uniqueId()
-            }
-          })
-          return res(
-            ctx.status(201),
-            ctx.json<{ list: ColumnModel[] }>(response),
-          )
-        },
-      ),
+      getCreateColumnModelBatchHandler(),
+      ...getTableTransactionHandlers({
+        concreteType:
+          'org.sagebionetworks.repo.model.table.TableUpdateTransactionResponse',
+        results: [
+          {
+            concreteType:
+              'org.sagebionetworks.repo.model.table.TableSchemaChangeResponse',
+            schema: [
+              // We don't currently use this schema, so it's ok if it's inaccurate
+            ],
+          },
+        ],
+      }),
     )
   })
   afterAll(() => server.close())
@@ -124,6 +135,9 @@ describe('TableColumnSchemaEditor', () => {
     )
     await setUp({
       entityId: mockTableEntityData.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
     })
 
     const numColumns = mockTableQueryData.columnModels!.length
@@ -135,8 +149,8 @@ describe('TableColumnSchemaEditor', () => {
       expect(nameFields[index]).toHaveValue(cm.name)
     })
   })
+
   it('User can update the form and submit the new data', async () => {
-    const updateTableSpy = jest.spyOn(SynapseClient, 'updateTable')
     server.use(
       getEntityBundleHandler({
         entity: mockTableEntityData.entity,
@@ -149,6 +163,9 @@ describe('TableColumnSchemaEditor', () => {
 
     const { user, saveButton } = await setUp({
       entityId: mockTableEntityData.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
     })
 
     // Add a column
@@ -156,7 +173,32 @@ describe('TableColumnSchemaEditor', () => {
     await user.click(saveButton)
 
     await waitFor(() => {
-      expect(updateTableSpy).toHaveBeenCalled()
+      const expectedExistingColumnIds = mockTableQueryData.columnModels!.map(
+        cm => cm.id,
+      )
+      expect(updateTableSpy).toHaveBeenCalledWith(
+        {
+          changes: [
+            {
+              // The new column was added, no columns were changed, moved, or removed
+              changes: [{ newColumnId: expect.any(String), oldColumnId: null }],
+              concreteType:
+                'org.sagebionetworks.repo.model.table.TableSchemaChangeRequest',
+              entityId: mockTableEntityData.id,
+              // The new column is at the end
+              orderedColumnIds: [
+                ...expectedExistingColumnIds,
+                expect.any(String),
+              ],
+            },
+          ],
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest',
+          entityId: mockTableEntityData.id,
+        },
+        MOCK_ACCESS_TOKEN,
+      )
+      expect(mockOnColumnsUpdated).toHaveBeenCalled()
     })
   })
 
@@ -172,8 +214,11 @@ describe('TableColumnSchemaEditor', () => {
         },
       }),
     )
-    await setUp({
+    const { user, saveButton } = await setUp({
       entityId: mockFileViewEntity.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
     })
 
     const addDefaultColumnsButton = await screen.findByRole('button', {
@@ -185,7 +230,7 @@ describe('TableColumnSchemaEditor', () => {
     // Verify we have no columns -- there will only be one checkbox on the screen for select all/none
     expect(screen.getAllByRole('checkbox')).toHaveLength(1)
 
-    await userEvent.click(addDefaultColumnsButton)
+    await user.click(addDefaultColumnsButton)
 
     await waitFor(() => {
       // The columns should have been added.
@@ -194,6 +239,35 @@ describe('TableColumnSchemaEditor', () => {
 
     // The default columns aren't editable, so we won't have a name text field.
     expect(screen.queryByLabelText('Name')).not.toBeInTheDocument()
+
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      expect(updateTableSpy).toHaveBeenCalledWith(
+        {
+          changes: [
+            {
+              // The default columns were added; they are all new
+              changes: expect.arrayContaining(
+                defaultFileViewColumnModels.map(cm => ({
+                  newColumnId: cm.id,
+                  oldColumnId: null,
+                })),
+              ),
+              concreteType:
+                'org.sagebionetworks.repo.model.table.TableSchemaChangeRequest',
+              entityId: mockFileViewEntity.id,
+              orderedColumnIds: defaultFileViewColumnModels.map(cm => cm.id),
+            },
+          ],
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest',
+          entityId: mockFileViewEntity.id,
+        },
+        MOCK_ACCESS_TOKEN,
+      )
+      expect(mockOnColumnsUpdated).toHaveBeenCalled()
+    })
   })
   it('User can add annotations columns to a view', async () => {
     // Must use a file view to get annotations
@@ -207,8 +281,11 @@ describe('TableColumnSchemaEditor', () => {
         },
       }),
     )
-    await setUp({
+    const { user, saveButton } = await setUp({
       entityId: mockFileViewEntity.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
     })
 
     const addAnnotationColumnsButton = await screen.findByRole('button', {
@@ -220,7 +297,7 @@ describe('TableColumnSchemaEditor', () => {
     // Verify we have no columns -- there will only be one checkbox on the screen for select all/none
     expect(screen.getAllByRole('checkbox')).toHaveLength(1)
 
-    await userEvent.click(addAnnotationColumnsButton)
+    await user.click(addAnnotationColumnsButton)
 
     await waitFor(() => {
       // The column(s) should have been added.
@@ -229,6 +306,37 @@ describe('TableColumnSchemaEditor', () => {
 
     // The annotation column(s) are editable, so we can find a name text field.
     await screen.findAllByLabelText('Name')
+
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      expect(updateTableSpy).toHaveBeenCalledWith(
+        {
+          changes: [
+            {
+              // The annotation columns were added; they are all new
+              changes: expect.arrayContaining(
+                MOCK_ANNOTATION_COLUMNS.results.map(cm => ({
+                  newColumnId: cm.id,
+                  oldColumnId: null,
+                })),
+              ),
+              concreteType:
+                'org.sagebionetworks.repo.model.table.TableSchemaChangeRequest',
+              entityId: mockFileViewEntity.id,
+              orderedColumnIds: MOCK_ANNOTATION_COLUMNS.results.map(
+                cm => cm.id,
+              ),
+            },
+          ],
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest',
+          entityId: mockFileViewEntity.id,
+        },
+        MOCK_ACCESS_TOKEN,
+      )
+      expect(mockOnColumnsUpdated).toHaveBeenCalled()
+    })
   })
 
   it('Existing default columns are not editable, except facetType', async () => {
@@ -251,6 +359,9 @@ describe('TableColumnSchemaEditor', () => {
     )
     const { user } = await setUp({
       entityId: mockFileViewEntity.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
     })
 
     // Verify we have one column, which has a checkbox, in addition to the "Select All" checkbox
@@ -301,6 +412,9 @@ describe('TableColumnSchemaEditor', () => {
     )
     const { user } = await setUp({
       entityId: mockTableEntityData.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
     })
     // Verify the import button appears on screen (in this case, the component is mocked)
     const importTableColumnsButton = await screen.findByTestId(
@@ -318,7 +432,6 @@ describe('TableColumnSchemaEditor', () => {
     })
   })
   it('Shows error messages if validation fails', async () => {
-    const updateTableSpy = jest.spyOn(SynapseClient, 'updateTable')
     server.use(
       getEntityBundleHandler({
         entity: mockTableEntityData.entity,
@@ -331,6 +444,9 @@ describe('TableColumnSchemaEditor', () => {
 
     const { user, saveButton } = await setUp({
       entityId: mockTableEntityData.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
     })
 
     // Add a column -- intentionally do not add a name
@@ -342,6 +458,7 @@ describe('TableColumnSchemaEditor', () => {
 
     await waitFor(() => {
       expect(updateTableSpy).not.toHaveBeenCalled()
+      expect(mockOnColumnsUpdated).not.toHaveBeenCalled()
     })
 
     // Now add the name and ensure we can successfully submit
@@ -350,12 +467,31 @@ describe('TableColumnSchemaEditor', () => {
 
     await user.click(saveButton)
     await waitFor(() => {
-      expect(updateTableSpy).toHaveBeenCalled()
+      expect(updateTableSpy).toHaveBeenCalledWith(
+        {
+          changes: [
+            {
+              changes: [{ newColumnId: expect.any(String), oldColumnId: null }],
+              concreteType:
+                'org.sagebionetworks.repo.model.table.TableSchemaChangeRequest',
+              entityId: mockTableEntityData.id,
+              orderedColumnIds: [
+                ...mockTableQueryData.columnModels!.map(cm => cm.id),
+                expect.any(String),
+              ],
+            },
+          ],
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest',
+          entityId: mockTableEntityData.id,
+        },
+        MOCK_ACCESS_TOKEN,
+      )
+      expect(mockOnColumnsUpdated).toHaveBeenCalled()
     })
   })
 
   it('Can update restricted values for STRING type', async () => {
-    const updateTableSpy = jest.spyOn(SynapseClient, 'updateTable')
     const stringColumnWithRestrictedVals: ColumnModel = {
       id: '1234',
       name: 'stringWithRestrictedVals',
@@ -375,6 +511,9 @@ describe('TableColumnSchemaEditor', () => {
 
     const { user, saveButton } = await setUp({
       entityId: mockTableEntityData.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
     })
 
     // Add a column
@@ -388,7 +527,7 @@ describe('TableColumnSchemaEditor', () => {
     await user.click(restrictedValuesInput)
     const valueEditorModal = await screen.findByRole('dialog')
 
-    let inputs = await within(valueEditorModal).findAllByRole('textbox')
+    const inputs = await within(valueEditorModal).findAllByRole('textbox')
     expect(inputs).toHaveLength(4)
     expect(inputs[0]).toHaveValue('foo')
     expect(inputs[1]).toHaveValue('true')
@@ -412,14 +551,35 @@ describe('TableColumnSchemaEditor', () => {
 
     await user.click(saveButton)
     await waitFor(() => {
-      expect(updateTableSpy).toHaveBeenCalled()
+      expect(updateTableSpy).toHaveBeenCalledWith(
+        {
+          changes: [
+            {
+              changes: [
+                {
+                  newColumnId: expect.any(String),
+                  oldColumnId: stringColumnWithRestrictedVals.id,
+                },
+              ],
+              concreteType:
+                'org.sagebionetworks.repo.model.table.TableSchemaChangeRequest',
+              entityId: mockTableEntityData.id,
+              orderedColumnIds: [expect.any(String)],
+            },
+          ],
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest',
+          entityId: mockTableEntityData.id,
+        },
+        MOCK_ACCESS_TOKEN,
+      )
+      expect(mockOnColumnsUpdated).toHaveBeenCalled()
     })
   })
 
   it('Can update restricted values for INTEGER type', async () => {
-    const updateTableSpy = jest.spyOn(SynapseClient, 'updateTable')
     const integerColumnWithRestrictedVals: ColumnModel = {
-      id: '1234',
+      id: '1235',
       name: 'integerWithRestrictedVals',
       columnType: ColumnTypeEnum.INTEGER,
       // `enumValues` is an array of strings, even for INTEGER columns
@@ -437,6 +597,9 @@ describe('TableColumnSchemaEditor', () => {
 
     const { user, saveButton } = await setUp({
       entityId: mockTableEntityData.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
     })
 
     // Add a column
@@ -481,7 +644,236 @@ describe('TableColumnSchemaEditor', () => {
 
     await user.click(saveButton)
     await waitFor(() => {
-      expect(updateTableSpy).toHaveBeenCalled()
+      expect(updateTableSpy).toHaveBeenCalledWith(
+        {
+          changes: [
+            {
+              changes: [
+                {
+                  newColumnId: expect.any(String),
+                  oldColumnId: integerColumnWithRestrictedVals.id,
+                },
+              ],
+              concreteType:
+                'org.sagebionetworks.repo.model.table.TableSchemaChangeRequest',
+              entityId: mockTableEntityData.id,
+              orderedColumnIds: [expect.any(String)],
+            },
+          ],
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest',
+          entityId: mockTableEntityData.id,
+        },
+        MOCK_ACCESS_TOKEN,
+      )
+      expect(mockOnColumnsUpdated).toHaveBeenCalled()
+    })
+  })
+  it('Maintains the column ID passed to the update function when a column is modified', async () => {
+    server.use(
+      getEntityBundleHandler({
+        entity: mockTableEntityData.entity,
+        tableBundle: {
+          columnModels: mockTableQueryData.columnModels!,
+          maxRowsPerPage: 25,
+        },
+      }),
+    )
+
+    const { user, saveButton } = await setUp({
+      entityId: mockTableEntityData.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
+    })
+
+    // Add a column
+    await modifyColumnModelInForm(0, {
+      columnName: 'changedColumnName',
+    })
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      const existingColumnIds = mockTableQueryData.columnModels!.map(
+        cm => cm.id,
+      )
+      expect(updateTableSpy).toHaveBeenCalledWith(
+        {
+          changes: [
+            {
+              changes: [
+                {
+                  // The first column was changed!
+                  oldColumnId: existingColumnIds[0],
+                  newColumnId: expect.any(String),
+                },
+              ],
+              concreteType:
+                'org.sagebionetworks.repo.model.table.TableSchemaChangeRequest',
+              entityId: mockTableEntityData.id,
+              // The new/changed column is at the beginning. The 2nd and 3rd columns will match the original columns
+              orderedColumnIds: [
+                expect.any(String),
+                ...existingColumnIds.slice(1),
+              ],
+            },
+          ],
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest',
+          entityId: mockTableEntityData.id,
+        },
+        MOCK_ACCESS_TOKEN,
+      )
+      expect(mockOnColumnsUpdated).toHaveBeenCalled()
+    })
+  })
+
+  it('Handles reordering columns', async () => {
+    server.use(
+      getEntityBundleHandler({
+        entity: mockTableEntityData.entity,
+        tableBundle: {
+          columnModels: mockTableQueryData.columnModels!,
+          maxRowsPerPage: 25,
+        },
+      }),
+    )
+
+    const { user, saveButton, moveDownButton } = await setUp({
+      entityId: mockTableEntityData.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
+    })
+
+    let checkboxes: HTMLInputElement[] = []
+    await waitFor(() => {
+      checkboxes = screen.getAllByRole('checkbox')
+      expect(checkboxes).toHaveLength(
+        mockTableQueryData.columnModels!.length + 1,
+      )
+    })
+
+    // Move the first column down one spot
+    // Note that the first checkbox is "Select All"
+    const firstColumnCheckbox = checkboxes[1]
+    expect(firstColumnCheckbox).not.toBeChecked()
+    await user.click(firstColumnCheckbox)
+    expect(firstColumnCheckbox).toBeChecked()
+
+    await user.click(moveDownButton)
+    await waitFor(() => {
+      // Verify the columns have been reordered by inspecting the checkboxes
+      expect(screen.getAllByRole('checkbox')[1]).not.toBeChecked()
+      expect(screen.getAllByRole('checkbox')[2]).toBeChecked()
+    })
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      const existingColumnIds = mockTableQueryData.columnModels!.map(
+        cm => cm.id,
+      )
+      expect(updateTableSpy).toHaveBeenCalledWith(
+        {
+          changes: [
+            {
+              // No columns were added or removed
+              changes: [],
+              concreteType:
+                'org.sagebionetworks.repo.model.table.TableSchemaChangeRequest',
+              entityId: mockTableEntityData.id,
+              // The first column was moved down one spot
+              orderedColumnIds: [
+                existingColumnIds[1],
+                existingColumnIds[0],
+                ...existingColumnIds.slice(2),
+              ],
+            },
+          ],
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest',
+          entityId: mockTableEntityData.id,
+        },
+        MOCK_ACCESS_TOKEN,
+      )
+      expect(mockOnColumnsUpdated).toHaveBeenCalled()
+    })
+  })
+  it('Handles failure on the update call', async () => {
+    const errorMessage = 'Uh oh, something went wrong!!!'
+    server.use(
+      getEntityBundleHandler({
+        entity: mockTableEntityData.entity,
+        tableBundle: {
+          columnModels: mockTableQueryData.columnModels!,
+          maxRowsPerPage: 25,
+        },
+      }),
+      ...getTableTransactionHandlers(
+        {
+          reason: errorMessage,
+        },
+        undefined,
+        400,
+      ),
+    )
+
+    const { user, saveButton } = await setUp({
+      entityId: mockTableEntityData.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
+    })
+
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      expect(updateTableSpy).toHaveBeenCalledWith(
+        {
+          changes: [
+            {
+              changes: [],
+              concreteType:
+                'org.sagebionetworks.repo.model.table.TableSchemaChangeRequest',
+              entityId: mockTableEntityData.id,
+              orderedColumnIds: mockTableQueryData.columnModels!.map(
+                cm => cm.id,
+              ),
+            },
+          ],
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest',
+          entityId: mockTableEntityData.id,
+        },
+        MOCK_ACCESS_TOKEN,
+      )
+    })
+    // `onColumnsUpdated` should NOT be called because the update failed
+    expect(mockOnColumnsUpdated).not.toHaveBeenCalled()
+  })
+  it('Clicking cancel calls onCancel', async () => {
+    server.use(
+      getEntityBundleHandler({
+        entity: mockTableEntityData.entity,
+        tableBundle: {
+          columnModels: mockTableQueryData.columnModels!,
+          maxRowsPerPage: 25,
+        },
+      }),
+    )
+
+    const { user, cancelButton } = await setUp({
+      entityId: mockTableEntityData.id,
+      open: true,
+      onColumnsUpdated: mockOnColumnsUpdated,
+      onCancel: mockOnCancel,
+    })
+
+    await user.click(cancelButton)
+
+    await waitFor(() => {
+      expect(mockOnColumnsUpdated).not.toHaveBeenCalled()
+      expect(mockOnCancel).toHaveBeenCalled()
     })
   })
 })

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.stories.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.stories.ts
@@ -56,5 +56,6 @@ export const Demo: Story = {
   },
   args: {
     entityId: mockTableEntityData.id,
+    open: true,
   },
 }

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorTestUtils.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditorTestUtils.ts
@@ -15,3 +15,15 @@ export async function addColumnModelToForm(
     await user.type(nameFields[nameFields.length - 1], columnName)
   }
 }
+
+export async function modifyColumnModelInForm(
+  index: number,
+  data: { columnName: string },
+  user: UserEvent | typeof userEvent = userEvent,
+) {
+  if (data.columnName) {
+    const nameField = (await screen.findAllByLabelText('Name'))[index]
+    await user.clear(nameField)
+    await user.type(nameField, data.columnName)
+  }
+}

--- a/packages/synapse-react-client/src/mocks/msw/handlers/asyncJobHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/asyncJobHandlers.ts
@@ -5,10 +5,12 @@ import {
 } from '../../../utils/functions/getEndpoint'
 import { uniqueId } from 'lodash-es'
 import {
+  AsynchJobState,
   AsynchronousJobStatus,
   AsyncJobId,
 } from '@sage-bionetworks/synapse-types'
 import { ASYNCHRONOUS_JOB_TOKEN } from '../../../utils/APIConstants'
+import { SynapseError } from '../../../utils/SynapseError'
 
 /**
  * Global mapping between async job token and request/response. This sort of acts as an in-memory database for asynchronous jobs.
@@ -30,15 +32,19 @@ const mapOfAsyncJobs = new Map<
  *   The generic asynchronous job retrieval handler will be generated automatically.
  * @param responseBody the response body, or a function that takes the request body and returns the response body
  * @param backendOrigin the backend origin to use for the handlers.
+ * @param serviceSpecificEndpointResponseStatus the status code to use for the service-specific endpoint. The asynchronous job endpoint will always return 200.
  */
 export function generateAsyncJobHandlers<
   TRequestBody = unknown,
-  TResponseBody extends DefaultBodyType = DefaultBodyType,
+  TResponseBody extends DefaultBodyType | SynapseError =
+    | DefaultBodyType
+    | SynapseError,
 >(
   requestPath: string,
   responsePath: (tokenParam: string) => string,
   responseBody: TResponseBody | ((requestBody: TRequestBody) => TResponseBody),
   backendOrigin = getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+  serviceSpecificEndpointResponseStatus = 201,
 ) {
   return [
     // Handler for the asynchronous job request endpoint.
@@ -75,10 +81,13 @@ export function generateAsyncJobHandlers<
         const responseObject: TResponseBody =
           typeof response === 'function' ? response(request) : response
 
+        const jobState: AsynchJobState =
+          serviceSpecificEndpointResponseStatus < 400 ? 'COMPLETE' : 'FAILED'
+
         return res(
-          ctx.status(201),
+          ctx.status(200),
           ctx.json<AsynchronousJobStatus<TRequestBody, TResponseBody>>({
-            jobState: 'COMPLETE',
+            jobState,
             jobCanceling: false,
             requestBody: request,
             etag: '00000000-0000-0000-0000-000000000000',
@@ -119,7 +128,10 @@ export function generateAsyncJobHandlers<
         const responseObject: TResponseBody =
           typeof response === 'function' ? response(request) : response
 
-        return res(ctx.status(201), ctx.json(responseObject))
+        return res(
+          ctx.status(serviceSpecificEndpointResponseStatus),
+          ctx.json(responseObject),
+        )
       },
     ),
   ]

--- a/packages/synapse-react-client/src/mocks/msw/handlers/tableQueryHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/tableQueryHandlers.ts
@@ -22,11 +22,14 @@ import {
   ColumnModel,
   QueryBundleRequest,
   QueryResultBundle,
+  TableUpdateTransactionRequest,
+  TableUpdateTransactionResponse,
   ViewColumnModelRequest,
   ViewColumnModelResponse,
 } from '@sage-bionetworks/synapse-types'
 import { generateAsyncJobHandlers } from './asyncJobHandlers'
 import defaultFileViewColumnModels from '../../query/defaultFileViewColumnModels'
+import { SynapseError } from '../../../utils/SynapseError'
 
 const BIT_TO_FIELD_MAP: Record<number, keyof QueryResultBundle> = {
   [BUNDLE_MASK_QUERY_RESULTS]: 'queryResult',
@@ -118,5 +121,23 @@ export function getCreateColumnModelBatchHandler(
         }),
       )
     },
+  )
+}
+
+export function getTableTransactionHandlers(
+  response: TableUpdateTransactionResponse | SynapseError,
+  backendOrigin = getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+  statusCode?: number,
+) {
+  return generateAsyncJobHandlers<
+    TableUpdateTransactionRequest,
+    TableUpdateTransactionResponse | SynapseError
+  >(
+    `/repo/v1/entity/:entityId/table/transaction/async/start`,
+    tokenParam =>
+      `/repo/v1/entity/:entityId/table/transaction/async/get/${tokenParam}`,
+    response,
+    backendOrigin,
+    statusCode,
   )
 }

--- a/packages/synapse-react-client/src/umd.index.ts
+++ b/packages/synapse-react-client/src/umd.index.ts
@@ -73,6 +73,7 @@ import TableColumnSchemaForm from './components/TableColumnSchemaEditor/TableCol
 import EntityHeaderTable from './components/EntityHeaderTable'
 import AccessRequirementRelatedProjectsList from './components/AccessRequirementRelatedProjectsList'
 import CreateTableViewWizard from './components/CreateTableViewWizard/CreateTableViewWizard'
+import TableColumnSchemaEditor from './components/TableColumnSchemaEditor/TableColumnSchemaEditor'
 
 // Also include scss in the bundle
 import './style/main.scss'
@@ -151,6 +152,7 @@ const SynapseComponents = {
   EntityHeaderTable,
   AccessRequirementRelatedProjectsList,
   CreateTableViewWizard,
+  TableColumnSchemaEditor,
 }
 
 // Include the version in the build

--- a/packages/synapse-react-client/src/utils/functions/IsEqualTreatUndefinedAsMissing.test.ts
+++ b/packages/synapse-react-client/src/utils/functions/IsEqualTreatUndefinedAsMissing.test.ts
@@ -1,0 +1,32 @@
+import { isEqualTreatUndefinedAsMissing } from './IsEqualTreatUndefinedAsMissing'
+
+describe('IsEqualTreatUndefinedAsMissing', () => {
+  test('undefined and missing object values are considered equal', () => {
+    expect(isEqualTreatUndefinedAsMissing({}, {})).toBe(true)
+    expect(isEqualTreatUndefinedAsMissing({ foo: true }, {})).toBe(false)
+    expect(
+      isEqualTreatUndefinedAsMissing({ foo: true }, { foo: undefined }),
+    ).toBe(false)
+
+    expect(
+      isEqualTreatUndefinedAsMissing(
+        { foo: true, bar: undefined },
+        { foo: true },
+      ),
+    ).toBe(true)
+
+    expect(
+      isEqualTreatUndefinedAsMissing({ foo: true, bar: null }, { foo: true }),
+    ).toBe(false)
+
+    expect(
+      isEqualTreatUndefinedAsMissing(
+        { foo: true, bar: { baz: undefined } },
+        { foo: true, bar: {} },
+      ),
+    ).toBe(true)
+
+    expect(isEqualTreatUndefinedAsMissing(undefined, null)).toBe(false)
+    expect(isEqualTreatUndefinedAsMissing('', undefined)).toBe(false)
+  })
+})

--- a/packages/synapse-react-client/src/utils/functions/IsEqualTreatUndefinedAsMissing.ts
+++ b/packages/synapse-react-client/src/utils/functions/IsEqualTreatUndefinedAsMissing.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// `any` is safe for these comparison functions
+import { isArray, isObject, includes, isEqualWith, omitBy } from 'lodash-es'
+
+const comparisonFunc = (a: any, b: any): boolean | undefined => {
+  if (isArray(a) || isArray(b)) return
+  if (!isObject(a) || !isObject(b)) return
+
+  if (!includes<any>(a, undefined) && !includes<any>(b, undefined)) return
+
+  // Call recursively, after filtering all undefined properties
+  return isEqualWith(
+    omitBy(a, value => value === undefined),
+    omitBy(b, value => value === undefined),
+    comparisonFunc,
+  )
+}
+
+/**
+ * A version of lodash's isEqual that treats undefined and missing as equal.
+ *
+ * Note: `null` and missing/undefined are not considered equal in this implementation
+ */
+export function isEqualTreatUndefinedAsMissing(a: any, b: any): boolean {
+  /* implementation lifted from https://stackoverflow.com/a/57894104 */
+  return isEqualWith(a, b, comparisonFunc)
+}

--- a/packages/synapse-react-client/src/utils/functions/TableColumnSchemaUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/TableColumnSchemaUtils.ts
@@ -4,16 +4,18 @@ import {
   TableUpdateTransactionRequest,
 } from '@sage-bionetworks/synapse-types'
 import { SetOptional } from 'type-fest'
-import { isEqual } from 'lodash-es'
 import { createColumnModels } from '../../synapse-client'
+import { isEqualTreatUndefinedAsMissing } from './IsEqualTreatUndefinedAsMissing'
 
 /**
- * Creates the column models for a change request and returns
- * the change request to be passed to the Synapse backend.
- * @param accessToken
- * @param tableId
- * @param oldSchema
- * @param proposedSchema
+ * Creates the column models for a change request and returns the change request to be passed to the Synapse backend.
+ *
+ * Note that to update a column model and preserve table data, the ID of the
+ * @param accessToken the Synapse access token
+ * @param tableId the ID of the table to change
+ * @param oldSchema the current schema of the table
+ * @param proposedSchema the proposed schema of the table. For TableEntities, the IDs should be preserved for columns
+ *                       that should maintain their data, even if the column model has changed
  */
 export async function createTableUpdateTransactionRequest(
   accessToken: string,
@@ -21,23 +23,27 @@ export async function createTableUpdateTransactionRequest(
   oldSchema: ColumnModel[],
   proposedSchema: SetOptional<ColumnModel, 'id'>[],
 ): Promise<TableUpdateTransactionRequest> {
-  // Create any models that do not have an ID, or that have changed
+  // Keep track of the old column models by ID
   const oldColumnModelId2Model: Map<string, ColumnModel> = new Map()
   for (const columnModel of oldSchema) {
     oldColumnModelId2Model.set(columnModel.id, columnModel)
   }
 
-  // The newSchema will match the proposed schema, but column models that have been changed will have the ID stripped
+  // Create the new column models.
+  // The newSchema will match the proposed schema, but column models that have been changed will end up getting a new ID
   let newSchema: SetOptional<ColumnModel, 'id'>[] = []
   for (const m of proposedSchema) {
     const copy: SetOptional<ColumnModel, 'id'> = {
       ...m,
     }
     if (copy.id != null) {
-      // any changes to the existing column model?
+      // If there are any changes to the existing column model, remove the ID before we create the new one
       const oldColumnModel: ColumnModel | undefined =
         oldColumnModelId2Model.get(copy.id)
-      if (oldColumnModel != undefined && !isEqual(oldColumnModel, copy)) {
+      if (
+        oldColumnModel != undefined &&
+        !isEqualTreatUndefinedAsMissing(oldColumnModel, copy)
+      ) {
         delete copy.id
       }
     }
@@ -47,23 +53,33 @@ export async function createTableUpdateTransactionRequest(
     .list
 
   // now that all columns have been created, figure out the column changes (create, update, and no-op)
-  // keep track of column ids to figure out what columns were deleted.
   const changes: ColumnChange[] = []
-  const columnIds: Set<string | null> = new Set()
+  const columnIdsThatWereChangedOrAdded: Set<string> = new Set()
   for (let i = 0; i < proposedSchema.length; i++) {
     const oldColumnId: string | null = proposedSchema[i].id ?? null
     const newColumnId: string | null = createdColumnModels[i].id ?? null
-    columnIds.add(oldColumnId)
-    columnIds.add(newColumnId)
-    if (oldColumnId !== newColumnId) {
+    if (oldColumnId) columnIdsThatWereChangedOrAdded.add(oldColumnId)
+    columnIdsThatWereChangedOrAdded.add(newColumnId)
+    if (
+      // The column has changed
+      oldColumnId != null &&
+      oldColumnId !== newColumnId
+    ) {
       changes.push({ oldColumnId, newColumnId })
+    } else if (
+      // the column is new and is defined by the user
+      oldColumnId == null ||
+      // the column is new but already has an ID (e.g. we are adding a default column to a view)
+      !oldColumnModelId2Model.has(oldColumnId)
+    ) {
+      changes.push({ oldColumnId: null, newColumnId })
     }
   }
 
   // delete columns that are not represented in the changes already (create or update)
   for (const oldColumnModel of oldSchema) {
     const oldColumnId: string | null = oldColumnModel.id
-    if (!columnIds.has(oldColumnId)) {
+    if (!columnIdsThatWereChangedOrAdded.has(oldColumnId)) {
       changes.push({ oldColumnId, newColumnId: null })
     }
   }

--- a/packages/synapse-types/src/Table/TableUpdate.ts
+++ b/packages/synapse-types/src/Table/TableUpdate.ts
@@ -1,5 +1,7 @@
 // http://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/TableUpdateTransactionRequest.html
 // Update a table
+import { ColumnModel } from './ColumnModel'
+
 export type TableUpdateTransactionRequest = {
   concreteType: 'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest'
   entityId: string
@@ -73,4 +75,29 @@ export type SnapshotRequest = {
   snapshotLabel?: string
   /* Optional. If createNewSnapshot=true, the Activity ID to be applied to the snapshot version. Null by default */
   snapshotActivityId?: string
+}
+
+/**
+ * An AsynchronousResponseBody returned from a table update transaction.
+ */
+export type TableUpdateTransactionResponse = {
+  concreteType: 'org.sagebionetworks.repo.model.table.TableUpdateTransactionResponse'
+  /* List of responses. There will be one response for each request in the transaction. */
+  results: TableUpdateResponse[]
+  /* The version number of the snapshot. Returned only, if a new snapshot was requested. */
+  snapshotVersionNumber?: number
+}
+
+/**
+ * https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/TableUpdateResponse.html
+ */
+export type TableUpdateResponse = TableSchemaChangeResponse
+// | TableSearchChangeResponse
+// | RowReferenceSetResults
+// | EntityUpdateResults
+// | UploadToTableResult
+
+export type TableSchemaChangeResponse = {
+  concreteType: 'org.sagebionetworks.repo.model.table.TableSchemaChangeResponse'
+  schema: ColumnModel[]
 }


### PR DESCRIPTION
 - TableColumnSchemaEditor is now in a dialog
 - Update `TableColumnSchemaUtils.createTableUpdateTransactionRequest` to fix bugs where columns were not properly updated or created
 - Add many tests to verify column update behavior