### PR TITLE
PORTALS-2936 - Add new ChallengeRequirementsModal

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
@@ -44,8 +44,8 @@ export type AccessRequirementListProps = {
   renderAsModal?: boolean
   /* Overrides the default dialog title. This only applies if renderAsModal is true */
   dialogTitle?: string
-  /* Called when the modal is hidden. This only applies if renderAsModal is true */
-  onHide?: () => void
+  /* Called when the user rejects the terms of a listed AccessRequirement. If renderAsModal is true, this is also called when the user closes the modal. */
+  onHide: () => void
   /* Displays the provided list of access requirements, instead of the ones fetched using the subject ID */
   accessRequirementFromProps?: Array<AccessRequirement>
 } & (

--- a/packages/synapse-react-client/src/components/ChallengeDetailPage/ChallengeDetailPage.stories.ts
+++ b/packages/synapse-react-client/src/components/ChallengeDetailPage/ChallengeDetailPage.stories.ts
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { ChallengeDetailPage } from './ChallengeDetailPage'
+import mockProject from '../../mocks/entity/mockProject'
 
 const meta = {
   title: 'Synapse/Challenge/ChallengeDetailPage',
@@ -14,8 +15,20 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Demo: Story = {
+export const MockDemo: Story = {
+  args: {
+    projectId: mockProject.id,
+  },
+  parameters: {
+    stack: 'mock',
+  },
+}
+
+export const ProductionDemo: Story = {
   args: {
     projectId: 'syn51208606',
+  },
+  parameters: {
+    stack: 'production',
   },
 }

--- a/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.integration.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import ChallengeRequirementsModal, {
+  ChallengeRequirementsModalProps,
+} from './ChallengeRequirementsModal'
+import { server } from '../../mocks/msw/server'
+import userEvent from '@testing-library/user-event'
+import SynapseClient from '../../synapse-client'
+import { MOCK_USER_ID } from '../../mocks/user/mock_user_profile'
+import mockProject from '../../mocks/entity/mockProject'
+import { MOCK_CHALLENGE_PARTICIPANT_TEAM_ID } from '../../mocks/team/mockTeam'
+import { getAccessRequirementStatusHandlers } from '../../mocks/msw/handlers/accessRequirementHandlers'
+import { BackendDestinationEnum } from '../../utils/functions'
+import { getEndpoint } from '../../utils/functions/getEndpoint'
+import { mockSelfSignAccessRequirement } from '../../mocks/mockAccessRequirements'
+import { MOCK_ACCESS_TOKEN } from '../../mocks/MockSynapseContext'
+
+async function renderComponent(props: ChallengeRequirementsModalProps) {
+  const user = userEvent.setup()
+  const component = render(<ChallengeRequirementsModal {...props} />, {
+    wrapper: createWrapper(),
+  })
+
+  const dialog = await screen.findByRole('dialog')
+  await within(dialog).findByRole('heading', {
+    name: 'Challenge Terms and Conditions',
+  })
+  const registerButton = await within(dialog).findByRole('button', {
+    name: 'Register',
+  })
+  const cancelButton = await within(dialog).findByRole('button', {
+    name: 'Cancel',
+  })
+  const closeModalButton = await within(dialog).findByRole('button', {
+    name: 'close',
+  })
+  return {
+    user,
+    component,
+    dialog,
+    registerButton,
+    cancelButton,
+    closeModalButton,
+  }
+}
+
+const mockOnRegisterComplete = jest.fn()
+const mockOnCancel = jest.fn()
+
+const addTeamMemberSpy = jest.spyOn(
+  SynapseClient,
+  'addTeamMemberAsAuthenticatedUserOrAdmin',
+)
+
+describe('ChallengeRequirementsModal', () => {
+  beforeAll(() => server.listen())
+  beforeEach(() => {
+    server.use(
+      ...getAccessRequirementStatusHandlers(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        [
+          {
+            accessRequirementId: String(mockSelfSignAccessRequirement.id),
+            concreteType:
+              'org.sagebionetworks.repo.model.dataaccess.BasicAccessRequirementStatus',
+            isApproved: false,
+          },
+        ],
+      ),
+    )
+  })
+  afterEach(() => {
+    server.restoreHandlers()
+    jest.clearAllMocks()
+  })
+  afterAll(() => server.close())
+
+  it("Shows a set of requirements. Once the user fulfills those requirements, they can click 'Register' to join the participant team.", async () => {
+    const { user, dialog, registerButton } = await renderComponent({
+      open: true,
+      projectId: mockProject.id,
+      onRegisterComplete: mockOnRegisterComplete,
+      onCancel: mockOnCancel,
+    })
+
+    // The button should be disabled because we do not meet the access requirements to join the team.
+    expect(registerButton).toBeDisabled()
+
+    // Accept the click-wrap access requirement
+    const acceptClickWrapButton = await within(dialog).findByRole('button', {
+      name: 'I Accept Terms of Use',
+    })
+    await user.click(acceptClickWrapButton)
+
+    // Now the button should be enabled
+    await waitFor(() => expect(registerButton).toBeEnabled())
+
+    // Click the register button and verify that we joined the team
+    await user.click(registerButton)
+    await waitFor(() => {
+      expect(addTeamMemberSpy).toHaveBeenCalledWith(
+        String(MOCK_CHALLENGE_PARTICIPANT_TEAM_ID),
+        String(MOCK_USER_ID),
+        MOCK_ACCESS_TOKEN,
+      )
+      expect(mockOnRegisterComplete).toHaveBeenCalled()
+      expect(mockOnRegisterComplete).toHaveBeenCalled()
+    })
+    expect(mockOnCancel).not.toHaveBeenCalled()
+  })
+
+  it('Calls onCancel when the user clicks the cancel button', async () => {
+    const { user, cancelButton } = await renderComponent({
+      open: true,
+      projectId: mockProject.id,
+      onRegisterComplete: mockOnRegisterComplete,
+      onCancel: mockOnCancel,
+    })
+
+    await user.click(cancelButton)
+
+    expect(mockOnCancel).toHaveBeenCalled()
+    expect(mockOnRegisterComplete).not.toHaveBeenCalled()
+  })
+
+  it('Calls onCancel when the user clicks the close button', async () => {
+    const { user, closeModalButton } = await renderComponent({
+      open: true,
+      projectId: mockProject.id,
+      onRegisterComplete: mockOnRegisterComplete,
+      onCancel: mockOnCancel,
+    })
+
+    await user.click(closeModalButton)
+
+    expect(mockOnCancel).toHaveBeenCalled()
+    expect(mockOnRegisterComplete).not.toHaveBeenCalled()
+  })
+
+  it('Calls onCancel when the user rejects AR terms', async () => {
+    const { user } = await renderComponent({
+      open: true,
+      projectId: mockProject.id,
+      onRegisterComplete: mockOnRegisterComplete,
+      onCancel: mockOnCancel,
+    })
+
+    const rejectTermsButton = await screen.findByRole('button', {
+      name: 'I do not accept',
+    })
+    await user.click(rejectTermsButton)
+
+    expect(mockOnCancel).toHaveBeenCalled()
+    expect(mockOnRegisterComplete).not.toHaveBeenCalled()
+  })
+})

--- a/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.tsx
@@ -1,0 +1,156 @@
+import React, { useCallback } from 'react'
+import { ConfirmationDialog } from '../ConfirmationDialog'
+import {
+  useGetAccessRequirementsForTeam,
+  useGetAccessRequirementStatuses,
+  useGetCurrentUserProfile,
+  useGetEntity,
+  useGetEntityChallenge,
+} from '../../synapse-queries'
+import {
+  useAddMemberToTeam,
+  useGetMembershipStatus,
+} from '../../synapse-queries/team/useTeamMembers'
+import { SynapseClientError, useSynapseContext } from '../../utils'
+import AccessRequirementList from '../AccessRequirementList/AccessRequirementList'
+import { RestrictableObjectType } from '@sage-bionetworks/synapse-types'
+import { SynapseSpinner } from '../LoadingScreen/LoadingScreen'
+import { Alert, Typography } from '@mui/material'
+import { isEmpty } from 'lodash-es'
+
+export type ChallengeRequirementsModalProps = {
+  open: boolean
+  projectId: string
+  onCancel: () => void
+  onRegisterComplete: () => void
+}
+
+/**
+ * The challenge requirements modal will
+ *  1. Display the access requirements that must be accepted to join a participant team. The component will guide the user through meeting the requirements.
+ *  2. If the user has accepted the requirements, the user can click 'Register' to join the team
+ *     If the user has not accepted the requirements, the user cannot register for the challenge.
+ */
+export default function ChallengeRequirementsModal(
+  props: ChallengeRequirementsModalProps,
+) {
+  const { open, projectId, onRegisterComplete, onCancel } = props
+  const { data: project, error: getEntityError } = useGetEntity(projectId)
+
+  const { accessToken } = useSynapseContext()
+
+  const { data: challenge, error: getChallengeError } =
+    useGetEntityChallenge(projectId)
+  const isLoggedIn = !!accessToken
+  const { data: userProfile, error: getProfileError } =
+    useGetCurrentUserProfile({
+      enabled: isLoggedIn,
+    })
+
+  const participantTeamId = challenge?.participantTeamId
+  const userId = userProfile?.ownerId
+
+  const { data: teamMembershipStatus, error: getMembershipStatusError } =
+    useGetMembershipStatus(participantTeamId!, userId!, {
+      enabled: Boolean(participantTeamId && userId),
+    })
+
+  const {
+    mutateAsync: addTeamMember,
+    isLoading: registrationIsPending,
+    error: registrationError,
+  } = useAddMemberToTeam()
+
+  const {
+    data: fetchedRequirementsForTeam,
+    isSuccess: hasFetchedRequirements,
+    error: getAccessRequirementsError,
+  } = useGetAccessRequirementsForTeam(challenge?.participantTeamId!, {
+    enabled: Boolean(challenge?.participantTeamId),
+  })
+
+  const requirementStatusesQueryResults = useGetAccessRequirementStatuses(
+    fetchedRequirementsForTeam?.map(ar => String(ar.id)) ?? [],
+  )
+
+  const meetsAllRequirements =
+    hasFetchedRequirements &&
+    requirementStatusesQueryResults.every(queryResult => {
+      return queryResult.status === 'success' && queryResult.data.isApproved
+    })
+
+  const registerForChallenge = useCallback(async () => {
+    if (participantTeamId && userId && !teamMembershipStatus?.isMember) {
+      await addTeamMember({
+        teamId: participantTeamId,
+        userId,
+      })
+    }
+    onRegisterComplete()
+  }, [
+    addTeamMember,
+    onRegisterComplete,
+    participantTeamId,
+    teamMembershipStatus?.isMember,
+    userId,
+  ])
+
+  const errors = [
+    getEntityError,
+    getChallengeError,
+    getProfileError,
+    getMembershipStatusError,
+    getAccessRequirementsError,
+    registrationError,
+  ].filter((e): e is SynapseClientError => Boolean(e))
+
+  let registerButtonText = teamMembershipStatus?.isMember
+    ? 'Continue'
+    : 'Register'
+  if (registrationIsPending) {
+    registerButtonText = 'Registering...'
+  }
+
+  return (
+    <ConfirmationDialog
+      open={open}
+      title={`Challenge Terms and Conditions`}
+      content={
+        <>
+          {participantTeamId && (
+            <AccessRequirementList
+              subjectId={participantTeamId}
+              subjectType={RestrictableObjectType.TEAM}
+              teamId={challenge?.participantTeamId}
+              renderAsModal={false}
+              requestObjectName={project?.name}
+              onHide={() => {
+                onCancel()
+              }}
+            />
+          )}
+          {!isEmpty(errors) && (
+            <Alert severity="error">
+              {errors.map((e, index) => (
+                <Typography variant={'body1'} key={index}>
+                  {e.reason}
+                </Typography>
+              ))}
+            </Alert>
+          )}
+        </>
+      }
+      onCancel={onCancel}
+      onConfirm={() => {
+        registerForChallenge()
+      }}
+      confirmButtonProps={{
+        children: registerButtonText,
+        // It's possible that the user joined the team, but requirements on the team changed since they became a member
+        // They do not need to re-join the team, but they should still be prompted to accept the requirements
+        startIcon: registrationIsPending ? <SynapseSpinner /> : undefined,
+        disabled: !meetsAllRequirements || registrationIsPending,
+      }}
+    />
+  )
+}

--- a/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.tsx
@@ -104,6 +104,8 @@ export default function ChallengeRequirementsModal(
     registrationError,
   ].filter((e): e is SynapseClientError => Boolean(e))
 
+   // It's possible that the user joined the team, but requirements on the team changed since they became a member
+   // They do not need to re-join the team, but they should still be prompted to accept the requirements
   let registerButtonText = teamMembershipStatus?.isMember
     ? 'Continue'
     : 'Register'
@@ -146,8 +148,6 @@ export default function ChallengeRequirementsModal(
       }}
       confirmButtonProps={{
         children: registerButtonText,
-        // It's possible that the user joined the team, but requirements on the team changed since they became a member
-        // They do not need to re-join the team, but they should still be prompted to accept the requirements
         startIcon: registrationIsPending ? <SynapseSpinner /> : undefined,
         disabled: !meetsAllRequirements || registrationIsPending,
       }}

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
@@ -121,47 +121,6 @@ const ChallengeTeamWizard: React.FunctionComponent<
   const { data: userProfile } = useGetCurrentUserProfile()
   // Retrieve the challenge associated with the projectId passed through props
   const { data: challenge } = useGetEntityChallenge(projectId)
-  const participantTeamId: string = challenge
-    ? challenge.participantTeamId
-    : EMPTY_ID
-  const userId = userProfile ? userProfile.ownerId : EMPTY_ID
-
-  // Verify that user is a member of the participant team
-  const { data: challengeTeamMembershipStatus } = useGetMembershipStatus(
-    participantTeamId,
-    userId,
-  )
-  useEffect(() => {
-    if (
-      challengeTeamMembershipStatus &&
-      !challengeTeamMembershipStatus?.isMember &&
-      accessToken
-    ) {
-      addTeamMemberAsAuthenticatedUserOrAdmin(
-        participantTeamId,
-        userId,
-        accessToken,
-      )
-        .then(() => {
-          queryClient.invalidateQueries(
-            keyFactory.getMembershipStatusQueryKey(participantTeamId, userId),
-          )
-          queryClient.invalidateQueries(
-            keyFactory.getIsUserMemberOfTeamQueryKey(participantTeamId, userId),
-          )
-        })
-        .catch(error => {
-          setErrorMessage(error.reason)
-        })
-    }
-  }, [
-    accessToken,
-    participantTeamId,
-    userId,
-    challengeTeamMembershipStatus,
-    queryClient,
-    keyFactory,
-  ])
 
   // Determine whether or not the given user belongs to any submission teams
   const { data: userSubmissionTeams, error: userSubmissionTeamError } =


### PR DESCRIPTION
See PORTALS-2936

- Add ChallengeRequirementsModal, which shows AccessRequirements. Once all ARs have been met, the user can 'register' by clicking the button to join the participant team
- Update ChallengeDetailPage to use the new ChallengeRequirementsModal instead of AccessRequirementList.
- Fix issue where closing the AR modal without accepting would still trigger joining the participant team
- Fix issue where the ChallengeTeamWizard would be shown even if the user was a member of the participant team.


https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/df414b44-21b9-48d4-ad8c-ec187d88df7e

