### PR TITLE
PORTALS-2912 - Add helpConfiguration for table columns

### DIFF
--- a/apps/portals/src/configurations/elportal/synapseConfigs/cohortbuilder.ts
+++ b/apps/portals/src/configurations/elportal/synapseConfigs/cohortbuilder.ts
@@ -72,6 +72,13 @@ export const individualsView: SynapseConfig = {
     facetsToPlot: ['Sex', 'dataTypes', 'Assays', 'Diagnosis', 'fileFormat'],
     isRowSelectionVisible: true,
     rowSelectionPrimaryKey: ['individualID'],
+    helpConfiguration: [
+      {
+        columnName: 'individualID',
+        helpText:
+          'A unique identifier that represents a study participant in this system. Individual IDs in our system do not match study-specific participant IDs.',
+      },
+    ],
     combineRangeFacetConfig: {
       label: 'Age',
       minFacetColumn: 'minAge',

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.stories.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.stories.tsx
@@ -354,6 +354,12 @@ export const Dataset: Story = {
     hideSqlEditorControl: false,
     shouldDeepLink: false,
     showExportToCavatica: true,
+    helpConfiguration: [
+      {
+        columnName: 'id',
+        helpText: 'This represents the unique ID in Synapse',
+      },
+    ],
   },
 }
 

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
@@ -89,6 +89,7 @@ type QueryWrapperPlotNavOwnProps = {
     | 'noContentPlaceholderType'
     | 'unitDescription'
     | 'additionalFiltersSessionStorageKey'
+    | 'helpConfiguration'
   > &
   Pick<QueryContextType, 'combineRangeFacetConfig'>
 
@@ -260,6 +261,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = (
     showLastUpdatedOn,
     unitDescription,
     additionalFiltersSessionStorageKey,
+    helpConfiguration,
   } = props
 
   const entityId = parseEntityIdFromSqlStatement(sql)
@@ -311,6 +313,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = (
         unitDescription={unitDescription}
         rgbIndex={props.rgbIndex}
         columnAliases={props.columnAliases}
+        helpConfiguration={helpConfiguration}
         visibleColumnCount={props.visibleColumnCount}
         defaultShowFacetVisualization={props.defaultShowFacetVisualization}
         defaultShowSearchBar={

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.integration.test.tsx
@@ -5,7 +5,10 @@ import { cloneDeep } from 'lodash-es'
 import React from 'react'
 import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
 import { SynapseConstants } from '../../utils'
-import { QueryVisualizationWrapper } from '../QueryVisualizationWrapper'
+import {
+  QueryVisualizationWrapper,
+  QueryVisualizationWrapperProps,
+} from '../QueryVisualizationWrapper'
 import SynapseTable, { SynapseTableProps } from './SynapseTable'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
 import { ENTITY_HEADERS, ENTITY_ID_VERSION } from '../../utils/APIConstants'
@@ -63,6 +66,7 @@ function renderTable(
   props?: SynapseTableProps,
   queryWrapperPropOverrides?: Partial<QueryWrapperProps>,
   mockEntity: Table = mockTableEntity,
+  queryVisualizationWrapperProps?: Partial<QueryVisualizationWrapperProps>,
 ) {
   const initQueryRequest: QueryBundleRequest = {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
@@ -111,7 +115,7 @@ function renderTable(
       initQueryRequest={initQueryRequest}
       {...queryWrapperPropOverrides}
     >
-      <QueryVisualizationWrapper>
+      <QueryVisualizationWrapper {...queryVisualizationWrapperProps}>
         <QueryContextConsumer>
           {context => {
             // Capture the query context so we can use it in our tests
@@ -583,5 +587,21 @@ describe('SynapseTable tests', () => {
         name: 'Filter by specific facet',
       }),
     ).not.toBeInTheDocument()
+  })
+
+  it('shows help text when provided by QueryVisualizationWrapper', async () => {
+    const helpText = 'Some description for the column'
+    renderTable(undefined, undefined, undefined, {
+      helpConfiguration: [
+        {
+          columnName: 'id',
+          helpText: helpText,
+        },
+      ],
+    })
+
+    // Verify that the ID column contains the icon button with the help text
+    const columnHeader = await screen.findByRole('columnheader', { name: 'Id' })
+    within(columnHeader).getByRole('button', { name: helpText })
   })
 })

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableRenderers.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableRenderers.tsx
@@ -17,7 +17,7 @@ import { useGetEntityHeader } from '../../synapse-queries'
 import FileEntityDirectDownload from '../DirectDownload/FileEntityDirectDownload'
 import HasAccessV2 from '../HasAccess'
 import { EnumFacetFilter } from '../widgets/query-filter/EnumFacetFilter/EnumFacetFilter'
-import { IconButton, Tooltip } from '@mui/material'
+import { Box, IconButton, Tooltip } from '@mui/material'
 import IconSvg from '../IconSvg'
 import EntityIDColumnCopyIcon from './EntityIDColumnCopyIcon'
 import { useQueryVisualizationContext } from '../QueryVisualizationWrapper/QueryVisualizationWrapper'
@@ -32,6 +32,7 @@ import {
   isRowSelectedAtom,
   selectedRowsAtom,
 } from '../QueryWrapper/TableRowSelectionState'
+import { HelpTwoTone } from '@mui/icons-material'
 
 // Add a prefix to these column IDs so they don't collide with actual column names
 const columnIdPrefix =
@@ -218,13 +219,14 @@ export function TableDataColumnHeader(
   const selectColumn = selectColumns.find(sc => sc.name === column.id)
   const columnModel = columnModels.find(cm => cm.name === column.id)
   const facets = data?.facets ?? []
-  const { getColumnDisplayName } = useQueryVisualizationContext()
+  const { getColumnDisplayName, getHelpText } = useQueryVisualizationContext()
 
   if (!selectColumn) {
     return <>{column.id}</>
   }
 
-  const displayColumnName = getColumnDisplayName(selectColumn!.name)
+  const displayColumnName = getColumnDisplayName(selectColumn.name)
+  const columnHelpText = getHelpText(selectColumn.name)
   // we have to figure out if the current column is a facet selection
   const facetIndex: number = facets.findIndex(
     (facetColumnResult: FacetColumnResult) => {
@@ -245,6 +247,7 @@ export function TableDataColumnHeader(
     selectColumn &&
     selectColumn.name == 'id' &&
     selectColumn.columnType == ColumnTypeEnum.ENTITYID
+
   return (
     <div className="SRC-split">
       <div className="SRC-centerContent">
@@ -256,7 +259,19 @@ export function TableDataColumnHeader(
           {displayColumnName}
         </span>
       </div>
-      <div className="SRC-centerContent" style={{ height: '22px' }}>
+      <Box
+        role={'menubar'}
+        display={'flex'}
+        alignItems="center"
+        sx={{ height: '22px', ml: 2, gap: 0.25 }}
+      >
+        {columnHelpText && (
+          <Tooltip title={columnHelpText} placement={'top'}>
+            <IconButton size={'small'}>
+              <HelpTwoTone fontSize={'inherit'} />
+            </IconButton>
+          </Tooltip>
+        )}
         {isFacetSelection && !isLockedColumn && columnModel && (
           <span>
             <EnumFacetFilter containerAs="Dropdown" facet={facet} />
@@ -287,7 +302,7 @@ export function TableDataColumnHeader(
           </Tooltip>
         )}
         {isEntityIDColumn && <EntityIDColumnCopyIcon size={'small'} />}
-      </div>
+      </Box>
     </div>
   )
 }


### PR DESCRIPTION
PORTALS-2912 
- Add helpConfiguration for table columns
- Surface help text on table column headers
- Add help text to ID column in EL Cohort Builder participants table

![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/2296bad3-b83a-44af-981d-6290dae1c003)
