### PR TITLE
Tweak no-unused-vars rule to allow vars starting with underscore

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -60,6 +60,16 @@ module.exports = {
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-extra-semi": "warn",
+    // Allow unused vars that start with an underscore
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ]
   },
   overrides: [
     {


### PR DESCRIPTION
e.g. the function `([_a, b]) => b` will no longer show a lint warning