### PR TITLE
SWC-6660

### DIFF
--- a/packages/synapse-react-client/src/components/entity/metadata/MetadataTable.tsx
+++ b/packages/synapse-react-client/src/components/entity/metadata/MetadataTable.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../utils/functions/FileHandleUtils'
 import useGetEntityBundle from '../../../synapse-queries/entity/useEntityBundle'
 import { UserBadge } from '../../UserCard/UserBadge'
+import { useGetUploadDestinationForStorageLocation } from '../../../synapse-queries/file/useUploadDestination'
 
 export type MetadataTableProps = {
   readonly entityId: string
@@ -29,10 +30,19 @@ export const MetadataTable = ({
   const dataFileHandle = entityBundle
     ? getDataFileHandle(entityBundle)
     : undefined
+  const parentId = entityBundle?.entity?.parentId
+  const storageLocationId = dataFileHandle?.storageLocationId
+  const { data: storageLocationUploadDestination } =
+    useGetUploadDestinationForStorageLocation(parentId!, storageLocationId!, {
+      enabled: parentId !== undefined && storageLocationId !== undefined,
+    })
 
   let fileLocationName = undefined
   if (dataFileHandle) {
-    fileLocationName = getStorageLocationName(dataFileHandle)
+    fileLocationName = getStorageLocationName(
+      dataFileHandle,
+      storageLocationUploadDestination,
+    )
   }
 
   return entityBundle ? (

--- a/packages/synapse-react-client/src/components/entity/metadata/MetadataTable.tsx
+++ b/packages/synapse-react-client/src/components/entity/metadata/MetadataTable.tsx
@@ -36,7 +36,7 @@ export const MetadataTable = ({
     useGetUploadDestinationForStorageLocation(parentId!, storageLocationId!, {
       enabled:
         parentId !== undefined &&
-        !(storageLocationId === undefined || storageLocationId === null),
+        storageLocationId != null,
     })
 
   let fileLocationName = undefined

--- a/packages/synapse-react-client/src/components/entity/metadata/MetadataTable.tsx
+++ b/packages/synapse-react-client/src/components/entity/metadata/MetadataTable.tsx
@@ -34,7 +34,9 @@ export const MetadataTable = ({
   const storageLocationId = dataFileHandle?.storageLocationId
   const { data: storageLocationUploadDestination } =
     useGetUploadDestinationForStorageLocation(parentId!, storageLocationId!, {
-      enabled: parentId !== undefined && storageLocationId !== undefined,
+      enabled:
+        parentId !== undefined &&
+        !(storageLocationId === undefined || storageLocationId === null),
     })
 
   let fileLocationName = undefined

--- a/packages/synapse-react-client/src/components/entity/page/title_bar/TitleBarProperties.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/entity/page/title_bar/TitleBarProperties.integration.test.tsx
@@ -5,6 +5,8 @@ import {
   EntityType,
   ExternalFileHandle,
   ExternalObjectStoreFileHandle,
+  S3FileHandle,
+  S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   VersionableEntity,
 } from '@sage-bionetworks/synapse-types'
 import { render, screen } from '@testing-library/react'
@@ -32,6 +34,10 @@ import TitleBarProperties, {
   TitleBarPropertiesProps,
 } from './TitleBarProperties'
 import * as UseGetEntityPropertiesModule from './useGetEntityTitleBarProperties'
+import {
+  MOCK_EXTERNAL_S3_STORAGE_LOCATION_ID,
+  mockExternalS3UploadDestination,
+} from '../../../../mocks/mock_upload_destination'
 
 const HAS_ACCESS_V2_DATA_TEST_ID = 'mock-has-access-v2'
 
@@ -216,6 +222,27 @@ describe('TitleBarProperties', () => {
 
       await screen.findByText(`Storage Location`)
       await screen.findByText('Synapse Storage')
+    })
+    it('File handle storage location bucket and baseKey', async () => {
+      const bucketName = mockExternalS3UploadDestination.bucket
+      useEntityBundleOverride({
+        ...mockFileEntity.bundle,
+        fileHandles: [
+          {
+            ...mockFileHandle,
+            concreteType: S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+            bucketName: bucketName,
+            storageLocationId: MOCK_EXTERNAL_S3_STORAGE_LOCATION_ID,
+          } as S3FileHandle,
+        ],
+      })
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      await screen.findByText(`Storage Location`)
+      await screen.findByText(
+        `s3://${bucketName}/${mockExternalS3UploadDestination.baseKey}`,
+      )
     })
     it('File handle endpoint, bucket, key', async () => {
       const endpointUrl = 'https://my-endpoint.fake'

--- a/packages/synapse-react-client/src/components/entity/page/title_bar/useGetEntityTitleBarProperties.tsx
+++ b/packages/synapse-react-client/src/components/entity/page/title_bar/useGetEntityTitleBarProperties.tsx
@@ -79,7 +79,7 @@ export function useGetEntityTitleBarProperties(
       enabled:
         !isContainer &&
         parentId !== undefined &&
-        !(storageLocationId === undefined || storageLocationId === null),
+        storageLocationId != null,
     })
 
   // If this is the latest entity version, show the "versionless" DOI if it exists.

--- a/packages/synapse-react-client/src/components/entity/page/title_bar/useGetEntityTitleBarProperties.tsx
+++ b/packages/synapse-react-client/src/components/entity/page/title_bar/useGetEntityTitleBarProperties.tsx
@@ -79,7 +79,7 @@ export function useGetEntityTitleBarProperties(
       enabled:
         !isContainer &&
         parentId !== undefined &&
-        storageLocationId !== undefined,
+        !(storageLocationId === undefined || storageLocationId === null),
     })
 
   // If this is the latest entity version, show the "versionless" DOI if it exists.

--- a/packages/synapse-react-client/src/mocks/entity/mockProject.ts
+++ b/packages/synapse-react-client/src/mocks/entity/mockProject.ts
@@ -1,6 +1,7 @@
 import {
   ACCESS_TYPE,
   AnnotationsValueType,
+  DoiAssociation,
   EntityBundle,
   EntityHeader,
   EntityJson,
@@ -19,6 +20,19 @@ export const mockProjectIds = times(20).map(i => i + 10001)
 
 const MOCK_PROJECT_ID = `syn10000`
 const MOCK_PROJECT_NAME = 'A Mock Project'
+
+export const mockDoiAssociation: DoiAssociation = {
+  associationId: '9606623',
+  etag: 'ddef9fe1-56b2-42f5-9a3c-db2d6f15401b',
+  doiUri: `10.7303/${MOCK_PROJECT_ID}`,
+  doiUrl: `https://repo-prod.prod.sagebase.org/repo/v1/doi/locate?id=${MOCK_PROJECT_ID}&type=ENTITY`,
+  objectId: MOCK_PROJECT_ID,
+  objectType: ObjectType.ENTITY,
+  associatedBy: `${MOCK_USER_ID}`,
+  associatedOn: '2021-01-04T15:42:18.000Z',
+  updatedBy: `${MOCK_USER_ID}`,
+  updatedOn: '2021-04-28T18:49:48.000Z',
+}
 
 const mockProjectEntity = {
   name: MOCK_PROJECT_NAME,
@@ -146,18 +160,7 @@ const mockProjectEntityBundle: EntityBundle = {
       },
     ],
   },
-  doiAssociation: {
-    associationId: '9606623',
-    etag: 'ddef9fe1-56b2-42f5-9a3c-db2d6f15401b',
-    doiUri: `10.7303/${MOCK_PROJECT_ID}`,
-    doiUrl: `https://repo-prod.prod.sagebase.org/repo/v1/doi/locate?id=${MOCK_PROJECT_ID}&type=ENTITY`,
-    objectId: MOCK_PROJECT_ID,
-    objectType: ObjectType.ENTITY,
-    associatedBy: `${MOCK_USER_ID}`,
-    associatedOn: '2021-01-04T15:42:18.000Z',
-    updatedBy: `${MOCK_USER_ID}`,
-    updatedOn: '2021-04-28T18:49:48.000Z',
-  },
+  doiAssociation: mockDoiAssociation,
   threadCount: 2,
   restrictionInformation: {
     restrictionLevel: RestrictionLevel.OPEN,

--- a/packages/synapse-react-client/src/mocks/mock_file_handle.ts
+++ b/packages/synapse-react-client/src/mocks/mock_file_handle.ts
@@ -1,4 +1,8 @@
-import { S3FileHandle } from '@sage-bionetworks/synapse-types'
+import {
+  EXTERNAL_OBJECT_STORE_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+  ExternalObjectStoreFileHandle,
+  S3FileHandle,
+} from '@sage-bionetworks/synapse-types'
 import { MOCK_USER_ID } from './user/mock_user_profile'
 
 export const MOCK_FILE_HANDLE_ID = '987654321'
@@ -30,6 +34,15 @@ export const mockFileHandle: S3FileHandle = {
   previewId: `${MOCK_PREVIEW_FILE_HANDLE_ID}`,
   isPreview: false,
 }
+
+export const mockExternalObjectStoreFileHandle: ExternalObjectStoreFileHandle =
+  {
+    ...mockFileHandle,
+    concreteType: EXTERNAL_OBJECT_STORE_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+    endpointUrl: 'https://my-endpoint.fake',
+    bucket: 'my-bucket',
+    fileKey: 'my-key',
+  }
 
 export const mockIrbApprovalFileHandle: S3FileHandle = {
   id: `${MOCK_DATA_ACCESS_SUBMISSION_IRB_APPROVAL_FILE_HANDLE_ID}`,

--- a/packages/synapse-react-client/src/mocks/mock_upload_destination.ts
+++ b/packages/synapse-react-client/src/mocks/mock_upload_destination.ts
@@ -1,0 +1,77 @@
+import {
+  ExternalGoogleCloudUploadDestination,
+  ExternalObjectStoreUploadDestination,
+  ExternalS3UploadDestination,
+  ExternalUploadDestination,
+  S3UploadDestination,
+  UploadDestination,
+  UploadType,
+} from '@sage-bionetworks/synapse-types'
+import { SYNAPSE_STORAGE_LOCATION_ID } from '../synapse-client'
+
+export const MOCK_EXTERNAL_S3_STORAGE_LOCATION_ID = 1111
+export const MOCK_EXTERNAL_GOOGLE_CLOUD_STORAGE_LOCATION_ID = 2222
+export const MOCK_EXTERNAL_STORAGE_LOCATION_ID = 3333
+export const MOCK_EXTERNAL_OBJECT_STORE_STORAGE_LOCATION_ID = 4444
+
+const baseUploadDestination: UploadDestination = {
+  storageLocationId: SYNAPSE_STORAGE_LOCATION_ID,
+  uploadType: UploadType.S3,
+  banner: '',
+  concreteType: 'org.sagebionetworks.repo.model.file.S3UploadDestination',
+}
+
+export const mockS3UploadDestination: S3UploadDestination = {
+  ...baseUploadDestination,
+  baseKey: 'exampleS3BaseKey',
+  stsEnabled: true,
+  concreteType: 'org.sagebionetworks.repo.model.file.S3UploadDestination',
+}
+
+export const mockExternalS3UploadDestination: ExternalS3UploadDestination = {
+  ...mockS3UploadDestination,
+  storageLocationId: MOCK_EXTERNAL_S3_STORAGE_LOCATION_ID,
+  endpointUrl: 'https://my-endpoint.fake',
+  bucket: 'myExternalS3Bucket',
+  concreteType:
+    'org.sagebionetworks.repo.model.file.ExternalS3UploadDestination',
+}
+
+export const mockExternalGoogleCloudUploadDestination: ExternalGoogleCloudUploadDestination =
+  {
+    ...baseUploadDestination,
+    baseKey: 'exampleGCPBaseKey',
+    storageLocationId: MOCK_EXTERNAL_GOOGLE_CLOUD_STORAGE_LOCATION_ID,
+    uploadType: UploadType.GOOGLECLOUDSTORAGE,
+    bucket: 'myExternalGCPBucket',
+    concreteType:
+      'org.sagebionetworks.repo.model.file.ExternalGoogleCloudUploadDestination',
+  }
+
+export const mockExternalUploadDestination: ExternalUploadDestination = {
+  ...baseUploadDestination,
+  storageLocationId: MOCK_EXTERNAL_STORAGE_LOCATION_ID,
+  uploadType: UploadType.HTTPS,
+  url: 'https://myurl.fake',
+  concreteType: 'org.sagebionetworks.repo.model.file.ExternalUploadDestination',
+}
+
+export const mockExternalObjectStoreUploadDestination: ExternalObjectStoreUploadDestination =
+  {
+    ...baseUploadDestination,
+    storageLocationId: MOCK_EXTERNAL_OBJECT_STORE_STORAGE_LOCATION_ID,
+    uploadType: UploadType.HTTPS,
+    endpointUrl: 'https://my-endpoint.fake',
+    bucket: 'myExternalObjectStoreBucket',
+    keyPrefixUUID: 'uuidKeyPrefix',
+    concreteType:
+      'org.sagebionetworks.repo.model.file.ExternalObjectStoreUploadDestination',
+  }
+
+export const mockUploadDestinations = [
+  mockS3UploadDestination,
+  mockExternalS3UploadDestination,
+  mockExternalGoogleCloudUploadDestination,
+  mockExternalUploadDestination,
+  mockExternalObjectStoreUploadDestination,
+]

--- a/packages/synapse-react-client/src/mocks/msw/handlers/entityHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/entityHandlers.ts
@@ -28,6 +28,7 @@ import { SynapseApiResponse } from '../handlers'
 import { UploadDestination, UploadType } from '@sage-bionetworks/synapse-types'
 import { uniqueId } from 'lodash-es'
 import { mockProjectsEntityData } from '../../entity/mockProject'
+import { mockUploadDestinations } from '../../mock_upload_destination'
 
 export const getEntityHandlers = (backendOrigin: string) => [
   /**
@@ -251,6 +252,26 @@ export const getEntityHandlers = (backendOrigin: string) => [
         concreteType: 'org.sagebionetworks.repo.model.file.S3UploadDestination',
       }
       return res(ctx.status(200), ctx.json(response))
+    },
+  ),
+
+  rest.get(
+    `${backendOrigin}/file/v1/entity/:id/uploadDestination/:storageLocationId`,
+    async (req, res, ctx) => {
+      let status = 404
+      let response: SynapseApiResponse<UploadDestination> = {
+        reason: `Mock Service worker could not find an uploadDestination using storageLocationId ${req.params.storageLocationId}`,
+      }
+      const uploadDestination = mockUploadDestinations.find(
+        e => Number(req.params.storageLocationId) === e.storageLocationId,
+      )
+
+      if (uploadDestination) {
+        response = uploadDestination
+        status = 200
+      }
+
+      return res(ctx.status(status), ctx.json(response))
     },
   ),
 

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -4630,6 +4630,24 @@ export function getDefaultUploadDestination(
 }
 
 /**
+ * Get the upload destination associated with the given storage location id.
+ * This will always return an upload destination
+ *
+ * https://rest-docs.synapse.org/rest/GET/entity/id/uploadDestination/storageLocationId.html
+ */
+export function getUploadDestinationForStorageLocation(
+  parentId: string,
+  storageLocationId: number,
+  accessToken?: string,
+): Promise<UploadDestination> {
+  return doGet<UploadDestination>(
+    `/file/v1/entity/${parentId}/uploadDestination/${storageLocationId}`,
+    accessToken,
+    BackendDestinationEnum.REPO_ENDPOINT,
+  )
+}
+
+/**
  * Retrieves the DOI for the object. Note: this call only retrieves the DOI association, if it exists.
  * To retrieve the metadata for the object, see GET /doi
  *

--- a/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
+++ b/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
@@ -471,6 +471,13 @@ export class KeyFactory {
     return this.getKey('uploadDestination', 'default', containerEntityId)
   }
 
+  public getUploadDestinationForStorageLocationQueryKey(
+    parentId: string,
+    storageLocationId: number,
+  ) {
+    return this.getKey('uploadDestination', parentId, storageLocationId)
+  }
+
   public getForumModeratorsQueryKey(forumId: string) {
     return this.getKey('moderators', forumId)
   }

--- a/packages/synapse-react-client/src/synapse-queries/file/useUploadDestination.ts
+++ b/packages/synapse-react-client/src/synapse-queries/file/useUploadDestination.ts
@@ -2,7 +2,10 @@ import { UseQueryOptions, useQuery } from 'react-query'
 import { SynapseClientError } from '../../utils/SynapseClientError'
 import { useSynapseContext } from '../../utils/context/SynapseContext'
 import { UploadDestination } from '@sage-bionetworks/synapse-types'
-import { getDefaultUploadDestination } from '../../synapse-client/SynapseClient'
+import {
+  getDefaultUploadDestination,
+  getUploadDestinationForStorageLocation,
+} from '../../synapse-client/SynapseClient'
 
 export function useGetDefaultUploadDestination(
   containerEntityId: string,
@@ -12,6 +15,29 @@ export function useGetDefaultUploadDestination(
   return useQuery<UploadDestination, SynapseClientError>(
     keyFactory.getDefaultUploadDestinationQueryKey(containerEntityId),
     () => getDefaultUploadDestination(containerEntityId, accessToken),
+    {
+      ...options,
+    },
+  )
+}
+
+export function useGetUploadDestinationForStorageLocation(
+  parentId: string,
+  storageLocationId: number,
+  options?: UseQueryOptions<UploadDestination, SynapseClientError>,
+) {
+  const { accessToken, keyFactory } = useSynapseContext()
+  return useQuery<UploadDestination, SynapseClientError>(
+    keyFactory.getUploadDestinationForStorageLocationQueryKey(
+      parentId,
+      storageLocationId,
+    ),
+    () =>
+      getUploadDestinationForStorageLocation(
+        parentId,
+        storageLocationId,
+        accessToken,
+      ),
     {
       ...options,
     },

--- a/packages/synapse-react-client/src/utils/functions/FileHandleUtils.test.ts
+++ b/packages/synapse-react-client/src/utils/functions/FileHandleUtils.test.ts
@@ -238,6 +238,15 @@ describe('File Handle Utils', () => {
       expect(result).toEqual('Synapse Storage')
     })
 
+    it("Returns 'Synapse Storage' for a file with a null storage location id", () => {
+      const fileHandle: S3FileHandle = {
+        ...mockFileHandle,
+        storageLocationId: null,
+        concreteType: S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+      }
+      const result = getStorageLocationName(fileHandle, undefined)
+      expect(result).toEqual('Synapse Storage')
+    })
     it('Returns an s3 path for an S3 file handle in a custom storage location', () => {
       const fileHandle: S3FileHandle = {
         ...mockFileHandle,
@@ -297,7 +306,7 @@ describe('File Handle Utils', () => {
       expect(result).toEqual(url)
     })
     it('Returns the bucket for an external object store file handle', () => {
-      const bucket = mockExternalObjectStoreUploadDestination.bucket
+      const { bucket, endpointUrl } = mockExternalObjectStoreUploadDestination
       const fileHandle: ExternalObjectStoreFileHandle = {
         ...mockExternalObjectStoreFileHandle,
         bucket: bucket,
@@ -307,7 +316,7 @@ describe('File Handle Utils', () => {
         fileHandle,
         mockExternalObjectStoreUploadDestination,
       )
-      expect(result).toEqual(bucket)
+      expect(result).toEqual(`${endpointUrl}/${bucket}`)
     })
   })
   describe('getUploadDestinationString', () => {

--- a/packages/synapse-react-client/src/utils/functions/FileHandleUtils.test.ts
+++ b/packages/synapse-react-client/src/utils/functions/FileHandleUtils.test.ts
@@ -4,41 +4,47 @@ import {
   EXTERNAL_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   EXTERNAL_OBJECT_STORE_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   ExternalFileHandle,
+  ExternalGoogleCloudUploadDestination,
   ExternalObjectStoreFileHandle,
+  ExternalObjectStoreUploadDestination,
+  ExternalS3UploadDestination,
+  ExternalUploadDestination,
+  FileEntity,
   GOOGLE_CLOUD_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   GoogleCloudFileHandle,
   PROXY_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   ProxyFileHandle,
   S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   S3FileHandle,
-} from '@sage-bionetworks/synapse-types'
-import {
-  ExternalGoogleCloudUploadDestination,
-  ExternalObjectStoreUploadDestination,
-  ExternalS3UploadDestination,
-  ExternalUploadDestination,
   S3UploadDestination,
   UploadType,
 } from '@sage-bionetworks/synapse-types'
-import { MOCK_USER_ID } from '../../../src/mocks/user/mock_user_profile'
+import mockFileEntityData from '../../mocks/entity/mockFileEntity'
+import {
+  mockExternalObjectStoreFileHandle,
+  mockFileHandle,
+} from '../../mocks/mock_file_handle'
+import { MOCK_USER_ID } from '../../mocks/user/mock_user_profile'
 import {
   getDataFileHandle,
   getFileHandleStorageInfo,
   getStorageLocationName,
   getUploadDestinationString,
-} from '../../../src/utils/functions/FileHandleUtils'
+} from './FileHandleUtils'
 
 describe('File Handle Utils', () => {
   describe('getDataFileHandle', () => {
     it('Returns the data file handle ID if it exists', () => {
       const dataFileHandleId = '123'
       const fileHandle = {
+        ...mockFileHandle,
         id: dataFileHandleId,
       }
       const entityBundle: EntityBundle = {
+        ...mockFileEntityData.bundle,
         entity: {
           dataFileHandleId: dataFileHandleId,
-        },
+        } as FileEntity,
         fileHandles: [fileHandle],
         entityType: EntityType.FILE,
       }
@@ -49,9 +55,10 @@ describe('File Handle Utils', () => {
     it('Returns undefined if the bundle does not contain a data file handle', () => {
       const dataFileHandleId = '123'
       const entityBundle: EntityBundle = {
+        ...mockFileEntityData.bundle,
         entity: {
           dataFileHandleId: dataFileHandleId,
-        },
+        } as FileEntity,
         fileHandles: [],
         entityType: EntityType.FILE,
       }
@@ -73,6 +80,9 @@ describe('File Handle Utils', () => {
         contentType: 'text/plain',
         contentSize: 123,
         createdBy: MOCK_USER_ID.toString(),
+        modifiedOn: '',
+        storageLocationId: 1234,
+        status: 'AVAILABLE',
       }
       const result = getFileHandleStorageInfo(fileHandle)
       expect(result).toEqual({ url: url })
@@ -93,6 +103,9 @@ describe('File Handle Utils', () => {
         contentType: 'text/plain',
         contentSize: 123,
         createdBy: MOCK_USER_ID.toString(),
+        modifiedOn: '',
+        storageLocationId: 1234,
+        status: 'AVAILABLE',
       }
       const result = getFileHandleStorageInfo(fileHandle)
       expect(result).toEqual({ endpoint, bucket, fileKey })
@@ -110,6 +123,9 @@ describe('File Handle Utils', () => {
         contentType: 'text/plain',
         contentSize: 123,
         createdBy: MOCK_USER_ID.toString(),
+        modifiedOn: '',
+        storageLocationId: 1234,
+        status: 'AVAILABLE',
       }
       const result = getFileHandleStorageInfo(fileHandle)
       expect(result).toEqual({ url: url })
@@ -130,6 +146,9 @@ describe('File Handle Utils', () => {
         contentType: 'text/plain',
         contentSize: 123,
         createdBy: MOCK_USER_ID.toString(),
+        isPreview: false,
+        modifiedOn: '',
+        status: 'AVAILABLE',
       }
       const result = getFileHandleStorageInfo(fileHandle)
       expect(result).toEqual({
@@ -151,6 +170,9 @@ describe('File Handle Utils', () => {
         contentType: 'text/plain',
         contentSize: 123,
         createdBy: MOCK_USER_ID.toString(),
+        isPreview: false,
+        modifiedOn: '',
+        status: 'AVAILABLE',
       }
       const result = getFileHandleStorageInfo(fileHandle)
       expect(result).toEqual({
@@ -173,6 +195,9 @@ describe('File Handle Utils', () => {
         contentType: 'text/plain',
         contentSize: 123,
         createdBy: MOCK_USER_ID.toString(),
+        isPreview: false,
+        modifiedOn: '',
+        status: 'AVAILABLE',
       }
       const result = getFileHandleStorageInfo(fileHandle)
       expect(result).toEqual({
@@ -184,6 +209,7 @@ describe('File Handle Utils', () => {
     it("Returns 'Synapse Storage' for a file in  Synapse Storage", () => {
       const storageLocationId = 1
       const fileHandle: S3FileHandle = {
+        ...mockFileHandle,
         storageLocationId: storageLocationId,
         concreteType: S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
       }
@@ -194,6 +220,7 @@ describe('File Handle Utils', () => {
     it('Returns an s3 path for an S3 file handle in a custom storage location', () => {
       const storageLocationId = 1243466
       const fileHandle: S3FileHandle = {
+        ...mockFileHandle,
         storageLocationId: storageLocationId,
         bucketName: 'myBucket',
         concreteType: S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
@@ -204,6 +231,7 @@ describe('File Handle Utils', () => {
     it('Returns a gs path for an Google Cloud file handle in a custom storage location', () => {
       const storageLocationId = 1243466
       const fileHandle: GoogleCloudFileHandle = {
+        ...mockFileHandle,
         storageLocationId: storageLocationId,
         bucketName: 'myBucket',
         concreteType: GOOGLE_CLOUD_FILE_HANDLE_CONCRETE_TYPE_VALUE,
@@ -214,6 +242,7 @@ describe('File Handle Utils', () => {
     it('Returns the file path for a ProxyFileHandle', () => {
       const path = 'https://example.com'
       const fileHandle: ProxyFileHandle = {
+        ...mockFileHandle,
         filePath: path,
         concreteType: PROXY_FILE_HANDLE_CONCRETE_TYPE_VALUE,
       }
@@ -224,6 +253,7 @@ describe('File Handle Utils', () => {
     it('Returns the external url for an External File Handle', () => {
       const url = 'https://example.com'
       const fileHandle: ExternalFileHandle = {
+        ...mockFileHandle,
         externalURL: url,
         concreteType: EXTERNAL_FILE_HANDLE_CONCRETE_TYPE_VALUE,
       }
@@ -232,24 +262,33 @@ describe('File Handle Utils', () => {
     })
     it('Returns the bucket for an external object store file handle', () => {
       const bucket = 'myExternalBucket'
-      const fileHandle: ExternalObjectStoreFileHandle = {
+      const fileHandle = {
+        ...mockExternalObjectStoreFileHandle,
         bucket: bucket,
         concreteType: EXTERNAL_OBJECT_STORE_FILE_HANDLE_CONCRETE_TYPE_VALUE,
-      }
+      } as ExternalObjectStoreFileHandle
       const result = getStorageLocationName(fileHandle)
       expect(result).toEqual(bucket)
     })
   })
   describe('getUploadDestinationString', () => {
+    const mockS3UploadDestination: S3UploadDestination = {
+      banner: '',
+      storageLocationId: 1,
+      uploadType: UploadType.S3,
+      concreteType: 'org.sagebionetworks.repo.model.file.S3UploadDestination',
+      stsEnabled: true,
+      baseKey: 'myKey',
+    }
+
     it("Returns 'Synapse Storage' the Synapse Storage upload destination", () => {
-      const uploadDestination: S3UploadDestination = {
-        concreteType: 'org.sagebionetworks.repo.model.file.S3UploadDestination',
-      }
+      const uploadDestination: S3UploadDestination = mockS3UploadDestination
       const result = getUploadDestinationString(uploadDestination)
       expect(result).toEqual('Synapse Storage')
     })
     it('Returns the URL for an ExternalUploadDestination', () => {
       const uploadDestination: ExternalUploadDestination = {
+        ...mockS3UploadDestination,
         concreteType:
           'org.sagebionetworks.repo.model.file.ExternalUploadDestination',
         uploadType: UploadType.HTTPS,
@@ -260,6 +299,7 @@ describe('File Handle Utils', () => {
     })
     it('Strips everything after the trailing slash for an ExternalUploadDestination with SFTP', () => {
       const uploadDestination: ExternalUploadDestination = {
+        ...mockS3UploadDestination,
         concreteType:
           'org.sagebionetworks.repo.model.file.ExternalUploadDestination',
         uploadType: UploadType.SFTP,
@@ -270,10 +310,12 @@ describe('File Handle Utils', () => {
     })
     it('Returns an s3 path for an ExternalS3UploadDestination', () => {
       const uploadDestination: ExternalS3UploadDestination = {
+        ...mockS3UploadDestination,
         concreteType:
           'org.sagebionetworks.repo.model.file.ExternalS3UploadDestination',
         bucket: 'myBucket',
         baseKey: 'myKey',
+        endpointUrl: 'https://example.com',
       }
       const result = getUploadDestinationString(uploadDestination)
       expect(result).toEqual('s3://myBucket/myKey')
@@ -281,6 +323,7 @@ describe('File Handle Utils', () => {
 
     it('Returns a gs path for an ExternalGoogleCloudUploadDestination', () => {
       const uploadDestination: ExternalGoogleCloudUploadDestination = {
+        ...mockS3UploadDestination,
         concreteType:
           'org.sagebionetworks.repo.model.file.ExternalGoogleCloudUploadDestination',
         bucket: 'myBucket',
@@ -292,10 +335,12 @@ describe('File Handle Utils', () => {
 
     it('Returns a path for an ExternalObjectStoreUploadDestination', () => {
       const uploadDestination: ExternalObjectStoreUploadDestination = {
+        ...mockS3UploadDestination,
         concreteType:
           'org.sagebionetworks.repo.model.file.ExternalObjectStoreUploadDestination',
         endpointUrl: 'https://example.com',
         bucket: 'myBucket',
+        keyPrefixUUID: 'uuid123',
       }
       const result = getUploadDestinationString(uploadDestination)
       expect(result).toEqual('https://example.com/myBucket')

--- a/packages/synapse-react-client/src/utils/functions/FileHandleUtils.test.ts
+++ b/packages/synapse-react-client/src/utils/functions/FileHandleUtils.test.ts
@@ -16,7 +16,6 @@ import {
   ProxyFileHandle,
   S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   S3FileHandle,
-  S3UploadDestination,
   UploadType,
 } from '@sage-bionetworks/synapse-types'
 import mockFileEntityData from '../../mocks/entity/mockFileEntity'
@@ -312,25 +311,13 @@ describe('File Handle Utils', () => {
     })
   })
   describe('getUploadDestinationString', () => {
-    const mockS3UploadDestination: S3UploadDestination = {
-      banner: '',
-      storageLocationId: SYNAPSE_STORAGE_LOCATION_ID,
-      uploadType: UploadType.S3,
-      concreteType: 'org.sagebionetworks.repo.model.file.S3UploadDestination',
-      stsEnabled: true,
-      baseKey: 'myKey',
-    }
-
     it("Returns 'Synapse Storage' the Synapse Storage upload destination", () => {
-      const uploadDestination: S3UploadDestination = mockS3UploadDestination
-      const result = getUploadDestinationString(uploadDestination)
+      const result = getUploadDestinationString(mockS3UploadDestination)
       expect(result).toEqual('Synapse Storage')
     })
     it('Returns the URL for an ExternalUploadDestination', () => {
       const uploadDestination: ExternalUploadDestination = {
-        ...mockS3UploadDestination,
-        concreteType:
-          'org.sagebionetworks.repo.model.file.ExternalUploadDestination',
+        ...mockExternalUploadDestination,
         uploadType: UploadType.HTTPS,
         url: 'https://testUrl.com/abcdef',
       }
@@ -339,9 +326,7 @@ describe('File Handle Utils', () => {
     })
     it('Strips everything after the trailing slash for an ExternalUploadDestination with SFTP', () => {
       const uploadDestination: ExternalUploadDestination = {
-        ...mockS3UploadDestination,
-        concreteType:
-          'org.sagebionetworks.repo.model.file.ExternalUploadDestination',
+        ...mockExternalUploadDestination,
         uploadType: UploadType.SFTP,
         url: 'sftp://testUrl.com/abcdef',
       }
@@ -350,9 +335,7 @@ describe('File Handle Utils', () => {
     })
     it('Returns an s3 path for an ExternalS3UploadDestination', () => {
       const uploadDestination: ExternalS3UploadDestination = {
-        ...mockS3UploadDestination,
-        concreteType:
-          'org.sagebionetworks.repo.model.file.ExternalS3UploadDestination',
+        ...mockExternalS3UploadDestination,
         bucket: 'myBucket',
         baseKey: 'myKey',
         endpointUrl: 'https://example.com',
@@ -363,9 +346,7 @@ describe('File Handle Utils', () => {
 
     it('Returns a gs path for an ExternalGoogleCloudUploadDestination', () => {
       const uploadDestination: ExternalGoogleCloudUploadDestination = {
-        ...mockS3UploadDestination,
-        concreteType:
-          'org.sagebionetworks.repo.model.file.ExternalGoogleCloudUploadDestination',
+        ...mockExternalGoogleCloudUploadDestination,
         bucket: 'myBucket',
         baseKey: 'myKey',
       }
@@ -375,9 +356,7 @@ describe('File Handle Utils', () => {
 
     it('Returns a path for an ExternalObjectStoreUploadDestination', () => {
       const uploadDestination: ExternalObjectStoreUploadDestination = {
-        ...mockS3UploadDestination,
-        concreteType:
-          'org.sagebionetworks.repo.model.file.ExternalObjectStoreUploadDestination',
+        ...mockExternalObjectStoreUploadDestination,
         endpointUrl: 'https://example.com',
         bucket: 'myBucket',
         keyPrefixUUID: 'uuid123',

--- a/packages/synapse-types/src/File/FileHandle.ts
+++ b/packages/synapse-types/src/File/FileHandle.ts
@@ -27,7 +27,7 @@ export interface FileHandle {
   /** The short, user visible name for this file. */
   fileName: string
   /** The optional storage location descriptor */
-  storageLocationId: number
+  storageLocationId: number | null
   /** The size of the file in bytes. */
   contentSize: number
   /** The status of the file handle as computed by the backend. This value cannot be changed, any file handle that is not AVAILABLE should not be used. */


### PR DESCRIPTION
component | change | main | feature
:---:|:---:|:---:|:---:
title bar - file in external S3 bucket | storage location | <img width="1435" alt="SWC-6660_externalS3_file_main" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/249e2429-b520-4ec2-b30c-d008473f4b70"> | <img width="1309" alt="SWC-6660_externalS3_file_feature" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/ae93e856-cff2-4d12-8ffb-20eda01e9e60">
title bar - folder in external S3 bucket | not changed | <img width="1440" alt="SWC-6660_externalS3_folder_main" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/10b5d411-5f61-4e95-88e5-4e7ba972672c"> | <img width="1311" alt="SWC-6660_externalS3_folder_feature" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/cc6bbb22-2ddd-415a-adde-eb082e9b24d4">
entity modal metadata - file in external S3 bucket | storage | <img width="706" alt="SWC-6660_entityModalMetadata_main" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/2df414e5-852b-453f-9655-095eba5cfeb6"> | <img width="642" alt="SWC-6660_entityModalMetadata_feature" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/71e6b12a-3e83-4a63-af59-8d03c339acac">
