### PR TITLE
PORTALS-2982: make TOC 'sticky', but prevent overflow in digitalhealth detail pages

### DIFF
--- a/apps/portals/src/portal-components/DetailsPage/_DetailsPage.scss
+++ b/apps/portals/src/portal-components/DetailsPage/_DetailsPage.scss
@@ -78,8 +78,8 @@ $svg-icon-height: 30px;
 
   .component-container {
     flex: 4;
-    // TODO: PORTALS-2982: Find alternative to overflow: hidden ?
-    overflow: hidden;
+    // PORTALS-2982: make TOC "sticky", but prevent overflow in digitalhealth detail pages
+    min-width: 0;
     [role='heading'] {
       padding-top: 30px;
     }


### PR DESCRIPTION
Digital Health detail pages are not overflowing --

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/2c0ea938-dd3c-4a91-9005-0ec359f0e35e

but TOC is still sticky in Challenge portal -- 

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/0d62d9b1-1ed4-4c48-a5cf-d9567b2bbf44

