### PR TITLE
PORTALS-2880: increase size of data icons in generic card

### DIFF
--- a/packages/synapse-react-client/src/assets/mui_components/Other.tsx
+++ b/packages/synapse-react-client/src/assets/mui_components/Other.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon'
 
 const Other = (props: SvgIconProps) => {
-  const { fill, style } = props
+  const { fill, style, ...rest } = props
   return (
-    <SvgIcon style={style}>
+    <SvgIcon style={style} {...rest}>
       <circle cx="4.71456" cy="12.7146" r="1.71456" fill={fill} />
       <circle cx="11.5728" cy="12.7146" r="1.71456" fill={fill} />
       <circle cx="18.431" cy="12.7146" r="1.71456" fill={fill} />

--- a/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
@@ -27,7 +27,7 @@ import {
   TargetEnum,
 } from '../CardContainerLogic'
 import HeaderCard from '../HeaderCard'
-import IconList, { IconListProps } from '../IconList'
+import IconList from '../IconList'
 import IconSvg, { type2SvgIconName } from '../IconSvg/IconSvg'
 import { CardFooter, Icon } from '../row_renderers/utils'
 import { FileHandleLink } from '../widgets/FileHandleLink'
@@ -544,11 +544,9 @@ class _GenericCard extends React.Component<GenericCardPropsInternal> {
                     <IconList
                       iconConfigs={columnIconOptions.columns.dataType}
                       iconNames={JSON.parse(dataTypeIconNames)}
-                      commonIconProps={
-                        {
-                          sx: { fontSize: '40px' },
-                        } as IconListProps['commonIconProps']
-                      }
+                      commonIconProps={{
+                        sx: { fontSize: '40px' },
+                      }}
                       useBackground={true}
                       useTheme={true}
                     />

--- a/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
@@ -544,6 +544,7 @@ class _GenericCard extends React.Component<GenericCardPropsInternal> {
                     <IconList
                       iconConfigs={columnIconOptions.columns.dataType}
                       iconNames={JSON.parse(dataTypeIconNames)}
+                      iconFontSize="40px"
                       useBackground={true}
                       useTheme={true}
                     />

--- a/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
@@ -27,7 +27,7 @@ import {
   TargetEnum,
 } from '../CardContainerLogic'
 import HeaderCard from '../HeaderCard'
-import IconList from '../IconList'
+import IconList, { IconListProps } from '../IconList'
 import IconSvg, { type2SvgIconName } from '../IconSvg/IconSvg'
 import { CardFooter, Icon } from '../row_renderers/utils'
 import { FileHandleLink } from '../widgets/FileHandleLink'
@@ -544,7 +544,11 @@ class _GenericCard extends React.Component<GenericCardPropsInternal> {
                     <IconList
                       iconConfigs={columnIconOptions.columns.dataType}
                       iconNames={JSON.parse(dataTypeIconNames)}
-                      iconFontSize="40px"
+                      commonIconProps={
+                        {
+                          sx: { fontSize: '40px' },
+                        } as IconListProps['commonIconProps']
+                      }
                       useBackground={true}
                       useTheme={true}
                     />

--- a/packages/synapse-react-client/src/components/IconList.tsx
+++ b/packages/synapse-react-client/src/components/IconList.tsx
@@ -1,14 +1,28 @@
 import React from 'react'
 import IconSvg, { IconSvgProps } from './IconSvg/IconSvg'
 
+type IconConfigs = {
+  [index: string]: IconSvgProps // if the icon option has the "label" set, it will show tooltip in IconSvg
+}
+
 export type IconListProps = {
-  iconConfigs: {
-    [index: string]: IconSvgProps // if the icon option has the "label" set, it will show tooltip in IconSvg
-  }
+  iconConfigs: IconConfigs
   iconNames: string[]
   iconFontSize?: string
   useTheme?: boolean
   useBackground?: boolean
+}
+
+const mergeIconFontSizeIntoIconConfigs = (
+  iconConfigs: IconConfigs,
+  iconFontSize: string,
+) => {
+  for (const key in iconConfigs) {
+    const existingSx = iconConfigs[key].sx
+    iconConfigs[key].sx = existingSx
+      ? { ...existingSx, fontSize: iconFontSize }
+      : { fontSize: iconFontSize }
+  }
 }
 
 const IconList: React.FunctionComponent<IconListProps> = props => {
@@ -22,6 +36,7 @@ const IconList: React.FunctionComponent<IconListProps> = props => {
   let noMatch: boolean = false
   const css = useTheme ? 'icon-list themed' : 'icon-list'
   const componentCss = useBackground ? `${css} bg-circle` : css
+  mergeIconFontSizeIntoIconConfigs(iconConfigs, iconFontSize)
 
   const buildIconList = () => {
     const unique = Array.from(new Set(iconNames))
@@ -32,13 +47,7 @@ const IconList: React.FunctionComponent<IconListProps> = props => {
         noMatch = true
         return
       } else {
-        return (
-          <IconSvg
-            style={{ fontSize: iconFontSize }}
-            key={el}
-            {...iconConfig}
-          />
-        )
+        return <IconSvg key={el} {...iconConfig} />
       }
     })
   }
@@ -47,7 +56,7 @@ const IconList: React.FunctionComponent<IconListProps> = props => {
     <span className={componentCss}>
       {buildIconList()}
       {noMatch && iconConfigs['other'] ? (
-        <IconSvg style={{ fontSize: iconFontSize }} {...iconConfigs['other']} />
+        <IconSvg {...iconConfigs['other']} />
       ) : (
         <></>
       )}

--- a/packages/synapse-react-client/src/components/IconList.tsx
+++ b/packages/synapse-react-client/src/components/IconList.tsx
@@ -6,12 +6,19 @@ export type IconListProps = {
     [index: string]: IconSvgProps // if the icon option has the "label" set, it will show tooltip in IconSvg
   }
   iconNames: string[]
+  iconFontSize?: string
   useTheme?: boolean
   useBackground?: boolean
 }
 
 const IconList: React.FunctionComponent<IconListProps> = props => {
-  const { iconConfigs, iconNames, useTheme, useBackground } = props
+  const {
+    iconConfigs,
+    iconNames,
+    iconFontSize = '24px',
+    useTheme,
+    useBackground,
+  } = props
   let noMatch: boolean = false
   const css = useTheme ? 'icon-list themed' : 'icon-list'
   const componentCss = useBackground ? `${css} bg-circle` : css
@@ -25,7 +32,13 @@ const IconList: React.FunctionComponent<IconListProps> = props => {
         noMatch = true
         return
       } else {
-        return <IconSvg key={el} {...iconConfig} />
+        return (
+          <IconSvg
+            style={{ fontSize: iconFontSize }}
+            key={el}
+            {...iconConfig}
+          />
+        )
       }
     })
   }
@@ -34,7 +47,7 @@ const IconList: React.FunctionComponent<IconListProps> = props => {
     <span className={componentCss}>
       {buildIconList()}
       {noMatch && iconConfigs['other'] ? (
-        <IconSvg {...iconConfigs['other']} />
+        <IconSvg style={{ fontSize: iconFontSize }} {...iconConfigs['other']} />
       ) : (
         <></>
       )}

--- a/packages/synapse-react-client/src/components/IconList.tsx
+++ b/packages/synapse-react-client/src/components/IconList.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import IconSvg, { IconSvgProps } from './IconSvg/IconSvg'
+import { merge } from 'lodash-es'
 
 type IconConfigs = {
   [index: string]: IconSvgProps // if the icon option has the "label" set, it will show tooltip in IconSvg
@@ -8,40 +9,39 @@ type IconConfigs = {
 export type IconListProps = {
   iconConfigs: IconConfigs
   iconNames: string[]
-  iconFontSize?: string
+  commonIconProps?: Omit<IconSvgProps, 'icon'>
   useTheme?: boolean
   useBackground?: boolean
 }
 
-const mergeIconFontSizeIntoIconConfigs = (
-  iconConfigs: IconConfigs,
-  iconFontSize: string,
-) => {
-  for (const key in iconConfigs) {
-    const existingSx = iconConfigs[key].sx
-    iconConfigs[key].sx = existingSx
-      ? { ...existingSx, fontSize: iconFontSize }
-      : { fontSize: iconFontSize }
-  }
+const defaultCommonIconProps: IconListProps['commonIconProps'] = {
+  sx: { fontSize: '24px' },
 }
 
 const IconList: React.FunctionComponent<IconListProps> = props => {
   const {
     iconConfigs,
     iconNames,
-    iconFontSize = '24px',
+    commonIconProps = defaultCommonIconProps,
     useTheme,
     useBackground,
   } = props
   let noMatch: boolean = false
   const css = useTheme ? 'icon-list themed' : 'icon-list'
   const componentCss = useBackground ? `${css} bg-circle` : css
-  mergeIconFontSizeIntoIconConfigs(iconConfigs, iconFontSize)
+
+  const mergedIconConfigs: IconConfigs = useMemo(() => {
+    const mergedIconConfigs: IconConfigs = {}
+    for (const [key, iconProps] of Object.entries(iconConfigs)) {
+      mergedIconConfigs[key] = merge({}, commonIconProps, iconProps)
+    }
+    return mergedIconConfigs
+  }, [iconConfigs, commonIconProps])
 
   const buildIconList = () => {
     const unique = Array.from(new Set(iconNames))
     return unique.map((el: any) => {
-      const iconConfig = iconConfigs[el]
+      const iconConfig = mergedIconConfigs[el]
       // if this data type value doesn't have a matching icon, we use the "other" icon
       if (!iconConfig) {
         noMatch = true
@@ -55,8 +55,8 @@ const IconList: React.FunctionComponent<IconListProps> = props => {
   return (
     <span className={componentCss}>
       {buildIconList()}
-      {noMatch && iconConfigs['other'] ? (
-        <IconSvg {...iconConfigs['other']} />
+      {noMatch && mergedIconConfigs['other'] ? (
+        <IconSvg {...mergedIconConfigs['other']} />
       ) : (
         <></>
       )}

--- a/packages/synapse-react-client/src/components/IconList/IconList.stories.ts
+++ b/packages/synapse-react-client/src/components/IconList/IconList.stories.ts
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react'
-import IconList from '../IconList'
+import IconList, { IconListProps } from '../IconList'
 
 const meta = {
   title: 'UI/IconList',
@@ -73,7 +73,9 @@ export const ThemeColorWithCircleBackground: Story = {
       geneVariants: { icon: 'geneVariants' },
       other: { icon: 'other' },
     },
-    iconFontSize: '40px',
+    commonIconProps: {
+      sx: { fontSize: '40px' },
+    } as IconListProps['commonIconProps'],
     useTheme: true,
     useBackground: true,
     iconNames: ['drugCombinationScreen', 'geneVariants', 'other'],

--- a/packages/synapse-react-client/src/components/IconList/IconList.stories.ts
+++ b/packages/synapse-react-client/src/components/IconList/IconList.stories.ts
@@ -71,10 +71,12 @@ export const ThemeColorWithCircleBackground: Story = {
     iconConfigs: {
       drugCombinationScreen: { icon: 'rat' },
       geneVariants: { icon: 'geneVariants' },
+      other: { icon: 'other' },
     },
+    iconFontSize: '40px',
     useTheme: true,
     useBackground: true,
-    iconNames: ['drugCombinationScreen', 'geneVariants'],
+    iconNames: ['drugCombinationScreen', 'geneVariants', 'other'],
   },
 }
 export const Tooltip: Story = {

--- a/packages/synapse-react-client/src/style/base/_icons.scss
+++ b/packages/synapse-react-client/src/style/base/_icons.scss
@@ -35,9 +35,6 @@
 
 .icon-list {
   display: inline-block;
-  svg {
-    font-size: 24px;
-  }
   path,
   circle {
     fill: currentColor;


### PR DESCRIPTION
staging:
<img width="1348" alt="PORTALS-2880_staging" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/9762d365-5491-4d7c-8450-832e781d81a3">

feature:
<img width="1358" alt="PORTALS-2880_feature" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/016da19d-1634-4039-9a72-6ac6d5375044">