### PR TITLE
SageAccountWeb - Remove excessive `InputLabel` components

### DIFF
--- a/apps/SageAccountWeb/src/components/AccountSettings.tsx
+++ b/apps/SageAccountWeb/src/components/AccountSettings.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Container,
   Grid,
-  InputLabel,
   Link,
   ListItemButton,
   MenuItem,
@@ -239,10 +238,8 @@ export const AccountSettings = () => {
                     margin="normal"
                     required
                   >
-                    <InputLabel shrink htmlFor="username">
-                      Username
-                    </InputLabel>
                     <TextField
+                      label={'Username'}
                       id="username"
                       name="username"
                       fullWidth
@@ -255,10 +252,8 @@ export const AccountSettings = () => {
                     variant="standard"
                     margin="normal"
                   >
-                    <InputLabel shrink htmlFor="firstName">
-                      First name
-                    </InputLabel>
                     <TextField
+                      label={'First name'}
                       id="firstName"
                       name="firstName"
                       fullWidth
@@ -271,10 +266,8 @@ export const AccountSettings = () => {
                     variant="standard"
                     margin="normal"
                   >
-                    <InputLabel shrink htmlFor="lastName">
-                      Last name
-                    </InputLabel>
                     <TextField
+                      label={'Last name'}
                       id="lastName"
                       name="lastName"
                       fullWidth
@@ -287,10 +280,8 @@ export const AccountSettings = () => {
                     variant="standard"
                     margin="normal"
                   >
-                    <InputLabel shrink htmlFor="position">
-                      Current position
-                    </InputLabel>
                     <TextField
+                      label={'Current position'}
                       id="position"
                       name="position"
                       fullWidth
@@ -303,10 +294,8 @@ export const AccountSettings = () => {
                     variant="standard"
                     margin="normal"
                   >
-                    <InputLabel shrink htmlFor="industry">
-                      Industry
-                    </InputLabel>
                     <TextField
+                      label={'Industry'}
                       id="industry"
                       name="industry"
                       fullWidth
@@ -319,10 +308,8 @@ export const AccountSettings = () => {
                     variant="standard"
                     margin="normal"
                   >
-                    <InputLabel shrink htmlFor="website">
-                      Website
-                    </InputLabel>
                     <TextField
+                      label={'Website'}
                       id="website"
                       name="website"
                       fullWidth
@@ -335,10 +322,8 @@ export const AccountSettings = () => {
                     variant="standard"
                     margin="normal"
                   >
-                    <InputLabel shrink htmlFor="location">
-                      City, Country
-                    </InputLabel>
                     <TextField
+                      label={'City, Country'}
                       id="location"
                       name="location"
                       fullWidth
@@ -351,10 +336,8 @@ export const AccountSettings = () => {
                     variant="standard"
                     margin="normal"
                   >
-                    <InputLabel shrink htmlFor="company">
-                      Institutional affiliation
-                    </InputLabel>
                     <TextField
+                      label={'Institutional affiliation'}
                       id="company"
                       name="company"
                       fullWidth
@@ -444,10 +427,8 @@ export const AccountSettings = () => {
                   margin="normal"
                   sx={{ marginBottom: '10px' }}
                 >
-                  <InputLabel shrink htmlFor="timezone-select">
-                    Choose a format
-                  </InputLabel>
                   <TextField
+                    label={'Choose a format'}
                     id="timezone-select"
                     value={isUTCTimeStaged}
                     fullWidth

--- a/apps/SageAccountWeb/src/components/ChangePassword.tsx
+++ b/apps/SageAccountWeb/src/components/ChangePassword.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Button, InputLabel, Link, TextField } from '@mui/material'
+import { Button, Link, TextField } from '@mui/material'
 import {
   ChangePasswordWithCurrentPassword,
   UserProfile,
@@ -78,14 +78,13 @@ export const ChangePassword = (props: ChangePasswordProps) => {
           variant="standard"
           margin="normal"
         >
-          <InputLabel shrink htmlFor="currentPassword" required>
-            Current password
-          </InputLabel>
           <TextField
             fullWidth
+            required
             type="password"
             id="currentPassword"
             name="currentPassword"
+            label={'Current password'}
             onChange={e => setOldPassword(e.target.value)}
             value={oldPassword || ''}
           />
@@ -96,14 +95,13 @@ export const ChangePassword = (props: ChangePasswordProps) => {
           variant="standard"
           margin="normal"
         >
-          <InputLabel shrink htmlFor="newPassword" required>
-            New password
-          </InputLabel>
           <TextField
             fullWidth
+            required
             type="password"
             id="newPassword"
             name="newPassword"
+            label={'New password'}
             onChange={e => setNewPassword(e.target.value)}
             value={newPassword || ''}
           />
@@ -115,14 +113,13 @@ export const ChangePassword = (props: ChangePasswordProps) => {
           margin="normal"
           sx={{ marginBottom: '10px' }}
         >
-          <InputLabel shrink htmlFor="confirmPassword" required>
-            Confirm password
-          </InputLabel>
           <TextField
             fullWidth
+            required
             type="password"
             id="confirmPassword"
             name="confirmPassword"
+            label={'Confirm password'}
             onChange={e => setConfirmPassword(e.target.value)}
             value={confirmPassword || ''}
           />

--- a/apps/SageAccountWeb/src/components/ConfigureEmail.tsx
+++ b/apps/SageAccountWeb/src/components/ConfigureEmail.tsx
@@ -14,7 +14,6 @@ import {
   Divider,
   FormControlLabel,
   IconButton,
-  InputLabel,
   TextField,
   Typography,
 } from '@mui/material'
@@ -175,11 +174,9 @@ export const ConfigureEmail = (props: ConfigureEmailProps) => {
         }
       })}
       <StyledFormControl variant="standard" margin="normal" fullWidth>
-        <InputLabel shrink htmlFor="additionalEmail">
-          Add an email address
-        </InputLabel>
         <Box sx={{ display: 'flex' }}>
           <TextField
+            label={'Add an email address'}
             id="additionalEmail"
             sx={{ flexGrow: 1, marginRight: '10px' }}
             value={newEmail}

--- a/apps/SageAccountWeb/src/components/CurrentAffiliationPage.tsx
+++ b/apps/SageAccountWeb/src/components/CurrentAffiliationPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { SourceAppLogo } from './SourceApp'
-import { InputLabel, TextField, Typography } from '@mui/material'
+import { TextField, Typography } from '@mui/material'
 import { LeftRightPanel } from './LeftRightPanel'
 import { StyledFormControl } from './StyledComponents'
 import {
@@ -42,11 +42,9 @@ export const CurrentAffiliationPage = () => {
               margin="normal"
               required
             >
-              <InputLabel shrink htmlFor="company">
-                Current Affiliation
-              </InputLabel>
               <TextField
                 fullWidth
+                label={'Current Affiliation'}
                 id="company"
                 name="company"
                 onChange={event => setNewAffiliation(event.target.value)}

--- a/apps/SageAccountWeb/src/components/ProfileValidation/ProfileFieldsEditor.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/ProfileFieldsEditor.tsx
@@ -1,4 +1,4 @@
-import { Box, InputLabel, TextField, useTheme } from '@mui/material'
+import { Box, TextField, useTheme } from '@mui/material'
 import { StyledFormControl } from '../StyledComponents'
 import React, { useState } from 'react'
 import { VerificationSubmission } from '@sage-bionetworks/synapse-types'
@@ -54,11 +54,10 @@ export const ProfileFieldsEditor = (props: ProfileFieldsEditorProps) => {
           margin="normal"
           sx={{ marginTop: '0px' }}
         >
-          <InputLabel shrink htmlFor="firstName" required>
-            First Name
-          </InputLabel>
           <TextField
             fullWidth
+            required
+            label={'First Name'}
             id="firstName"
             name="firstName"
             onChange={handleChange}
@@ -67,11 +66,10 @@ export const ProfileFieldsEditor = (props: ProfileFieldsEditorProps) => {
           />
         </StyledFormControl>
         <StyledFormControl fullWidth variant="standard" margin="normal">
-          <InputLabel shrink htmlFor="lasttName" required>
-            Last Name
-          </InputLabel>
           <TextField
             fullWidth
+            required
+            label={'Last Name'}
             id="lastName"
             name="lastName"
             onChange={handleChange}
@@ -85,11 +83,9 @@ export const ProfileFieldsEditor = (props: ProfileFieldsEditorProps) => {
           margin="normal"
           required
         >
-          <InputLabel shrink htmlFor="company">
-            Current Affiliation
-          </InputLabel>
           <TextField
             fullWidth
+            label={'Current Affiliation'}
             id="company"
             name="company"
             onChange={handleChange}
@@ -103,10 +99,8 @@ export const ProfileFieldsEditor = (props: ProfileFieldsEditorProps) => {
           margin="normal"
           required
         >
-          <InputLabel shrink htmlFor="location">
-            Location
-          </InputLabel>
           <TextField
+            label={'Location'}
             id="location"
             name="location"
             fullWidth

--- a/apps/SageAccountWeb/src/components/RegisterAccount1.tsx
+++ b/apps/SageAccountWeb/src/components/RegisterAccount1.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import {
   Box,
   Button,
-  InputLabel,
   Link,
   TextField,
   Typography,
@@ -222,10 +221,8 @@ export const RegisterAccount1 = () => {
                         margin="normal"
                         sx={formControlSx}
                       >
-                        <InputLabel shrink htmlFor="emailAddress" required>
-                          Email address
-                        </InputLabel>
                         <TextField
+                          label={'Email address'}
                           fullWidth
                           id="emailAddress"
                           name="emailAddress"
@@ -273,11 +270,9 @@ export const RegisterAccount1 = () => {
                         margin="normal"
                         sx={formControlSx}
                       >
-                        <InputLabel shrink htmlFor="username" required>
-                          Username
-                        </InputLabel>
                         <TextField
                           fullWidth
+                          label={'Username'}
                           id="username"
                           name="username"
                           required

--- a/apps/SageAccountWeb/src/components/RegisterAccount2.tsx
+++ b/apps/SageAccountWeb/src/components/RegisterAccount2.tsx
@@ -1,4 +1,4 @@
-import { Button, InputLabel, TextField, Typography } from '@mui/material'
+import { Button, TextField, Typography } from '@mui/material'
 import { StyledFormControl } from './StyledComponents'
 import React, { useEffect, useState } from 'react'
 import { displayToast, SynapseClient } from 'synapse-react-client'
@@ -101,11 +101,10 @@ export const RegisterAccount2 = (props: RegisterAccount2Props) => {
                 variant="standard"
                 margin="normal"
               >
-                <InputLabel shrink htmlFor="username" required>
-                  Choose a username
-                </InputLabel>
                 <TextField
                   fullWidth
+                  required
+                  label={'Choose a username'}
                   id="username"
                   name="username"
                   onChange={e => setUsername(e.target.value)}
@@ -113,11 +112,9 @@ export const RegisterAccount2 = (props: RegisterAccount2Props) => {
                 />
               </StyledFormControl>
               <StyledFormControl fullWidth variant="standard" margin="normal">
-                <InputLabel shrink htmlFor="firstName">
-                  First name
-                </InputLabel>
                 <TextField
                   fullWidth
+                  label={'First name'}
                   id="firstName"
                   name="firstName"
                   onChange={e => setFirstName(e.target.value)}
@@ -125,11 +122,9 @@ export const RegisterAccount2 = (props: RegisterAccount2Props) => {
                 />
               </StyledFormControl>
               <StyledFormControl fullWidth variant="standard" margin="normal">
-                <InputLabel shrink htmlFor="lastName">
-                  Last name
-                </InputLabel>
                 <TextField
                   fullWidth
+                  label={'Last name'}
                   id="lastName"
                   name="lastName"
                   onChange={e => setLastName(e.target.value)}
@@ -142,12 +137,11 @@ export const RegisterAccount2 = (props: RegisterAccount2Props) => {
                 variant="standard"
                 margin="normal"
               >
-                <InputLabel shrink htmlFor="password1" required>
-                  Password
-                </InputLabel>
                 <TextField
                   type="password"
                   fullWidth
+                  required
+                  label={'Password'}
                   id="password1"
                   name="password1"
                   onChange={e => setPassword1(e.target.value)}
@@ -160,12 +154,11 @@ export const RegisterAccount2 = (props: RegisterAccount2Props) => {
                 variant="standard"
                 margin="normal"
               >
-                <InputLabel shrink htmlFor="password2" required>
-                  Confirm password
-                </InputLabel>
                 <TextField
                   type="password"
                   fullWidth
+                  required
+                  label={'Confirm password'}
                   id="password2"
                   name="password2"
                   onChange={e => setPassword2(e.target.value)}

--- a/apps/SageAccountWeb/src/components/ResetPassword.tsx
+++ b/apps/SageAccountWeb/src/components/ResetPassword.tsx
@@ -1,9 +1,8 @@
-import { Box, Button, InputLabel, TextField, Typography } from '@mui/material'
+import { Box, Button, TextField, Typography } from '@mui/material'
 import { StyledFormControl } from '../components/StyledComponents'
 import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
-import { SynapseClient } from 'synapse-react-client'
-import { displayToast } from 'synapse-react-client'
+import { displayToast, SynapseClient } from 'synapse-react-client'
 import {
   ChangePasswordWithToken,
   PasswordResetSignedToken,
@@ -105,14 +104,13 @@ export const ResetPassword = (props: ResetPasswordProps) => {
                   margin="normal"
                   sx={formControlSx}
                 >
-                  <InputLabel shrink htmlFor="newPassword" required>
-                    New password
-                  </InputLabel>
                   <TextField
                     fullWidth
+                    required
                     type="password"
                     id="newPassword"
                     name="newPassword"
+                    label={'New password'}
                     onChange={e => setNewPassword(e.target.value)}
                     value={newPassword || ''}
                   />
@@ -124,14 +122,13 @@ export const ResetPassword = (props: ResetPasswordProps) => {
                   margin="normal"
                   sx={formControlSx}
                 >
-                  <InputLabel shrink htmlFor="confirmPassword" required>
-                    Confirm password
-                  </InputLabel>
                   <TextField
                     fullWidth
+                    required
                     type="password"
                     id="confirmPassword"
                     name="confirmPassword"
+                    label={'Confirm password'}
                     onChange={e => setConfirmPassword(e.target.value)}
                     value={confirmPassword || ''}
                   />
@@ -164,11 +161,10 @@ export const ResetPassword = (props: ResetPasswordProps) => {
                 margin="normal"
                 sx={formControlSx}
               >
-                <InputLabel shrink htmlFor="username" required>
-                  Email address or username
-                </InputLabel>
                 <TextField
                   fullWidth
+                  required
+                  label={'Email address or username'}
                   id="username"
                   name="username"
                   onChange={e => setUserName(e.target.value)}


### PR DESCRIPTION
The TextField component has its own `label` prop that will render this component internally. This will fix the excessive spacing between the label and the field.

|Before|After|
|---|---|
| ![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/95fe138d-ef40-4e3c-804a-e85989dad10a) | ![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/8ff73fe1-007d-44fb-b035-75f2398798a0) |