### PR TITLE
SWC-6725, SWC-6722, SWC-6674 - Fix table cache issues

### DIFF
--- a/packages/synapse-react-client/src/components/CertificationQuiz/CertificationQuiz.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/CertificationQuiz/CertificationQuiz.integration.test.tsx
@@ -25,6 +25,7 @@ import { useGetCurrentUserBundle } from '../../synapse-queries/user/useUserBundl
 import { mockUserBundle } from '../../mocks/user/mock_user_profile'
 import { formatDate } from '../../utils/functions/DateFormatter'
 import dayjs from 'dayjs'
+import { noop } from 'lodash-es'
 
 window.open = jest.fn()
 jest.mock('../../synapse-queries/user/useCertificationQuiz', () => {
@@ -47,7 +48,7 @@ const mockUseGetCurrentUserBundle = useGetCurrentUserBundle as jest.Mock
 
 const mockToastFn = jest
   .spyOn(ToastMessage, 'displayToast')
-  .mockImplementation(() => {})
+  .mockImplementation(() => noop)
 const gettingStartedUrl =
   'https://help.synapse.org/docs/Getting-Started.2055471150.html'
 

--- a/packages/synapse-react-client/src/components/MissingQueryResultsWarning/MissingQueryResultsWarning.tsx
+++ b/packages/synapse-react-client/src/components/MissingQueryResultsWarning/MissingQueryResultsWarning.tsx
@@ -1,8 +1,8 @@
 import { WarningSharp } from '@mui/icons-material'
 import React from 'react'
 import { SynapseConstants } from '../../utils'
-import { isDataset } from '../../utils/functions/EntityTypeUtils'
-import useGetQueryResultBundle from '../../synapse-queries/entity/useGetQueryResultBundle'
+import { isEntityRefCollectionView } from '../../utils/functions/EntityTypeUtils'
+import { useGetQueryResultBundleWithAsyncStatus } from '../../synapse-queries'
 import { QueryBundleRequest, Table } from '@sage-bionetworks/synapse-types'
 import { Typography } from '@mui/material'
 import { HelpPopover } from '../HelpPopover/HelpPopover'
@@ -26,9 +26,9 @@ export type MissingQueryResultsWarningProps = {
 const MissingQueryResultsWarning: React.FunctionComponent<
   MissingQueryResultsWarningProps
 > = ({ entity }) => {
-  // Currently, Datasets are the only table type for which we can reliably get this info.
+  // Currently, Datasets and Dataset collections are the only table type for which we can reliably get this info.
   // Other cases will need a new service, tracked by PLFM-7046
-  const isMissingResultsCalculable = entity && isDataset(entity)
+  const isMissingResultsCalculable = entity && isEntityRefCollectionView(entity)
 
   const request: QueryBundleRequest = {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
@@ -43,15 +43,18 @@ const MissingQueryResultsWarning: React.FunctionComponent<
     partMask: SynapseConstants.BUNDLE_MASK_QUERY_COUNT,
   }
 
-  const { data: queryResult } = useGetQueryResultBundle(request, {
-    enabled: isMissingResultsCalculable,
-  })
+  const { data: queryResult } = useGetQueryResultBundleWithAsyncStatus(
+    request,
+    {
+      enabled: isMissingResultsCalculable,
+    },
+  )
   if (isMissingResultsCalculable && queryResult && entity) {
-    const totalVisibleResults = queryResult.queryCount!
+    const totalVisibleResults = queryResult.responseBody!.queryCount!
     const totalResults = entity.items?.length ?? 0
 
     if (totalVisibleResults === totalResults) {
-      // All of the results are visible, so there is no need to show a warning.
+      // All the results are visible, so there is no need to show a warning.
       return <></>
     }
 

--- a/packages/synapse-react-client/src/components/OAuthClientManagement/CreateOAuthClient.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/OAuthClientManagement/CreateOAuthClient.integration.test.tsx
@@ -20,10 +20,11 @@ import {
 } from '../../utils/functions/getEndpoint'
 import { WarningDialog } from '../SynapseForm/WarningDialog'
 import SynapseClient from '../../synapse-client'
+import { noop } from 'lodash-es'
 
 const mockToastFn = jest
   .spyOn(ToastMessage, 'displayToast')
-  .mockImplementation(() => {})
+  .mockImplementation(() => noop)
 jest.mock('../../../src/components/SynapseForm/WarningDialog', () => ({
   WarningDialog: jest.fn().mockImplementation(() => {
     return <div></div>

--- a/packages/synapse-react-client/src/components/QueryVisualizationWrapper/NoContentPlaceholder.tsx
+++ b/packages/synapse-react-client/src/components/QueryVisualizationWrapper/NoContentPlaceholder.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { NoContentPlaceholderType } from '../SynapseTable'
+import SearchResultsNotFound from '../SynapseTable/SearchResultsNotFound'
+import ThisTableIsEmpty from '../SynapseTable/TableIsEmpty'
+import NoContentAvailable from '../SynapseTable/NoContentAvailable'
+
+type NoContentPlaceholderProps = {
+  type: NoContentPlaceholderType
+  hasResettableFilters: boolean
+}
+
+export default function NoContentPlaceholder(props: NoContentPlaceholderProps) {
+  const { type, hasResettableFilters } = props
+  switch (type) {
+    case NoContentPlaceholderType.INTERACTIVE:
+      if (hasResettableFilters) {
+        return <SearchResultsNotFound />
+      } else {
+        return <ThisTableIsEmpty />
+      }
+    case NoContentPlaceholderType.HIDDEN:
+      return <></>
+    case NoContentPlaceholderType.STATIC:
+    default:
+      return <NoContentAvailable />
+  }
+}

--- a/packages/synapse-react-client/src/components/QueryVisualizationWrapper/QueryVisualizationWrapper.tsx
+++ b/packages/synapse-react-client/src/components/QueryVisualizationWrapper/QueryVisualizationWrapper.tsx
@@ -7,17 +7,15 @@ import React, {
   useState,
 } from 'react'
 import { useDeepCompareMemoize } from 'use-deep-compare-effect'
-import { useQueryContext } from '../QueryContext/QueryContext'
-import NoContentAvailable from '../SynapseTable/NoContentAvailable'
-import { NoContentPlaceholderType } from '../SynapseTable/NoContentPlaceholderType'
-import SearchResultsNotFound from '../SynapseTable/SearchResultsNotFound'
-import ThisTableIsEmpty from '../SynapseTable/TableIsEmpty'
+import { useQueryContext } from '../QueryContext'
+import { NoContentPlaceholderType } from '../SynapseTable'
 import { unCamelCase } from '../../utils/functions/unCamelCase'
 import { ColumnType } from '@sage-bionetworks/synapse-types'
 import { getDisplayValue } from '../../utils/functions/getDataFromFromStorage'
 import useMutuallyExclusiveState from '../../utils/hooks/useMutuallyExclusiveState'
 import { useAtomValue } from 'jotai'
 import { tableQueryDataAtom } from '../QueryWrapper/QueryWrapper'
+import NoContentPlaceholderComponent from './NoContentPlaceholder'
 
 type ColumnOrFacetHelpConfig = {
   /** Text that describes the column or facet */
@@ -229,21 +227,15 @@ export function QueryVisualizationWrapper(
     [helpConfiguration],
   )
 
-  const NoContentPlaceholder = useCallback(() => {
-    switch (noContentPlaceholderType) {
-      case NoContentPlaceholderType.INTERACTIVE:
-        if (hasResettableFilters) {
-          return <SearchResultsNotFound />
-        } else {
-          return <ThisTableIsEmpty />
-        }
-      case NoContentPlaceholderType.HIDDEN:
-        return <></>
-      case NoContentPlaceholderType.STATIC:
-      default:
-        return <NoContentAvailable />
-    }
-  }, [noContentPlaceholderType, hasResettableFilters])
+  const NoContentPlaceholder = useCallback(
+    () => (
+      <NoContentPlaceholderComponent
+        type={noContentPlaceholderType}
+        hasResettableFilters={hasResettableFilters}
+      />
+    ),
+    [noContentPlaceholderType, hasResettableFilters],
+  )
 
   const context: QueryVisualizationContextType = useMemo(
     () => ({

--- a/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/SchemaDrivenAnnotationsEditor.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/SchemaDrivenAnnotationsEditor.integration.test.tsx
@@ -31,7 +31,7 @@ import { SynapseContextType } from '../../utils/context/SynapseContext'
 import mockFileEntity from '../../mocks/entity/mockFileEntity'
 import { mockSchemaBinding, mockValidationSchema } from '../../mocks/mockSchema'
 import { rest, server } from '../../mocks/msw/server'
-import { cloneDeep } from 'lodash-es'
+import { cloneDeep, noop } from 'lodash-es'
 
 async function chooseAutocompleteOption(el: HTMLElement, option: string) {
   await userEvent.clear(el)
@@ -41,7 +41,7 @@ async function chooseAutocompleteOption(el: HTMLElement, option: string) {
 
 const mockToastFn = jest
   .spyOn(ToastMessage, 'displayToast')
-  .mockImplementation(() => {})
+  .mockImplementation(() => noop)
 
 const mockAsyncTokenId = 888888
 

--- a/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
+++ b/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
@@ -1,24 +1,23 @@
 import React, { useEffect, useMemo } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import {
+  defaultQueryClientConfig,
+  SynapseClientError,
   SynapseContextProvider,
   SynapseContextType,
-} from '../utils/context/SynapseContext'
+} from '../utils'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import SynapseClient from '../synapse-client'
-import { SynapseToastContainer } from './ToastMessage/ToastMessage'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import dayjs from 'dayjs'
-import {
+import SynapseClient, {
   getAccessTokenFromCookie,
   getAuthenticatedOn,
   getUserProfile,
   signOut,
-} from '../synapse-client/SynapseClient'
-import { SynapseClientError } from '../utils/SynapseClientError'
+} from '../synapse-client'
+import { SynapseToastContainer } from './ToastMessage'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import dayjs from 'dayjs'
 import { STACK_MAP, SynapseStack } from '../utils/functions/getEndpoint'
 import useDetectSSOCode from '../utils/hooks/useDetectSSOCode'
-import { defaultQueryClientConfig } from '../utils/context/FullContextProvider'
 
 export async function sessionChangeHandler() {
   let accessToken: string | undefined = await getAccessTokenFromCookie()
@@ -54,7 +53,6 @@ function overrideEndpoint(stack: SynapseStack) {
   ;(window as any)['SRC'] = {
     OVERRIDE_ENDPOINT_CONFIG: endpointConfig,
   }
-  storybookQueryClient.resetQueries()
 }
 
 /**
@@ -99,12 +97,11 @@ export function StorybookComponentWrapper(props: {
   useEffect(() => {
     async function resetCache() {
       await storybookQueryClient.cancelQueries()
-      storybookQueryClient.removeQueries()
-      await storybookQueryClient.invalidateQueries()
+      await storybookQueryClient.resetQueries()
     }
 
-    resetCache()
-  }, [accessToken])
+    void resetCache()
+  }, [accessToken, currentStack])
 
   const synapseContext: Partial<SynapseContextType> = useMemo(
     () => ({

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.integration.test.tsx
@@ -52,6 +52,7 @@ import { mockFileViewEntity } from '../../mocks/entity/mockFileView'
 import { mockProjectViewEntity } from '../../mocks/entity/mockProjectView'
 import { mockDatasetEntity } from '../../mocks/entity/mockDataset'
 import { mockQueryResult } from '../../mocks/query/mockProjectViewQueryResults'
+import * as NoContentPlaceholderModule from '../QueryVisualizationWrapper/NoContentPlaceholder'
 
 const synapseTableEntityId = 'syn16787123'
 
@@ -142,6 +143,9 @@ jest.spyOn(UserCardModule, 'default').mockImplementation(() => {
 
 jest.spyOn(AddToDownloadListV2Module, 'default').mockImplementation(() => {
   return <div data-testid="AddToDownloadListV2" />
+})
+jest.spyOn(NoContentPlaceholderModule, 'default').mockImplementation(() => {
+  return <div data-testid="NoContentPlaceholder" />
 })
 
 describe('SynapseTable tests', () => {
@@ -607,5 +611,36 @@ describe('SynapseTable tests', () => {
     // Verify that the ID column contains the icon button with the help text
     const columnHeader = await screen.findByRole('columnheader', { name: 'Id' })
     within(columnHeader).getByRole('button', { name: helpText })
+  })
+
+  it('Shows NoContentPlaceholder when there are no results', async () => {
+    const queryResultBundleWithNoRows: QueryResultBundle = {
+      concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
+      queryCount: 1,
+      selectColumns: [{ name: 'study', columnType: 'STRING' }],
+      columnModels: [
+        {
+          id: '1',
+          name: 'study',
+          columnType: 'STRING',
+        },
+      ],
+      lastUpdatedOn: '2023-08-28T07:27:00.667Z',
+      queryResult: {
+        concreteType: 'org.sagebionetworks.repo.model.table.QueryResult',
+        queryResults: {
+          concreteType: 'org.sagebionetworks.repo.model.table.RowSet',
+          tableId: MOCK_TABLE_ENTITY_ID,
+          etag: '53e1e27a-dbf3-4db3-acd1-dafca30b894c',
+          headers: [{ name: 'study', columnType: 'STRING' }],
+          rows: [],
+        },
+      },
+    }
+    server.use(...getHandlersForTableQuery(queryResultBundleWithNoRows))
+
+    renderTable()
+
+    await screen.findByTestId('NoContentPlaceholder')
   })
 })

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
@@ -209,8 +209,11 @@ export function SynapseTable(props: SynapseTableProps) {
     return <></>
   }
   const hasResults = (data.queryResult?.queryResults.rows.length ?? 0) > 0
-  // Show the No Results UI if the current page has no rows, and this is the first page of data (offset === 0).
-  if (!hasResults && queryRequest.query.offset === 0) {
+  // Show the No Results UI if the current page has no rows, and this is the first page of data (offset === 0 or null/undefined).
+  if (
+    !hasResults &&
+    (queryRequest.query.offset === 0 || queryRequest.query.offset == null)
+  ) {
     return <NoContentPlaceholder />
   }
 

--- a/packages/synapse-react-client/src/components/SynapseTable/datasets/DatasetItemsEditor.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/datasets/DatasetItemsEditor.integration.test.tsx
@@ -5,7 +5,7 @@ import {
   waitForElementToBeRemoved,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { cloneDeep } from 'lodash-es'
+import { cloneDeep, noop } from 'lodash-es'
 import React from 'react'
 import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
 import {
@@ -14,14 +14,11 @@ import {
   getCopy,
 } from './DatasetItemsEditor'
 import * as ToastMessageModule from '../../ToastMessage/ToastMessage'
-import { displayToast } from '../../ToastMessage/ToastMessage'
+import { displayToast } from '../../ToastMessage'
 import { createWrapper } from '../../../testutils/TestingLibraryUtils'
 import { ENTITY_ID } from '../../../utils/APIConstants'
-import {
-  BackendDestinationEnum,
-  getEndpoint,
-} from '../../../utils/functions/getEndpoint'
-import { SynapseContextType } from '../../../utils/context/SynapseContext'
+import { BackendDestinationEnum, getEndpoint } from '../../../utils/functions'
+import { SynapseContextType } from '../../../utils'
 import {
   EntityRef,
   EntityType,
@@ -52,7 +49,9 @@ jest.mock(
       children({ height: 450, width: 1200 }),
 )
 
-jest.spyOn(ToastMessageModule, 'displayToast').mockImplementation(() => {})
+jest.spyOn(ToastMessageModule, 'displayToast').mockImplementation(() => {
+  return noop
+})
 
 const mockFileReference: Reference = {
   targetId: mockFileEntity.id!,

--- a/packages/synapse-react-client/src/components/SynapseTable/datasets/DatasetItemsEditor.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/datasets/DatasetItemsEditor.tsx
@@ -7,7 +7,7 @@ import BaseTable, {
 import { isEqual, upperFirst } from 'lodash-es'
 import pluralize from 'pluralize'
 import React, { useEffect, useMemo, useState } from 'react'
-import { SkeletonTable } from '../../Skeleton/SkeletonTable'
+import { SkeletonTable } from '../../Skeleton'
 import {
   convertToEntityType,
   entityTypeToFriendlyName,
@@ -18,15 +18,15 @@ import {
   useGetEntity,
   useGetEntityPath,
   useUpdateEntity,
-} from '../../../synapse-queries/entity/useEntity'
-import { useSet } from '../../../utils/hooks/useSet'
+} from '../../../synapse-queries'
+import { useSet } from '../../../utils/hooks'
 import {
   EntityRef,
   EntityRefCollectionView,
   EntityType,
   Reference,
 } from '@sage-bionetworks/synapse-types'
-import { RequiredProperties } from '../../../utils/types/RequiredProperties'
+import { RequiredProperties } from '../../../utils'
 import {
   BadgeIconsRenderer,
   CellRendererProps,
@@ -44,7 +44,7 @@ import { FinderScope } from '../../EntityFinder/tree/EntityTree'
 import { VersionSelectionType } from '../../EntityFinder/VersionSelectionType'
 import { BlockingLoader } from '../../LoadingScreen/LoadingScreen'
 import WarningDialog from '../../SynapseForm/WarningDialog'
-import { displayToast } from '../../ToastMessage/ToastMessage'
+import { displayToast } from '../../ToastMessage'
 import { Checkbox } from '../../widgets/Checkbox'
 import WideButton from '../../../components/styled/WideButton'
 
@@ -113,6 +113,72 @@ export function getCopy(entity?: EntityRefCollectionView) {
   }
 }
 
+function getDataSetDifference(
+  oldDataSet: EntityRef[],
+  changedItems: EntityRef[],
+) {
+  const unchangedItems = oldDataSet.filter(
+    oldItem =>
+      !changedItems.find(newItem => newItem.entityId === oldItem.entityId),
+  )
+  const deletedItems = [...unchangedItems]
+  const { updatedItems, newItems } = changedItems.reduce(
+    (results, result) => {
+      const oldItem = oldDataSet.find(old => old.entityId === result.entityId)
+      if (oldItem) {
+        if (result.versionNumber !== oldItem.versionNumber) {
+          results['updatedItems'].push(result)
+        } else {
+          unchangedItems.push(result)
+        }
+      } else {
+        results['newItems'].push(result)
+      }
+      return results
+    },
+    { updatedItems: [], newItems: [] } as {
+      updatedItems: EntityRef[]
+      newItems: EntityRef[]
+    },
+  )
+
+  return { unchangedItems, updatedItems, newItems, deletedItems }
+}
+
+function getDatasetChangedToastMessageTitle(
+  previousDatasetToUpdate?: RequiredProperties<
+    EntityRefCollectionView,
+    'items'
+  >,
+  datasetToUpdate?: RequiredProperties<EntityRefCollectionView, 'items'>,
+) {
+  const { updatedItems, newItems, deletedItems } = getDataSetDifference(
+    previousDatasetToUpdate?.items ?? [],
+    datasetToUpdate?.items!,
+  )
+  let toastTitle = ''
+
+  // "X items(s) deleted"
+  if (deletedItems.length > 0) {
+    toastTitle += `${deletedItems.length} Item${
+      deletedItems.length === 1 ? '' : 's'
+    } removed`
+  } else {
+    // "Y item(s) added"
+    toastTitle += `${newItems.length} Item${
+      newItems.length === 1 ? '' : 's'
+    } added`
+
+    // "and Z item(s) updated", only shown if there are updated items
+    if (updatedItems.length > 0) {
+      toastTitle += ` and ${updatedItems.length} Item${
+        updatedItems.length === 1 ? '' : 's'
+      } updated`
+    }
+  }
+  return toastTitle
+}
+
 export type DatasetItemsEditorProps = {
   /* The synId of the EntityRefCollectionView to modify */
   entityId: string
@@ -140,6 +206,12 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
     useState<RequiredProperties<EntityRefCollectionView, 'items'>>()
   const [previousDatasetToUpdate, setPreviousDatasetToUpdate] =
     useState<RequiredProperties<EntityRefCollectionView, 'items'>>()
+
+  // Stores the `close` function that will be used to hide the last toast that prompted the user to save
+  const [onCloseLastSavePromptToast, setOnCloseLastSavePromptToast] = useState<
+    { close: () => void } | undefined
+  >()
+
   const setDatasetToUpdate = (
     dataset: React.SetStateAction<
       RequiredProperties<EntityRefCollectionView, 'items'> | undefined
@@ -152,7 +224,7 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
   const { data: fetchedDataset, refetch } = useGetEntity<
     RequiredProperties<EntityRefCollectionView, 'items'>
   >(entityId, undefined, {
-    enabled: !datasetToUpdate,
+    staleTime: Infinity,
   })
 
   const {
@@ -172,8 +244,7 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
   } = useMemo(() => getCopy(fetchedDataset), [fetchedDataset])
 
   useEffect(() => {
-    // Don't update when we already have datasetToUpdate
-    if (!datasetToUpdate && fetchedDataset) {
+    if (fetchedDataset) {
       // SWC-5876: Dataset Items may be undefined. This has the same inherent meaning as the empty list, so we'll just change it to save us some null checks.
       if (fetchedDataset.items == null) {
         fetchedDataset.items = []
@@ -181,7 +252,7 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
       setDatasetToUpdate(fetchedDataset)
       setHasChangedSinceLastSave(false)
     }
-  }, [fetchedDataset, datasetToUpdate])
+  }, [fetchedDataset])
 
   const {
     set: selectedIds,
@@ -189,8 +260,8 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
     remove: removeSelectedId,
     clear: clearSelectedIds,
   } = useSet<string>()
-  const allItemsAreSelected = !!(
-    datasetToUpdate && datasetToUpdate.items.length === selectedIds.size
+  const allItemsAreSelected = Boolean(
+    datasetToUpdate && datasetToUpdate.items.length === selectedIds.size,
   )
 
   useEffect(() => {
@@ -199,30 +270,19 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
     }
   }, [hasChangedSinceLastSave, onUnsavedChangesChange])
 
-  useEffect(() => {
-    if (
-      previousDatasetToUpdate &&
-      datasetToUpdate &&
-      !isEqual(previousDatasetToUpdate, datasetToUpdate)
-    ) {
-      const toastMessageTitle = getToastMessageTitle()
-      displayToast(SAVE_TO_CONTINUE, 'info', {
-        title: toastMessageTitle,
-        primaryButtonConfig: {
-          text: SAVE_CHANGES,
-          onClick: () => mutate(datasetToUpdate),
-        },
-      })
-    }
-    setPreviousDatasetToUpdate(datasetToUpdate)
-  }, [datasetToUpdate])
-
   // We get the project ID to show the "Current Project" context in the Entity Finder.
   const { data: path } = useGetEntityPath(entityId)
   const projectId = path?.path[1]?.id
 
   const { mutate, isPending: updateIsPending } =
     useUpdateEntity<EntityRefCollectionView>({
+      onMutate: () => {
+        // Close existing toast that prompted the user to save
+        if (onCloseLastSavePromptToast) {
+          onCloseLastSavePromptToast.close()
+          setOnCloseLastSavePromptToast(undefined)
+        }
+      },
       onSuccess: () => {
         setHasChangedSinceLastSave(false)
         if (onSave) {
@@ -253,6 +313,36 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
       },
     })
 
+  useEffect(() => {
+    // When changes are made (but not saved) to the datasetToUpdate, show a notification that summarizes the change and prompts the user to save
+    if (
+      previousDatasetToUpdate &&
+      datasetToUpdate &&
+      !isEqual(previousDatasetToUpdate.items, datasetToUpdate.items) &&
+      !updateIsPending
+    ) {
+      const toastMessageTitle = getDatasetChangedToastMessageTitle(
+        previousDatasetToUpdate,
+        datasetToUpdate,
+      )
+      // Replace existing toast that prompts the user to save before showing the new one
+      if (onCloseLastSavePromptToast) {
+        onCloseLastSavePromptToast.close()
+      }
+      const onCloseToast = displayToast(SAVE_TO_CONTINUE, 'info', {
+        title: toastMessageTitle,
+        primaryButtonConfig: {
+          text: SAVE_CHANGES,
+          onClick: () => mutate(datasetToUpdate),
+        },
+      })
+      setOnCloseLastSavePromptToast({ close: onCloseToast })
+    }
+    setPreviousDatasetToUpdate(datasetToUpdate)
+    // Only run when datasetToUpdate changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasetToUpdate])
+
   const tableData = datasetToUpdate?.items.map((item: EntityRef) => {
     return {
       ...item,
@@ -264,66 +354,6 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
       },
     }
   })
-
-  function getDataSetDifference(
-    oldDataSet: EntityRef[],
-    changedItems: EntityRef[],
-  ) {
-    const unchangedItems = oldDataSet.filter(
-      oldItem =>
-        !changedItems.find(newItem => newItem.entityId === oldItem.entityId),
-    )
-    const deletedItems = [...unchangedItems]
-    const { updatedItems, newItems } = changedItems.reduce(
-      (results, result) => {
-        const oldItem = oldDataSet.find(old => old.entityId === result.entityId)
-        if (oldItem) {
-          if (result.versionNumber !== oldItem.versionNumber) {
-            results['updatedItems'].push(result)
-          } else {
-            unchangedItems.push(result)
-          }
-        } else {
-          results['newItems'].push(result)
-        }
-        return results
-      },
-      { updatedItems: [], newItems: [] } as {
-        updatedItems: EntityRef[]
-        newItems: EntityRef[]
-      },
-    )
-
-    return { unchangedItems, updatedItems, newItems, deletedItems }
-  }
-
-  function getToastMessageTitle() {
-    const { updatedItems, newItems, deletedItems } = getDataSetDifference(
-      previousDatasetToUpdate?.items!,
-      datasetToUpdate?.items!,
-    )
-    let toastTitle = ''
-
-    // "X items(s) deleted"
-    if (deletedItems.length > 0) {
-      toastTitle += `${deletedItems.length} Item${
-        deletedItems.length === 1 ? '' : 's'
-      } removed`
-    } else {
-      // "Y item(s) added"
-      toastTitle += `${newItems.length} Item${
-        newItems.length === 1 ? '' : 's'
-      } added`
-
-      // "and Z item(s) updated", only shown if there are updated items
-      if (updatedItems.length > 0) {
-        toastTitle += ` and ${updatedItems.length} Item${
-          updatedItems.length === 1 ? '' : 's'
-        } updated`
-      }
-    }
-    return toastTitle
-  }
 
   function addItemsToDataset(itemsToAdd: Reference[]) {
     setDatasetToUpdate(datasetToUpdate => {

--- a/packages/synapse-react-client/src/components/ToastMessage/ToastMessage.tsx
+++ b/packages/synapse-react-client/src/components/ToastMessage/ToastMessage.tsx
@@ -87,7 +87,7 @@ export const displayToast = (
   message: string,
   variant?: 'info' | 'success' | 'warning' | 'danger',
   toastMessageOptions: ToastMessageOptions = {},
-) => {
+): (() => void) => {
   const id = uniqueId('synToast-')
   const onClose = () => {
     toast.dismiss(id)
@@ -151,4 +151,6 @@ export const displayToast = (
       duration: autoCloseInMs,
     },
   )
+
+  return onClose
 }

--- a/packages/synapse-react-client/src/components/download_list/TableQueryDownloadConfirmation.test.tsx
+++ b/packages/synapse-react-client/src/components/download_list/TableQueryDownloadConfirmation.test.tsx
@@ -29,6 +29,7 @@ import {
 import QueryWrapper from '../QueryWrapper'
 import { MOCK_USER_ID } from '../../mocks/user/mock_user_profile'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import { noop } from 'lodash-es'
 
 jest.mock('../../../src/synapse-queries', () => {
   const actual = jest.requireActual('../../../src/synapse-queries')
@@ -53,7 +54,7 @@ const mockDownloadConfirmationUi = jest
 
 const mockToastFn = jest
   .spyOn(ToastMessage, 'displayToast')
-  .mockImplementation(() => {})
+  .mockImplementation(() => noop)
 
 const addFilesToDownloadListResponse: AddToDownloadListResponse = {
   concreteType:

--- a/packages/synapse-react-client/src/synapse-queries/entity/useEntity.ts
+++ b/packages/synapse-react-client/src/synapse-queries/entity/useEntity.ts
@@ -105,14 +105,13 @@ export function useCreateEntity(
     mutationFn: (entity: Entity) =>
       SynapseClient.createEntity(entity, accessToken),
     onSuccess: async (newEntity, variables, ctx) => {
+      const entityDataQueryKey = keyFactory.getEntityQueryKey(newEntity.id!)
+      queryClient.setQueryData(entityDataQueryKey, newEntity)
       await invalidateAllQueriesForEntity(
         queryClient,
         keyFactory,
         newEntity.id!,
-      )
-      queryClient.setQueryData(
-        keyFactory.getEntityQueryKey(newEntity.id!),
-        newEntity,
+        entityDataQueryKey,
       )
 
       if (options?.onSuccess) {
@@ -133,14 +132,13 @@ export function useUpdateEntity<T extends Entity>(
     mutationFn: (entity: T) =>
       SynapseClient.updateEntity<T>(entity, accessToken),
     onSuccess: async (updatedEntity, variables, ctx) => {
+      const entityDataQueryKey = keyFactory.getEntityQueryKey(updatedEntity.id!)
+      queryClient.setQueryData(entityDataQueryKey, updatedEntity)
       await invalidateAllQueriesForEntity(
         queryClient,
         keyFactory,
         updatedEntity.id!,
-      )
-      queryClient.setQueryData(
-        keyFactory.getEntityQueryKey(updatedEntity.id!),
-        updatedEntity,
+        entityDataQueryKey,
       )
 
       if (options?.onSuccess) {
@@ -302,12 +300,18 @@ export function useUpdateViaJson(
     },
     onSuccess: async (data, variables, ctx) => {
       const entityId = data.id
-
-      await invalidateAllQueriesForEntity(queryClient, keyFactory, entityId)
-      queryClient.setQueryData(
-        // This annotation data will never include derived annotations, which are calculated by the backend asynchronously
-        keyFactory.getEntityJsonQueryKey(entityId, undefined, false),
-        data,
+      // This annotation data will never include derived annotations, which are calculated by the backend asynchronously
+      const entityJsonQueryKey = keyFactory.getEntityJsonQueryKey(
+        entityId,
+        undefined,
+        false,
+      )
+      queryClient.setQueryData(entityJsonQueryKey, data)
+      await invalidateAllQueriesForEntity(
+        queryClient,
+        keyFactory,
+        entityId,
+        entityJsonQueryKey,
       )
 
       if (options?.onSuccess) {
@@ -394,14 +398,13 @@ export function useUpdateEntityACL(
     mutationFn: (acl: AccessControlList) =>
       SynapseClient.updateEntityACL(acl, accessToken),
     onSuccess: async (updatedACL: AccessControlList, variables, ctx) => {
+      const entityAclQueryKey = keyFactory.getEntityACLQueryKey(updatedACL.id)
+      queryClient.setQueryData(entityAclQueryKey, updatedACL)
       await invalidateAllQueriesForEntity(
         queryClient,
         keyFactory,
         updatedACL.id,
-      )
-      queryClient.setQueryData(
-        keyFactory.getEntityACLQueryKey(updatedACL.id),
-        updatedACL,
+        entityAclQueryKey,
       )
 
       if (options?.onSuccess) {

--- a/packages/synapse-react-client/src/synapse-queries/entity/useExportToCavatica.test.tsx
+++ b/packages/synapse-react-client/src/synapse-queries/entity/useExportToCavatica.test.tsx
@@ -10,11 +10,12 @@ import {
 import { DEFAULT_PAGE_SIZE } from '../../utils/SynapseConstants'
 import { SynapseError } from '../../utils/SynapseError'
 import * as ToastMessage from '../../components/ToastMessage/ToastMessage'
+import { noop } from 'lodash-es'
 window.open = jest.fn()
 
 const mockToastFn = jest
   .spyOn(ToastMessage, 'displayToast')
-  .mockImplementation(() => {})
+  .mockImplementation(() => noop)
 
 const tableId = 'syn42'
 const resultsFileHandleId = '12345'

--- a/packages/synapse-react-client/src/utils/functions/EntityTypeUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/EntityTypeUtils.ts
@@ -257,7 +257,9 @@ export const isDatasetCollection = isTypeViaConcreteTypeFactory<
   Entity
 >(DATASET_COLLECTION_CONCRETE_TYPE_VALUE)
 
-export const isEntityRefCollectionView = (entity: Entity) =>
+export const isEntityRefCollectionView = (
+  entity: Entity,
+): entity is Dataset | DatasetCollection =>
   isDataset(entity) || isDatasetCollection(entity)
 
 export const isEntityView = isTypeViaConcreteTypeFactory<EntityView, Entity>(


### PR DESCRIPTION
- Change invalidation logic so table query data is reset (cached data is removed and listeners are notified), fixing SWC-6722
- Do not `await` retrieval of new table query data after an update that triggers cache invalidation, fixing SWC-6674
- NoContentPlaceholder component should be shown when query offset is null/undefined, fixing SWC-6725
- Change Dataset editor toast messages to only show one prompt to save at a time, and hide the toast when the user initiates the request to save changes.