### PR TITLE
Fix issue where pagination did not work for the AccessApprovalsTable

### DIFF
--- a/packages/synapse-react-client/src/components/dataaccess/AccessApprovalsTable.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/AccessApprovalsTable.integration.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
-import { server } from '../../mocks/msw/server'
+import { rest, server } from '../../mocks/msw/server'
 import { render, screen } from '@testing-library/react'
-import { AccessApprovalSearchResult } from '@sage-bionetworks/synapse-types'
+import {
+  AccessApprovalSearchRequest,
+  AccessApprovalSearchResponse,
+  AccessApprovalSearchResult,
+} from '@sage-bionetworks/synapse-types'
 import {
   AccessApprovalsTable,
   AccessApprovalsTableProps,
@@ -12,16 +16,11 @@ import {
   mockAccessApprovalSearchResult2,
   mockApprovalSearchResponse,
 } from '../../mocks/MockAccessApprovals'
-import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
-import * as UseAccessApprovalsModule from '../../synapse-queries/dataaccess/useAccessApprovals'
 import userEvent from '@testing-library/user-event'
-
-const mockSearchAccessApprovalsInfinite = jest.spyOn(
-  UseAccessApprovalsModule,
-  'useSearchAccessApprovalsInfinite',
-)
-
-const mockFetchNextPage = jest.fn()
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from '../../utils/functions/getEndpoint'
 
 const page2: AccessApprovalSearchResult[] = [mockAccessApprovalSearchResult2]
 
@@ -34,47 +33,28 @@ function renderComponent(props: AccessApprovalsTableProps) {
 describe('AccessApprovalsTable tests', () => {
   beforeAll(() => {
     server.listen()
-    mockSearchAccessApprovalsInfinite.mockReturnValue({
-      data: {
-        pages: [
-          {
+    server.use(
+      rest.post(
+        `${getEndpoint(
+          BackendDestinationEnum.REPO_ENDPOINT,
+        )}/repo/v1/accessApproval/search`,
+        async (req, res, ctx) => {
+          const requestBody: AccessApprovalSearchRequest = await req.json()
+          let responseBody: AccessApprovalSearchResponse = {
             results: mockApprovalSearchResponse.results,
             nextPageToken: mockApprovalSearchResponse.nextPageToken,
-          },
-          {
-            results: page2,
-            nextPageToken: undefined,
-          },
-        ],
-        pageParams: [],
-      },
-      fetchNextPage: mockFetchNextPage,
-      hasNextPage: true,
-      isLoading: false,
-      isSuccess: true,
-      isError: false,
-      isLoadingError: false,
-      error: null,
-      isIdle: false,
-      isRefetchError: false,
-      status: 'success',
-      fetchPreviousPage: jest.fn(),
-      isFetchingNextPage: false,
-      isFetchingPreviousPage: false,
-      dataUpdatedAt: 0,
-      errorUpdatedAt: 0,
-      failureCount: 0,
-      errorUpdateCount: 0,
-      isFetched: false,
-      isFetchedAfterMount: false,
-      isFetching: false,
-      isPlaceholderData: false,
-      isPreviousData: false,
-      isRefetching: false,
-      isStale: false,
-      refetch: jest.fn(),
-      remove: jest.fn(),
-    })
+          }
+
+          if (requestBody.nextPageToken) {
+            responseBody = {
+              results: page2,
+              nextPageToken: undefined,
+            }
+          }
+          return res(ctx.status(200), ctx.json(responseBody))
+        },
+      ),
+    )
   })
   afterEach(() => {
     server.restoreHandlers()
@@ -95,29 +75,24 @@ describe('AccessApprovalsTable tests', () => {
     await screen.findByText('Expires')
   })
 
-  it('Renders all of the data', async () => {
+  it('Renders first page of data', async () => {
     renderComponent({
       accessorId: MOCK_USER_ID.toString(),
     })
-    mockAllIsIntersecting(true)
-    expect(
-      await screen.findAllByText(
-        mockAccessApprovalSearchResult2.accessRequirementId,
-      ),
-    ).toHaveLength(51)
+
+    await screen.findByText(
+      mockApprovalSearchResponse.results[0].accessRequirementId,
+    )
   })
 
-  it('Renders show more button when it has a next page', async () => {
-    mockAllIsIntersecting(true)
+  it('pagination works', async () => {
     renderComponent({
       accessorId: MOCK_USER_ID.toString(),
     })
-    const moreButton = screen.queryByRole('button', { name: 'Show More' })
-    expect(
-      screen.queryByRole('button', { name: 'Show More' }),
-    ).toBeInTheDocument()
-    await userEvent.click(moreButton!)
-    const item2 = await screen.findAllByText('Access Requirement2')
-    expect(item2).toHaveLength(1)
+    const showMoreButton = await screen.findByRole('button', {
+      name: 'Show More',
+    })
+    await userEvent.click(showMoreButton)
+    await screen.findByText(page2[0].accessRequirementId)
   })
 })

--- a/packages/synapse-react-client/src/components/dataaccess/AccessApprovalsTable.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/AccessApprovalsTable.tsx
@@ -140,13 +140,13 @@ export const AccessApprovalsTable: React.FunctionComponent<
           No Results
         </Typography>
       )}
-      {!hasNextPage ? (
-        ''
-      ) : (
+      {hasNextPage && (
         <Button
           variant="outlined"
           color="primary"
-          onClick={() => fetchNextPage}
+          onClick={() => {
+            fetchNextPage()
+          }}
         >
           Show More
         </Button>

--- a/packages/synapse-react-client/src/mocks/MockAccessApprovals.ts
+++ b/packages/synapse-react-client/src/mocks/MockAccessApprovals.ts
@@ -5,28 +5,25 @@ import {
 } from '@sage-bionetworks/synapse-types'
 import { MOCK_USER_ID } from './user/mock_user_profile'
 
-const mockSearchResults = []
-for (let i = 0; i < 50; i++) {
-  mockSearchResults.push({
-    accessRequirementId: '9602629',
-    accessRequirementName: 'Access Requirement',
-    accessRequirementVersion: '3',
-    id: (Date.now() + i).toString(),
-    modifiedOn: '2022-05-24T21:20:58.420Z',
-    expiredOn: '2022-05-24T21:20:58.420Z',
-    reviewerId: MOCK_USER_ID.toString(),
-    state: ApprovalState.APPROVED,
-    submitterId: MOCK_USER_ID.toString(),
-  })
-}
-
-export const mockApprovalSearchResponse = {
-  results: mockSearchResults,
+export const mockApprovalSearchResponse: AccessApprovalSearchResponse = {
+  results: [
+    {
+      accessRequirementId: '9602629',
+      accessRequirementName: 'Access Requirement',
+      accessRequirementVersion: '3',
+      id: Date.now().toString(),
+      modifiedOn: '2022-05-24T21:20:58.420Z',
+      expiredOn: '2022-05-24T21:20:58.420Z',
+      reviewerId: MOCK_USER_ID.toString(),
+      state: ApprovalState.APPROVED,
+      submitterId: MOCK_USER_ID.toString(),
+    },
+  ],
   nextPageToken: '50a0',
 } satisfies AccessApprovalSearchResponse
 
 export const mockAccessApprovalSearchResult2: AccessApprovalSearchResult = {
-  accessRequirementId: '9602629',
+  accessRequirementId: '9602630',
   accessRequirementName: 'Access Requirement2',
   accessRequirementVersion: '3',
   id: '9602632',


### PR DESCRIPTION
Fix a case where `fetchNextPage` was never called, and fixed tests that made it seem like this worked.

I don't think this significantly impacted production, I think few users (if any) have enough approvals to hit the page limit (which I think is 50).