### PR TITLE
PORTALS-2768: only show icon, no text in SynapseTable access column

### DIFF
--- a/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.integration.test.tsx
@@ -1,35 +1,31 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
-import {
-  HasAccessV2,
-  HasAccessProps,
-} from '../../src/components/HasAccess/HasAccessV2'
-import { createWrapper } from '../../src/testutils/TestingLibraryUtils'
-import { ENTITY_BUNDLE_V2 } from '../../src/utils/APIConstants'
+import { HasAccessV2, HasAccessProps } from './HasAccessV2'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import { ENTITY_BUNDLE_V2 } from '../../utils/APIConstants'
 import {
   BackendDestinationEnum,
   getEndpoint,
-} from '../../src/utils/functions/getEndpoint'
-import { SRC_SIGN_IN_CLASS } from '../../src/utils/SynapseConstants'
-import { SynapseContextType } from '../../src/utils/context/SynapseContext'
+} from '../../utils/functions/getEndpoint'
+import { SRC_SIGN_IN_CLASS } from '../../utils/SynapseConstants'
+import { SynapseContextType } from '../../utils/context/SynapseContext'
 import {
   EntityBundle,
   RestrictableObjectType,
   RestrictionInformationRequest,
   RestrictionInformationResponse,
 } from '@sage-bionetworks/synapse-types'
-import { mockFolderEntity } from '../../src/mocks/entity/mockEntity'
-import mockFileEntityData from '../../src/mocks/entity/mockFileEntity'
-import { MOCK_CONTEXT_VALUE } from '../../src/mocks/MockSynapseContext'
+import { mockFolderEntity } from '../../mocks/entity/mockEntity'
+import mockFileEntityData from '../../mocks/entity/mockFileEntity'
+import { MOCK_CONTEXT_VALUE } from '../../mocks/MockSynapseContext'
 import {
   mockOpenRestrictionInformation,
   mockUnmetControlledDataRestrictionInformationACT,
-} from '../../src/mocks/mock_has_access_data'
-import { rest, server } from '../../src/mocks/msw/server'
+} from '../../mocks/mock_has_access_data'
+import { rest, server } from '../../mocks/msw/server'
 
 const entityId = mockFileEntityData.id
 const mockFileEntityBundle = mockFileEntityData.bundle
-const isInDownloadList: boolean = true
 
 const renderComponent = (
   props: HasAccessProps,
@@ -41,7 +37,6 @@ const renderComponent = (
 }
 const props: HasAccessProps = {
   entityId,
-  isInDownloadList,
 }
 
 const onGetRestrictionInformation = jest.fn()
@@ -86,7 +81,7 @@ describe('HasAccess tests', () => {
 
   it('User has all permissions on a standard FileEntity and any Access Requirements have been met', async () => {
     const entityBundle: EntityBundle = {
-      entity: mockFileEntityBundle.entity,
+      ...mockFileEntityBundle,
       permissions: {
         ...mockFileEntityBundle.permissions,
         canDownload: true,
@@ -115,8 +110,10 @@ describe('HasAccess tests', () => {
 
   it('The entity is a Folder entity', async () => {
     const entityBundle: EntityBundle = {
+      ...mockFileEntityBundle,
       entity: mockFolderEntity,
       permissions: {
+        ...mockFileEntityBundle.permissions,
         canDownload: true,
       },
     }
@@ -144,6 +141,7 @@ describe('HasAccess tests', () => {
   describe('Authorization blocked by ACL', () => {
     it('Handles a file entity where download access is blocked because of missing DOWNLOAD permission, and the user is signed in', async () => {
       const entityBundle: EntityBundle = {
+        ...mockFileEntityBundle,
         entity: mockFileEntityBundle.entity,
         permissions: {
           ...mockFileEntityBundle.permissions,
@@ -177,6 +175,7 @@ describe('HasAccess tests', () => {
         accessToken: undefined,
       }
       const entityBundle: EntityBundle = {
+        ...mockFileEntityBundle,
         entity: mockFileEntityBundle.entity,
         permissions: {
           ...mockFileEntityBundle.permissions,
@@ -211,6 +210,7 @@ describe('HasAccess tests', () => {
   describe('File is controlled by Access Requirements', () => {
     it('User has ACL permissions but not AR permissions', async () => {
       const entityBundle: EntityBundle = {
+        ...mockFileEntityBundle,
         entity: mockFileEntityBundle.entity,
         permissions: {
           ...mockFileEntityBundle.permissions,
@@ -247,6 +247,7 @@ describe('HasAccess tests', () => {
         accessToken: undefined,
       }
       const entityBundle: EntityBundle = {
+        ...mockFileEntityBundle,
         entity: mockFileEntityBundle.entity,
         permissions: {
           ...mockFileEntityBundle.permissions,
@@ -280,6 +281,7 @@ describe('HasAccess tests', () => {
 
     it('User does not have ACL permissions and does not have AR permissions', async () => {
       const entityBundle: EntityBundle = {
+        ...mockFileEntityBundle,
         entity: mockFileEntityBundle.entity,
         permissions: {
           ...mockFileEntityBundle.permissions,

--- a/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.tsx
+++ b/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import SynapseClient from '../../synapse-client'
 import {
   BackendDestinationEnum,
@@ -197,7 +197,7 @@ export function HasAccessV2(props: HasAccessProps) {
     restrictionInformationRequest,
   )
 
-  const handleGetAccess = () => {
+  const handleGetAccess = useCallback(() => {
     // TODO: The fetch should really happen in the AR List component.
     // If we need to open the AR page in synapse, the logic should be in the modal and it should just close itself right away
     SynapseClient.getAllAccessRequirements(accessToken, entityId).then(
@@ -215,7 +215,7 @@ export function HasAccessV2(props: HasAccessProps) {
         }
       },
     )
-  }
+  }, [accessToken, entityId])
 
   // Show Access Requirements
   const accessRequirementsJsx = useMemo(() => {
@@ -267,6 +267,8 @@ export function HasAccessV2(props: HasAccessProps) {
     restrictionInformation,
     accessRequirements,
     displayAccessRequirement,
+    handleGetAccess,
+    props.className,
   ])
 
   if (fileHandleDownloadType === undefined) {

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableRenderers.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableRenderers.tsx
@@ -191,6 +191,7 @@ function AccessCell(props: CellContext<Row, unknown>) {
         key={entityId}
         entityId={entityId}
         entityVersionNumber={versionNumber}
+        showButtonText={false}
       />
     </div>
   )
@@ -200,6 +201,7 @@ export const accessColumn = columnHelper.display({
   id: `${columnIdPrefix}.Access`,
   enableResizing: false,
   cell: AccessCell,
+  maxSize: 50,
   meta: {
     align: 'center',
   },


### PR DESCRIPTION
### Request Access - Table

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/5b32f799-2c96-4de8-a0ee-4ec54ffd02b5

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/767506a3-b97d-4477-b9c8-5363a2ebafa5

### View Terms - Table

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/caa0e87f-c298-48ec-8cd1-69e496a23e44

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/8ae58c45-3d7d-4146-b8fc-f82d26fa3c6d

### Request Access - Options

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/c569093e-ba77-41e2-93a2-410e10f0dc86

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/0f8e0fd5-cd7f-4f21-aa38-da97c752bb01

### Title Bar

main: 
<img width="1172" alt="main_titleBar" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/bc7405d1-f54f-4c2b-9b04-25d1373cbfab">

feature: 
<img width="1167" alt="feature_titleBar" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/16996342-b29b-42bb-ab5c-8527ee7798e8">

