### PR TITLE
PORTALS-2817, PORTALS-2818 - Fixes for EntityModal (Annotation Editor v2)

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirement/AddConditionsForUseButton/AddConditionsForUseButton.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirement/AddConditionsForUseButton/AddConditionsForUseButton.integration.test.tsx
@@ -10,11 +10,12 @@ import {
   BackendDestinationEnum,
   getEndpoint,
 } from '../../../utils/functions/getEndpoint'
-import { ENTITY_BUNDLE_V2, USER_BUNDLE } from '../../../utils/APIConstants'
+import { USER_BUNDLE } from '../../../utils/APIConstants'
 import mockFileEntity from '../../../mocks/entity/mockFileEntity'
 import userEvent from '@testing-library/user-event'
 import { mockUnmetControlledDataRestrictionInformationACT } from '../../../mocks/mock_has_access_data'
 import { mockUserBundle } from '../../../mocks/user/mock_user_profile'
+import { getEntityBundleHandler } from '../../../mocks/msw/handlers/entityHandlers'
 
 function renderComponent(props: AddConditionsForUseButtonProps) {
   return render(<AddConditionsForUseButton {...props} />, {
@@ -86,19 +87,14 @@ describe('AddConditionsForUseButton', () => {
   })
 
   it('Button is not shown if there are restrictions', () => {
+    const bundle: EntityBundle = {
+      ...mockFileEntity.bundle,
+      restrictionInformation: mockUnmetControlledDataRestrictionInformationACT,
+    }
     server.use(
-      rest.get(
-        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
-          ':entity',
-        )}`,
-        async (req, res, ctx) => {
-          const result: EntityBundle = {
-            ...mockFileEntity.bundle,
-            restrictionInformation:
-              mockUnmetControlledDataRestrictionInformationACT,
-          }
-          return res(ctx.status(200), ctx.json(result))
-        },
+      getEntityBundleHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        bundle,
       ),
     )
 
@@ -111,21 +107,17 @@ describe('AddConditionsForUseButton', () => {
   })
 
   it("Button is not shown if the user doesn't have permission to impose restrictions", () => {
+    const bundle: EntityBundle = {
+      ...mockFileEntity.bundle,
+      permissions: {
+        ...mockFileEntity.bundle.permissions,
+        canChangePermissions: false,
+      },
+    }
     server.use(
-      rest.get(
-        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
-          ':entity',
-        )}`,
-        async (req, res, ctx) => {
-          const result: EntityBundle = {
-            ...mockFileEntity.bundle,
-            permissions: {
-              ...mockFileEntity.bundle.permissions,
-              canChangePermissions: false,
-            },
-          }
-          return res(ctx.status(200), ctx.json(result))
-        },
+      getEntityBundleHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        bundle,
       ),
     )
 

--- a/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.integration.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react'
 import React from 'react'
 import { HasAccessV2, HasAccessProps } from './HasAccessV2'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
-import { ENTITY_BUNDLE_V2 } from '../../utils/APIConstants'
 import {
   BackendDestinationEnum,
   getEndpoint,
@@ -24,6 +23,7 @@ import {
   mockUnmetControlledDataRestrictionInformationRestricted,
 } from '../../mocks/mock_has_access_data'
 import { rest, server } from '../../mocks/msw/server'
+import { getEntityBundleHandler } from '../../mocks/msw/handlers/entityHandlers'
 
 const entityId = mockFileEntityData.id
 const mockFileEntityBundle = mockFileEntityData.bundle
@@ -60,13 +60,9 @@ const onGetRestrictionInformation = jest.fn()
 
 function useMswEntityBundle(entityBundle: EntityBundle) {
   server.use(
-    rest.post(
-      `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
-        ':entityId',
-      )}`,
-      async (req, res, ctx) => {
-        return res(ctx.status(200), ctx.json(entityBundle))
-      },
+    getEntityBundleHandler(
+      getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+      entityBundle,
     ),
   )
 }

--- a/packages/synapse-react-client/src/components/entity/metadata/EntityModal.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/entity/metadata/EntityModal.integration.test.tsx
@@ -223,7 +223,7 @@ describe('EntityModal tests', () => {
     })
 
     const editButton = await screen.findByRole('button', { name: 'Edit' })
-    await userEvent.click(editButton)
+    await user.click(editButton)
 
     expect(onEditModeChanged).toHaveBeenLastCalledWith(true)
 
@@ -270,7 +270,7 @@ describe('EntityModal tests', () => {
     })
 
     const editButton = await screen.findByRole('button', { name: 'Edit' })
-    await userEvent.click(editButton)
+    await user.click(editButton)
 
     expect(onEditModeChanged).toHaveBeenLastCalledWith(true)
 

--- a/packages/synapse-react-client/src/components/entity/metadata/EntityModal.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/entity/metadata/EntityModal.integration.test.tsx
@@ -4,18 +4,21 @@ import { cloneDeep } from 'lodash-es'
 import React from 'react'
 import { EntityModal, EntityModalProps } from './EntityModal'
 import { createWrapper } from '../../../testutils/TestingLibraryUtils'
-import { ENTITY_BUNDLE_V2 } from '../../../utils/APIConstants'
 import {
   BackendDestinationEnum,
   getEndpoint,
 } from '../../../utils/functions/getEndpoint'
 import { SynapseContextType } from '../../../utils'
 import mockFileEntityData from '../../../mocks/entity/mockFileEntity'
-import { rest, server } from '../../../mocks/msw/server'
+import { server } from '../../../mocks/msw/server'
 import {
   FileEntity,
   UserEntityPermissions,
 } from '@sage-bionetworks/synapse-types'
+import {
+  getEntityBundleHandler,
+  getVersionedEntityBundleHandler,
+} from '../../../mocks/msw/handlers/entityHandlers'
 
 const {
   id: MOCK_FILE_ENTITY_ID,
@@ -110,16 +113,12 @@ describe('EntityModal tests', () => {
   })
 
   it('Shows the edit button when the user has edit permissions', async () => {
+    const bundle = cloneDeep(mockFileEntityBundle)
+    bundle.permissions = PERMISSIONS_CAN_EDIT
     server.use(
-      rest.post(
-        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
-          ':entityId',
-        )}`,
-        async (req, res, ctx) => {
-          const response = cloneDeep(mockFileEntityBundle)
-          response.permissions = PERMISSIONS_CAN_EDIT
-          return res(ctx.status(200), ctx.json(response))
-        },
+      getEntityBundleHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        bundle,
       ),
     )
 
@@ -128,16 +127,13 @@ describe('EntityModal tests', () => {
   })
 
   it('Does not show the edit button when the user does not have edit permissions', () => {
+    const bundle = cloneDeep(mockFileEntityBundle)
+    bundle.permissions = PERMISSIONS_CANNOT_EDIT
+
     server.use(
-      rest.post(
-        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
-          ':entityId',
-        )}`,
-        async (req, res, ctx) => {
-          const response = cloneDeep(mockFileEntityBundle)
-          response.permissions = PERMISSIONS_CANNOT_EDIT
-          return res(ctx.status(200), ctx.json(response))
-        },
+      getEntityBundleHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        bundle,
       ),
     )
 
@@ -148,18 +144,14 @@ describe('EntityModal tests', () => {
   })
 
   it('Does not show the edit button for annotations when looking at an older version', () => {
+    const bundle = cloneDeep(mockFileEntityBundle)
+    ;(bundle.entity as FileEntity).isLatestVersion = false
+    bundle.permissions = PERMISSIONS_CAN_EDIT
+
     server.use(
-      rest.post(
-        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
-          ':entityId',
-          ':versionNumber',
-        )}`,
-        async (req, res, ctx) => {
-          const response = cloneDeep(mockFileEntityBundle)
-          ;(response.entity as FileEntity).isLatestVersion = false
-          response.permissions = PERMISSIONS_CAN_EDIT
-          return res(ctx.status(200), ctx.json(response))
-        },
+      getVersionedEntityBundleHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        bundle,
       ),
     )
 
@@ -171,17 +163,14 @@ describe('EntityModal tests', () => {
 
   it('Opens the annotation editor when edit is clicked', async () => {
     const onEditModeChanged = jest.fn()
+    const bundle = cloneDeep(mockFileEntityBundle)
+    ;(bundle.entity as FileEntity).isLatestVersion = true
+    bundle.permissions = PERMISSIONS_CAN_EDIT
+
     server.use(
-      rest.post(
-        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
-          ':entityId',
-        )}`,
-        async (req, res, ctx) => {
-          const response = cloneDeep(mockFileEntityBundle)
-          ;(response.entity as FileEntity).isLatestVersion = true
-          response.permissions = PERMISSIONS_CAN_EDIT
-          return res(ctx.status(200), ctx.json(response))
-        },
+      getEntityBundleHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        bundle,
       ),
     )
 
@@ -202,17 +191,15 @@ describe('EntityModal tests', () => {
   it('Cancelling out of edit mode using the cancel button triggers a warning before disabling edit mode', async () => {
     const onEditModeChanged = jest.fn()
     const onClose = jest.fn()
+
+    const bundle = cloneDeep(mockFileEntityBundle)
+    ;(bundle.entity as FileEntity).isLatestVersion = true
+    bundle.permissions = PERMISSIONS_CAN_EDIT
+
     server.use(
-      rest.post(
-        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
-          ':entityId',
-        )}`,
-        async (req, res, ctx) => {
-          const response = cloneDeep(mockFileEntityBundle)
-          ;(response.entity as FileEntity).isLatestVersion = true
-          response.permissions = PERMISSIONS_CAN_EDIT
-          return res(ctx.status(200), ctx.json(response))
-        },
+      getEntityBundleHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        bundle,
       ),
     )
 
@@ -249,17 +236,15 @@ describe('EntityModal tests', () => {
   it('Cancelling out of edit mode using the modal "x" triggers a warning before calling onClose', async () => {
     const onEditModeChanged = jest.fn()
     const onClose = jest.fn()
+
+    const bundle = cloneDeep(mockFileEntityBundle)
+    ;(bundle.entity as FileEntity).isLatestVersion = true
+    bundle.permissions = PERMISSIONS_CAN_EDIT
+
     server.use(
-      rest.post(
-        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
-          ':entityId',
-        )}`,
-        async (req, res, ctx) => {
-          const response = cloneDeep(mockFileEntityBundle)
-          ;(response.entity as FileEntity).isLatestVersion = true
-          response.permissions = PERMISSIONS_CAN_EDIT
-          return res(ctx.status(200), ctx.json(response))
-        },
+      getEntityBundleHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        bundle,
       ),
     )
 

--- a/packages/synapse-react-client/src/components/entity/metadata/EntityModal.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/entity/metadata/EntityModal.integration.test.tsx
@@ -9,10 +9,13 @@ import {
   BackendDestinationEnum,
   getEndpoint,
 } from '../../../utils/functions/getEndpoint'
-import { SynapseContextType } from '../../../utils/context/SynapseContext'
+import { SynapseContextType } from '../../../utils'
 import mockFileEntityData from '../../../mocks/entity/mockFileEntity'
 import { rest, server } from '../../../mocks/msw/server'
-import { FileEntity } from '@sage-bionetworks/synapse-types'
+import {
+  FileEntity,
+  UserEntityPermissions,
+} from '@sage-bionetworks/synapse-types'
 
 const {
   id: MOCK_FILE_ENTITY_ID,
@@ -44,9 +47,45 @@ function renderComponent(
   propOverrides?: Partial<EntityModalProps>,
   wrapperProps?: SynapseContextType,
 ) {
-  render(<EntityModal {...defaultProps} {...propOverrides} />, {
-    wrapper: createWrapper(wrapperProps),
-  })
+  const user = userEvent.setup()
+  const component = render(
+    <EntityModal {...defaultProps} {...propOverrides} />,
+    {
+      wrapper: createWrapper(wrapperProps),
+    },
+  )
+
+  const dialog = screen.getByRole('dialog')
+  const closeButton = screen.getByRole('button', { name: 'close' })
+
+  return { user, component, dialog, closeButton }
+}
+
+const PERMISSIONS_CAN_EDIT: UserEntityPermissions = {
+  canEdit: true,
+  // the rest don't matter
+  canAddChild: false,
+  canCertifiedUserAddChild: false,
+  canCertifiedUserEdit: false,
+  canChangePermissions: false,
+  canChangeSettings: false,
+  canDelete: false,
+  canDownload: false,
+  canEnableInheritance: false,
+  canModerate: false,
+  canMove: false,
+  canPublicRead: false,
+  canUpload: false,
+  canView: false,
+  isCertificationRequired: false,
+  isCertifiedUser: false,
+  isEntityOpenData: false,
+  ownerPrincipalId: 0,
+}
+
+const PERMISSIONS_CANNOT_EDIT: UserEntityPermissions = {
+  ...PERMISSIONS_CAN_EDIT,
+  canEdit: false,
 }
 
 describe('EntityModal tests', () => {
@@ -61,11 +100,11 @@ describe('EntityModal tests', () => {
   })
 
   it('Shows annotations when the tab is switched', async () => {
-    renderComponent()
+    const { user } = renderComponent()
     const annotationsTab = (await screen.findAllByRole('tab')).filter(
       tab => tab.innerHTML === 'ANNOTATIONS',
     )[0]
-    await userEvent.click(annotationsTab)
+    await user.click(annotationsTab)
 
     await screen.findByText('Mock Annotations Table')
   })
@@ -78,28 +117,7 @@ describe('EntityModal tests', () => {
         )}`,
         async (req, res, ctx) => {
           const response = cloneDeep(mockFileEntityBundle)
-          response.permissions = {
-            canEdit: true,
-
-            // the rest don't matter
-            canAddChild: false,
-            canCertifiedUserAddChild: false,
-            canCertifiedUserEdit: false,
-            canChangePermissions: false,
-            canChangeSettings: false,
-            canDelete: false,
-            canDownload: false,
-            canEnableInheritance: false,
-            canModerate: false,
-            canMove: false,
-            canPublicRead: false,
-            canUpload: false,
-            canView: false,
-            isCertificationRequired: false,
-            isCertifiedUser: false,
-            isEntityOpenData: false,
-            ownerPrincipalId: 0,
-          }
+          response.permissions = PERMISSIONS_CAN_EDIT
           return res(ctx.status(200), ctx.json(response))
         },
       ),
@@ -117,28 +135,7 @@ describe('EntityModal tests', () => {
         )}`,
         async (req, res, ctx) => {
           const response = cloneDeep(mockFileEntityBundle)
-          response.permissions = {
-            canEdit: false,
-
-            // the rest don't matter
-            canAddChild: false,
-            canCertifiedUserAddChild: false,
-            canCertifiedUserEdit: false,
-            canChangePermissions: false,
-            canChangeSettings: false,
-            canDelete: false,
-            canDownload: false,
-            canEnableInheritance: false,
-            canModerate: false,
-            canMove: false,
-            canPublicRead: false,
-            canUpload: false,
-            canView: false,
-            isCertificationRequired: false,
-            isCertifiedUser: false,
-            isEntityOpenData: false,
-            ownerPrincipalId: 0,
-          }
+          response.permissions = PERMISSIONS_CANNOT_EDIT
           return res(ctx.status(200), ctx.json(response))
         },
       ),
@@ -160,27 +157,7 @@ describe('EntityModal tests', () => {
         async (req, res, ctx) => {
           const response = cloneDeep(mockFileEntityBundle)
           ;(response.entity as FileEntity).isLatestVersion = false
-          response.permissions = {
-            canEdit: true,
-            // the rest don't matter
-            canAddChild: false,
-            canCertifiedUserAddChild: false,
-            canCertifiedUserEdit: false,
-            canChangePermissions: false,
-            canChangeSettings: false,
-            canDelete: false,
-            canDownload: false,
-            canEnableInheritance: false,
-            canModerate: false,
-            canMove: false,
-            canPublicRead: false,
-            canUpload: false,
-            canView: false,
-            isCertificationRequired: false,
-            isCertifiedUser: false,
-            isEntityOpenData: false,
-            ownerPrincipalId: 0,
-          }
+          response.permissions = PERMISSIONS_CAN_EDIT
           return res(ctx.status(200), ctx.json(response))
         },
       ),
@@ -193,6 +170,7 @@ describe('EntityModal tests', () => {
   })
 
   it('Opens the annotation editor when edit is clicked', async () => {
+    const onEditModeChanged = jest.fn()
     server.use(
       rest.post(
         `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
@@ -201,38 +179,119 @@ describe('EntityModal tests', () => {
         async (req, res, ctx) => {
           const response = cloneDeep(mockFileEntityBundle)
           ;(response.entity as FileEntity).isLatestVersion = true
-          response.permissions = {
-            canEdit: true,
-            // the rest don't matter
-            canAddChild: false,
-            canCertifiedUserAddChild: false,
-            canCertifiedUserEdit: false,
-            canChangePermissions: false,
-            canChangeSettings: false,
-            canDelete: false,
-            canDownload: false,
-            canEnableInheritance: false,
-            canModerate: false,
-            canMove: false,
-            canPublicRead: false,
-            canUpload: false,
-            canView: false,
-            isCertificationRequired: false,
-            isCertifiedUser: false,
-            isEntityOpenData: false,
-            ownerPrincipalId: 0,
-          }
+          response.permissions = PERMISSIONS_CAN_EDIT
           return res(ctx.status(200), ctx.json(response))
         },
       ),
     )
 
-    renderComponent({ initialTab: 'ANNOTATIONS' })
+    const { user } = renderComponent({
+      initialTab: 'ANNOTATIONS',
+      onEditModeChanged,
+    })
+
+    const editButton = await screen.findByRole('button', { name: 'Edit' })
+    await user.click(editButton)
+
+    expect(onEditModeChanged).toHaveBeenLastCalledWith(true)
+
+    // Text that appears in the editor component if there's a schema
+    await screen.findByText('Mock Annotation Editor', { exact: false })
+  })
+
+  it('Cancelling out of edit mode using the cancel button triggers a warning before disabling edit mode', async () => {
+    const onEditModeChanged = jest.fn()
+    const onClose = jest.fn()
+    server.use(
+      rest.post(
+        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
+          ':entityId',
+        )}`,
+        async (req, res, ctx) => {
+          const response = cloneDeep(mockFileEntityBundle)
+          ;(response.entity as FileEntity).isLatestVersion = true
+          response.permissions = PERMISSIONS_CAN_EDIT
+          return res(ctx.status(200), ctx.json(response))
+        },
+      ),
+    )
+
+    const { user } = renderComponent({
+      initialTab: 'ANNOTATIONS',
+      onEditModeChanged,
+      onClose,
+    })
 
     const editButton = await screen.findByRole('button', { name: 'Edit' })
     await userEvent.click(editButton)
 
-    // Text that appears in the editor component if there's a schema
+    expect(onEditModeChanged).toHaveBeenLastCalledWith(true)
+
+    // Text that appears in the editor component
     await screen.findByText('Mock Annotation Editor', { exact: false })
+
+    // Click the cancel button
+    const cancelButton = await screen.findByRole('button', { name: 'Cancel' })
+    await user.click(cancelButton)
+
+    // Verify the confirmation appears
+    screen.getByText('Unsaved Changes')
+    const confirmButton = screen.getByRole('button', {
+      name: 'OK',
+    })
+    await user.click(confirmButton)
+
+    expect(onEditModeChanged).toHaveBeenLastCalledWith(false)
+    // onClose should have never been called, because we did not click the dialog close button
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('Cancelling out of edit mode using the modal "x" triggers a warning before calling onClose', async () => {
+    const onEditModeChanged = jest.fn()
+    const onClose = jest.fn()
+    server.use(
+      rest.post(
+        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
+          ':entityId',
+        )}`,
+        async (req, res, ctx) => {
+          const response = cloneDeep(mockFileEntityBundle)
+          ;(response.entity as FileEntity).isLatestVersion = true
+          response.permissions = PERMISSIONS_CAN_EDIT
+          return res(ctx.status(200), ctx.json(response))
+        },
+      ),
+    )
+
+    const { user, closeButton } = renderComponent({
+      initialTab: 'ANNOTATIONS',
+      onEditModeChanged,
+      onClose,
+    })
+
+    const editButton = await screen.findByRole('button', { name: 'Edit' })
+    await userEvent.click(editButton)
+
+    expect(onEditModeChanged).toHaveBeenLastCalledWith(true)
+
+    // Text that appears in the editor component
+    await screen.findByText('Mock Annotation Editor', { exact: false })
+
+    // Click the modal close button
+    await user.click(closeButton)
+
+    // Verify the confirmation appears
+    screen.getByText('Unsaved Changes')
+    // Verify we didn't call the callback (yet)
+    expect(onClose).not.toHaveBeenCalled()
+
+    const confirmButton = screen.getByRole('button', {
+      name: 'OK',
+    })
+    await user.click(confirmButton)
+
+    expect(onEditModeChanged).toHaveBeenLastCalledWith(false)
+    // onClose be called, since that was what the user originally tried to do
+    expect(onClose).toHaveBeenCalled()
   })
 })

--- a/packages/synapse-react-client/src/components/entity/metadata/EntityModal.tsx
+++ b/packages/synapse-react-client/src/components/entity/metadata/EntityModal.tsx
@@ -59,6 +59,9 @@ export function EntityModal(props: EntityModalProps) {
   const [showEditCancellationWarning, setShowEditCancellationWarning] =
     useState(false)
   const [isInEditMode, setIsInEditMode] = useState(false)
+
+  // Need to store variable behavior for when the user confirms they want to cancel editing
+  // We may return to the readonly view, or we might close the entire modal, depending on what they clicked.
   const [onCancelEdit, setOnCancelEdit] = useState<() => void>(() =>
     setIsInEditMode(false),
   )

--- a/packages/synapse-react-client/src/components/entity/page/title_bar/EntityPageTitleBar.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/entity/page/title_bar/EntityPageTitleBar.integration.test.tsx
@@ -5,22 +5,22 @@ import EntityPageTitleBar, {
 import { render, screen } from '@testing-library/react'
 import { createWrapper } from '../../../../testutils/TestingLibraryUtils'
 import mockFileEntity from '../../../../mocks/entity/mockFileEntity'
+import * as EntityActionMenuModule from '../action_menu/EntityActionMenu'
 import { EntityActionMenuProps } from '../action_menu/EntityActionMenu'
 import {
   DockerRepository,
   EntityBundle,
   EntityType,
 } from '@sage-bionetworks/synapse-types'
-import { rest, server } from '../../../../mocks/msw/server'
+import { server } from '../../../../mocks/msw/server'
 import {
   BackendDestinationEnum,
   getEndpoint,
 } from '../../../../utils/functions/getEndpoint'
-import { ENTITY_BUNDLE_V2 } from '../../../../utils/APIConstants'
 import * as FavoriteButtonModule from '../../../favorites/FavoriteButton'
-import * as EntityActionMenuModule from '../action_menu/EntityActionMenu'
 import * as TitleBarPropertiesModule from './TitleBarProperties'
 import * as TitleBarVersionInfoModule from './EntityTitleBarVersionInfo'
+import { getVersionedEntityBundleHandler } from '../../../../mocks/msw/handlers/entityHandlers'
 
 const TITLE_BAR_PROPERTIES_TEST_ID = 'title-bar-properties'
 const TITLE_BAR_VERSION_INFO_TEST_ID = 'title-bar-version-info'
@@ -57,15 +57,9 @@ function renderComponent(props: EntityPageTitleBarProps) {
 
 function useEntityBundleOverride(bundle: EntityBundle) {
   server.use(
-    rest.post(
-      `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
-        ':entityId',
-        ':versionNumber',
-      )}`,
-
-      async (req, res, ctx) => {
-        return res(ctx.status(200), ctx.json(bundle))
-      },
+    getVersionedEntityBundleHandler(
+      getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+      bundle,
     ),
   )
 }

--- a/packages/synapse-react-client/src/components/entity/page/title_bar/TitleBarProperties.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/entity/page/title_bar/TitleBarProperties.integration.test.tsx
@@ -5,8 +5,8 @@ import {
   EntityType,
   ExternalFileHandle,
   ExternalObjectStoreFileHandle,
-  S3FileHandle,
   S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+  S3FileHandle,
   VersionableEntity,
 } from '@sage-bionetworks/synapse-types'
 import { render, screen } from '@testing-library/react'
@@ -20,10 +20,7 @@ import { mockDoiAssociation } from '../../../../mocks/entity/mockProject'
 import { mockFileHandle } from '../../../../mocks/mock_file_handle'
 import { rest, server } from '../../../../mocks/msw/server'
 import { createWrapper } from '../../../../testutils/TestingLibraryUtils'
-import {
-  DOI_ASSOCIATION,
-  ENTITY_BUNDLE_V2,
-} from '../../../../utils/APIConstants'
+import { DOI_ASSOCIATION } from '../../../../utils/APIConstants'
 import { calculateFriendlyFileSize } from '../../../../utils/functions/calculateFriendlyFileSize'
 import {
   BackendDestinationEnum,
@@ -38,6 +35,7 @@ import {
   MOCK_EXTERNAL_S3_STORAGE_LOCATION_ID,
   mockExternalS3UploadDestination,
 } from '../../../../mocks/mock_upload_destination'
+import { getEntityBundleHandler } from '../../../../mocks/msw/handlers/entityHandlers'
 
 const HAS_ACCESS_V2_DATA_TEST_ID = 'mock-has-access-v2'
 
@@ -51,14 +49,9 @@ const mockOnActClick = jest.fn()
 
 function useEntityBundleOverride(bundle: EntityBundle) {
   server.use(
-    rest.post(
-      `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
-        ':entityId',
-      )}`,
-
-      async (req, res, ctx) => {
-        return res(ctx.status(200), ctx.json(bundle))
-      },
+    getEntityBundleHandler(
+      getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+      bundle,
     ),
   )
 }

--- a/packages/synapse-react-client/src/mocks/msw/handlers/entityHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/entityHandlers.ts
@@ -18,17 +18,82 @@ import {
   PaginatedResults,
   ProjectHeaderList,
   Reference,
+  UploadDestination,
+  UploadType,
   VersionableEntity,
+  VersionInfo,
 } from '@sage-bionetworks/synapse-types'
-import { VersionInfo } from '@sage-bionetworks/synapse-types'
 import mockEntities from '../../entity'
 import { MOCK_INVALID_PROJECT_NAME } from '../../entity/mockEntity'
 import { mockSchemaBinding } from '../../mockSchema'
 import { SynapseApiResponse } from '../handlers'
-import { UploadDestination, UploadType } from '@sage-bionetworks/synapse-types'
 import { uniqueId } from 'lodash-es'
 import { mockProjectsEntityData } from '../../entity/mockProject'
 import { mockUploadDestinations } from '../../mock_upload_destination'
+
+export function getEntityBundleHandler(
+  backendOrigin: string,
+  bundle?: Partial<EntityBundle>,
+) {
+  return rest.post(
+    `${backendOrigin}${ENTITY_BUNDLE_V2(':entityId')}`,
+    async (req, res, ctx) => {
+      let status = 404
+      let response: SynapseApiResponse<EntityBundle> = {
+        reason: `Mock Service worker could not find a mock entity bundle with ID ${req.params.entityId}`,
+      }
+      if (bundle) {
+        response = bundle as EntityBundle
+        status = 200
+      } else {
+        const entityData = mockEntities.find(
+          entity => entity.id === req.params.entityId,
+        )
+        if (entityData?.bundle) {
+          response = entityData.bundle
+          status = 200
+        }
+      }
+      return res(ctx.status(status), ctx.json(response))
+    },
+  )
+}
+
+export function getVersionedEntityBundleHandler(
+  backendOrigin: string,
+  bundle?: Partial<EntityBundle>,
+) {
+  return rest.post(
+    `${backendOrigin}${ENTITY_BUNDLE_V2(':entityId', ':versionNumber')}`,
+    async (req, res, ctx) => {
+      const entityId = req.params.entityId
+      const versionNumber = parseInt(req.params.versionNumber as string)
+      let status = 404
+      let response: SynapseApiResponse<EntityBundle> = {
+        reason: `Mock Service worker could not find a mock entity bundle with ID ${entityId}`,
+      }
+      if (bundle) {
+        response = bundle as EntityBundle
+        status = 200
+      } else {
+        const entityData = mockEntities.find(entity => entity.id === entityId)
+        if (entityData) {
+          const bundle = entityData.bundle
+          if (entityData.versions && entityData.versions[versionNumber]) {
+            response = {
+              ...bundle,
+              entity: entityData.versions[versionNumber],
+            } as EntityBundle
+          } else {
+            response = bundle as EntityBundle
+          }
+          status = 200
+        }
+      }
+      return res(ctx.status(status), ctx.json(response))
+    },
+  )
+}
 
 export const getEntityHandlers = (backendOrigin: string) => [
   /**
@@ -127,50 +192,9 @@ export const getEntityHandlers = (backendOrigin: string) => [
     },
   ),
 
-  rest.post(
-    `${backendOrigin}${ENTITY_BUNDLE_V2(':entityId')}`,
-    async (req, res, ctx) => {
-      let status = 404
-      let response: SynapseApiResponse<EntityBundle> = {
-        reason: `Mock Service worker could not find a mock entity bundle with ID ${req.params.entityId}`,
-      }
-      const entityData = mockEntities.find(
-        entity => entity.id === req.params.entityId,
-      )
-      if (entityData?.bundle) {
-        response = entityData.bundle
-        status = 200
-      }
-      return res(ctx.status(status), ctx.json(response))
-    },
-  ),
+  getEntityBundleHandler(backendOrigin),
+  getVersionedEntityBundleHandler(backendOrigin),
 
-  rest.post(
-    `${backendOrigin}${ENTITY_BUNDLE_V2(':entityId', ':versionNumber')}`,
-    async (req, res, ctx) => {
-      const entityId = req.params.entityId
-      const versionNumber = parseInt(req.params.versionNumber as string)
-      let status = 404
-      let response: SynapseApiResponse<EntityBundle> = {
-        reason: `Mock Service worker could not find a mock entity bundle with ID ${entityId}`,
-      }
-      const entityData = mockEntities.find(entity => entity.id === entityId)
-      if (entityData) {
-        const bundle = entityData.bundle
-        if (entityData.versions && entityData.versions[versionNumber]) {
-          response = {
-            ...bundle,
-            entity: entityData.versions[versionNumber],
-          } as EntityBundle
-        } else {
-          response = bundle as EntityBundle
-        }
-        status = 200
-      }
-
-      return res(ctx.status(status), ctx.json(response))
-    },
-  ),
   rest.get(
     `${backendOrigin}${ENTITY_SCHEMA_BINDING(':entityId')}`,
     async (req, res, ctx) => {


### PR DESCRIPTION
PORTALS-2817 and PORTALS-2818
- Add confirmation dialog when closing the annotations editor
- Expose new prop `onEditModeChanged` and synchronize with `useEffect`. Will be used to toggle `GlobalApplicationState.setIsEditing` in SWC
- Improve modal title
- Remove weird cancel button that turns into the confirm cancel button