### PR TITLE
SWC-6545 - Refactor to remove deprecated query options

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.tsx
@@ -46,12 +46,6 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
     useGetResearchProject(String(managedACTAccessRequirement.id), {
       // Infinite staleTime ensures this won't be refetched unless explicitly invalidated by the mutation
       staleTime: Infinity,
-      onError: e => {
-        console.log(
-          'RequestDataAccessStep1: Error getting research project data: ',
-          e,
-        )
-      },
     })
 
   // Populate the form with existing data if it exists

--- a/packages/synapse-react-client/src/components/ChallengeDataDownload/ChallengeDataTable.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeDataDownload/ChallengeDataTable.tsx
@@ -73,7 +73,7 @@ export const ChallengeDataTable: React.FunctionComponent<DetailsViewProps> = ({
 }) => {
   const queryClient = useQueryClient()
 
-  const { accessToken } = useSynapseContext()
+  const { accessToken, keyFactory } = useSynapseContext()
 
   const showSelectColumn = selectColumnType !== 'none'
 
@@ -83,10 +83,14 @@ export const ChallengeDataTable: React.FunctionComponent<DetailsViewProps> = ({
   const cancelQuery = () => {
     // It's likely that the user will be throttled by the Synapse backend and may be waiting a
     // noticeable amount of time for the current request, so cancel it (in addition to cancelling future requests)
-    queryClient.cancelQueries([
-      'entitychildren',
-      getChildrenInfiniteRequestObject,
-    ])
+    if (getChildrenInfiniteRequestObject) {
+      queryClient.cancelQueries(
+        keyFactory.getEntityChildrenQueryKey(
+          getChildrenInfiniteRequestObject,
+          true,
+        ),
+      )
+    }
     setShowLoadingScreen(false)
     setShouldSelectAll(false)
   }
@@ -173,9 +177,16 @@ export const ChallengeDataTable: React.FunctionComponent<DetailsViewProps> = ({
                         // Show the loading screen since we must fetch data (potentially a lot) to finish the task
                         setShowLoadingScreen(true)
 
+                        const limit = 1
+                        const offset = 0
                         const versions = await queryClient.fetchQuery(
-                          ['entity', e.id, 'versions', { offset: 0, limit: 1 }],
-                          () => getEntityVersions(e.id, accessToken, 0, 1),
+                          keyFactory.getPaginatedEntityVersionsQueryKey(
+                            e.id,
+                            limit,
+                            offset,
+                          ),
+                          () =>
+                            getEntityVersions(e.id, accessToken, offset, limit),
                         )
                         // we pick the first version in the list because it is the most recent
                         latestVersion = versions.results[0]?.versionNumber
@@ -209,6 +220,7 @@ export const ChallengeDataTable: React.FunctionComponent<DetailsViewProps> = ({
     shouldSelectAll,
     toggleSelection,
     visibleTypes,
+    keyFactory,
   ])
 
   const tableData = entities.reduce(

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/ChallengeSubmission.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/ChallengeSubmission.tsx
@@ -73,10 +73,7 @@ export function ChallengeSubmission({
   const { data: userProfile, isLoading: isProfileLoading } =
     useGetCurrentUserProfile({
       enabled: isLoggedIn,
-      onError: () => {
-        setLoading(false)
-        setErrorMessage(`Error: Could not retrieve user profile`)
-      },
+      useErrorBoundary: true,
     })
 
   // Retrieve the challenge associated with the projectId passed through props
@@ -121,17 +118,15 @@ export function ChallengeSubmission({
     newProject?.alias ?? EMPTY_ID,
     {
       enabled: newProject !== undefined && !!challenge && !!submissionTeam,
-      onError: error => {
-        setLoading(false)
-        setProjectAliasFound(false)
-        setErrorMessage(error.reason)
-      },
+      useErrorBoundary: true,
     },
   )
   useEffect(() => {
     if (entityAlias) {
       setProjectAliasFound(true)
       setChallengeProjectId(entityAlias.id)
+    } else {
+      setProjectAliasFound(false)
     }
   }, [entityAlias])
 
@@ -142,10 +137,7 @@ export function ChallengeSubmission({
   const { data: entityACL } = useGetEntityACL(challengeProjectId ?? EMPTY_ID, {
     enabled: !!challengeProjectId && isProjectNewlyCreated === true,
     refetchInterval: Infinity,
-    onError: error => {
-      setLoading(false)
-      setErrorMessage(error.reason)
-    },
+    useErrorBoundary: true,
   })
 
   useEffect(() => {
@@ -177,10 +169,7 @@ export function ChallengeSubmission({
     {
       enabled: !!challengeProjectId,
       refetchInterval: Infinity,
-      onError: error => {
-        setLoading(false)
-        setErrorMessage(error.reason)
-      },
+      useErrorBoundary: true,
     },
   )
 

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/ChallengeSubmissionStepper.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/ChallengeSubmissionStepper.tsx
@@ -231,7 +231,9 @@ function ChallengeSubmissionStepper({
       onCancel={hide}
       onStepChange={handleStepChange as (arg: string) => void}
       open={isShowingModal}
-      onConfirm={onConfirmHandler}
+      onConfirm={() => {
+        onConfirmHandler()
+      }}
       confirming={confirming}
       step={step}
       content={stepperContent()}

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/SubmissionDirectoryList.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/SubmissionDirectoryList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Box, Button, Typography } from '@mui/material'
 import { DataGrid, GridCellParams, GridColDef } from '@mui/x-data-grid'
 import { RadioOption } from '../widgets/RadioGroup'
@@ -130,9 +130,13 @@ function SubmissionDirectoryList({
   }, [entityType, pageSize])
 
   const queries = useGetEntities(getPageHeaders())
-  const entities = queries
-    .filter(q => q.status === 'success')
-    .map(q => q.data) as EntityItem[]
+  const entities = useMemo(
+    () =>
+      queries
+        .filter(q => q.status === 'success')
+        .map(q => q.data) as EntityItem[],
+    [queries],
+  )
   const areEntitiesLoading = queries.some(q => q.isLoading)
 
   const entityChangeHandler = async (value: string) => {

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/SubmissionDirectoryList.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/SubmissionDirectoryList.tsx
@@ -92,16 +92,22 @@ function SubmissionDirectoryList({
   const { data: headerResults, refetch } = useGetEntityChildren(request, {
     enabled: !!challengeProjectId,
     useErrorBoundary: true,
-    onSuccess: data => {
+  })
+
+  useEffect(() => {
+    if (headerResults) {
       const newHeaders = [...fetchedHeaders]
       const headerPage = Math.floor(((page + 1) * PER_PAGE) / HEADERS_PER_PAGE)
       const start = headerPage * HEADERS_PER_PAGE
-      newHeaders.splice(start, start + HEADERS_PER_PAGE, ...data.page)
+      newHeaders.splice(start, start + HEADERS_PER_PAGE, ...headerResults.page)
       setFetchedHeaders(newHeaders)
       setFetchNextPage(false)
-      setNextPageToken(data.nextPageToken)
-    },
-  })
+      setNextPageToken(headerResults.nextPageToken)
+    }
+    // TODO: Temporary useEffect hook to remove onSuccess QueryOption for @tanstack/react-query v5
+    // Refactor this component to remove this effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [headerResults])
 
   function getPageHeaders() {
     const pageStart = page * PER_PAGE
@@ -123,9 +129,11 @@ function SubmissionDirectoryList({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entityType, pageSize])
 
-  const { isLoading: areEntitiesLoading, data: entities } = useGetEntities(
-    getPageHeaders(),
-  )
+  const queries = useGetEntities(getPageHeaders())
+  const entities = queries
+    .filter(q => q.status === 'success')
+    .map(q => q.data) as EntityItem[]
+  const areEntitiesLoading = queries.some(q => q.isLoading)
 
   const entityChangeHandler = async (value: string) => {
     setCanSubmit(false)

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
@@ -25,7 +25,6 @@ import {
 } from '../../synapse-queries'
 import { ANONYMOUS_PRINCIPAL_ID } from '../../utils/SynapseConstants'
 import { useGetMembershipStatus } from '../../synapse-queries/team/useTeamMembers'
-import { SynapseClientError } from '../../utils/SynapseClientError'
 
 import { Typography } from '@mui/material'
 import { useQueryClient } from 'react-query'
@@ -144,25 +143,29 @@ const ChallengeTeamWizard: React.FunctionComponent<
     }
   }, [userSubmissionTeams, userSubmissionTeamError])
 
-  useGetMembershipStatus(
-    selectedTeam?.id ?? EMPTY_ID,
-    userProfile?.ownerId ?? EMPTY_ID,
-    {
-      enabled: !!selectedTeam && !!userProfile,
-      onSettled: (
-        data: TeamMembershipStatus | undefined,
-        error: SynapseClientError | null,
-      ) => {
-        // console.log('useGetMembershipStatus', data, error)
-        if (data) {
-          setMembershipStatus({ ...membershipStatus, [data.teamId]: data })
-        }
-        if (error) {
-          setErrorMessage(error.reason)
-        }
+  const { data: teamMembershipStatus, error: teamMembershipError } =
+    useGetMembershipStatus(
+      selectedTeam?.id ?? EMPTY_ID,
+      userProfile?.ownerId ?? EMPTY_ID,
+      {
+        enabled: !!selectedTeam && !!userProfile,
       },
-    },
-  )
+    )
+
+  useEffect(() => {
+    if (teamMembershipStatus) {
+      setMembershipStatus(prev => ({
+        ...prev,
+        [teamMembershipStatus.teamId]: teamMembershipStatus,
+      }))
+    }
+  }, [teamMembershipStatus])
+
+  useEffect(() => {
+    if (teamMembershipError) {
+      setErrorMessage(teamMembershipError.reason)
+    }
+  }, [teamMembershipError])
 
   /*************************
    * React to state changes

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
@@ -437,10 +437,7 @@ const ChallengeTeamWizard: React.FunctionComponent<
     onClose()
   }
 
-  const onConfirmHandlerMap: Record<
-    string,
-    (() => Promise<void>) | (() => undefined)
-  > | void = {
+  const onConfirmHandlerMap: Record<string, () => Promise<void> | void> = {
     CREATE_NEW_TEAM: handleCreateTeam,
     JOIN_REQUEST_FORM: handleRequestMembership,
     JOIN_REQUEST_SENT: () => {
@@ -531,7 +528,9 @@ const ChallengeTeamWizard: React.FunctionComponent<
       onCancel={hide}
       onStepChange={handleStepChange as (arg: string) => void}
       open={isShowingModal}
-      onConfirm={onConfirmHandler}
+      onConfirm={() => {
+        onConfirmHandler()
+      }}
       confirming={confirming}
       step={step}
       content={createContent()}

--- a/packages/synapse-react-client/src/components/StepperDialog/StepperDialog.stories.tsx
+++ b/packages/synapse-react-client/src/components/StepperDialog/StepperDialog.stories.tsx
@@ -96,8 +96,9 @@ export const Demo: Story = {
   args: {
     errorMessage: '',
     onCancel: () => alert('Here we would close the stepper'),
-    onConfirm: () =>
-      Promise.resolve(alert('Here we would confirm some important action')),
+    onConfirm: () => {
+      alert('Here we would confirm some important action')
+    },
     confirming: false,
     onStepChange: () => undefined,
     open: true,

--- a/packages/synapse-react-client/src/components/StepperDialog/StepperDialog.tsx
+++ b/packages/synapse-react-client/src/components/StepperDialog/StepperDialog.tsx
@@ -9,7 +9,7 @@ export type Step = {
   id: string
   title: string
   cancelButtonText?: string
-  onConfirm?: (() => Promise<void>) | (() => undefined)
+  onConfirm?: () => void
   confirmStep?: string
   confirmEnabled?: boolean
   confirmButtonText?: string
@@ -24,7 +24,7 @@ export type Steps = Step[]
 export type StepperDialogProps = {
   errorMessage: string | undefined
   onCancel: () => void
-  onConfirm: (() => Promise<void>) | (() => undefined)
+  onConfirm: () => void
   confirming?: boolean
   onStepChange: (arg: string) => void
   open: boolean

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -1064,10 +1064,12 @@ export const getEntityHeaders = (
  * https://rest-docs.synapse.org/rest/GET/entity/alias/alias.html
  */
 export const getEntityAlias = (alias: string, accessToken?: string) => {
-  return doGet<EntityId>(
-    ENTITY_ALIAS(alias),
-    accessToken,
-    BackendDestinationEnum.REPO_ENDPOINT,
+  return allowNotFoundError(() =>
+    doGet<EntityId>(
+      ENTITY_ALIAS(alias),
+      accessToken,
+      BackendDestinationEnum.REPO_ENDPOINT,
+    ),
   )
 }
 

--- a/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
+++ b/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
@@ -207,7 +207,7 @@ export class KeyFactory {
   private getKey(...args: any[]): QueryKey {
     return [
       this.accessToken == null
-        ? this.accessToken
+        ? 'anonymous'
         : btoa(String(hashCode(this.accessToken))),
       ...removeTrailingUndefinedElements(args),
     ]

--- a/packages/synapse-react-client/src/synapse-queries/entity/useEntity.ts
+++ b/packages/synapse-react-client/src/synapse-queries/entity/useEntity.ts
@@ -62,7 +62,6 @@ export function useGetEntities(
   options?: UseQueryOptions<Entity[], SynapseClientError>,
 ) {
   const { accessToken, keyFactory } = useSynapseContext()
-  const headerIds = entityHeaders.map(header => header.id).join()
   const queries = useMemo(
     () =>
       entityHeaders.map(header => {
@@ -77,22 +76,12 @@ export function useGetEntities(
               header.id,
               header.versionNumber,
             ),
+          options,
         }
       }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [headerIds],
+    [accessToken, entityHeaders, keyFactory, options],
   )
-  const results = useQueries(queries)
-  const isLoading = results.some(result => result.isLoading)
-  const entities: Entity[] = results
-    .filter(query => query.data !== undefined)
-    .map(query => query.data!)
-  return useMemo(() => {
-    // @ts-ignore
-    if (!isLoading && options?.onSuccess) options.onSuccess(entities)
-    return { isLoading, data: entities }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading, headerIds])
+  return useQueries(queries)
 }
 
 export function useCreateEntity(
@@ -363,7 +352,7 @@ export function useGetEntityPermissions(
 ) {
   const { accessToken, keyFactory } = useSynapseContext()
   return useQuery<UserEntityPermissions | null, SynapseClientError>(
-    keyFactory.getEntityAliasQueryKey(entityId),
+    keyFactory.getEntityPermissionsQueryKey(entityId),
     () => SynapseClient.getEntityPermissions(entityId, accessToken),
     options,
   )

--- a/packages/synapse-react-client/src/synapse-queries/subscription/useSubscription.ts
+++ b/packages/synapse-react-client/src/synapse-queries/subscription/useSubscription.ts
@@ -83,32 +83,25 @@ export function useGetAllSubscriptions(
     queryKeyOverride ?? keyFactory.getAllSubscriptionsQueryKey(query),
     async context => {
       const offset = context.pageParam as number | undefined
-      return await SynapseClient.getAllSubscriptions(
+      const subscriptions = await SynapseClient.getAllSubscriptions(
         accessToken,
         10,
         offset,
         query,
       )
+      subscriptions.results.forEach(subscription => {
+        queryClient.setQueryData(
+          keyFactory.getSubscriptionQueryKey(
+            subscription.objectId,
+            subscription.objectType,
+          ),
+          subscription,
+        )
+      })
+      return subscriptions
     },
     {
       ...options,
-      onSuccess: data => {
-        // Set the query data for each individual subscription that was retrieved
-        data.pages.forEach(subscription => {
-          queryClient.setQueryData(
-            keyFactory.getSubscriptionQueryKey(
-              subscription.objectId,
-              subscription.objectType,
-            ),
-            subscription,
-          )
-        })
-
-        if (options?.onSuccess) {
-          options.onSuccess(data)
-        }
-      },
-
       select: data =>
         ({
           pages: data.pages.flatMap(page => page.results),

--- a/packages/synapse-react-client/src/synapse-queries/user/useUserBundle.ts
+++ b/packages/synapse-react-client/src/synapse-queries/user/useUserBundle.ts
@@ -96,19 +96,23 @@ export function useGetUserProfile(
 
   return useQuery<UserProfile, SynapseClientError>(
     queryKey,
-    () => SynapseClient.getUserProfileById(principalId, accessToken),
+    async () => {
+      const profile = await SynapseClient.getUserProfileById(
+        principalId,
+        accessToken,
+      )
+
+      // If the profile is re-fetched, save it to sessionStorage
+      sessionStorage.setItem(sessionStorageCacheKey, JSON.stringify(profile))
+
+      return profile
+    },
     {
       ...options,
-
       // Use the sessionStorage cache to pre-populate profile data.
       initialData: cachedValue
         ? (JSON.parse(cachedValue) as UserProfile)
         : undefined,
-
-      // If the profile is re-fetched, save it to sessionStorage
-      onSuccess: profile => {
-        sessionStorage.setItem(sessionStorageCacheKey, JSON.stringify(profile))
-      },
     },
   )
 }


### PR DESCRIPTION
- Removed all uses of `onSuccess`, `onSettled`, `onError` query options, which are removed in @tanstack/react-query v5
- Clean up a few cases where we should be using the QueryKey KeyFactory