### PR TITLE
SWC-6545 - Prep tests for react-query upgrade

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.test.tsx
@@ -39,7 +39,7 @@ import {
 import userEvent from '@testing-library/user-event'
 import { MOCK_ACCESS_TOKEN } from '../../../../mocks/MockSynapseContext'
 import * as UserSearchBoxV2Module from '../../../UserSearchBox/UserSearchBoxV2'
-import { SynapseClientError } from '../../../../utils/SynapseClientError'
+import { SynapseClientError } from '../../../../utils'
 import MarkdownSynapse from '../../../Markdown/MarkdownSynapse'
 import * as AccessRequirementListUtils from '../../AccessRequirementListUtils'
 
@@ -141,18 +141,13 @@ const defaultProps: DataAccessRequestAccessorsFilesFormProps = {
   onSubmissionCreated: mockOnSubmissionCreated,
 }
 
-async function renderComponent(
-  props: DataAccessRequestAccessorsFilesFormProps,
-) {
-  let renderResult
-  // We must await asynchronous events for our assertions to pass
-  // eslint-disable-next-line @typescript-eslint/require-await
-  await act(async () => {
-    renderResult = render(<DataAccessRequestAccessorsFilesForm {...props} />, {
-      wrapper: createWrapper(),
-    })
+function renderComponent(props: DataAccessRequestAccessorsFilesFormProps) {
+  const user = userEvent.setup()
+  const component = render(<DataAccessRequestAccessorsFilesForm {...props} />, {
+    wrapper: createWrapper({ withErrorBoundary: true }),
   })
-  return renderResult
+
+  return { user, component }
 }
 
 const DOWNLOAD_DUC_TEMPLATE_TEXT = 'Download DUC Template'
@@ -173,7 +168,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
         { userId: String(MOCK_USER_ID), type: AccessType.GAIN_ACCESS },
       ],
     })
-    await renderComponent(defaultProps)
+    const { user } = renderComponent(defaultProps)
 
     // Verify that only the current user appears
     await screen.findByText(
@@ -214,7 +209,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
     // One remove button should be present for user 2
     const removeAccessorButton = await screen.findByLabelText('Remove user')
 
-    await userEvent.click(removeAccessorButton)
+    await user.click(removeAccessorButton)
 
     // Once again, verify that only the current user appears and no remove buttons appear
     await screen.findByText(
@@ -246,7 +241,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
       ],
     })
 
-    await renderComponent(defaultProps)
+    const { user } = renderComponent(defaultProps)
 
     // Verify that both users appear
     await screen.findByText(
@@ -265,7 +260,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
       name: 'Revoke',
     })
     // Let's revoke user 2's access
-    await userEvent.click(revokeOption)
+    await user.click(revokeOption)
 
     // No remove buttons should be present, because current users cannot be removed as an accessor
     expect(screen.queryByLabelText('Remove user')).not.toBeInTheDocument()
@@ -302,7 +297,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
 
     // Submit the request so we can inspect the request object
     const submitButton = await screen.findByRole('button', { name: 'Submit' })
-    await userEvent.click(submitButton)
+    await user.click(submitButton)
 
     await waitFor(() => {
       expect(mockUpdateDataAccessRequest).toHaveBeenCalled()
@@ -347,14 +342,17 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
       ),
     )
 
-    await expect(renderComponent(defaultProps)).rejects.toThrow(errorMessage)
+    renderComponent(defaultProps)
+
+    const alert = await screen.findByRole('alert')
+    within(alert).getByText(errorMessage)
 
     consoleErrorSpy.mockRestore()
   })
 
   it('should show DUC template and field if required', async () => {
     mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
-    await renderComponent({
+    renderComponent({
       ...defaultProps,
       managedACTAccessRequirement: {
         ...mockManagedACTAccessRequirement,
@@ -366,9 +364,9 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
     await screen.findByRole('button', { name: UPLOAD_DUC_BUTTON_TEXT })
   })
 
-  it('should not show DUC template and field if not required', async () => {
+  it('should not show DUC template and field if not required', () => {
     mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
-    await renderComponent({
+    renderComponent({
       ...defaultProps,
       managedACTAccessRequirement: {
         ...mockManagedACTAccessRequirement,
@@ -386,7 +384,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
 
   it('should show IRB field if required', async () => {
     mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
-    await renderComponent({
+    renderComponent({
       ...defaultProps,
       managedACTAccessRequirement: {
         ...mockManagedACTAccessRequirement,
@@ -397,9 +395,9 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
     await screen.findByRole('button', { name: UPLOAD_IRB_LETTER_BUTTON_TEXT })
   })
 
-  it('should not show IRB field if not required', async () => {
+  it('should not show IRB field if not required', () => {
     mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
-    await renderComponent({
+    renderComponent({
       ...defaultProps,
       managedACTAccessRequirement: {
         ...mockManagedACTAccessRequirement,
@@ -414,7 +412,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
 
   it('should show attachments if required', async () => {
     mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
-    await renderComponent({
+    renderComponent({
       ...defaultProps,
       managedACTAccessRequirement: {
         ...mockManagedACTAccessRequirement,
@@ -425,9 +423,9 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
     await screen.findByRole('button', { name: UPLOAD_ATTACHMENT_BUTTON_TEXT })
   })
 
-  it('should not show attachments if not required', async () => {
+  it('should not show attachments if not required', () => {
     mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
-    await renderComponent({
+    renderComponent({
       ...defaultProps,
       managedACTAccessRequirement: {
         ...mockManagedACTAccessRequirement,
@@ -442,13 +440,13 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
 
   it('should show publications and summary of use for a renewal', async () => {
     mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_RENEWAL)
-    await renderComponent(defaultProps)
+    renderComponent(defaultProps)
     await screen.findByLabelText(PUBLICATIONS_FIELD_LABEL_TEXT)
     await screen.findByLabelText(SUMMARY_OF_USE_FIELD_LABEL_TEXT)
   })
-  it('should not show publications and summary of use for a request', async () => {
+  it('should not show publications and summary of use for a request', () => {
     mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
-    await renderComponent(defaultProps)
+    renderComponent(defaultProps)
 
     expect(
       screen.queryByLabelText(PUBLICATIONS_FIELD_LABEL_TEXT),
@@ -464,7 +462,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
       ...MOCK_DATA_ACCESS_REQUEST,
       accessorChanges: emptyAccessorChanges,
     })
-    await renderComponent(defaultProps)
+    const { user } = renderComponent(defaultProps)
 
     // Verify that the current user appears
     await screen.findByText(
@@ -474,7 +472,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
 
     // Submit the request so we can inspect the request object
     const submitButton = await screen.findByRole('button', { name: 'Submit' })
-    await userEvent.click(submitButton)
+    await user.click(submitButton)
 
     await waitFor(() => {
       expect(mockUpdateDataAccessRequest).toHaveBeenCalled()
@@ -508,7 +506,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
       ...MOCK_DATA_ACCESS_REQUEST,
       accessorChanges: accessorChangesWithDuplicate,
     })
-    await renderComponent(defaultProps)
+    const { user } = renderComponent(defaultProps)
 
     // Verify that each accessor only appears once
     await screen.findByText(
@@ -522,7 +520,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
 
     // Submit the request so we can inspect the request object
     const submitButton = await screen.findByRole('button', { name: 'Submit' })
-    await userEvent.click(submitButton)
+    await user.click(submitButton)
 
     await waitFor(() => {
       expect(mockUpdateDataAccessRequest).toHaveBeenCalled()
@@ -551,7 +549,7 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
 
   it('Shows the AR wiki', async () => {
     mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
-    await renderComponent(defaultProps)
+    renderComponent(defaultProps)
     await screen.findByTestId(MARKDOWN_SYNAPSE_TEST_ID)
     expect(mockMarkdownSynapse).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.test.tsx
@@ -90,7 +90,6 @@ async function setUp(props: ResearchProjectFormProps) {
     name: 'Save changes',
   })
   const cancelButton = await screen.findByRole('button', { name: 'Cancel' })
-  const wiki = screen.queryByTestId(MARKDOWN_SYNAPSE_TEST_ID)
   return {
     component,
     user,
@@ -99,7 +98,6 @@ async function setUp(props: ResearchProjectFormProps) {
     iduInput,
     saveChangesButton,
     cancelButton,
-    wiki,
   }
 }
 
@@ -125,6 +123,12 @@ describe('ResearchProjectForm', () => {
     expect(projectLeadInput).toBeInTheDocument()
     expect(institutionInput).toBeInTheDocument()
     expect(iduInput).not.toBeInTheDocument()
+
+    // Ensure the server data has finished loading by checking that the inputs are not disabled
+    await waitFor(() => {
+      expect(projectLeadInput).not.toBeDisabled()
+      expect(institutionInput).not.toBeDisabled()
+    })
 
     const projectLead = 'My name'
     const institution = 'My institution'
@@ -168,6 +172,13 @@ describe('ResearchProjectForm', () => {
     expect(projectLeadInput).toBeInTheDocument()
     expect(institutionInput).toBeInTheDocument()
     expect(iduInput).toBeInTheDocument()
+
+    // Ensure the server data has finished loading by checking that the inputs are not disabled
+    await waitFor(() => {
+      expect(projectLeadInput).not.toBeDisabled()
+      expect(institutionInput).not.toBeDisabled()
+      expect(iduInput).not.toBeDisabled()
+    })
 
     const projectLead = 'My name'
     const institution = 'My institution'
@@ -292,11 +303,12 @@ describe('ResearchProjectForm', () => {
   })
 
   it('Shows the AR wiki', async () => {
-    const { wiki } = await setUp({
+    await setUp({
       ...defaultProps,
     })
 
-    expect(wiki).toBeInTheDocument()
+    await screen.findByTestId(MARKDOWN_SYNAPSE_TEST_ID)
+
     expect(mockMarkdownSynapse).toHaveBeenCalledWith(
       expect.objectContaining({
         wikiId: mockManagedACTAccessRequirementWikiPageKey.wikiPageId,

--- a/packages/synapse-react-client/src/components/Authentication/Login.test.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/Login.test.tsx
@@ -111,8 +111,12 @@ describe('StandaloneLoginForm', () => {
     )
     expect(callback).not.toHaveBeenCalled()
 
-    const otpInputs = await screen.findAllByRole('textbox')
-    expect(otpInputs).toHaveLength(6)
+    let otpInputs: HTMLElement[] = []
+
+    await waitFor(() => {
+      otpInputs = screen.getAllByRole('textbox')
+      expect(otpInputs).toHaveLength(6)
+    })
     for (let i = 0; i < otpInputs.length; i++) {
       await userEvent.type(otpInputs[i], String(i + 1))
     }
@@ -164,7 +168,7 @@ describe('StandaloneLoginForm', () => {
     )
     expect(callback).not.toHaveBeenCalled()
 
-    await userEvent.click(screen.getByText('Use a backup code instead'))
+    await userEvent.click(await screen.findByText('Use a backup code instead'))
 
     const recoveryCode = 'abcd-1234-zxcv-5678'
     const recoveryCodeInput = await screen.findByRole('textbox')

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.test.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.test.tsx
@@ -4,6 +4,7 @@ import {
   render,
   RenderResult,
   screen,
+  waitFor,
   within,
 } from '@testing-library/react'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
@@ -117,20 +118,21 @@ describe('ChallengeTeamWizard tests', () => {
   })
 
   it('Selects the Team', async () => {
-    const { container } = await renderComponent(defaultProps)
-    console.log({ container })
+    await renderComponent(defaultProps)
     const btn = await screen.findByRole('button', { name: 'Next' })
     expect(btn).toHaveAttribute('disabled')
-    const rows = await screen.findAllByRole('row')
+    let rows: HTMLElement[] = []
+    await waitFor(() => {
+      rows = screen.getAllByRole('row')
+      expect(rows.length).toBeGreaterThan(1)
+    })
     const row = rows[1]
     expect(row).toHaveAttribute('aria-selected', 'false')
-    // const radio = container.querySelector('#src-radio-1')
-    const radio = within(row).getByRole('radio')
+
+    const radio = await within(row).findByRole('radio')
     expect(radio).toHaveAttribute('value', team1.id)
     const ele = radio.parentElement!
-    console.log({ ele })
     await userEvent.click(ele)
-    console.log({ radio })
     expect(row).toHaveAttribute('aria-selected', 'true')
   })
 

--- a/packages/synapse-react-client/src/components/CreateTableViewWizard/CreateTableViewWizard.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/CreateTableViewWizard/CreateTableViewWizard.integration.test.tsx
@@ -198,7 +198,10 @@ describe('CreateTableWizard integration tests', () => {
     expect(screen.getByLabelText('Folders')).not.toBeChecked()
     await user.click(screen.getByLabelText('Folders'))
     expect(screen.getByLabelText('Folders')).toBeChecked()
-    await user.click(screen.getByRole('button', { name: 'Next' }))
+
+    const nextButton = screen.getByRole('button', { name: 'Next' })
+    await waitFor(() => expect(nextButton).not.toBeDisabled())
+    await user.click(nextButton)
 
     // Default columns should be added immediately
     defaultFileViewColumnModels.forEach(cm => {

--- a/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.test.tsx
+++ b/packages/synapse-react-client/src/components/EvaluationFinder/EvaluationFinder.test.tsx
@@ -53,10 +53,11 @@ describe('EvaluationFinder', () => {
     await userEvent.click(nextPageButton)
 
     // Page 2 will be shown
-    evaluationsToSelect = await screen.findAllByRole('checkbox')
-    expect(evaluationsToSelect).toHaveLength(1)
-    expect(nextPageButton).toBeDisabled()
-
+    await waitFor(() => {
+      evaluationsToSelect = screen.getAllByRole('checkbox')
+      expect(evaluationsToSelect).toHaveLength(1)
+      expect(nextPageButton).toBeDisabled()
+    })
     // Go back to page 1
     const previousPageButton = await screen.findByRole('button', {
       name: 'Previous Page',

--- a/packages/synapse-react-client/src/components/FeaturedToolsList/FeaturedToolsList.test.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedToolsList/FeaturedToolsList.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import FeaturedToolsList from './FeaturedToolsList'
 import { QueryResultBundle } from '@sage-bionetworks/synapse-types'
 import syn26344826Json from '../../mocks/query/syn26344826.json'
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
 import SynapseClient from '../../synapse-client'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
@@ -40,7 +40,9 @@ describe('basic tests', () => {
     // We must await asynchronous events for our assertions to pass
     // eslint-disable-next-line @typescript-eslint/require-await
     const { container } = await act(async () => init())
-    expect(container.querySelector('.FeaturedToolCard')).toBeDefined()
-    expect(container.querySelectorAll('.FeaturedToolCard')).toHaveLength(3)
+    await waitFor(() => {
+      expect(container.querySelector('.FeaturedToolCard')).toBeDefined()
+      expect(container.querySelectorAll('.FeaturedToolCard')).toHaveLength(3)
+    })
   })
 })

--- a/packages/synapse-react-client/src/components/Forum/ForumPage.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/Forum/ForumPage.integration.test.tsx
@@ -3,33 +3,12 @@ import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { ForumPage, ForumPageProps } from './ForumPage'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
-import { FORUM, FORUM_THREAD } from '../../utils/APIConstants'
-import {
-  BackendDestinationEnum,
-  getEndpoint,
-} from '../../utils/functions/getEndpoint'
-import { PaginatedResults } from '@sage-bionetworks/synapse-types'
-import { DiscussionThreadBundle } from '@sage-bionetworks/synapse-types'
-import {
-  SubscriptionObjectType,
-  Topic,
-  SubscriptionPagedResults,
-  SubscriberPagedResults,
-} from '@sage-bionetworks/synapse-types'
-import {
-  mockDiscussionThreadBundle,
-  mockDiscussionThreadBundle2,
-} from '../../mocks/discussion/mock_discussion'
+import { SubscriptionObjectType, Topic } from '@sage-bionetworks/synapse-types'
 import { MOCK_ACCESS_TOKEN } from '../../mocks/MockSynapseContext'
-import { rest, server } from '../../mocks/msw/server'
+import { server } from '../../mocks/msw/server'
 import SynapseClient from '../../synapse-client'
-import { PaginatedIds } from '@sage-bionetworks/synapse-types'
 import failOnConsole from 'jest-fail-on-console'
-
-const MOCK_FORUM_ID = 'syn123'
-const MOCK_SUBSCRIPTION_ID = '123'
-
-let serverSideHasSubscribed = false
+import { MOCK_FORUM_ID } from '../../mocks/discussion/mock_discussion'
 
 const defaultProps: ForumPageProps = {
   forumId: MOCK_FORUM_ID,
@@ -45,35 +24,6 @@ const followRequest: Topic = {
 jest.spyOn(SynapseClient, 'postSubscription')
 jest.spyOn(SynapseClient, 'deleteSubscription')
 
-const forumThread: PaginatedResults<DiscussionThreadBundle>[] = [
-  {
-    totalNumberOfResults: 2,
-    results: [mockDiscussionThreadBundle],
-  },
-  {
-    totalNumberOfResults: 2,
-    results: [mockDiscussionThreadBundle2],
-  },
-]
-
-const mockSubscriptionPagedEmptyResult: SubscriptionPagedResults = {
-  results: [],
-  totalNumberOfResults: 0,
-}
-
-const mockSubscriptionPagedResult: SubscriptionPagedResults = {
-  results: [
-    {
-      subscriptionId: MOCK_SUBSCRIPTION_ID,
-      subscriberId: 'syn123',
-      objectId: MOCK_FORUM_ID,
-      objectType: SubscriptionObjectType.FORUM,
-      createdOn: '2022-09-29',
-    },
-  ],
-  totalNumberOfResults: 1,
-}
-
 function renderComponent() {
   render(<ForumPage {...defaultProps} />, {
     wrapper: createWrapper(),
@@ -85,74 +35,7 @@ describe('Forum Table test', () => {
   beforeAll(() => {
     server.listen()
   })
-  beforeEach(() => {
-    server.use(
-      rest.get(
-        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${FORUM_THREAD(
-          MOCK_FORUM_ID,
-        )}`,
-        async (req, res, ctx) => {
-          const offset = req.url.searchParams.get('offset') ?? '0'
-          return res(ctx.status(200), ctx.json(forumThread[parseInt(offset)]))
-        },
-      ),
-      rest.post(
-        `${getEndpoint(
-          BackendDestinationEnum.REPO_ENDPOINT,
-        )}/repo/v1/subscription/list`,
-        async (req, res, ctx) => {
-          const response: SubscriptionPagedResults = serverSideHasSubscribed
-            ? mockSubscriptionPagedResult
-            : mockSubscriptionPagedEmptyResult
-          return res(ctx.status(200), ctx.json(response))
-        },
-      ),
-      rest.post(
-        `${getEndpoint(
-          BackendDestinationEnum.REPO_ENDPOINT,
-        )}/repo/v1/subscription`,
-        async (req, res, ctx) => {
-          serverSideHasSubscribed = true
-          return res(
-            ctx.status(201),
-            ctx.json(mockSubscriptionPagedResult.results[0]),
-          )
-        },
-      ),
-      rest.delete(
-        `${getEndpoint(
-          BackendDestinationEnum.REPO_ENDPOINT,
-        )}/repo/v1/subscription/:id`,
-        async (req, res, ctx) => {
-          serverSideHasSubscribed = false
-          return res(ctx.status(200), ctx.body(''))
-        },
-      ),
-      rest.post(
-        `${getEndpoint(
-          BackendDestinationEnum.REPO_ENDPOINT,
-        )}/repo/v1/subscription/subscribers`,
-        async (req, res, ctx) => {
-          const resp: SubscriberPagedResults = {
-            subscribers: [],
-          }
-          return res(ctx.status(200), ctx.json(resp))
-        },
-      ),
-      rest.get(
-        `${getEndpoint(
-          BackendDestinationEnum.REPO_ENDPOINT,
-        )}${FORUM}/:id/moderators`,
-        async (req, res, ctx) => {
-          const resp: PaginatedIds = {
-            results: [],
-            totalNumberOfResults: 0,
-          }
-          return res(ctx.status(200), ctx.json(resp))
-        },
-      ),
-    )
-  })
+
   afterEach(() => {
     server.resetHandlers()
     jest.clearAllMocks()
@@ -176,7 +59,6 @@ describe('Forum Table test', () => {
 
   it('Has a follow button', async () => {
     // Initially, not subscribed
-    serverSideHasSubscribed = false
 
     renderComponent()
 
@@ -201,7 +83,7 @@ describe('Forum Table test', () => {
     await waitFor(() => {
       expect(SynapseClient.deleteSubscription).toHaveBeenCalledWith(
         MOCK_ACCESS_TOKEN,
-        MOCK_SUBSCRIPTION_ID,
+        expect.any(String),
       )
     })
   })

--- a/packages/synapse-react-client/src/components/Forum/ForumPage.stories.ts
+++ b/packages/synapse-react-client/src/components/Forum/ForumPage.stories.ts
@@ -1,17 +1,21 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { ForumPage } from './ForumPage'
+import { MOCK_FORUM_ID } from '../../mocks/discussion/mock_discussion'
 
 const meta = {
   title: 'Synapse/ForumPage',
   component: ForumPage,
+  parameters: {
+    stack: 'mock',
+  },
 } satisfies Meta
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const ForumPageDemo: Story = {
   args: {
-    forumId: '381943',
-    limit: 20,
+    forumId: MOCK_FORUM_ID,
+    limit: 5,
     onClickLink: () => alert('This functionality has not been implemented yet'),
   },
 }

--- a/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.integration.test.tsx
@@ -30,7 +30,7 @@ const mockFileEntityBundle = mockFileEntityData.bundle
 
 const renderComponent = (
   props: HasAccessProps,
-  wrapperProps?: SynapseContextType,
+  wrapperProps?: Partial<SynapseContextType>,
 ) => {
   return render(<HasAccessV2 {...props} />, {
     wrapper: createWrapper(wrapperProps),
@@ -179,8 +179,7 @@ describe('HasAccess tests', () => {
       )
     })
     it('Handles a file entity where download access is blocked because of missing DOWNLOAD permission, and the user is not signed in', async () => {
-      const wrapperProps: SynapseContextType = {
-        ...MOCK_CONTEXT_VALUE,
+      const wrapperProps: Partial<SynapseContextType> = {
         accessToken: undefined,
       }
       const entityBundle: EntityBundle = {

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.integration.test.tsx
@@ -373,18 +373,22 @@ describe('SynapseTable tests', () => {
 
   it('renders facet controls in the column headers', async () => {
     renderTable()
+
     // there are a total of 13 columns in view, so we expect
     // 13 headers
-    expect(await screen.findAllByRole('columnheader')).toHaveLength(
-      totalColumns,
-    )
+    await waitFor(() => {
+      expect(screen.getAllByRole('columnheader')).toHaveLength(totalColumns)
+    })
+
     // there are five facets for the dataset so there should be 5
     // faceted columns
-    expect(
-      await screen.findAllByRole('button', {
-        name: 'Filter by specific facet',
-      }),
-    ).toHaveLength(5)
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('button', {
+          name: 'Filter by specific facet',
+        }),
+      ).toHaveLength(5)
+    })
   })
 
   it('handle column sort press works', async () => {

--- a/packages/synapse-react-client/src/components/TimelinePlot/TimelinePlotSpeciesSelector.test.tsx
+++ b/packages/synapse-react-client/src/components/TimelinePlot/TimelinePlotSpeciesSelector.test.tsx
@@ -52,11 +52,11 @@ describe('TimelinePlotSpeciesSelector tests', () => {
       .mockResolvedValueOnce(queryResultBundleJson)
 
     await renderTimelineSelector()
-    await waitFor(() =>
-      expect(SynapseClient.getFullQueryTableResults).toHaveBeenCalledTimes(1),
-    )
+    await waitFor(() => {
+      expect(SynapseClient.getFullQueryTableResults).toHaveBeenCalledTimes(1)
+      expect(setSpecies).toHaveBeenCalledWith('Mus musculus')
+    })
     // verify the first row has been selected by default
-    expect(setSpecies).toHaveBeenCalledWith('Mus musculus')
     const dropdown = await screen.findByRole('combobox')
     await userEvent.click(dropdown)
     await userEvent.click(await screen.findByText('Saccharomyces'))

--- a/packages/synapse-react-client/src/components/dataaccess/AccessRequestSubmissionTable.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/AccessRequestSubmissionTable.integration.test.tsx
@@ -164,8 +164,10 @@ describe('Access Request Submission Table tests', () => {
       ),
     })
     await screen.findAllByText('@' + MOCK_USER_NAME_2)
-    screen.getByRole('cell', { name: 'Synapse Access and Compliance Team' })
-    screen.getByRole('cell', {
+    await screen.findByRole('cell', {
+      name: 'Synapse Access and Compliance Team',
+    })
+    await screen.findByRole('cell', {
       name: formatDate(
         dayjs(mockSubmissionSearchResponse.results[0].createdOn),
       ),

--- a/packages/synapse-react-client/src/mocks/discussion/mock_discussion.ts
+++ b/packages/synapse-react-client/src/mocks/discussion/mock_discussion.ts
@@ -11,7 +11,7 @@ import {
   generateDiscussionThreadBundle,
   generateForum,
 } from '../faker/generateDiscussion'
-import { mockProjects } from '../entity/mockProject'
+import mockProject, { mockProjects } from '../entity/mockProject'
 
 export const MOCK_FORUM_ID = '984321189'
 
@@ -29,12 +29,10 @@ const generatedDiscussionThreadBundles = mockForums.flatMap(forum => {
   )
 })
 
-export const MOCK_SUBSCRIPTION_ID = '123'
-
 export const mockDiscussionThreadBundle: DiscussionThreadBundle = {
   id: '999',
   forumId: MOCK_FORUM_ID,
-  projectId: '123',
+  projectId: mockProject.id,
   title: 'mockTitle1',
   createdOn: '2022-09-28',
   createdBy: mockUserProfileData.ownerId,
@@ -53,7 +51,7 @@ export const mockDiscussionThreadBundle: DiscussionThreadBundle = {
 export const mockDiscussionThreadBundle2: DiscussionThreadBundle = {
   ...mockDiscussionThreadBundle,
   id: '888',
-  projectId: '12',
+  projectId: mockProject.id,
   title: 'mockTitle2',
   createdBy: mockUserProfileData2.ownerId,
   numberOfViews: 14,
@@ -67,7 +65,7 @@ export const mockDiscussionReplyBundle: DiscussionReplyBundle = {
   threadId: mockDiscussionThreadBundle.id,
 }
 
-export const mockDiscussionThreadBundles = [
+export const mockDiscussionThreadBundles: DiscussionThreadBundle[] = [
   ...generatedDiscussionThreadBundles,
   mockDiscussionThreadBundle,
   mockDiscussionThreadBundle2,

--- a/packages/synapse-react-client/src/mocks/msw/handlers/discussionHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/discussionHandlers.ts
@@ -1,11 +1,40 @@
 import { rest } from 'msw'
-import { FORUM, THREAD } from '../../../utils/APIConstants'
-import { Forum } from '@sage-bionetworks/synapse-types'
+import { FORUM, FORUM_THREAD, THREAD } from '../../../utils/APIConstants'
+import {
+  CreateDiscussionThread,
+  DiscussionFilter,
+  DiscussionThreadBundle,
+  Forum,
+  PaginatedIds,
+  PaginatedResults,
+} from '@sage-bionetworks/synapse-types'
 import { SynapseApiResponse } from '../handlers'
 import {
   mockDiscussionThreadBundles,
   mockForums,
 } from '../../discussion/mock_discussion'
+import { MOCK_USER_ID } from '../../user/mock_user_profile'
+import { uniqueId } from 'lodash-es'
+import mockProject from '../../entity/mockProject'
+
+const forums: Forum[] = [...mockForums]
+
+const threads: DiscussionThreadBundle[] = [...mockDiscussionThreadBundles]
+
+function getAllThreadsMatchingForum(forumId: string, filter: DiscussionFilter) {
+  return threads
+    .filter(thread => thread.forumId === forumId)
+    .filter(thread => {
+      switch (filter) {
+        case DiscussionFilter.NO_FILTER:
+          return true
+        case DiscussionFilter.DELETED_ONLY:
+          return thread.isDeleted
+        case DiscussionFilter.EXCLUDE_DELETED:
+          return !thread.isDeleted
+      }
+    })
+}
 
 export function getDiscussionHandlers(backendOrigin: string) {
   return [
@@ -15,7 +44,7 @@ export function getDiscussionHandlers(backendOrigin: string) {
         reason: `MSW could not find a mock forum object with ID ${req.params.id}`,
       }
 
-      const match = mockForums.find(f => f.id === req.params.id)
+      const match = forums.find(f => f.id === req.params.id)
       if (match) {
         status = 200
         resp = match
@@ -36,9 +65,7 @@ export function getDiscussionHandlers(backendOrigin: string) {
         }
       }
 
-      const match = mockDiscussionThreadBundles.find(
-        dtb => dtb.id === req.params.id,
-      )
+      const match = threads.find(dtb => dtb.id === req.params.id)
       if (match) {
         status = 200
         resp = match
@@ -46,5 +73,67 @@ export function getDiscussionHandlers(backendOrigin: string) {
 
       return res(ctx.status(status), ctx.json(resp))
     }),
+
+    rest.post(`${backendOrigin}${THREAD}`, async (req, res, ctx) => {
+      const request: CreateDiscussionThread = await req.json()
+
+      const newDiscussionThreadBundle: DiscussionThreadBundle = {
+        id: uniqueId(),
+        forumId: request.forumId,
+        projectId: mockProject.id,
+        title: request.title,
+        createdOn: new Date().toISOString(),
+        createdBy: String(MOCK_USER_ID),
+        modifiedOn: new Date().toISOString(),
+        etag: 'etag',
+        messageKey: 'todo key',
+        numberOfViews: 0,
+        numberOfReplies: 0,
+        lastActivity: new Date().toISOString(),
+        activeAuthors: [String(MOCK_USER_ID)],
+        isEdited: false,
+        isDeleted: false,
+        isPinned: false,
+      }
+
+      threads.push(newDiscussionThreadBundle)
+      return res(ctx.status(201), ctx.json(newDiscussionThreadBundle))
+    }),
+
+    rest.get(
+      `${backendOrigin}${FORUM_THREAD(':forumId')}`,
+      async (req, res, ctx) => {
+        const offsetParam = req.url.searchParams.get('offset')
+        const offset = offsetParam ? parseInt(offsetParam) : 0
+        const limitParam = req.url.searchParams.get('limit')
+        const limit = limitParam ? parseInt(limitParam) : 10
+        const filter: DiscussionFilter =
+          (req.params.filter as DiscussionFilter) ??
+          DiscussionFilter.EXCLUDE_DELETED
+
+        const matchingThreads = getAllThreadsMatchingForum(
+          req.params.forumId as string,
+          filter,
+        )
+
+        const response: SynapseApiResponse<
+          PaginatedResults<DiscussionThreadBundle>
+        > = {
+          results: matchingThreads.slice(offset, offset + limit),
+          totalNumberOfResults: matchingThreads.length,
+        }
+        return res(ctx.status(200), ctx.json(response))
+      },
+    ),
+    rest.get(
+      `${backendOrigin}${FORUM}/:id/moderators`,
+      async (req, res, ctx) => {
+        const resp: PaginatedIds = {
+          results: [String(MOCK_USER_ID)],
+          totalNumberOfResults: 1,
+        }
+        return res(ctx.status(200), ctx.json(resp))
+      },
+    ),
   ]
 }

--- a/packages/synapse-react-client/src/mocks/msw/handlers/subscriptionHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/subscriptionHandlers.ts
@@ -1,57 +1,80 @@
 import { rest } from 'msw'
 import {
+  SortDirection,
+  SubscriberPagedResults,
   Subscription,
   SubscriptionObjectType,
   SubscriptionPagedResults,
   SubscriptionRequest,
+  Topic,
 } from '@sage-bionetworks/synapse-types'
 import { SynapseApiResponse } from '../handlers'
 import { forumSubscriptions, threadSubscriptions } from '../../mockSubscription'
+import { remove, uniqueId } from 'lodash-es'
+import { MOCK_USER_ID } from '../../user/mock_user_profile'
+
+const subscriptions: Subscription[] = [
+  ...forumSubscriptions,
+  ...threadSubscriptions,
+]
+
+function getSubscriptions(
+  objectType?: SubscriptionObjectType,
+  sortDirection: SortDirection = 'ASC',
+  offset = 0,
+  limit = 10,
+  idList?: string[],
+): SubscriptionPagedResults {
+  const allResults = subscriptions
+    .filter(s => {
+      if (objectType) {
+        return s.objectType === objectType
+      }
+      return true
+    })
+    .filter(s => {
+      if (idList) {
+        return idList.includes(s.objectId)
+      }
+      return true
+    })
+    .sort((a, b) => {
+      const val =
+        new Date(b.createdOn).getTime() - new Date(a.createdOn).getTime()
+      return sortDirection === 'ASC' ? val : -1 * val
+    })
+
+  const totalNumberOfResults = allResults.length
+
+  return {
+    results: allResults.slice(offset, offset + limit),
+    totalNumberOfResults,
+  }
+}
 
 export function getSubscriptionHandlers(backendOrigin: string) {
   return [
     rest.get(
       `${backendOrigin}/repo/v1/subscription/all`,
       async (req, res, ctx) => {
-        const objectType = req.url.searchParams.get('objectType')
-        const sortDirection = req.url.searchParams.get('sortDirection')
-        const offset = req.url.searchParams.get('offset')
-        const limit = req.url.searchParams.get('limit')
-        let allResults: Subscription[] = []
-        if (objectType === SubscriptionObjectType.FORUM) {
-          allResults = forumSubscriptions
-        } else if (objectType === SubscriptionObjectType.THREAD) {
-          allResults = threadSubscriptions
-        }
+        const objectType =
+          (req.url.searchParams.get('objectType') as SubscriptionObjectType) ??
+          undefined
+        const sortDirection =
+          (req.url.searchParams.get('sortDirection') as SortDirection) ??
+          undefined
+        const offsetParam = req.url.searchParams.get('offset')
+        const offset = offsetParam ? parseInt(offsetParam) : undefined
+        const limitParam = req.url.searchParams.get('limit')
+        const limit = limitParam ? parseInt(limitParam) : undefined
 
-        const totalResults = allResults.length
-
-        if (sortDirection) {
-          allResults = allResults.sort((a, b) => {
-            const val =
-              new Date(b.createdOn).getTime() - new Date(a.createdOn).getTime()
-            return sortDirection === 'ASC' ? val : -1 * val
-          })
-        }
-
-        let offsetValue = 0
-        let limitValue = undefined
-        if (offset) {
-          offsetValue = parseInt(offset)
-        }
-        if (limit) {
-          limitValue = parseInt(limit)
-        }
-
-        allResults = allResults.slice(
-          offsetValue,
-          offsetValue + (limitValue ?? 0),
-        )
-
-        const resp: SynapseApiResponse<SubscriptionPagedResults> = {
-          results: allResults,
-          totalNumberOfResults: totalResults,
-        }
+        const resp: SynapseApiResponse<SubscriptionPagedResults> =
+          getSubscriptions(
+            objectType ?? undefined,
+            sortDirection,
+            offset,
+            limit,
+          )
 
         return res(ctx.status(200), ctx.json(resp))
       },
@@ -60,23 +83,57 @@ export function getSubscriptionHandlers(backendOrigin: string) {
       `${backendOrigin}/repo/v1/subscription/list`,
       async (req, res, ctx) => {
         const request: SubscriptionRequest = await req.json()
-        const objectType = request.objectType
-        let allResults: Subscription[] = []
-        if (objectType === SubscriptionObjectType.FORUM) {
-          allResults = forumSubscriptions
-        } else if (objectType === SubscriptionObjectType.THREAD) {
-          allResults = threadSubscriptions
+
+        const resp: SynapseApiResponse<SubscriptionPagedResults> =
+          getSubscriptions(
+            request.objectType,
+            request.sortDirection,
+            undefined,
+            undefined,
+            request.idList,
+          )
+
+        return res(ctx.status(200), ctx.json(resp))
+      },
+    ),
+    rest.post(
+      `${backendOrigin}/repo/v1/subscription`,
+      async (req, res, ctx) => {
+        const requestBody: Topic = await req.json()
+
+        const newSubscription: Subscription = {
+          subscriptionId: uniqueId(),
+          subscriberId: String(MOCK_USER_ID),
+          objectId: requestBody.objectId,
+          objectType: requestBody.objectType,
+          createdOn: new Date().toISOString(),
         }
 
-        allResults.filter(sub => request.idList.includes(sub.subscriptionId))
+        subscriptions.push(newSubscription)
+        return res(ctx.status(201), ctx.json(newSubscription))
+      },
+    ),
+    rest.delete(
+      `${backendOrigin}/repo/v1/subscription/:id`,
+      async (req, res, ctx) => {
+        const subscriptionId = req.params.id as string
+        remove(subscriptions, s => s.subscriptionId === subscriptionId)
+        return res(ctx.status(200), ctx.body(''))
+      },
+    ),
+    rest.post(
+      `${backendOrigin}/repo/v1/subscription/subscribers`,
+      async (req, res, ctx) => {
+        const topic: Topic = await req.json()
 
-        const totalResults = allResults.length
+        const matchingSubscriptions = subscriptions.filter(
+          s =>
+            s.objectType === topic.objectType && s.objectId === topic.objectId,
+        )
 
-        const resp: SynapseApiResponse<SubscriptionPagedResults> = {
-          results: allResults,
-          totalNumberOfResults: totalResults,
+        const resp: SubscriberPagedResults = {
+          subscribers: matchingSubscriptions.map(s => s.subscriberId),
         }
-
         return res(ctx.status(200), ctx.json(resp))
       },
     ),

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -1462,7 +1462,7 @@ export const addTeamMemberAsAuthenticatedUserOrAdmin = (
 export function createMembershipInvitation(
   membershipInvitation: CreateMembershipInvitationRequest,
   accessToken: string | undefined,
-): Promise<EntityHeader> {
+): Promise<MembershipInvitation> {
   return doPost(
     `${REPO}/membershipInvitation`,
     membershipInvitation,
@@ -1541,14 +1541,14 @@ export const getMembershipStatus = (
 }
 
 /**
- * Create a membership request and send an email notification to the administrators of the team.
+ * Create a membership request and send an email notification to the administrators of the team. The Team must be specified. Optionally, the creator may include a message and/or expiration date for the request. If no expiration date is specified then the request never expires.
  *
- * @returns a TeamMember if the user is a member of the team, or null if the user is not.
+ * https://rest-docs.synapse.org/rest/POST/membershipRequest.html
  */
 export const createMembershipRequest = (
   membershipRequest: CreateMembershipRequestRequest,
   accessToken?: string,
-): Promise<MembershipRequest | null> => {
+): Promise<MembershipRequest> => {
   const url = `/repo/v1/membershipRequest`
   return doPost<MembershipRequest>(
     url,
@@ -4290,7 +4290,7 @@ export const forumSearch = (
  * https://rest-docs.synapse.org/rest/GET/forum/forumId/threads.html
  */
 
-export const getForumThread = (
+export const getForumThreads = (
   accessToken: string | undefined,
   forumId: string,
   offset: number = 0,
@@ -4301,7 +4301,7 @@ export const getForumThread = (
 ) => {
   const params = new URLSearchParams()
   params.set('offset', offset.toString())
-  params.set('limit', limit?.toString())
+  params.set('limit', limit.toString())
   params.set('sort', sort)
   params.set('ascending', ascending.toString())
   params.set('filter', filter)

--- a/packages/synapse-react-client/src/synapse-queries/forum/useForum.ts
+++ b/packages/synapse-react-client/src/synapse-queries/forum/useForum.ts
@@ -57,7 +57,7 @@ export function useGetForumInfinite(
   >(
     keyFactory.getForumThreadsQueryKey(forumId, limit, sort, ascending, filter),
     async context => {
-      return SynapseClient.getForumThread(
+      return SynapseClient.getForumThreads(
         accessToken,
         forumId,
         context.pageParam,

--- a/packages/synapse-react-client/src/testutils/TestingLibraryUtils.tsx
+++ b/packages/synapse-react-client/src/testutils/TestingLibraryUtils.tsx
@@ -22,7 +22,7 @@ export const createWrapperAndQueryClient = (
   // This is also easier/more reliable than clearing the queryCache after each test.
   // See https://github.com/tannerlinsley/react-query/discussions/1441
   const queryClient = new QueryClient(defaultQueryClientConfig)
-  const wrapperProps = props ?? MOCK_CONTEXT_VALUE
+  const wrapperProps = { ...MOCK_CONTEXT_VALUE, ...props }
   return {
     wrapperFn: function RtlWrapper({ children }: RtlWrapperProps) {
       return (


### PR DESCRIPTION
- Modify many tests so they pass before/after react-query upgrade. Most cases just required waiting for the DOM to update before inspecting elements
- Change test wrapper to merge prop overrides with defaults instead of replacing
- Change ForumPage tests to use MSW
- Configure handlers for discussions and subscriptions
- Fix return type for `SynapseClient.createMembershipInvitation`, `SynapseClient.createMembershipRequest`