### PR TITLE
PORTALS-2916 - Temporarily simplify the colors used in facet plots until the palette is improved

### DIFF
--- a/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNavPanel.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNavPanel.tsx
@@ -80,8 +80,10 @@ export async function extractPlotDataArray(
   accessToken?: string,
 ) {
   const colorPalette = getContrastColorPalette(
-    index % 2 === 0 ? 'even' : 'odd',
-    Math.floor(index / 2),
+    // Use only the odd palette, using the same offset for all plots until palettes are improved.
+    // See PORTALS-2916
+    'odd', // index % 2 === 0 ? 'even' : 'odd',
+    0, // Math.floor(index / 2),
     facetToPlot.facetValues.length,
   )
 

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/PlotsContainer.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/PlotsContainer.tsx
@@ -257,7 +257,7 @@ export default function PlotsContainer(props: PlotsContainerProps) {
               showPlotVisualization ? '' : 'hidden'
             } ${showMoreButtonState === 'LESS' ? 'less' : ''}`}
           >
-            <div className="PlotNav__row" role="list">
+            <div className="PlotsContainer__row" role="list">
               {plotUiStateArray.map(plotUiState => {
                 const isCustomPlot = '__custom' in plotUiState.plotId
                 const customPlotProps = customPlots.find(customPlot =>


### PR DESCRIPTION
Temporary improvement for PORTALS-2916

Also fix an issue where facets would appear full-width instead of in a grid