### PR TITLE
PORTALS-2938 - Refactor CreateChallengeTeam component logic, fix missing MembershipInvitation message

### DIFF
--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
@@ -1,31 +1,28 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import StepperDialog, { Step } from '../StepperDialog/StepperDialog'
-
 import {
   ErrorResponse,
-  Team,
   TeamMembershipStatus,
 } from '@sage-bionetworks/synapse-types'
-import { CreateChallengeTeam, CreateTeamRequest } from './CreateChallengeTeam'
+import {
+  CreateChallengeTeam,
+  CreateChallengeTeamHandle,
+} from './CreateChallengeTeam'
 import { SelectChallengeTeam } from './SelectChallengeTeam'
 import { RegistrationSuccessful } from './RegistrationSuccessful'
 import { JoinRequestForm } from './JoinRequestForm'
 import { useSynapseContext } from '../../utils'
 import {
   addTeamMemberAsAuthenticatedUserOrAdmin,
-  createMembershipInvitation,
   createMembershipRequest,
-  createTeam,
-  registerChallengeTeam,
 } from '../../synapse-client'
 import {
   useGetCurrentUserProfile,
   useGetEntityChallenge,
+  useGetMembershipStatus,
   useGetUserSubmissionTeams,
 } from '../../synapse-queries'
 import { ANONYMOUS_PRINCIPAL_ID } from '../../utils/SynapseConstants'
-import { useGetMembershipStatus } from '../../synapse-queries/team/useTeamMembers'
-
 import { Typography } from '@mui/material'
 import { useQueryClient } from '@tanstack/react-query'
 
@@ -91,7 +88,7 @@ const ChallengeTeamWizard: React.FunctionComponent<
   const [loading, setLoading] = useState<boolean>(true)
   const [step, setStep] = useState<Step>(steps.SELECT_YOUR_CHALLENGE_TEAM)
   const [errorMessage, setErrorMessage] = useState<string>()
-  const [selectedTeam, setSelectedTeam] = useState<Team | undefined>()
+  const [selectedTeamId, setSelectedTeamId] = useState<string | undefined>()
   const [createdNewTeam, setCreatedNewTeam] = useState<boolean>(false)
   const [confirming, setConfirming] = useState<boolean>(false)
   const [hasSubmissionTeam, setHasSubmissionTeam] = useState<boolean>(false)
@@ -100,17 +97,9 @@ const ChallengeTeamWizard: React.FunctionComponent<
   const [membershipStatus, setMembershipStatus] = useState<
     Record<string, TeamMembershipStatus>
   >({})
-  const [inviteMembersSuccess, setInviteMembersSuccess] =
-    useState<boolean>(false)
-  const [registerChallengeSuccess, setRegisterChallengeSuccess] =
-    useState<boolean>(false)
-  const [newTeam, setNewTeam] = useState<CreateTeamRequest>({
-    name: '',
-    description: '',
-    message: '',
-    invitees: '',
-  })
   const [joinMessage, setJoinMessage] = useState<string>('')
+
+  const createChallengeTeamRef = useRef<CreateChallengeTeamHandle>(null)
 
   /************************
    * Data population hooks
@@ -145,10 +134,10 @@ const ChallengeTeamWizard: React.FunctionComponent<
 
   const { data: teamMembershipStatus, error: teamMembershipError } =
     useGetMembershipStatus(
-      selectedTeam?.id ?? EMPTY_ID,
+      selectedTeamId ?? EMPTY_ID,
       userProfile?.ownerId ?? EMPTY_ID,
       {
-        enabled: !!selectedTeam && !!userProfile,
+        enabled: !!selectedTeamId && !!userProfile,
       },
     )
 
@@ -172,14 +161,14 @@ const ChallengeTeamWizard: React.FunctionComponent<
    ************************/
 
   const canUserJoinTeam = () => {
-    if (selectedTeam && selectedTeam.id in membershipStatus) {
+    if (selectedTeamId && selectedTeamId in membershipStatus) {
       const {
         canJoin,
         membershipApprovalRequired,
         isMember,
         hasOpenInvitation,
         hasOpenRequest,
-      } = membershipStatus[selectedTeam.id]
+      } = membershipStatus[selectedTeamId]
 
       if (isMember) {
         // User cannot join this team, disable Next button
@@ -230,23 +219,11 @@ const ChallengeTeamWizard: React.FunctionComponent<
     }
   }, [accessToken, userProfile, projectId, challenge])
 
-  /**
-   * When creating a new team, wait for the team to be registered to the challenge
-   * and for invited members to be invited before proceeding to confirmation view.
-   */
-  useEffect(() => {
-    if (inviteMembersSuccess && registerChallengeSuccess) {
-      setConfirming(false)
-      handleStepChange(step.confirmStep as StepsEnum)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [registerChallengeSuccess, inviteMembersSuccess, step])
-
   // Determine the user's eligibility to join the selected team
   useEffect(() => {
     if (
-      selectedTeam &&
-      selectedTeam.id in membershipStatus &&
+      selectedTeamId &&
+      selectedTeamId in membershipStatus &&
       step.id === StepsEnum.SELECT_YOUR_CHALLENGE_TEAM
     ) {
       const { canJoin, errorMessage } = canUserJoinTeam()
@@ -258,26 +235,17 @@ const ChallengeTeamWizard: React.FunctionComponent<
       if (errorMessage) setErrorMessage(errorMessage)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [membershipStatus, selectedTeam, step])
+  }, [membershipStatus, selectedTeamId, step])
 
   /************************
    * Form update handlers
    * *********************/
 
   // SELECT_YOUR_CHALLENGE_TEAM: user has selected an existing challenge team from the table
-  const handleSelectTeam = (team: Team) => {
-    if (team) {
-      // Setting selectedTeam will trigger the useMembershipStatus hook
-      setErrorMessage(undefined)
-      setSelectedTeam(team)
-    }
-  }
-
-  // CREATE_NEW_TEAM: form change handler
-  const handleChangeTeamInfo = (updatedTeam: CreateTeamRequest) => {
-    setNewTeam(updatedTeam)
-    const confirmEnabled = updatedTeam.name.length > 1
-    setStep({ ...step, confirmEnabled })
+  const handleSelectTeam = (teamId: string) => {
+    // Setting selectedTeam will trigger the useMembershipStatus hook
+    setErrorMessage(undefined)
+    setSelectedTeamId(teamId)
   }
 
   /************************
@@ -285,7 +253,7 @@ const ChallengeTeamWizard: React.FunctionComponent<
    * *********************/
 
   // JOIN_REQUEST_FORM: Add user to an existing public team or a team the user has an open invitation to
-  const addUserToTeam = (teamId = selectedTeam?.id) => {
+  const addUserToTeam = (teamId = selectedTeamId) => {
     if (!teamId || !userProfile || !accessToken) return
     setConfirming(true)
     setErrorMessage(undefined)
@@ -313,13 +281,13 @@ const ChallengeTeamWizard: React.FunctionComponent<
 
   // JOIN_REQUEST_FORM: User is requesting to join an existing non-public challenge team
   const handleRequestMembership = async () => {
-    if (userProfile && selectedTeam) {
+    if (userProfile && selectedTeamId) {
       setConfirming(true)
       setStep({ ...step, nextEnabled: false })
       setErrorMessage(undefined)
       await createMembershipRequest(
         {
-          teamId: selectedTeam.id,
+          teamId: selectedTeamId,
           userId: userProfile.ownerId,
           message: joinMessage,
         },
@@ -340,105 +308,20 @@ const ChallengeTeamWizard: React.FunctionComponent<
     }
   }
 
-  // CREATE_NEW_TEAM: Add newly created team to the challenge
-  const handleRegisterChallengeTeam = async (teamId: string | number) => {
-    const msg = 'Error registering challenge team'
-    // console.log({ teamId, challenge })
-    if (teamId && challenge) {
-      setErrorMessage(undefined)
-      setRegisterChallengeSuccess(false)
-      await registerChallengeTeam(
-        {
-          challengeId: challenge.id,
-          teamId: String(teamId),
-        },
-        accessToken,
-      )
-        .then(() => {
-          setRegisterChallengeSuccess(true)
-        })
-        .catch((err: ErrorResponse) => {
-          setErrorMessage(`${msg}: ${err.reason}`)
-          setConfirming(false)
-        })
-    } else {
-      setErrorMessage(`${msg}: Invalid team.`)
-      setConfirming(false)
-    }
-  }
-
-  // CREATE_NEW_TEAM: Invite a comma-delimited list of emails to join the team
-  const handleInviteTeamMembers = async (
-    teamId: string | number,
-    invitees: string,
-  ) => {
-    if (!invitees.length) {
-      setInviteMembersSuccess(true)
-      return
-    }
-    const msg = 'Error inviting members'
-    if (teamId) {
-      setErrorMessage(undefined)
-      setInviteMembersSuccess(false)
-      const emails = invitees.split(',')
-      const errors: string[] = []
-      for (const inviteeEmail of emails) {
-        await createMembershipInvitation(
-          { teamId: String(teamId), inviteeEmail: inviteeEmail.trim() },
-          accessToken,
-        ).catch(() => {
-          errors.push(inviteeEmail.trim())
-        })
-      }
-
-      if (errors.length) {
-        setErrorMessage(`${msg}: ${errors.join(', ')}`)
-        setConfirming(false)
-      } else {
-        setInviteMembersSuccess(true)
-      }
-    } else {
-      setErrorMessage(`${msg}: Invalid team.`)
-      setConfirming(false)
-    }
-  }
-
-  // CREATE_NEW_TEAM: Create a new team to join the challenge
-  const handleCreateTeam = async () => {
-    if (newTeam && newTeam.name && newTeam.name.length > 1) {
-      setStep({ ...step, confirmEnabled: false })
-      setConfirming(true)
-      setErrorMessage(undefined)
-      await createTeam(
-        { name: newTeam.name, description: newTeam.description },
-        accessToken,
-      )
-        .then(response => {
-          setCreatedNewTeam(true)
-          setSelectedTeam(response)
-          // Add newly created team to challenge
-          handleRegisterChallengeTeam(response.id)
-          // Invite emails to new team
-          handleInviteTeamMembers(response.id, newTeam.invitees)
-        })
-        .catch((err: ErrorResponse) => {
-          setConfirming(false)
-          setErrorMessage(`Error creating team: ${err.reason}`)
-          setStep({ ...step, confirmEnabled: true })
-        })
-    }
-  }
-
   const hide = () => {
     setErrorMessage(undefined)
     setCreatedNewTeam(false)
-    setSelectedTeam(undefined)
+    setSelectedTeamId(undefined)
     setStep({ ...step, nextEnabled: false })
     onClose()
   }
 
   const onConfirmHandlerMap: Record<string, () => Promise<void> | void> = {
-    CREATE_NEW_TEAM: handleCreateTeam,
+    CREATE_NEW_TEAM: () => {
+      if (createChallengeTeamRef.current) {
+        createChallengeTeamRef.current.submit()
+      }
+    },
     JOIN_REQUEST_FORM: handleRequestMembership,
     JOIN_REQUEST_SENT: () => {
       hide()
@@ -454,7 +337,9 @@ const ChallengeTeamWizard: React.FunctionComponent<
           <SelectChallengeTeam
             challengeId={challenge.id}
             onCreateTeam={() => handleStepChange(StepsEnum.CREATE_NEW_TEAM)}
-            onSelectTeam={handleSelectTeam}
+            onSelectTeam={team => {
+              handleSelectTeam(team.id)
+            }}
           />
         ) : (
           <></>
@@ -462,7 +347,7 @@ const ChallengeTeamWizard: React.FunctionComponent<
       case StepsEnum.JOIN_REQUEST_FORM:
         return (
           <JoinRequestForm
-            team={selectedTeam}
+            teamId={selectedTeamId}
             joinMessageChange={setJoinMessage}
           />
         )
@@ -478,14 +363,25 @@ const ChallengeTeamWizard: React.FunctionComponent<
         return (
           <RegistrationSuccessful
             createdNewTeam={createdNewTeam}
-            teamName={selectedTeam?.name}
+            teamId={selectedTeamId}
           />
         )
       case StepsEnum.CREATE_NEW_TEAM:
         return (
           <CreateChallengeTeam
-            onChangeTeamInfo={handleChangeTeamInfo}
-            onError={setErrorMessage}
+            ref={createChallengeTeamRef}
+            challengeId={challenge!.id}
+            onCanSubmitChange={canCreateTeam => {
+              setStep(step => ({
+                ...step,
+                confirmEnabled: canCreateTeam,
+              }))
+            }}
+            onFinished={newTeamId => {
+              setCreatedNewTeam(true)
+              setSelectedTeamId(newTeamId)
+              setStep(steps[StepsEnum.REGISTRATION_SUCCESSFUL])
+            }}
           />
         )
       default:

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/CreateChallengeTeam.stories.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/CreateChallengeTeam.stories.tsx
@@ -1,0 +1,85 @@
+import { Meta, StoryObj } from '@storybook/react'
+import getAllChallengeHandlers from '../../mocks/msw/handlers/challengeHandlers'
+import { MOCK_REPO_ORIGIN } from '../../utils/functions/getEndpoint'
+import { getUserProfileHandlers } from '../../mocks/msw/handlers/userProfileHandlers'
+import { SynapseContextConsumer, SynapseContextProvider } from '../../utils'
+import React, { useRef, useState } from 'react'
+import getAllTeamHandlers from '../../mocks/msw/handlers/teamHandlers'
+import {
+  CreateChallengeTeam,
+  CreateChallengeTeamHandle,
+} from './CreateChallengeTeam'
+import { mockChallenge } from '../../mocks/challenge/mockChallenge'
+import { Button } from '@mui/material'
+
+const meta: Meta<typeof CreateChallengeTeam> = {
+  title: 'Synapse/Challenge/CreateChallengeTeam',
+  component: CreateChallengeTeam,
+  parameters: {
+    stack: 'mock',
+    msw: {
+      handlers: [
+        ...getAllTeamHandlers(MOCK_REPO_ORIGIN),
+        ...getAllChallengeHandlers(MOCK_REPO_ORIGIN),
+        ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
+  decorators: [
+    Story => (
+      <SynapseContextConsumer>
+        {context => (
+          <SynapseContextProvider
+            synapseContext={{
+              ...context,
+              accessToken: 'fake token',
+            }}
+          >
+            <Story />
+          </SynapseContextProvider>
+        )}
+      </SynapseContextConsumer>
+    ),
+  ],
+  render: function RenderFn(args) {
+    const [canSubmit, setCanSubmit] = useState(false)
+    const ref = useRef<CreateChallengeTeamHandle>(null)
+
+    return (
+      <>
+        <CreateChallengeTeam
+          {...args}
+          onCanSubmitChange={canSubmit => {
+            setCanSubmit(canSubmit)
+            if (args?.onCanSubmitChange) {
+              args.onCanSubmitChange(canSubmit)
+            }
+          }}
+          ref={ref}
+        />
+        {ref.current && (
+          <Button
+            onClick={() => {
+              ref.current!.submit()
+            }}
+            variant={'contained'}
+            disabled={!canSubmit}
+            sx={{ my: 2 }}
+          >
+            Submit
+          </Button>
+        )}
+      </>
+    )
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  args: {
+    challengeId: mockChallenge.id,
+  },
+}

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/CreateChallengeTeam.test.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/CreateChallengeTeam.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import {
+  CreateChallengeTeam,
+  CreateChallengeTeamHandle,
+  TOO_MANY_INVITEES_ERROR,
+} from './CreateChallengeTeam'
+import {
+  MOCK_CHALLENGE_ID,
+  mockChallengeTeam,
+} from '../../mocks/challenge/mockChallenge'
+import userEvent from '@testing-library/user-event'
+import { mockTeamData } from '../../mocks/team/mockTeam'
+import {
+  ChallengeTeam,
+  MembershipInvitation,
+  Team,
+} from '@sage-bionetworks/synapse-types'
+import { SynapseClientError } from '../../utils'
+import useCreateAndRegisterChallengeTeam from './useCreateAndRegisterChallengeTeam'
+
+jest.mock('./useCreateAndRegisterChallengeTeam')
+
+const mockCreateAndRegisterTeam = jest.fn()
+const mockUseCreateAndRegisterTeam = jest
+  .mocked(useCreateAndRegisterChallengeTeam)
+  .mockReturnValue({
+    createAndRegisterTeam: mockCreateAndRegisterTeam,
+    isPending: false,
+    errors: undefined,
+  })
+
+function renderComponent() {
+  const user = userEvent.setup()
+  const ref = React.createRef<CreateChallengeTeamHandle>()
+  const mockOnCanSubmitChange = jest.fn()
+  const mockOnFinished = jest.fn()
+
+  const component = render(
+    <CreateChallengeTeam
+      ref={ref}
+      challengeId={MOCK_CHALLENGE_ID}
+      onCanSubmitChange={mockOnCanSubmitChange}
+      onFinished={mockOnFinished}
+    />,
+  )
+
+  const nameField = screen.getByRole('textbox', { name: 'Team Name' })
+  const descriptionField = screen.getByRole('textbox', {
+    name: 'Team Description',
+  })
+  const messageField = screen.getByRole('textbox', {
+    name: 'Recruitment Message',
+  })
+  const inviteeField = screen.getByRole('textbox', {
+    name: /Emails/,
+    exact: false,
+  })
+
+  return {
+    user,
+    ref,
+    component,
+    nameField,
+    descriptionField,
+    messageField,
+    inviteeField,
+    mockOnCanSubmitChange,
+    mockOnFinished,
+  }
+}
+
+const TEAM_NAME = 'My challenge submission team'
+const TEAM_DESCRIPTION = 'The description for the new team'
+const RECRUITMENT_MESSAGE = 'Come join my team!'
+const EMAILS_TO_SEND = ['foo@bar.com', 'abc@xyz.com', 'qwerty@ui.op']
+
+const MUTATION_SUCCESS_RESULT: [Team, ChallengeTeam, MembershipInvitation[]] = [
+  mockTeamData,
+  mockChallengeTeam(),
+  [],
+]
+
+describe('CreateChallengeTeam', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('Successfully creates a team', async () => {
+    mockCreateAndRegisterTeam.mockResolvedValue(MUTATION_SUCCESS_RESULT)
+
+    const {
+      ref,
+      user,
+      nameField,
+      descriptionField,
+      messageField,
+      inviteeField,
+      mockOnCanSubmitChange,
+      mockOnFinished,
+    } = renderComponent()
+
+    await user.type(nameField, TEAM_NAME)
+    await user.type(descriptionField, TEAM_DESCRIPTION)
+    await user.type(messageField, RECRUITMENT_MESSAGE)
+    await user.type(inviteeField, EMAILS_TO_SEND.join(', '))
+
+    // Verify that we can submit the form
+    expect(mockOnCanSubmitChange).toHaveBeenLastCalledWith(true)
+
+    // Verify the form has not been submitted yet
+    expect(mockCreateAndRegisterTeam).not.toHaveBeenCalled()
+    expect(mockOnFinished).not.toHaveBeenCalled()
+
+    // Submit the form
+    act(() => {
+      ref.current!.submit()
+    })
+
+    // Verify that the data was passed to the hook, and onFinished was called
+    await waitFor(() => {
+      expect(mockCreateAndRegisterTeam).toHaveBeenCalledTimes(1)
+      expect(mockCreateAndRegisterTeam).toHaveBeenCalledWith(
+        {
+          name: TEAM_NAME,
+          description: TEAM_DESCRIPTION,
+        },
+        MOCK_CHALLENGE_ID,
+        EMAILS_TO_SEND,
+        RECRUITMENT_MESSAGE,
+      )
+      expect(mockOnFinished).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('Prevents submitting the form before a team name is filled in', async () => {
+    const { user, nameField, mockOnCanSubmitChange } = renderComponent()
+
+    // Verify that the form cannot be submitted
+    expect(mockOnCanSubmitChange).toHaveBeenLastCalledWith(false)
+
+    await user.type(nameField, TEAM_NAME)
+
+    // Verify that we can submit the form
+    expect(mockOnCanSubmitChange).toHaveBeenLastCalledWith(true)
+  })
+
+  it('Does not permit inviting more than 3 email addresses', async () => {
+    const { user, nameField, inviteeField, mockOnCanSubmitChange } =
+      renderComponent()
+
+    await user.type(nameField, TEAM_NAME)
+    await user.type(inviteeField, EMAILS_TO_SEND.join(', '))
+
+    // Verify that we can submit the form with 3 email addresses
+    expect(mockOnCanSubmitChange).toHaveBeenLastCalledWith(true)
+
+    // Add another and verify that an error appears
+    await user.type(inviteeField, ', tooMany@emails.net')
+    const alert = await screen.findByRole('alert')
+    within(alert).getByText(TOO_MANY_INVITEES_ERROR)
+  })
+
+  it('Does not call onFinished when the mutation returns an error', async () => {
+    const errorMessage = 'A team with that name already exists, so pick another'
+    const error = new SynapseClientError(
+      400,
+      errorMessage,
+      expect.getState().currentTestName!,
+    )
+    // TODO: Update the hook result to return an error AFTER mockCreateAndRegisterTeam is called
+    mockUseCreateAndRegisterTeam.mockReturnValue({
+      createAndRegisterTeam: mockCreateAndRegisterTeam,
+      isPending: false,
+      errors: [error],
+    })
+    mockCreateAndRegisterTeam.mockImplementation(() => {
+      return Promise.reject(error)
+    })
+
+    const { ref, user, nameField, mockOnCanSubmitChange, mockOnFinished } =
+      renderComponent()
+
+    await user.type(nameField, TEAM_NAME)
+
+    // Verify that we can submit the form
+    expect(mockOnCanSubmitChange).toHaveBeenLastCalledWith(true)
+
+    // Verify the form has not been submitted yet
+    expect(mockCreateAndRegisterTeam).not.toHaveBeenCalled()
+    expect(mockOnFinished).not.toHaveBeenCalled()
+
+    // Submit the form
+    act(() => {
+      ref.current!.submit()
+    })
+
+    // Verify that the data was passed to the hook, and onFinished was NOT called
+    await waitFor(() => {
+      expect(mockCreateAndRegisterTeam).toHaveBeenCalledTimes(1)
+      expect(mockCreateAndRegisterTeam).toHaveBeenCalledWith(
+        {
+          name: TEAM_NAME,
+          description: '',
+        },
+        MOCK_CHALLENGE_ID,
+        [],
+        '',
+      )
+      expect(mockOnFinished).not.toHaveBeenCalled()
+    })
+
+    // Verify the error appears
+    const alert = await screen.findByRole('alert')
+    within(alert).getByText(errorMessage)
+  })
+})

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/CreateChallengeTeam.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/CreateChallengeTeam.tsx
@@ -1,101 +1,191 @@
-import React, { useState } from 'react'
-import { Box, Typography } from '@mui/material'
+import React, { useEffect, useImperativeHandle, useMemo, useState } from 'react'
+import { Alert, Box, Typography } from '@mui/material'
 import TextField from '../TextField'
+import { CreateTeamRequest, Team } from '@sage-bionetworks/synapse-types'
+import useCreateAndRegisterChallengeTeam from './useCreateAndRegisterChallengeTeam'
+import { isEmpty, noop } from 'lodash-es'
+import { parse } from 'papaparse'
 
 type CreateChallengeTeamProps = {
-  onChangeTeamInfo: (update: CreateTeamRequest) => void
-  onError?: (msg: string) => void
+  challengeId: string
+  onCanSubmitChange?: (canSubmit: boolean) => void
+  onFinished?: (teamId: string) => void
 }
 
-export type CreateTeamRequest = {
-  name: string
-  description: string
-  message: string
-  invitees: string
+const INVITEE_LIMIT = 3
+export const TOO_MANY_INVITEES_ERROR =
+  'Please limit the initial number of invited members to three. You may add additional members after the team has been created.'
+
+export type CreateChallengeTeamHandle = {
+  // Allow the parent component to trigger a submit of the form, so this may be embedded in an arbitrary modal.
+  submit: () => void
 }
 
-export const CreateChallengeTeam = ({
-  onChangeTeamInfo,
-  onError,
-}: CreateChallengeTeamProps) => {
-  const [team, setTeam] = useState<CreateTeamRequest>({
-    name: '',
-    description: '',
-    message: '',
-    invitees: '',
-  })
+export const CreateChallengeTeam = React.forwardRef(
+  function CreateChallengeTeam(
+    props: CreateChallengeTeamProps,
+    ref: React.ForwardedRef<CreateChallengeTeamHandle>,
+  ) {
+    const { challengeId, onCanSubmitChange = noop, onFinished = noop } = props
+    const [team, setTeam] = useState<CreateTeamRequest>({
+      name: '',
+      description: '',
+    })
+    const [invitationMessage, setInvitationMessage] = useState('')
+    const [rawInvitees, setRawInvitees] = useState('')
 
-  const handleTeamUpdate = (update: Record<string, string>) => {
-    const updatedTeam: CreateTeamRequest = { ...team, ...update }
-    setTeam(updatedTeam)
-    onChangeTeamInfo(updatedTeam)
-  }
-
-  const handleInviteesUpdate = (inviteeString: string) => {
-    const invitees = inviteeString.split(',')
-    if (invitees.length > 3) {
-      if (onError)
-        return onError(
-          'Please limit the initial number of invited members to three. You may add additional members after the team has been created.',
-        )
+    const handleTeamUpdate = (update: Partial<Team>) => {
+      const updatedTeam: CreateTeamRequest = { ...team, ...update }
+      setTeam(updatedTeam)
     }
-    handleTeamUpdate({ invitees: inviteeString })
-  }
 
-  return (
-    <Box>
-      <Typography variant="body1" sx={{ lineHeight: '20px' }}>
-        Create a new team for this Challenge!
-      </Typography>
-      <TextField
-        id="name"
-        label="Team Name"
-        value={team.name}
-        fullWidth
-        autoFocus
-        required
-        onChange={event => handleTeamUpdate({ name: event.target.value })}
-      />
-      <Box display="flex">
+    const { inviteesParseResult, parsedInvitees } = useMemo(() => {
+      const inviteesParseResult = parse<string[]>(rawInvitees, {
+        delimiter: ',',
+        transform(value) {
+          return value.trim()
+        },
+      })
+      const parsedInvitees: string[] = inviteesParseResult.data[0] || []
+
+      return { inviteesParseResult, parsedInvitees }
+    }, [rawInvitees])
+
+    const numberOfInvitees = parsedInvitees.length
+    const tooManyInvitees = numberOfInvitees > INVITEE_LIMIT
+
+    const formDataIsValid = Boolean(
+      team && team.name && team.name.length > 1 && !tooManyInvitees,
+    )
+
+    useEffect(() => {
+      onCanSubmitChange(formDataIsValid)
+    }, [formDataIsValid, onCanSubmitChange])
+
+    const {
+      createAndRegisterTeam,
+      isPending: mutationIsPending,
+      errors,
+    } = useCreateAndRegisterChallengeTeam()
+
+    useImperativeHandle(
+      ref,
+      () => {
+        return {
+          submit() {
+            if (!formDataIsValid) {
+              console.warn(
+                'Attempted to submit when form data was not valid. Nothing will happen.',
+              )
+              return
+            }
+            createAndRegisterTeam(
+              team,
+              challengeId,
+              parsedInvitees,
+              invitationMessage,
+            )
+              .then(([newTeam]) => {
+                onFinished(newTeam.id)
+              })
+              .catch(() => {
+                // The hook will return errors, so no need to handle them here
+              })
+          },
+        }
+      },
+      [
+        formDataIsValid,
+        parsedInvitees,
+        createAndRegisterTeam,
+        team,
+        challengeId,
+        invitationMessage,
+        onFinished,
+      ],
+    )
+
+    return (
+      <Box>
+        <Typography variant="body1" sx={{ lineHeight: '20px' }}>
+          Create a new team for this Challenge!
+        </Typography>
         <TextField
-          id="description"
-          label={
-            <Box display="flex" gap={2}>
-              <Box>Team Description</Box>
-            </Box>
-          }
-          value={team.description}
+          id="name"
+          label="Team Name"
+          value={team.name}
           fullWidth
-          multiline
-          rows={4}
-          onChange={event =>
-            handleTeamUpdate({ description: event.target.value })
-          }
+          autoFocus
+          required
+          onChange={event => handleTeamUpdate({ name: event.target.value })}
+          disabled={mutationIsPending}
         />
-      </Box>
-      <Box display="flex">
+        <Box display="flex">
+          <TextField
+            id="description"
+            label={
+              <Box display="flex" gap={2}>
+                <Box>Team Description</Box>
+              </Box>
+            }
+            value={team.description}
+            fullWidth
+            multiline
+            rows={4}
+            onChange={event =>
+              handleTeamUpdate({ description: event.target.value })
+            }
+            disabled={mutationIsPending}
+          />
+        </Box>
+        <Box display="flex">
+          <TextField
+            id="message"
+            label={
+              <Box display="flex" gap={2}>
+                <Box>Recruitment Message</Box>
+              </Box>
+            }
+            value={invitationMessage}
+            fullWidth
+            multiline
+            rows={4}
+            onChange={event => setInvitationMessage(event.target.value)}
+            disabled={mutationIsPending}
+          />
+        </Box>
         <TextField
-          id="message"
-          label={
-            <Box display="flex" gap={2}>
-              <Box>Recruitment Message</Box>
-            </Box>
-          }
-          value={team.message}
+          id="invitees"
+          label="Emails of Additional Members to Invite (max 3)"
+          placeholder="Enter emails separated by comma"
+          value={rawInvitees}
           fullWidth
-          multiline
-          rows={4}
-          onChange={event => handleTeamUpdate({ message: event.target.value })}
+          onChange={event => setRawInvitees(event.target.value)}
+          disabled={mutationIsPending}
         />
+        {(tooManyInvitees ||
+          !isEmpty(inviteesParseResult.errors) ||
+          errors) && (
+          <Alert severity="error">
+            {tooManyInvitees && (
+              <Typography variant={'body1'}>
+                {TOO_MANY_INVITEES_ERROR}
+              </Typography>
+            )}
+            {inviteesParseResult.errors.map((error, index) => (
+              <Typography key={index} variant={'body1'}>
+                {error.message}
+              </Typography>
+            ))}
+            {errors &&
+              errors.map(error => (
+                <Typography key={error.reason} variant={'body1'}>
+                  {error.reason}
+                </Typography>
+              ))}
+          </Alert>
+        )}
       </Box>
-      <TextField
-        id="invitees"
-        label="Emails of Additional Members to Invite (max 3)"
-        placeholder="Enter emails separated by comma"
-        value={team.invitees}
-        fullWidth
-        onChange={event => handleInviteesUpdate(event.target.value)}
-      />
-    </Box>
-  )
-}
+    )
+  },
+)

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/JoinRequestForm.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/JoinRequestForm.tsx
@@ -1,23 +1,41 @@
 import React, { ChangeEvent, useState } from 'react'
-import { Box, TextField, Typography } from '@mui/material'
-import { Team } from '@sage-bionetworks/synapse-types'
+import { Alert, Box, TextField, Typography } from '@mui/material'
+import { useGetTeam } from '../../synapse-queries'
+import { SynapseSpinner } from '../LoadingScreen/LoadingScreen'
 
 type JoinRequestFormProps = {
-  team: Team | undefined
+  teamId: string | undefined
   joinMessageChange: (msg: string) => void
 }
 
 export const JoinRequestForm = ({
-  team,
+  teamId,
   joinMessageChange,
 }: JoinRequestFormProps) => {
   const [message, setMessage] = useState<string>('')
-  if (!team) return null
+  const {
+    data: team,
+    status,
+    error,
+  } = useGetTeam(teamId!, { enabled: !!teamId })
+  if (!teamId) return null
 
   const handleMessageChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const value = event.target.value
     setMessage(value)
     joinMessageChange(value)
+  }
+
+  if (status === 'pending') {
+    return (
+      <Box display="flex" flexDirection="column" gap={1}>
+        <SynapseSpinner />
+      </Box>
+    )
+  }
+
+  if (status === 'error') {
+    return <Alert severity={'error'}>{error.message}</Alert>
   }
 
   return (

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/RegistrationSuccessful.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/RegistrationSuccessful.tsx
@@ -1,23 +1,43 @@
-import { Typography } from '@mui/material'
+import { Alert, Typography } from '@mui/material'
 import { Box } from '@mui/material'
 import React from 'react'
+import { useGetTeam } from '../../synapse-queries'
+import { SynapseSpinner } from '../LoadingScreen/LoadingScreen'
 
 type RegistrationSuccessfulProps = {
   createdNewTeam: boolean
-  teamName: string | undefined
+  teamId: string | undefined
 }
 
 export const RegistrationSuccessful = ({
   createdNewTeam,
-  teamName,
+  teamId,
 }: RegistrationSuccessfulProps) => {
-  if (!teamName) return null
+  const {
+    data: team,
+    status,
+    error,
+  } = useGetTeam(teamId!, { enabled: !!teamId })
+
+  if (!teamId) return null
+
+  if (status === 'pending') {
+    return (
+      <Box display="flex" flexDirection="column" gap={1}>
+        <SynapseSpinner />
+      </Box>
+    )
+  }
+
+  if (status === 'error') {
+    return <Alert severity={'error'}>{error.message}</Alert>
+  }
 
   return (
     <>
       <Typography variant="body1" sx={{ lineHeight: '20px' }}>
         You have successfully {createdNewTeam ? 'created' : 'joined'} team{' '}
-        <b>{teamName}</b> and have been added to this challenge.
+        <b>{team.name}</b> and have been added to this challenge.
       </Typography>
       {createdNewTeam && (
         <Box>

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/useCreateAndRegisterChallengeTeam.test.ts
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/useCreateAndRegisterChallengeTeam.test.ts
@@ -1,0 +1,293 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import useCreateAndRegisterChallengeTeam from './useCreateAndRegisterChallengeTeam'
+import SynapseClient from '../../synapse-client'
+import { MOCK_USER_ID } from '../../mocks/user/mock_user_profile'
+import { uniqueId } from 'lodash-es'
+import { MOCK_ACCESS_TOKEN } from '../../mocks/MockSynapseContext'
+import {
+  ChallengeTeam,
+  CreateChallengeTeamRequest,
+  CreateMembershipInvitationRequest,
+  CreateTeamRequest,
+  MembershipInvitation,
+  Team,
+} from '@sage-bionetworks/synapse-types'
+import { SynapseClientError } from '../../utils'
+
+function render() {
+  const renderedHook = renderHook(() => useCreateAndRegisterChallengeTeam(), {
+    wrapper: createWrapper(),
+  })
+
+  expect(renderedHook.result.current.createAndRegisterTeam).toBeDefined()
+  expect(renderedHook.result.current.isPending).toBe(false)
+  expect(renderedHook.result.current.errors).not.toBeDefined()
+
+  return renderedHook
+}
+const mockCreateTeam = jest.spyOn(SynapseClient, 'createTeam')
+const mockInviteUser = jest.spyOn(SynapseClient, 'createMembershipInvitation')
+const mockRegisterForChallenge = jest.spyOn(
+  SynapseClient,
+  'registerChallengeTeam',
+)
+
+const apiError = new SynapseClientError(
+  400,
+  'Something failed',
+  expect.getState().currentTestName!,
+)
+
+function createTeamSuccessMock(teamRequest: CreateTeamRequest): Promise<Team> {
+  return Promise.resolve({
+    ...teamRequest,
+    id: uniqueId(),
+    etag: 'etag',
+    createdOn: new Date().toISOString(),
+    createdBy: String(MOCK_USER_ID),
+    modifiedOn: new Date().toISOString(),
+    modifiedBy: String(MOCK_USER_ID),
+  })
+}
+
+function inviteUserSuccessMock(
+  invitationRequest: CreateMembershipInvitationRequest,
+): Promise<MembershipInvitation> {
+  return Promise.resolve({
+    ...invitationRequest,
+    id: uniqueId(),
+    createdOn: new Date().toISOString(),
+    createdBy: String(MOCK_USER_ID),
+  })
+}
+
+function registerForChallengeSuccessMock(
+  request: CreateChallengeTeamRequest,
+): Promise<ChallengeTeam> {
+  return Promise.resolve({
+    ...request,
+    id: uniqueId(),
+    etag: 'etag',
+  })
+}
+
+const teamName = 'foobar'
+const challengeId = '456789'
+const inviteeEmails = ['foo@bar.com', 'fake@email.net']
+const message = 'Join my team!'
+
+describe('useCreateAndRegisterChallengeTeam', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('creates a team, registers it for a challenge, and sends invitations to join the team', async () => {
+    mockCreateTeam.mockImplementation(createTeamSuccessMock)
+    mockInviteUser.mockImplementation(inviteUserSuccessMock)
+    mockRegisterForChallenge.mockImplementation(registerForChallengeSuccessMock)
+
+    const { result } = render()
+
+    let responses: Awaited<
+      ReturnType<typeof result.current.createAndRegisterTeam>
+    > | null = null
+    await act(async () => {
+      responses = await result.current.createAndRegisterTeam(
+        { name: teamName },
+        challengeId,
+        inviteeEmails,
+        message,
+      )
+    })
+
+    expect(responses).toBeDefined()
+
+    // Check team creation
+    expect(mockCreateTeam).toHaveBeenCalledWith(
+      { name: teamName },
+      MOCK_ACCESS_TOKEN,
+    )
+    const createdTeam = responses![0]
+    expect(createdTeam.name).toBe(teamName)
+
+    // Check challenge registration
+    expect(mockRegisterForChallenge).toHaveBeenCalledWith(
+      {
+        teamId: createdTeam.id,
+        challengeId,
+      },
+      MOCK_ACCESS_TOKEN,
+    )
+    expect(responses![1]).toEqual(
+      expect.objectContaining({
+        teamId: createdTeam.id,
+        challengeId,
+      }),
+    )
+
+    // Check invitations
+    expect(mockInviteUser).toHaveBeenCalledTimes(inviteeEmails.length)
+    for (const inviteeEmail of inviteeEmails) {
+      expect(mockInviteUser).toHaveBeenCalledWith(
+        {
+          teamId: createdTeam.id,
+          inviteeEmail,
+          message,
+        },
+        MOCK_ACCESS_TOKEN,
+      )
+    }
+    expect(responses![2].length).toBe(inviteeEmails.length)
+  })
+  it('does not send invitations if no emails are specified', async () => {
+    const emptyInviteeEmails: string[] = []
+    mockCreateTeam.mockImplementation(createTeamSuccessMock)
+    mockInviteUser.mockImplementation(inviteUserSuccessMock)
+    mockRegisterForChallenge.mockImplementation(registerForChallengeSuccessMock)
+
+    const { result } = render()
+
+    let responses: Awaited<
+      ReturnType<typeof result.current.createAndRegisterTeam>
+    > | null = null
+    await act(async () => {
+      responses = await result.current.createAndRegisterTeam(
+        { name: teamName },
+        challengeId,
+        emptyInviteeEmails,
+        message,
+      )
+    })
+
+    expect(responses).toBeDefined()
+
+    // Check team creation
+    expect(mockCreateTeam).toHaveBeenCalledWith(
+      { name: teamName },
+      MOCK_ACCESS_TOKEN,
+    )
+    const createdTeam = responses![0]
+    expect(createdTeam.name).toBe(teamName)
+
+    // Check challenge registration
+    expect(mockRegisterForChallenge).toHaveBeenCalledWith(
+      {
+        teamId: createdTeam.id,
+        challengeId,
+      },
+      MOCK_ACCESS_TOKEN,
+    )
+    expect(responses![1]).toEqual(
+      expect.objectContaining({
+        teamId: createdTeam.id,
+        challengeId,
+      }),
+    )
+
+    // Check invitations
+    expect(mockInviteUser).not.toHaveBeenCalled()
+    expect(responses![2].length).toBe(0)
+  })
+  it('returns an error if the team creation fails, and does not attempt registration or invitations', async () => {
+    mockCreateTeam.mockRejectedValue(apiError)
+
+    const { result } = render()
+
+    await act(async () => {
+      await expect(
+        result.current.createAndRegisterTeam(
+          { name: teamName },
+          challengeId,
+          inviteeEmails,
+          message,
+        ),
+      ).rejects.toThrow(apiError)
+    })
+
+    // Check team creation
+    expect(mockCreateTeam).toHaveBeenCalledWith(
+      { name: teamName },
+      MOCK_ACCESS_TOKEN,
+    )
+
+    expect(result.current.errors).toHaveLength(1)
+    expect(result.current.errors![0].status).toBe(apiError.status)
+    expect(result.current.errors![0].message).toBe(apiError.message)
+
+    expect(mockRegisterForChallenge).not.toHaveBeenCalled()
+    expect(mockInviteUser).not.toHaveBeenCalled()
+  })
+
+  it('returns an error if the challenge registration fails, invitations are still sent', async () => {
+    mockCreateTeam.mockImplementation(createTeamSuccessMock)
+    mockInviteUser.mockImplementation(inviteUserSuccessMock)
+    mockRegisterForChallenge.mockRejectedValue(apiError)
+
+    const { result } = render()
+
+    await act(async () => {
+      await expect(
+        result.current.createAndRegisterTeam(
+          { name: teamName },
+          challengeId,
+          inviteeEmails,
+          message,
+        ),
+      ).rejects.toThrow(apiError)
+    })
+
+    // Check team creation
+    expect(mockCreateTeam).toHaveBeenCalledWith(
+      { name: teamName },
+      MOCK_ACCESS_TOKEN,
+    )
+
+    // Check challenge registration
+    expect(mockRegisterForChallenge).toHaveBeenCalled()
+    // Check invitations
+    expect(mockInviteUser).toHaveBeenCalledTimes(inviteeEmails.length)
+
+    await waitFor(() => {
+      expect(result.current.errors).toHaveLength(1)
+      expect(result.current.errors![0].status).toBe(apiError.status)
+      expect(result.current.errors![0].message).toBe(apiError.message)
+    })
+  })
+
+  it('returns an error if invitations fail, challenge registration is still attempted', async () => {
+    mockCreateTeam.mockImplementation(createTeamSuccessMock)
+    mockInviteUser.mockRejectedValue(apiError)
+    mockRegisterForChallenge.mockImplementation(registerForChallengeSuccessMock)
+
+    const { result } = render()
+
+    await act(async () => {
+      await expect(
+        result.current.createAndRegisterTeam(
+          { name: teamName },
+          challengeId,
+          inviteeEmails,
+          message,
+        ),
+      ).rejects.toThrow(apiError)
+    })
+
+    // Check team creation
+    expect(mockCreateTeam).toHaveBeenCalledWith(
+      { name: teamName },
+      MOCK_ACCESS_TOKEN,
+    )
+
+    // Check challenge registration
+    expect(mockRegisterForChallenge).toHaveBeenCalled()
+    // Check invitations
+    expect(mockInviteUser).toHaveBeenCalledTimes(1)
+
+    await waitFor(() => {
+      expect(result.current.errors).toHaveLength(1)
+      expect(result.current.errors![0].status).toBe(apiError.status)
+      expect(result.current.errors![0].message).toBe(apiError.message)
+    })
+  })
+})

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/useCreateAndRegisterChallengeTeam.ts
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/useCreateAndRegisterChallengeTeam.ts
@@ -1,0 +1,110 @@
+import {
+  useCreateTeam,
+  useInviteUserToTeam,
+  useRegisterTeamForChallenge,
+} from '../../synapse-queries'
+import { useCallback, useMemo } from 'react'
+import {
+  ChallengeTeam,
+  CreateTeamRequest,
+  MembershipInvitation,
+  Team,
+} from '@sage-bionetworks/synapse-types'
+import { SynapseClientError } from '../../utils'
+
+/**
+ * Hook that in one call will
+ *  - Create a team
+ *  - Register that team for a challenge
+ *  - Send invitations to join the team to a defined list of email addresses
+ */
+export default function useCreateAndRegisterChallengeTeam() {
+  const {
+    mutateAsync: createTeam,
+    isPending: createTeamIsPending,
+    error: createTeamError,
+  } = useCreateTeam()
+  const {
+    mutateAsync: inviteUserToTeam,
+    isPending: invitationIsPending,
+    error: invitationError,
+  } = useInviteUserToTeam()
+  const {
+    mutateAsync: registerTeamForChallenge,
+    isPending: challengeRegistrationIsPending,
+    error: challengeRegistrationError,
+  } = useRegisterTeamForChallenge()
+
+  // Invite the comma-delimited list of emails to join the team
+  const handleInviteTeamMembers = useCallback(
+    async (
+      teamId: string,
+      inviteeEmails: string[],
+      invitationMessage: string,
+    ) => {
+      const results: MembershipInvitation[] = []
+      // Send the invitations sequentially
+      for (const inviteeEmail of inviteeEmails) {
+        const membershipInvitation = await inviteUserToTeam({
+          teamId: teamId,
+          inviteeEmail: inviteeEmail.trim(),
+          message: invitationMessage,
+        })
+        results.push(membershipInvitation)
+      }
+      return results
+    },
+    [inviteUserToTeam],
+  )
+
+  const createAndRegisterTeam = useCallback(
+    async (
+      teamToCreate: CreateTeamRequest,
+      challengeId: string,
+      invitees: string[],
+      invitationMessage: string,
+    ): Promise<[Team, ChallengeTeam, MembershipInvitation[]]> => {
+      // Create the team
+      const newTeam = await createTeam(teamToCreate)
+
+      // Register for the challenge and invite the team members--we can do these simultaneously
+      const registerPromise = registerTeamForChallenge({
+        teamId: newTeam.id,
+        challengeId,
+      })
+      const sendInvitationsPromise = handleInviteTeamMembers(
+        newTeam.id,
+        invitees,
+        invitationMessage,
+      )
+
+      return Promise.all([
+        Promise.resolve(newTeam),
+        registerPromise,
+        sendInvitationsPromise,
+      ])
+    },
+    [createTeam, handleInviteTeamMembers, registerTeamForChallenge],
+  )
+
+  const errors = useMemo(() => {
+    const hasError =
+      createTeamError || invitationError || challengeRegistrationError
+    const errors = hasError
+      ? [createTeamError, invitationError, challengeRegistrationError].filter(
+          (e): e is SynapseClientError => e != null,
+        )
+      : undefined
+
+    return errors
+  }, [challengeRegistrationError, createTeamError, invitationError])
+
+  return {
+    createAndRegisterTeam,
+    isPending:
+      createTeamIsPending ||
+      invitationIsPending ||
+      challengeRegistrationIsPending,
+    errors,
+  }
+}

--- a/packages/synapse-react-client/src/synapse-queries/challenge/index.ts
+++ b/packages/synapse-react-client/src/synapse-queries/challenge/index.ts
@@ -1,0 +1,1 @@
+export * from './useChallenge'

--- a/packages/synapse-react-client/src/synapse-queries/challenge/useChallenge.ts
+++ b/packages/synapse-react-client/src/synapse-queries/challenge/useChallenge.ts
@@ -1,0 +1,43 @@
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from '@tanstack/react-query'
+import {
+  ChallengeTeam,
+  CreateChallengeTeamRequest,
+} from '@sage-bionetworks/synapse-types'
+import { SynapseClientError, useSynapseContext } from '../../utils'
+import SynapseClient from '../../synapse-client'
+
+export function useRegisterTeamForChallenge(
+  options?: Partial<
+    UseMutationOptions<
+      ChallengeTeam,
+      SynapseClientError,
+      CreateChallengeTeamRequest
+    >
+  >,
+) {
+  const { accessToken, keyFactory } = useSynapseContext()
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    ChallengeTeam,
+    SynapseClientError,
+    CreateChallengeTeamRequest
+  >({
+    ...options,
+    mutationFn: request =>
+      SynapseClient.registerChallengeTeam(request, accessToken),
+    onSuccess: async (data, request, context) => {
+      if (options?.onSuccess) {
+        return options.onSuccess(data, request, context)
+      }
+      await queryClient.invalidateQueries({
+        queryKey: keyFactory.getChallengeTeamListQueryKey(request.challengeId),
+      })
+      return
+    },
+  })
+}

--- a/packages/synapse-react-client/src/synapse-queries/index.ts
+++ b/packages/synapse-react-client/src/synapse-queries/index.ts
@@ -1,3 +1,4 @@
+export * from './challenge'
 export * from './dataaccess'
 export * from './download'
 export * from './entity'

--- a/packages/synapse-react-client/src/synapse-queries/team/useTeam.ts
+++ b/packages/synapse-react-client/src/synapse-queries/team/useTeam.ts
@@ -1,8 +1,12 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import {
+  useMutation,
+  UseMutationOptions,
+  useQuery,
+  UseQueryOptions,
+} from '@tanstack/react-query'
 import SynapseClient from '../../synapse-client'
-import { SynapseClientError } from '../../utils/SynapseClientError'
-import { useSynapseContext } from '../../utils/context/SynapseContext'
-import { Team } from '@sage-bionetworks/synapse-types'
+import { SynapseClientError, useSynapseContext } from '../../utils'
+import { CreateTeamRequest, Team } from '@sage-bionetworks/synapse-types'
 
 export function useGetTeam(
   teamId: string,
@@ -10,9 +14,21 @@ export function useGetTeam(
 ) {
   const { accessToken, keyFactory } = useSynapseContext()
 
-  return useQuery({
+  return useQuery<Team, SynapseClientError>({
     ...options,
     queryKey: keyFactory.getTeamQueryKey(teamId),
     queryFn: () => SynapseClient.getTeam(teamId, accessToken),
+  })
+}
+
+export function useCreateTeam(
+  options?: Partial<
+    UseMutationOptions<Team, SynapseClientError, CreateTeamRequest>
+  >,
+) {
+  const { accessToken } = useSynapseContext()
+  return useMutation<Team, SynapseClientError, CreateTeamRequest>({
+    ...options,
+    mutationFn: team => SynapseClient.createTeam(team, accessToken),
   })
 }

--- a/packages/synapse-react-client/src/synapse-queries/team/useTeamMembers.ts
+++ b/packages/synapse-react-client/src/synapse-queries/team/useTeamMembers.ts
@@ -9,6 +9,8 @@ import SynapseClient, { deleteMemberFromTeam } from '../../synapse-client'
 import { SynapseClientError } from '../../utils/SynapseClientError'
 import { useSynapseContext } from '../../utils/context/SynapseContext'
 import {
+  CreateMembershipInvitationRequest,
+  MembershipInvitation,
   PaginatedResults,
   TeamMember,
   TeamMembershipStatus,
@@ -55,6 +57,28 @@ export function useGetMembershipStatus(
     queryKey: keyFactory.getMembershipStatusQueryKey(teamId, userId),
     queryFn: () =>
       SynapseClient.getMembershipStatus(teamId, userId, accessToken),
+  })
+}
+
+export function useInviteUserToTeam(
+  options?: Partial<
+    UseMutationOptions<
+      MembershipInvitation,
+      SynapseClientError,
+      CreateMembershipInvitationRequest
+    >
+  >,
+) {
+  const { accessToken } = useSynapseContext()
+
+  return useMutation<
+    MembershipInvitation,
+    SynapseClientError,
+    CreateMembershipInvitationRequest
+  >({
+    ...options,
+    mutationFn: invitation =>
+      SynapseClient.createMembershipInvitation(invitation, accessToken!),
   })
 }
 


### PR DESCRIPTION
- Add useCreateAndRegisterChallengeTeam hook to manage creating a team, registering it for the challenge, and inviting members in one step.
 - Update CreateChallengeTeam to internally create and register the challenge team
 - Fix PORTALS-2938 by including the message in the Membership Invitations