### PR TITLE
PORTALS-2937

### DIFF
--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamSearch.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamSearch.tsx
@@ -15,7 +15,6 @@ export const ChallengeTeamSearch = ({
   const width = rowCount > 5 ? 'calc(100% - 8px)' : '100%'
   return (
     <Box
-      component="form"
       sx={{
         p: '4px 4px',
         display: 'flex',


### PR DESCRIPTION
PORTALS-2937

The input field submits the `form` component on enter. This search field doesn't do anything when pressing enter (the search updates on keypress), so I don't think a `form` element is really necessary here