### PR TITLE
PORTALS-2915: set max width for observation cards and left align View More button

### DIFF
--- a/packages/synapse-react-client/src/components/CardContainer/CardContainer.tsx
+++ b/packages/synapse-react-client/src/components/CardContainer/CardContainer.tsx
@@ -108,7 +108,7 @@ export function CardContainer(props: CardContainerProps) {
     schema[element.name] = index
   })
   const showViewMoreButton = (applyInitialLimit || hasNextPage) && (
-    <Box display="flex" justifyContent="flex-end">
+    <Box display="flex" justifyContent="flex-start">
       <WideButton
         variant="contained"
         color="secondary"

--- a/packages/synapse-react-client/src/components/CardContainerLogic/CardContainerLogic.stories.ts
+++ b/packages/synapse-react-client/src/components/CardContainerLogic/CardContainerLogic.stories.ts
@@ -55,7 +55,7 @@ export const EmptyResults: Story = {
 
 export const ObservationCard: Story = {
   args: {
-    sql: `SELECT "Observation Submitter Name" as "submitterName", Synapse_id as "submitterUserId", "Observation Time" as "time", "Observation Time Units" as "timeUnits", "Observation Text" as "text", "Observation Type" as "tag" FROM syn26344832 WHERE "Observation Time" IS NOT NULL`,
+    sql: `SELECT * FROM syn51735464`,
     type: OBSERVATION_CARD,
     limit: 3,
   },

--- a/packages/synapse-react-client/src/style/components/row_renderers/_observation-card.scss
+++ b/packages/synapse-react-client/src/style/components/row_renderers/_observation-card.scss
@@ -1,6 +1,8 @@
 @use '../../abstracts/variables' as SRC;
 
 .ObservationCard {
+  max-width: 850px;
+
   &__submitter {
     background-color: SRC.$gray-light;
     padding: 10px 25px;


### PR DESCRIPTION
card | main | feature
:---:|:---:|:---:
observation | <img width="552" alt="main_observation_cards" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/2914cfc9-bf37-4038-8516-9850472968f9"> | <img width="549" alt="feature_observation_cards" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/e81d26b4-48f8-41d3-8033-a909e9bf724b">
dataset | <img width="551" alt="main_dataset_cards" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/9292bd5a-e0ce-4074-be0a-7c521abf2842"> | <img width="551" alt="feature_dataset_cards" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/a8505827-b6a7-4a75-a0db-01894af742c4"> 
study / publication | <img width="554" alt="main_study_publication_cards" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/6cb33d33-347d-411a-b87d-2046cf306f85"> | <img width="550" alt="feature_study_publication_cards" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/033877b8-6ee5-4597-a435-7fe041ea7c9b">