### PR TITLE
PORTALS-2670 - Use Synapse theme/config for PersonalAccessToken, OAuth2 Client pages

### DIFF
--- a/apps/SageAccountWeb/src/AppInitializer.tsx
+++ b/apps/SageAccountWeb/src/AppInitializer.tsx
@@ -2,12 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Redirect } from 'react-router-dom'
 import { getSearchParam } from './URLUtils'
 import { SignedTokenInterface } from '@sage-bionetworks/synapse-types'
-import { createTheme, ThemeProvider } from '@mui/material/styles'
-import { sageAccountWebThemeOverrides } from './style/theme'
-import { Theme } from '@mui/material'
 import {
-  useLastLoginInfoState,
-  SynapseTheme,
   SynapseUtilityFunctions,
   useApplicationSessionContext,
   useFramebuster,
@@ -16,56 +11,13 @@ import { AppContextProvider } from './AppContext'
 import { useSourceApp } from './components/useSourceApp'
 
 function AppInitializer(props: { children?: React.ReactNode }) {
-  const [appId, setAppId] = useState<string>()
   const [redirectURL, setRedirectURL] = useState<string>()
-  const [theme, setTheme] = useState<Theme>(
-    createTheme(
-      SynapseTheme.defaultMuiThemeOptions,
-      sageAccountWebThemeOverrides,
-    ),
-  )
+
   const [signedToken, setSignedToken] = useState<
     SignedTokenInterface | undefined
   >()
-  const { currentSourceAppNameState } = useLastLoginInfoState()
   const isFramed = useFramebuster()
-
-  useEffect(() => {
-    const searchParamAppId = getSearchParam('appId')
-    const localStorageAppId = localStorage.getItem('sourceAppId')
-    if (searchParamAppId) {
-      localStorage.setItem('sourceAppId', searchParamAppId)
-      setAppId(searchParamAppId)
-    } else if (localStorageAppId) {
-      setAppId(localStorageAppId)
-    } else {
-      // fallback to Sage Bionetworks
-      localStorage.setItem('sourceAppId', 'SAGE')
-      setAppId('SAGE')
-    }
-  }, [])
-
-  const sourceApp = useSourceApp(appId)
-
-  useEffect(() => {
-    if (sourceApp?.friendlyName) {
-      currentSourceAppNameState.set(sourceApp.friendlyName)
-    }
-  }, [currentSourceAppNameState, sourceApp?.friendlyName])
-
-  useEffect(() => {
-    if (sourceApp?.palette) {
-      setTheme(
-        createTheme(
-          SynapseTheme.defaultMuiThemeOptions,
-          sageAccountWebThemeOverrides,
-          {
-            palette: sourceApp.palette,
-          },
-        ),
-      )
-    }
-  }, [sourceApp?.appId])
+  const { appId } = useSourceApp()
 
   useEffect(() => {
     const searchParamSignedToken = getSearchParam('signedToken')
@@ -115,13 +67,11 @@ function AppInitializer(props: { children?: React.ReactNode }) {
         signedToken,
       }}
     >
-      <ThemeProvider theme={theme}>
-        {acceptsTermsOfUse === false &&
-          location.pathname != '/authenticated/signTermsOfUse' && (
-            <Redirect to="/authenticated/signTermsOfUse" />
-          )}
-        {!isFramed && props.children}
-      </ThemeProvider>
+      {acceptsTermsOfUse === false &&
+        location.pathname != '/authenticated/signTermsOfUse' && (
+          <Redirect to="/authenticated/signTermsOfUse" />
+        )}
+      {!isFramed && props.children}
     </AppContextProvider>
   )
 }

--- a/apps/SageAccountWeb/src/components/OAuthClientManagementPage.tsx
+++ b/apps/SageAccountWeb/src/components/OAuthClientManagementPage.tsx
@@ -4,8 +4,9 @@ import { StyledOuterContainer } from './StyledComponents'
 import { Box, Paper, Typography } from '@mui/material'
 import { BackButton } from './BackButton'
 import { OAuthClientManagement } from 'synapse-react-client'
+import { SourceAppProvider, SYNAPSE_SOURCE_APP_ID } from './useSourceApp'
 
-export const OAuthClientManagementPage = () => {
+export function OAuthClientManagementPageInternal() {
   return (
     <StyledOuterContainer className="OAuthClientManagementPage">
       <Paper
@@ -35,5 +36,13 @@ export const OAuthClientManagementPage = () => {
         </Box>
       </Paper>
     </StyledOuterContainer>
+  )
+}
+export function OAuthClientManagementPage() {
+  // OAuth2 clients are exclusively for Synapse, so use the Synapse theme
+  return (
+    <SourceAppProvider sourceAppId={SYNAPSE_SOURCE_APP_ID}>
+      <OAuthClientManagementPageInternal />
+    </SourceAppProvider>
   )
 }

--- a/apps/SageAccountWeb/src/components/PersonalAccessTokensPage.tsx
+++ b/apps/SageAccountWeb/src/components/PersonalAccessTokensPage.tsx
@@ -4,8 +4,9 @@ import { StyledOuterContainer } from './StyledComponents'
 import { Box, Paper, Typography } from '@mui/material'
 import { BackButton } from './BackButton'
 import { AccessTokenPage } from 'synapse-react-client'
+import { SourceAppProvider, SYNAPSE_SOURCE_APP_ID } from './useSourceApp'
 
-export const PersonalAccessTokensPage = () => {
+export function PersonalAccessTokensPageInternal() {
   return (
     <StyledOuterContainer className="PersonalAccessTokenPage">
       <Paper
@@ -32,5 +33,14 @@ export const PersonalAccessTokensPage = () => {
         </Box>
       </Paper>
     </StyledOuterContainer>
+  )
+}
+
+export function PersonalAccessTokensPage() {
+  // PersonalAccessTokens are exclusively for Synapse, so use the Synapse theme
+  return (
+    <SourceAppProvider sourceAppId={SYNAPSE_SOURCE_APP_ID}>
+      <PersonalAccessTokensPageInternal />
+    </SourceAppProvider>
   )
 }

--- a/apps/SageAccountWeb/src/components/ProfileAvatar.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileAvatar.tsx
@@ -36,18 +36,18 @@ export const ProfileAvatar = (props: ProfileAvatarProps) => {
   useEffect(() => {
     if (userProfile?.profilePicureFileHandleId) {
       SynapseClient.getFileHandleByIdURL(
-        userProfile?.profilePicureFileHandleId as string,
+        userProfile.profilePicureFileHandleId,
         accessToken,
       ).then(picUrl => {
         setProfilePicUrl(picUrl)
       })
     }
-  }, [userProfile])
+  }, [accessToken, userProfile])
 
   const updateUserProfile = async (newFileHandleId: string) => {
     try {
       if (userProfile) {
-        userProfile.profilePicureFileHandleId = newFileHandleId as string
+        userProfile.profilePicureFileHandleId = newFileHandleId
         await SynapseClient.updateMyUserProfile(userProfile, accessToken)
         displayToast('Profile picture has been successfully updated', 'success')
         onProfileUpdated()

--- a/apps/SageAccountWeb/src/components/SageResourcesPage.tsx
+++ b/apps/SageAccountWeb/src/components/SageResourcesPage.tsx
@@ -5,15 +5,17 @@ import { useHistory } from 'react-router-dom'
 import { StyledOuterContainer } from './StyledComponents'
 import { BackButton } from './BackButton'
 import { useSourceAppConfigs } from './useSourceAppConfigs'
-import { useSourceApp } from './useSourceApp'
+import {
+  DEFAULT_SOURCE_APP_ID,
+  SourceAppProvider,
+  useSourceApp,
+} from './useSourceApp'
 
-export type SageResourcesPageProps = {}
-
-export const SageResourcesPage = (props: SageResourcesPageProps) => {
+export function SageResourcesPageInternal() {
   const history = useHistory()
   const theme = useTheme()
   const sourceAppConfigs = useSourceAppConfigs()
-  const sageSourceAppConfig = useSourceApp('SAGE')
+  const sageSourceAppConfig = useSourceApp()
   return (
     <StyledOuterContainer>
       <Paper
@@ -100,5 +102,14 @@ export const SageResourcesPage = (props: SageResourcesPageProps) => {
         </Box>
       </Paper>
     </StyledOuterContainer>
+  )
+}
+
+export function SageResourcesPage() {
+  return (
+    // This page should always use the Sage Bionetworks resources and theme
+    <SourceAppProvider sourceAppId={DEFAULT_SOURCE_APP_ID}>
+      <SageResourcesPageInternal />
+    </SourceAppProvider>
   )
 }

--- a/apps/SageAccountWeb/src/components/SourceApp.tsx
+++ b/apps/SageAccountWeb/src/components/SourceApp.tsx
@@ -1,4 +1,4 @@
-import { Box, SxProps, Typography } from '@mui/material'
+import { Box, BoxProps, Typography } from '@mui/material'
 import React from 'react'
 import { SkeletonTable } from 'synapse-react-client'
 import Skeleton from '@mui/material/Skeleton'
@@ -31,10 +31,10 @@ export const SourceApp = (props: SourceAppProps) => {
   )
 }
 
-export const SourceAppLogo: React.FC<{ sx?: SxProps }> = ({ sx }) => {
+export function SourceAppLogo(props: Omit<BoxProps, 'children' | 'className'>) {
   const sourceAppConfig = useSourceApp()
   return (
-    <Box className="SourceAppLogo" sx={sx}>
+    <Box className="SourceAppLogo" {...props}>
       {sourceAppConfig ? (
         sourceAppConfig.logo
       ) : (

--- a/apps/SageAccountWeb/src/components/useSourceApp.tsx
+++ b/apps/SageAccountWeb/src/components/useSourceApp.tsx
@@ -34,9 +34,9 @@ function useConfigureSourceAppFromQueryParams() {
     useLocalStorageValue(SOURCE_APP_ID_LOCALSTORAGE_KEY)
 
   useEffect(() => {
-    const searchParamAppId = getSearchParam(SOURCE_APP_ID_QUERY_PARAM_KEY)
-    if (searchParamAppId) {
-      setLocalStorageAppId(searchParamAppId)
+    const appIdFromSearchParam = getSearchParam(SOURCE_APP_ID_QUERY_PARAM_KEY)
+    if (appIdFromSearchParam) {
+      setLocalStorageAppId(appIdFromSearchParam)
     } else if (!localStorageAppId) {
       // fallback to Sage Bionetworks
       setLocalStorageAppId(DEFAULT_SOURCE_APP_ID)
@@ -65,9 +65,8 @@ export function useSynchronizeCurrentSourceAppNameForLogin(
 }
 
 /**
- * Provides context necessary for most components in SRC.
+ * Provides context for the 'source app', which will be used for theming and branding so this app feels connected to the application the user is coming from.
  *
- * The SynapseContextProvider must be wrapped in a react-query QueryClientProvider.
  * @param props sourceAppId: An optional source app ID to use. If not provided, the source app ID will be read from localStorage, or default to 'SAGE'.
  */
 export function SourceAppProvider(props: SourceAppContextProviderProps) {
@@ -128,7 +127,7 @@ export function SourceAppProvider(props: SourceAppContextProviderProps) {
 export function useSourceApp(): SourceAppContextType {
   const context = useContext(SourceAppContext)
   if (context === undefined) {
-    console.error('useSourceApp must be used within a SourceAppContextProvider')
+    console.error('useSourceApp must be used within a SourceAppProvider')
     return STATIC_SOURCE_APP_CONFIG
   }
   return context

--- a/apps/SageAccountWeb/src/components/useSourceApp.tsx
+++ b/apps/SageAccountWeb/src/components/useSourceApp.tsx
@@ -1,25 +1,135 @@
 import { sourceAppConfigTableID } from '../resources'
 import { SourceAppConfig } from './SourceAppConfigs'
-import { useSourceAppConfigs } from './useSourceAppConfigs'
+import {
+  STATIC_SOURCE_APP_CONFIG,
+  useSourceAppConfigs,
+} from './useSourceAppConfigs'
+import React, { useContext, useEffect, useMemo } from 'react'
+import { getSearchParam } from '../URLUtils'
+import { useLocalStorageValue } from '@react-hookz/web'
+import { SynapseTheme, useLastLoginInfoState } from 'synapse-react-client'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
+import { sageAccountWebThemeOverrides } from '../style/theme'
 
-export const useSourceApp = (
-  targetSourceAppId?: string,
-): SourceAppConfig | undefined => {
-  const sourceAppId = targetSourceAppId ?? localStorage.getItem('sourceAppId')
+export type SourceAppContextType = SourceAppConfig
+
+const SOURCE_APP_ID_QUERY_PARAM_KEY = 'appId'
+const SOURCE_APP_ID_LOCALSTORAGE_KEY = 'sourceAppId'
+export const DEFAULT_SOURCE_APP_ID = 'SAGE'
+export const SYNAPSE_SOURCE_APP_ID = 'synapse.org'
+
+/**
+ * This must be exported to use the context in class components.
+ */
+export const SourceAppContext = React.createContext<SourceAppContextType>(
+  STATIC_SOURCE_APP_CONFIG,
+)
+
+export type SourceAppContextProviderProps = React.PropsWithChildren<{
+  sourceAppId?: string
+}>
+
+function useConfigureSourceAppFromQueryParams() {
+  const { value: localStorageAppId, set: setLocalStorageAppId } =
+    useLocalStorageValue(SOURCE_APP_ID_LOCALSTORAGE_KEY)
+
+  useEffect(() => {
+    const searchParamAppId = getSearchParam(SOURCE_APP_ID_QUERY_PARAM_KEY)
+    if (searchParamAppId) {
+      setLocalStorageAppId(searchParamAppId)
+    } else if (!localStorageAppId) {
+      // fallback to Sage Bionetworks
+      setLocalStorageAppId(DEFAULT_SOURCE_APP_ID)
+    }
+  }, [localStorageAppId, setLocalStorageAppId])
+}
+
+/**
+ * Synchronizes the current state of the `currentSourceAppName` localStorage value.
+ * The value may be used at a later date in the Login component to inform a user if they have a OneSage account
+ * that was used for a different application.
+ */
+export function useSynchronizeCurrentSourceAppNameForLogin(
+  sourceApp?: SourceAppConfig,
+) {
+  const { currentSourceAppNameState } = useLastLoginInfoState()
+  const { value: idFromLocalStorage } = useLocalStorageValue(
+    SOURCE_APP_ID_LOCALSTORAGE_KEY,
+  )
+
+  useEffect(() => {
+    if (idFromLocalStorage && sourceApp?.friendlyName) {
+      currentSourceAppNameState.set(sourceApp.friendlyName)
+    }
+  }, [idFromLocalStorage, currentSourceAppNameState, sourceApp?.friendlyName])
+}
+
+/**
+ * Provides context necessary for most components in SRC.
+ *
+ * The SynapseContextProvider must be wrapped in a react-query QueryClientProvider.
+ * @param props sourceAppId: An optional source app ID to use. If not provided, the source app ID will be read from localStorage, or default to 'SAGE'.
+ */
+export function SourceAppProvider(props: SourceAppContextProviderProps) {
+  const { children, sourceAppId: idFromProps } = props
+
+  useConfigureSourceAppFromQueryParams()
+  useSynchronizeCurrentSourceAppNameForLogin()
+
+  const { value: idFromLocalStorage, set: setIdFromLocalStorage } =
+    useLocalStorageValue(SOURCE_APP_ID_LOCALSTORAGE_KEY)
+
+  const sourceAppId = idFromProps ?? idFromLocalStorage
+
   const sourceAppConfigs = useSourceAppConfigs()
+  const defaultSageSourceApp =
+    sourceAppConfigs?.find(config => config.appId === DEFAULT_SOURCE_APP_ID) ??
+    STATIC_SOURCE_APP_CONFIG
 
   // PORTALS-2746: Find target source app.  Fallback to Sage Bionetworks source app if target not found.
   const sourceApp = sourceAppConfigs?.find(
     config => config.appId === sourceAppId,
   )
-  const defaultSageSourceApp = sourceAppConfigs?.find(
-    config => config.appId === 'SAGE',
-  )
   if (sourceAppConfigs !== undefined && sourceApp == undefined) {
     console.error(
       `Source appId '${sourceAppId}' not found in the Synapse configuration table (${sourceAppConfigTableID})!`,
     )
-    localStorage.setItem('sourceAppId', 'SAGE')
+    if (idFromProps == null) {
+      // The invalid sourceAppId came from localStorage; reset it to the default
+      setIdFromLocalStorage(DEFAULT_SOURCE_APP_ID)
+    }
   }
-  return sourceApp ?? defaultSageSourceApp
+
+  const theme = useMemo(() => {
+    if (sourceApp?.palette) {
+      return createTheme(
+        SynapseTheme.defaultMuiThemeOptions,
+        sageAccountWebThemeOverrides,
+        {
+          palette: sourceApp.palette,
+        },
+      )
+    } else {
+      return createTheme(
+        SynapseTheme.defaultMuiThemeOptions,
+        sageAccountWebThemeOverrides,
+      )
+    }
+  }, [sourceApp?.palette])
+
+  return (
+    <SourceAppContext.Provider value={sourceApp ?? defaultSageSourceApp}>
+      {/* The theme is determined by the sourceApp, so render the ThemeProvider here*/}
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </SourceAppContext.Provider>
+  )
+}
+
+export function useSourceApp(): SourceAppContextType {
+  const context = useContext(SourceAppContext)
+  if (context === undefined) {
+    console.error('useSourceApp must be used within a SourceAppContextProvider')
+    return STATIC_SOURCE_APP_CONFIG
+  }
+  return context
 }

--- a/apps/SageAccountWeb/src/components/useSourceAppConfigs.tsx
+++ b/apps/SageAccountWeb/src/components/useSourceAppConfigs.tsx
@@ -9,6 +9,18 @@ import {
 import SourceAppImage from './SourceAppImage'
 import { sourceAppConfigTableID } from '../resources'
 
+// A static SourceAppConfig to use as a fallback in case the request to get source app configs fails
+export const STATIC_SOURCE_APP_CONFIG: SourceAppConfig = {
+  appId: '',
+  appURL: '',
+  description: '',
+  friendlyName: 'Sage Bionetworks',
+  requestAffiliation: false,
+  logo: <></>,
+  isPublicized: true,
+  palette: { ...Palettes.palette },
+}
+
 export const useSourceAppConfigs = (): SourceAppConfig[] | undefined => {
   const { data: tableQueryResult } =
     SynapseQueries.useGetQueryResultBundleWithAsyncStatus({

--- a/packages/synapse-react-client/src/components/OAuthClientManagement/OAuthManagement.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/OAuthClientManagement/OAuthManagement.integration.test.tsx
@@ -94,8 +94,8 @@ describe('oAuthManagement tests', () => {
     screen.findByText(mockClientList1.results[0].client_name)
 
     await screen.findByText('Yes')
-    await screen.findAllByRole('button', { name: 'EDIT' })
-    await screen.findAllByRole('button', { name: 'GENERATE SECRET' })
+    await screen.findAllByRole('button', { name: 'Edit' })
+    await screen.findAllByRole('button', { name: 'Generate Secret' })
   })
 
   it('Handles pagination', async () => {

--- a/packages/synapse-react-client/src/components/OAuthClientManagement/OAuthManagement.tsx
+++ b/packages/synapse-react-client/src/components/OAuthClientManagement/OAuthManagement.tsx
@@ -12,6 +12,7 @@ import CopyToClipboardInput from '../CopyToClipboardInput/CopyToClipboardInput'
 import { displayToast } from '../ToastMessage/ToastMessage'
 import { DialogBase } from '../DialogBase'
 import { Button, Link } from '@mui/material'
+import { AddCircleTwoTone } from '@mui/icons-material'
 
 export const OAuthManagement: React.FunctionComponent = () => {
   const { accessToken } = useSynapseContext()
@@ -57,6 +58,7 @@ export const OAuthManagement: React.FunctionComponent = () => {
           setIsEdit(false)
         }}
         sx={{ float: 'right' }}
+        startIcon={<AddCircleTwoTone />}
       >
         Create New Client
       </Button>
@@ -89,7 +91,7 @@ export const OAuthManagement: React.FunctionComponent = () => {
                       size="small"
                       onClick={() => setIsShowingVerification(true)}
                     >
-                      SUBMIT VERIFICATION
+                      Submit Verification
                     </Button>
                   )}
                 </td>
@@ -102,7 +104,7 @@ export const OAuthManagement: React.FunctionComponent = () => {
                     }}
                     size="small"
                   >
-                    GENERATE SECRET
+                    Generate Secret
                   </Button>
                 </td>
                 <td>
@@ -115,7 +117,7 @@ export const OAuthManagement: React.FunctionComponent = () => {
                     }}
                     size="small"
                   >
-                    EDIT
+                    Edit
                   </Button>
                 </td>
               </tr>


### PR DESCRIPTION
- Store SourceAppConfig in context to apply a particular SourceApp + Theme to an entire subtree
- Use synapse.org theme for OAuthClientManagementPage and PersonalAccessTokensPage
- Clean up related effects between `useSourceApp` and `AppInitializer` and put them in the new `SourceAppProvider