### PR TITLE
PORTALS-2651 - Replace a few Bootstrap tables with custom styling + TanStack React Table

### DIFF
--- a/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTable.tsx
+++ b/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTable.tsx
@@ -50,6 +50,7 @@ import { FinderScope } from '../EntityFinder/tree/EntityTree'
 import { useEntityHeaderTableState } from './useEntityHeaderTableState'
 import { noop, upperFirst } from 'lodash-es'
 import pluralize from 'pluralize'
+import { StyledTableContainer } from '../styled/StyledTableContainer'
 
 const DEFAULT_FINDER_CONFIG: EntityFinderModalProps['configuration'] = {
   selectMultiple: true,
@@ -362,20 +363,12 @@ export const EntityHeaderTable = (props: EntityHeaderTableProps) => {
         )}
       </Box>
       {totalRowCount > 0 && (
-        <Box
-          sx={theme => ({
-            overflow: 'auto',
-            maxHeight: '250px',
-            paddingLeft: '2px',
+        <StyledTableContainer
+          sx={{
             th: {
-              height: '38px',
-              backgroundColor: theme.palette.grey[200],
               zIndex: 100,
             },
-            ['tr:nth-of-type(2n)']: {
-              backgroundColor: theme.palette.grey[100],
-            },
-          })}
+          }}
         >
           <table style={{ borderCollapse: 'collapse', width: '100%' }}>
             <thead>
@@ -480,7 +473,7 @@ export const EntityHeaderTable = (props: EntityHeaderTableProps) => {
               })}
             </tbody>
           </table>
-        </Box>
+        </StyledTableContainer>
       )}
       <EntityFinderModal
         configuration={entityFinderConfiguration}

--- a/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTableCellRenderers.tsx
+++ b/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTableCellRenderers.tsx
@@ -37,20 +37,23 @@ export function EntityHeaderTypeCell(
     </Typography>
   )
 }
-export function CheckBoxHeader(
-  props: HeaderContext<EntityHeaderOrDummy, string | null>,
+export function CheckBoxHeader<TData = never, TValue = never>(
+  props: HeaderContext<TData, TValue>,
 ) {
   const { table } = props
   return (
     <Checkbox
+      inputProps={{
+        'aria-label': 'Select All',
+      }}
       checked={table.getIsAllRowsSelected()}
       indeterminate={table.getIsSomeRowsSelected()}
       onClick={table.getToggleAllRowsSelectedHandler()}
     />
   )
 }
-export function CheckBoxCell(
-  props: CellContext<EntityHeaderOrDummy, string | null>,
+export function CheckBoxCell<TData = never, TValue = never>(
+  props: CellContext<TData, TValue>,
 ) {
   const { row } = props
   return (

--- a/packages/synapse-react-client/src/components/Forum/ForumPage.stories.ts
+++ b/packages/synapse-react-client/src/components/Forum/ForumPage.stories.ts
@@ -5,17 +5,30 @@ import { MOCK_FORUM_ID } from '../../mocks/discussion/mock_discussion'
 const meta = {
   title: 'Synapse/ForumPage',
   component: ForumPage,
-  parameters: {
-    stack: 'mock',
+  args: {
+    onClickLink: () => alert('This functionality has not been implemented yet'),
   },
 } satisfies Meta
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const ForumPageDemo: Story = {
+  parameters: {
+    stack: 'mock',
+  },
   args: {
     forumId: MOCK_FORUM_ID,
     limit: 5,
-    onClickLink: () => alert('This functionality has not been implemented yet'),
+  },
+}
+
+export const ProdHelpForum: Story = {
+  parameters: {
+    stack: 'production',
+  },
+
+  args: {
+    forumId: '1032',
+    limit: 10,
   },
 }

--- a/packages/synapse-react-client/src/components/Forum/ForumPage.tsx
+++ b/packages/synapse-react-client/src/components/Forum/ForumPage.tsx
@@ -57,7 +57,7 @@ export const ForumPage: React.FC<ForumPageProps> = ({
   }
 
   return (
-    <div className="ForumTable bootstrap-4-backport">
+    <div className="ForumTable">
       <div className="ForumTable__top-level-control">
         <SubscribersModal
           id={forumId}

--- a/packages/synapse-react-client/src/components/Forum/ForumTable.tsx
+++ b/packages/synapse-react-client/src/components/Forum/ForumTable.tsx
@@ -1,18 +1,28 @@
 import dayjs from 'dayjs'
-import React, { useState } from 'react'
-import { Table } from 'react-bootstrap'
-import SortIcon from '../../assets/icons/Sort'
+import React, { useMemo, useState } from 'react'
 import { useGetForumThreadsInfinite } from '../../synapse-queries/forum/useForum'
 import { AVATAR } from '../../utils/SynapseConstants'
 import {
-  Direction,
   DiscussionFilter,
+  DiscussionThreadBundle,
   DiscussionThreadOrder,
 } from '@sage-bionetworks/synapse-types'
 import IconSvg from '../IconSvg/IconSvg'
 import UserCard from '../UserCard/UserCard'
 import { Button, Link } from '@mui/material'
 import { UserBadge } from '../UserCard/UserBadge'
+import { StyledTableContainer } from '../styled/StyledTableContainer'
+import {
+  ColumnDef,
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  SortingState,
+  Table,
+  useReactTable,
+} from '@tanstack/react-table'
+import ColumnHeader from '../styled/ColumnHeader'
+import { isEmpty } from 'lodash-es'
 
 export type ForumTableProps = {
   forumId: string
@@ -21,158 +31,192 @@ export type ForumTableProps = {
   filter: DiscussionFilter
 }
 
+const columnHelper = createColumnHelper<DiscussionThreadBundle>()
+
+function getColumns(
+  onClickLink: (threadId: string) => void,
+): ColumnDef<DiscussionThreadBundle, any>[] {
+  return [
+    columnHelper.accessor('title', {
+      header: props => <ColumnHeader {...props} title={'Topic'} />,
+      cell: ({ row }) => (
+        <Link onClick={() => onClickLink(row.original.id)}>
+          {row.original.isPinned ? <IconSvg icon="pushpin" /> : <></>}
+          {row.original.title}
+        </Link>
+      ),
+      enableSorting: true,
+      size: 250,
+    }),
+    columnHelper.accessor('createdBy', {
+      header: props => <ColumnHeader {...props} title={'Author'} />,
+      cell: ({ getValue }) => <UserBadge userId={getValue()} />,
+      enableSorting: false,
+      size: 60,
+    }),
+    columnHelper.accessor('activeAuthors', {
+      header: props => <ColumnHeader {...props} title={'Active Users'} />,
+      cell: ({ getValue }) =>
+        getValue().map((userId: string) => (
+          <div key={userId} className="avatarContainer">
+            <UserCard
+              showCardOnHover={true}
+              className="ActiveUsers"
+              size={AVATAR}
+              avatarSize={'MEDIUM'}
+              ownerId={userId}
+            />
+          </div>
+        )),
+      enableSorting: false,
+    }),
+    columnHelper.accessor('numberOfReplies', {
+      header: props => <ColumnHeader {...props} title={'Replies'} />,
+      cell: ({ getValue }) => getValue().toLocaleString(),
+      enableSorting: true,
+      minSize: 10,
+      size: 20,
+    }),
+    columnHelper.accessor('numberOfViews', {
+      header: props => <ColumnHeader {...props} title={'Views'} />,
+      cell: ({ getValue }) => getValue().toLocaleString(),
+      enableSorting: true,
+      minSize: 10,
+      size: 20,
+    }),
+    columnHelper.accessor('lastActivity', {
+      header: props => <ColumnHeader {...props} title={'Activity'} />,
+      cell: ({ getValue }) => dayjs(getValue()).format('L'),
+      enableSorting: true,
+      size: 30,
+    }),
+  ]
+}
+
 export const ForumTable: React.FC<ForumTableProps> = ({
   forumId,
   limit,
   filter,
   onClickLink,
 }) => {
-  const [sort, setSort] = useState<DiscussionThreadOrder>(
-    DiscussionThreadOrder.PINNED_AND_LAST_ACTIVITY,
-  )
-  const [isAscending, setIsAscending] = useState(false)
+  const [tableSortState, setTableSortState] = useState<SortingState>([
+    {
+      desc: true,
+      id: 'lastActivity',
+    },
+  ])
+
+  const discussionThreadOrder = useMemo(() => {
+    if (!isEmpty(tableSortState)) {
+      if (tableSortState[0].id == 'lastActivity') {
+        return DiscussionThreadOrder.PINNED_AND_LAST_ACTIVITY
+      } else if (tableSortState[0].id == 'numberOfReplies') {
+        return DiscussionThreadOrder.NUMBER_OF_REPLIES
+      } else if (tableSortState[0].id == 'title') {
+        return DiscussionThreadOrder.THREAD_TITLE
+      } else if (tableSortState[0].id == 'numberOfViews') {
+        return DiscussionThreadOrder.NUMBER_OF_VIEWS
+      }
+    }
+    return DiscussionThreadOrder.PINNED_AND_LAST_ACTIVITY
+  }, [tableSortState])
 
   const { data, hasNextPage, fetchNextPage } = useGetForumThreadsInfinite(
     forumId,
     limit,
-    sort,
-    isAscending,
+    discussionThreadOrder,
+    !tableSortState[0]?.desc,
     filter,
   )
 
-  const threads = data?.pages.flatMap(page => page.results) ?? []
+  const threads = useMemo(
+    () => data?.pages.flatMap(page => page.results) ?? [],
+    [data],
+  )
 
-  const onSort = (field: DiscussionThreadOrder) => {
-    if (sort == field) {
-      setSort(field)
-      setIsAscending(!isAscending)
-    } else {
-      setSort(field)
-      setIsAscending(false)
-    }
-  }
+  const columns = useMemo(() => getColumns(onClickLink), [onClickLink])
+
+  const table: Table<DiscussionThreadBundle> =
+    useReactTable<DiscussionThreadBundle>({
+      data: threads,
+      columns: columns,
+      state: {
+        sorting: tableSortState,
+      },
+      onSortingChange: setTableSortState,
+      getRowId: row => row.id,
+      getCoreRowModel: getCoreRowModel(),
+      columnResizeMode: 'onChange',
+      manualSorting: true,
+      enableMultiSort: false,
+    })
 
   return (
-    <div className="ForumTable bootstrap-4-backport">
-      <Table>
-        <thead>
-          <tr>
-            <th>
-              <span className="SRC-split">
-                <span>Topic</span>
-                <SortIcon
-                  role="button"
-                  aria-label="Sort by Topic"
-                  active={sort === DiscussionThreadOrder.THREAD_TITLE}
-                  direction={
-                    sort === DiscussionThreadOrder.THREAD_TITLE
-                      ? isAscending === false
-                        ? Direction.DESC
-                        : Direction.ASC
-                      : Direction.DESC
-                  }
-                  onClick={() => onSort(DiscussionThreadOrder.THREAD_TITLE)}
-                />
-              </span>
-            </th>
-            <th>Author</th>
-            <th>Active Users</th>
-            <th>
-              <span className="SRC-split">
-                <span>Replies</span>
-                <SortIcon
-                  role="button"
-                  aria-label="Sort by Replies"
-                  active={sort === DiscussionThreadOrder.NUMBER_OF_REPLIES}
-                  direction={
-                    sort === DiscussionThreadOrder.NUMBER_OF_REPLIES
-                      ? isAscending === false
-                        ? Direction.DESC
-                        : Direction.ASC
-                      : Direction.DESC
-                  }
-                  onClick={() =>
-                    onSort(DiscussionThreadOrder.NUMBER_OF_REPLIES)
-                  }
-                />
-              </span>
-            </th>
-            <th>
-              <span className="SRC-split">
-                <span>Views</span>
-                <SortIcon
-                  role="button"
-                  aria-label="Sort by Views"
-                  active={sort === DiscussionThreadOrder.NUMBER_OF_VIEWS}
-                  direction={
-                    sort === DiscussionThreadOrder.NUMBER_OF_VIEWS
-                      ? isAscending === false
-                        ? Direction.DESC
-                        : Direction.ASC
-                      : Direction.DESC
-                  }
-                  onClick={() => onSort(DiscussionThreadOrder.NUMBER_OF_VIEWS)}
-                />
-              </span>
-            </th>
-            <th>
-              <span className="SRC-split">
-                <span>Activity</span>
-                <SortIcon
-                  role="button"
-                  aria-label="Sort by Last Activity"
-                  active={
-                    sort === DiscussionThreadOrder.PINNED_AND_LAST_ACTIVITY
-                  }
-                  direction={
-                    sort === DiscussionThreadOrder.PINNED_AND_LAST_ACTIVITY
-                      ? isAscending === false
-                        ? Direction.DESC
-                        : Direction.ASC
-                      : Direction.DESC
-                  }
-                  onClick={() =>
-                    onSort(DiscussionThreadOrder.PINNED_AND_LAST_ACTIVITY)
-                  }
-                />
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {threads.map(item => {
-            return (
-              <tr key={item.id}>
-                <td>
-                  <Link onClick={() => onClickLink(item.id)}>
-                    {item.isPinned ? <IconSvg icon="pushpin" /> : <></>}
-                    {item.title}
-                  </Link>
-                </td>
-                <td>
-                  <UserBadge userId={item.createdBy} />
-                </td>
-                <td>
-                  {item.activeAuthors.map(user => (
-                    <div key={user} className="avatarContainer">
-                      <UserCard
-                        showCardOnHover={true}
-                        className="ActiveUsers"
-                        size={AVATAR}
-                        avatarSize={'MEDIUM'}
-                        ownerId={user}
-                      />
-                    </div>
+    <div className="ForumTable">
+      <StyledTableContainer
+        sx={{
+          my: 2,
+          ['th,td']: { px: 1 },
+          td: {
+            py: 1,
+          },
+        }}
+      >
+        <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+          <thead>
+            {table.getHeaderGroups().map(headerGroup => {
+              return (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map(header => (
+                    <th
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      style={{ width: header.getSize() }}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                      {header.column.getCanResize() && (
+                        <div
+                          className={`resizer ${
+                            header.column.getIsResizing() ? 'isResizing' : ''
+                          }`}
+                          onMouseDown={header.getResizeHandler()}
+                          onTouchStart={header.getResizeHandler()}
+                        />
+                      )}
+                    </th>
                   ))}
-                </td>
-                <td>{item.numberOfReplies}</td>
-                <td>{item.numberOfViews}</td>
-                <td>{dayjs(item.lastActivity).format('L')}</td>
+                </tr>
+              )
+            })}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map(row => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map(cell => {
+                  return (
+                    <td
+                      key={cell.id}
+                      style={{
+                        width: cell.column.getSize(),
+                      }}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </td>
+                  )
+                })}
               </tr>
-            )
-          })}
-        </tbody>
-      </Table>
+            ))}
+          </tbody>
+        </table>
+      </StyledTableContainer>
       {hasNextPage && (
         <Button
           variant="outlined"

--- a/packages/synapse-react-client/src/components/OAuthClientManagement/OAuthManagement.tsx
+++ b/packages/synapse-react-client/src/components/OAuthClientManagement/OAuthManagement.tsx
@@ -21,6 +21,7 @@ import {
   Table,
   useReactTable,
 } from '@tanstack/react-table'
+import ColumnHeader from '../styled/ColumnHeader'
 
 const columnHelper = createColumnHelper<OAuthClient>()
 
@@ -64,21 +65,21 @@ export const OAuthManagement: React.FunctionComponent = () => {
   const columns: ColumnDef<OAuthClient, any>[] = useMemo(
     () => [
       columnHelper.accessor('createdOn', {
-        header: 'Created',
+        header: props => <ColumnHeader {...props} title={'Created'} />,
         cell: info => formatDate(dayjs(info.getValue())),
       }),
       columnHelper.accessor('modifiedOn', {
-        header: 'Modified',
+        header: props => <ColumnHeader {...props} title={'Modified'} />,
         cell: info => formatDate(dayjs(info.getValue())),
       }),
       columnHelper.accessor('client_id', {
-        header: 'ID',
+        header: props => <ColumnHeader {...props} title={'ID'} />,
       }),
       columnHelper.accessor('client_name', {
-        header: 'Client',
+        header: props => <ColumnHeader {...props} title={'Client'} />,
       }),
       columnHelper.accessor('verified', {
-        header: 'Verified',
+        header: props => <ColumnHeader {...props} title={'Verified'} />,
         cell: ({ getValue }) =>
           getValue() ? (
             'Yes'
@@ -94,7 +95,7 @@ export const OAuthManagement: React.FunctionComponent = () => {
       }),
       {
         id: 'generateSecret',
-        header: 'App Secret',
+        header: props => <ColumnHeader {...props} title={'App Secret'} />,
         cell: ({ row }) => (
           <Button
             variant="outlined"
@@ -110,7 +111,7 @@ export const OAuthManagement: React.FunctionComponent = () => {
       },
       {
         id: 'actions',
-        header: 'Actions',
+        header: props => <ColumnHeader {...props} title={'Actions'} />,
         cell: ({ row }) => (
           <Button
             variant="outlined"
@@ -134,6 +135,7 @@ export const OAuthManagement: React.FunctionComponent = () => {
     columns,
     getRowId: row => row.client_id!,
     enableRowSelection: true,
+    enableSorting: false,
     getCoreRowModel: getCoreRowModel(),
     columnResizeMode: 'onChange',
   })
@@ -154,7 +156,13 @@ export const OAuthManagement: React.FunctionComponent = () => {
           Create New Client
         </Button>
       </Box>
-      <StyledTableContainer>
+      <StyledTableContainer
+        sx={{
+          td: {
+            py: 1,
+          },
+        }}
+      >
         <table style={{ borderCollapse: 'collapse', width: '100%' }}>
           <thead>
             {table.getHeaderGroups().map(headerGroup => {
@@ -196,8 +204,6 @@ export const OAuthManagement: React.FunctionComponent = () => {
                       key={cell.id}
                       style={{
                         width: cell.column.getSize(),
-                        paddingTop: '8px',
-                        paddingBottom: '8px',
                       }}
                     >
                       {flexRender(

--- a/packages/synapse-react-client/src/components/OAuthClientManagement/OAuthManagement.tsx
+++ b/packages/synapse-react-client/src/components/OAuthClientManagement/OAuthManagement.tsx
@@ -1,5 +1,4 @@
-import React, { useState } from 'react'
-import { Table } from 'react-bootstrap'
+import React, { useMemo, useState } from 'react'
 import { formatDate } from '../../utils/functions/DateFormatter'
 import dayjs from 'dayjs'
 import { useGetOAuthClientInfinite } from '../../synapse-queries'
@@ -7,12 +6,23 @@ import { CreateOAuthModal } from './CreateOAuthClient'
 import { OAuthClient } from '@sage-bionetworks/synapse-types'
 import WarningDialog from '../SynapseForm/WarningDialog'
 import SynapseClient from '../../synapse-client'
-import { useSynapseContext } from '../../utils/context/SynapseContext'
+import { useSynapseContext } from '../../utils'
 import CopyToClipboardInput from '../CopyToClipboardInput/CopyToClipboardInput'
-import { displayToast } from '../ToastMessage/ToastMessage'
+import { displayToast } from '../ToastMessage'
 import { DialogBase } from '../DialogBase'
-import { Button, Link } from '@mui/material'
+import { Box, Button, Link } from '@mui/material'
 import { AddCircleTwoTone } from '@mui/icons-material'
+import { StyledTableContainer } from '../styled/StyledTableContainer'
+import {
+  ColumnDef,
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  Table,
+  useReactTable,
+} from '@tanstack/react-table'
+
+const columnHelper = createColumnHelper<OAuthClient>()
 
 export const OAuthManagement: React.FunctionComponent = () => {
   const { accessToken } = useSynapseContext()
@@ -27,7 +37,10 @@ export const OAuthManagement: React.FunctionComponent = () => {
   const [isShowingVerification, setIsShowingVerification] = useState(false)
 
   const { data, hasNextPage, fetchNextPage } = useGetOAuthClientInfinite()
-  const oAuthClientList = data?.pages.flatMap(page => page.results) ?? []
+  const oAuthClientList = useMemo(
+    () => data?.pages.flatMap(page => page.results) ?? [],
+    [data],
+  )
 
   const warningHeader = 'Are you absolutely sure?'
   const warningBody =
@@ -48,83 +61,157 @@ export const OAuthManagement: React.FunctionComponent = () => {
     }
   }
 
+  const columns: ColumnDef<OAuthClient, any>[] = useMemo(
+    () => [
+      columnHelper.accessor('createdOn', {
+        header: 'Created',
+        cell: info => formatDate(dayjs(info.getValue())),
+      }),
+      columnHelper.accessor('modifiedOn', {
+        header: 'Modified',
+        cell: info => formatDate(dayjs(info.getValue())),
+      }),
+      columnHelper.accessor('client_id', {
+        header: 'ID',
+      }),
+      columnHelper.accessor('client_name', {
+        header: 'Client',
+      }),
+      columnHelper.accessor('verified', {
+        header: 'Verified',
+        cell: ({ getValue }) =>
+          getValue() ? (
+            'Yes'
+          ) : (
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => setIsShowingVerification(true)}
+            >
+              Submit Verification
+            </Button>
+          ),
+      }),
+      {
+        id: 'generateSecret',
+        header: 'App Secret',
+        cell: ({ row }) => (
+          <Button
+            variant="outlined"
+            onClick={() => {
+              setSelectedClient(row.original)
+              setIsShowingSecretWarning(true)
+            }}
+            size="small"
+          >
+            Generate Secret
+          </Button>
+        ),
+      },
+      {
+        id: 'actions',
+        header: 'Actions',
+        cell: ({ row }) => (
+          <Button
+            variant="outlined"
+            onClick={() => {
+              setSelectedClient(row.original)
+              setIsEdit(true)
+              setIsShowingCreateClientModal(true)
+            }}
+            size="small"
+          >
+            Edit
+          </Button>
+        ),
+      },
+    ],
+    [],
+  )
+
+  const table: Table<OAuthClient> = useReactTable<OAuthClient>({
+    data: oAuthClientList,
+    columns,
+    getRowId: row => row.client_id!,
+    enableRowSelection: true,
+    getCoreRowModel: getCoreRowModel(),
+    columnResizeMode: 'onChange',
+  })
+
   return (
-    <div className="bootstrap-4-backport">
-      <Button
-        variant="contained"
-        color="primary"
-        onClick={() => {
-          setIsShowingCreateClientModal(true)
-          setIsEdit(false)
-        }}
-        sx={{ float: 'right' }}
-        startIcon={<AddCircleTwoTone />}
-      >
-        Create New Client
-      </Button>
-      <Table striped>
-        <thead>
-          <tr>
-            <th>Created</th>
-            <th>Modified</th>
-            <th>ID</th>
-            <th>Client</th>
-            <th>Verified</th>
-            <th>App Secret</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {oAuthClientList.map(item => {
-            return (
-              <tr key={item.client_id}>
-                <td>{formatDate(dayjs(item.createdOn))}</td>
-                <td>{formatDate(dayjs(item.modifiedOn))}</td>
-                <td>{item.client_id}</td>
-                <td>{item.client_name}</td>
-                <td>
-                  {item.verified ? (
-                    'Yes'
-                  ) : (
-                    <Button
-                      variant="outlined"
-                      size="small"
-                      onClick={() => setIsShowingVerification(true)}
+    <div>
+      <Box display={'flex'} width={'100%'} justifyContent={'flex-end'} mb={2}>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => {
+            setIsShowingCreateClientModal(true)
+            setIsEdit(false)
+          }}
+          sx={{ float: 'right' }}
+          startIcon={<AddCircleTwoTone />}
+        >
+          Create New Client
+        </Button>
+      </Box>
+      <StyledTableContainer>
+        <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+          <thead>
+            {table.getHeaderGroups().map(headerGroup => {
+              return (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map(header => (
+                    <th
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      style={{ width: header.getSize() }}
                     >
-                      Submit Verification
-                    </Button>
-                  )}
-                </td>
-                <td>
-                  <Button
-                    variant="outlined"
-                    onClick={() => {
-                      setSelectedClient(item)
-                      setIsShowingSecretWarning(true)
-                    }}
-                    size="small"
-                  >
-                    Generate Secret
-                  </Button>
-                </td>
-                <td>
-                  <Button
-                    variant="outlined"
-                    onClick={() => {
-                      setSelectedClient(item)
-                      setIsEdit(true)
-                      setIsShowingCreateClientModal(true)
-                    }}
-                    size="small"
-                  >
-                    Edit
-                  </Button>
-                </td>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                      {header.column.getCanResize() && (
+                        <div
+                          className={`resizer ${
+                            header.column.getIsResizing() ? 'isResizing' : ''
+                          }`}
+                          onMouseDown={header.getResizeHandler()}
+                          onTouchStart={header.getResizeHandler()}
+                        />
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              )
+            })}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map(row => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map(cell => {
+                  return (
+                    <td
+                      key={cell.id}
+                      style={{
+                        width: cell.column.getSize(),
+                        paddingTop: '8px',
+                        paddingBottom: '8px',
+                      }}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </td>
+                  )
+                })}
               </tr>
-            )
-          })}
-        </tbody>
-      </Table>
+            ))}
+          </tbody>
+        </table>
+      </StyledTableContainer>
       {hasNextPage && (
         <div className="text-center">
           <Button

--- a/packages/synapse-react-client/src/components/styled/ColumnHeader.tsx
+++ b/packages/synapse-react-client/src/components/styled/ColumnHeader.tsx
@@ -28,8 +28,6 @@ export default function ColumnHeader<TData = unknown, TValue = unknown>(
     additionalButtons,
   } = props
 
-  column.getCanFilter
-
   return (
     <Box
       display={'flex'}

--- a/packages/synapse-react-client/src/components/styled/ColumnHeader.tsx
+++ b/packages/synapse-react-client/src/components/styled/ColumnHeader.tsx
@@ -1,0 +1,90 @@
+import { HeaderContext } from '@tanstack/react-table'
+import { Box, IconButton, Tooltip } from '@mui/material'
+import { HelpTwoTone } from '@mui/icons-material'
+import IconSvg from '../IconSvg'
+import React from 'react'
+
+type ColumnHeaderProps = {
+  title?: React.ReactNode
+  helpText?: React.ReactNode
+  additionalButtons?: React.ReactNode
+
+  // TODO: Replace with props that can be passed to a reusable filter control
+  filterControl?: React.ReactNode
+}
+
+/**
+ * Styled table column header component for use with @tanstack/react-table, with extra optional props for additional
+ * UI features
+ */
+export default function ColumnHeader<TData = unknown, TValue = unknown>(
+  props: ColumnHeaderProps & HeaderContext<TData, TValue>,
+) {
+  const {
+    column,
+    title = props.column.id,
+    helpText,
+    filterControl,
+    additionalButtons,
+  } = props
+
+  column.getCanFilter
+
+  return (
+    <Box
+      display={'flex'}
+      alignContent={'center'}
+      alignItems={'center'}
+      justifyContent={'space-between'}
+    >
+      <span
+        style={{
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {title}
+      </span>
+      <Box
+        role={'menubar'}
+        display={'flex'}
+        alignItems="center"
+        sx={{
+          height: '22px',
+          ml: 2,
+          gap: 0.25,
+        }}
+      >
+        {helpText && (
+          <Tooltip title={helpText} placement={'top'}>
+            <IconButton size={'small'}>
+              <HelpTwoTone fontSize={'inherit'} />
+            </IconButton>
+          </Tooltip>
+        )}
+        {column.getCanFilter() && filterControl}
+        {column.getCanSort() && (
+          <Tooltip title={`Sort ${title}`} placement={'top'}>
+            <IconButton
+              role="button"
+              aria-label="sort"
+              size={'small'}
+              tabIndex={0}
+              onKeyPress={() => column.toggleSorting()}
+              onClick={() => column.toggleSorting()}
+            >
+              <IconSvg
+                icon={column.getIsSorted() === 'asc' ? 'sortUp' : 'sortDown'}
+                wrap={false}
+                sx={{
+                  color: column.getIsSorted() ? 'primary.main' : 'grey.700',
+                  backgroundColor: 'none',
+                }}
+              />
+            </IconButton>
+          </Tooltip>
+        )}
+        {additionalButtons}
+      </Box>
+    </Box>
+  )
+}

--- a/packages/synapse-react-client/src/components/styled/StyledTableContainer.tsx
+++ b/packages/synapse-react-client/src/components/styled/StyledTableContainer.tsx
@@ -1,0 +1,23 @@
+import { Box, BoxProps, styled } from '@mui/material'
+import { StyledComponent } from '@emotion/styled'
+
+export const StyledTableContainer: StyledComponent<BoxProps> = styled(Box)(
+  ({ theme }) => ({
+    overflow: 'auto',
+    maxHeight: '250px',
+    paddingLeft: '2px',
+    th: {
+      height: '38px',
+      backgroundColor: theme.palette.grey[200],
+    },
+    ['th:first-of-type']: {
+      paddingLeft: '10px',
+    },
+    ['td:first-of-type']: {
+      paddingLeft: '10px',
+    },
+    ['tr:nth-of-type(2n)']: {
+      backgroundColor: theme.palette.grey[100],
+    },
+  }),
+)

--- a/packages/synapse-react-client/src/components/trash/TrashCanList.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/trash/TrashCanList.integration.test.tsx
@@ -8,14 +8,11 @@ import {
   TRASHCAN_RESTORE,
   TRASHCAN_VIEW,
 } from '../../utils/APIConstants'
+import { BackendDestinationEnum, getEndpoint } from '../../utils/functions'
 import {
-  BackendDestinationEnum,
-  getEndpoint,
-} from '../../utils/functions/getEndpoint'
-import {
+  EntityType,
   PaginatedResults,
   TrashedEntity,
-  EntityType,
 } from '@sage-bionetworks/synapse-types'
 import mockDatasetData from '../../mocks/entity/mockDataset'
 import mockFileEntityData from '../../mocks/entity/mockFileEntity'

--- a/packages/synapse-react-client/src/components/trash/TrashCanList.tsx
+++ b/packages/synapse-react-client/src/components/trash/TrashCanList.tsx
@@ -1,61 +1,32 @@
 import dayjs from 'dayjs'
-import React, { useEffect, useRef, useState } from 'react'
-import { Table } from 'react-bootstrap'
+import React, { useMemo, useState } from 'react'
 import { formatDate } from '../../utils/functions/DateFormatter'
 import { entityTypeToFriendlyName } from '../../utils/functions/EntityTypeUtils'
-import { useGetEntity } from '../../synapse-queries'
 import {
   useGetItemsInTrashCanInfinite,
   usePurgeEntities,
   useRestoreEntities,
 } from '../../synapse-queries/trash/useTrashCan'
-import { SynapseClientError } from '../../utils/SynapseClientError'
+import { SynapseClientError } from '../../utils'
 import { TrashedEntity } from '@sage-bionetworks/synapse-types'
-import { Alert, Button, Typography } from '@mui/material'
+import { Alert, Box, Button, Typography } from '@mui/material'
 import { EntityLink } from '../EntityLink'
 import { BlockingLoader, SynapseSpinner } from '../LoadingScreen/LoadingScreen'
 import WarningDialog from '../SynapseForm/WarningDialog'
-import { Checkbox } from '../widgets/Checkbox'
-
-type TrashCanListItemProps = {
-  item: TrashedEntity
-  isSelected: boolean
-  setIsSelected: (isSelected: boolean) => void
-  onRestore: () => void
-}
-
-function TrashCanListItem(props: TrashCanListItemProps) {
-  const { item, isSelected, setIsSelected, onRestore } = props
-  const { data: parentEntity } = useGetEntity(item.originalParentId)
-  return (
-    <tr>
-      <td>
-        <Checkbox
-          label={`Select ${item.entityId}`}
-          hideLabel={true}
-          checked={isSelected}
-          onChange={setIsSelected}
-        />
-      </td>
-      <td>{item.entityId}</td>
-      <td>{item.entityName}</td>
-      <td>{entityTypeToFriendlyName(item.entityType)}</td>
-      {/* <td>TypePlaceholder</td> */}
-      <td>
-        <>
-          {parentEntity && <EntityLink entity={parentEntity} />} (
-          {item.originalParentId})
-        </>
-      </td>
-      <td>{formatDate(dayjs(item.deletedOn))}</td>
-      <td>
-        <Button size="small" variant="outlined" onClick={onRestore}>
-          Restore
-        </Button>
-      </td>
-    </tr>
-  )
-}
+import {
+  ColumnDef,
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  RowSelectionState,
+  Table,
+  useReactTable,
+} from '@tanstack/react-table'
+import {
+  CheckBoxCell,
+  CheckBoxHeader,
+} from '../EntityHeaderTable/EntityHeaderTableCellRenderers'
+import { StyledTableContainer } from '../styled/StyledTableContainer'
 
 /**
  * Convert an array of Promise results to an array of errors
@@ -70,18 +41,66 @@ function toSynapseClientErrorList(
     .map(result => result.reason as SynapseClientError)
 }
 
+const columnHelper = createColumnHelper<TrashedEntity>()
+
+function getTrashCanColumns(
+  onRestore: (entityId: string) => void,
+): ColumnDef<TrashedEntity, any>[] {
+  return [
+    {
+      id: 'select',
+      header: CheckBoxHeader,
+      cell: CheckBoxCell,
+      maxSize: 50,
+    },
+    columnHelper.accessor('entityId', {
+      header: 'ID',
+    }),
+    columnHelper.accessor('entityName', {
+      header: 'Name',
+    }),
+    columnHelper.accessor('entityType', {
+      header: 'Entity Type',
+      cell: info => entityTypeToFriendlyName(info.getValue()),
+    }),
+    columnHelper.accessor('originalParentId', {
+      header: 'Location',
+      cell: info => (
+        <>
+          {info.getValue() && <EntityLink entity={info.getValue()} />} (
+          {info.getValue()})
+        </>
+      ),
+      size: 200,
+    }),
+    columnHelper.accessor('deletedOn', {
+      header: 'Deleted On',
+      cell: info => formatDate(dayjs(info.getValue())),
+    }),
+    {
+      id: 'restoreButton',
+      header: '',
+      cell: ({ row }) => (
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={() => {
+            onRestore(row.original.entityId)
+            row.toggleSelected(false)
+          }}
+        >
+          Restore
+        </Button>
+      ),
+      maxSize: 100,
+    },
+  ]
+}
+
 export function TrashCanList() {
-  const isMounted = useRef(true)
-  const [selected, setSelected] = useState<Set<string>>(new Set())
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
   const [errors, setErrors] = useState<SynapseClientError[]>([])
-
-  useEffect(() => {
-    isMounted.current = true
-    return () => {
-      isMounted.current = false
-    }
-  })
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
 
   /**
    * When a mutation operation settles, update the list of errors and clear the selected set
@@ -90,14 +109,12 @@ export function TrashCanList() {
     results?: PromiseSettledResult<void>[],
     error?: SynapseClientError | null,
   ) {
-    if (isMounted.current) {
-      if (results) {
-        setErrors(toSynapseClientErrorList(results))
-      } else if (error) {
-        setErrors([error])
-      }
-      setSelected(new Set())
+    if (results) {
+      setErrors(toSynapseClientErrorList(results))
+    } else if (error) {
+      setErrors([error])
     }
+    setRowSelection({})
   }
 
   const { mutate: restore, isPending: isPendingRestore } = useRestoreEntities({
@@ -113,21 +130,38 @@ export function TrashCanList() {
     useGetItemsInTrashCanInfinite({
       throwOnError: true,
     })
+  const items = useMemo(
+    () => data?.pages.flatMap(page => page.results) ?? [],
+    [data],
+  )
 
-  const items = data?.pages.flatMap(page => page.results) ?? []
+  const columns = useMemo<ColumnDef<TrashedEntity, any>[]>(
+    () =>
+      getTrashCanColumns(entityId => {
+        restore(entityId)
+      }),
+    [restore],
+  )
 
-  const isAllSelected = selected.size === items.length
+  const table: Table<TrashedEntity> = useReactTable<TrashedEntity>({
+    data: items,
+    columns,
+    state: {
+      rowSelection: rowSelection,
+    },
+    getRowId: row => row.entityId,
+    enableRowSelection: true,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    columnResizeMode: 'onChange',
+  })
 
-  const onSelectAll = () => {
-    if (isAllSelected) {
-      setSelected(new Set())
-    } else {
-      setSelected(new Set(items.map(item => item.entityId)))
-    }
-  }
+  const selectedEntityIds = table
+    .getSelectedRowModel()
+    .rows.map(row => row.original.entityId)
 
   return (
-    <div className="bootstrap-4-backport">
+    <div>
       <BlockingLoader
         show={isMutating}
         headlineText={isPendingPurge ? 'Deleting...' : 'Restoring...'}
@@ -148,7 +182,7 @@ export function TrashCanList() {
         confirmButtonText="Delete"
         confirmButtonColor="error"
         onConfirm={() => {
-          purge(selected)
+          purge(selectedEntityIds)
           setShowDeleteConfirmation(false)
         }}
         onCancel={() => {
@@ -158,54 +192,73 @@ export function TrashCanList() {
       />
       {isLoading && <SynapseSpinner />}
       {!isLoading && items.length === 0 && (
-        <Typography variant="body1">Trash Can is currently empty.</Typography>
+        <Alert severity={'info'} sx={{ my: 2 }}>
+          <Typography variant="body1">
+            Your trash can is currently empty.
+          </Typography>
+        </Alert>
       )}
       {!isLoading && items.length > 0 && (
         <>
-          <Table striped borderless bordered={false}>
-            <thead>
-              <tr>
-                <th>
-                  <Checkbox
-                    label="Select All"
-                    hideLabel={true}
-                    checked={isAllSelected}
-                    onChange={onSelectAll}
-                  />
-                </th>
-                <th>ID</th>
-                <th>Name</th>
-                <th>Entity Type</th>
-                {/* <th>TypePlaceholder</th> */}
-                <th>Location</th>
-                <th>Deleted On</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.map(item => (
-                <TrashCanListItem
-                  key={item.entityId}
-                  item={item}
-                  isSelected={selected.has(item.entityId)}
-                  setIsSelected={isSelected => {
-                    setSelected(selected => {
-                      if (isSelected) {
-                        selected.add(item.entityId)
-                      } else {
-                        selected.delete(item.entityId)
-                      }
-                      return new Set(selected)
-                    })
-                  }}
-                  onRestore={() => {
-                    restore(item.entityId)
-                    selected.delete(item.entityId)
-                  }}
-                />
-              ))}
-            </tbody>
-          </Table>
+          <StyledTableContainer my={4}>
+            <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+              <thead>
+                {table.getHeaderGroups().map(headerGroup => {
+                  return (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map(header => (
+                        <th
+                          key={header.id}
+                          colSpan={header.colSpan}
+                          style={{ width: header.getSize() }}
+                        >
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext(),
+                              )}
+                          {header.column.getCanResize() && (
+                            <div
+                              className={`resizer ${
+                                header.column.getIsResizing()
+                                  ? 'isResizing'
+                                  : ''
+                              }`}
+                              onMouseDown={header.getResizeHandler()}
+                              onTouchStart={header.getResizeHandler()}
+                            />
+                          )}
+                        </th>
+                      ))}
+                    </tr>
+                  )
+                })}
+              </thead>
+
+              <tbody>
+                {table.getRowModel().rows.map(row => (
+                  <tr key={row.id}>
+                    {row.getVisibleCells().map(cell => {
+                      return (
+                        <td
+                          key={cell.id}
+                          style={{
+                            width: cell.column.getSize(),
+                          }}
+                        >
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </td>
+                      )
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </StyledTableContainer>
           {errors.length > 0 && (
             <Alert severity={'error'} sx={{ mb: 1 }}>
               The following errors were encountered:
@@ -216,13 +269,7 @@ export function TrashCanList() {
               </ul>
             </Alert>
           )}
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'flex-end',
-              gap: '10px',
-            }}
-          >
+          <Box display="flex" justifyContent="flex-end" gap={2}>
             {hasNextPage && (
               <Button
                 variant="contained"
@@ -238,7 +285,7 @@ export function TrashCanList() {
             <Button
               variant="contained"
               color="error"
-              disabled={selected.size === 0}
+              disabled={selectedEntityIds.length === 0}
               onClick={() => {
                 setShowDeleteConfirmation(true)
               }}
@@ -247,14 +294,14 @@ export function TrashCanList() {
             </Button>
             <Button
               variant="outlined"
-              disabled={selected.size === 0}
+              disabled={selectedEntityIds.length === 0}
               onClick={() => {
-                restore(selected)
+                restore(selectedEntityIds)
               }}
             >
               Restore Selected
             </Button>
-          </div>
+          </Box>
         </>
       )}
     </div>

--- a/packages/synapse-react-client/src/style/components/_discussion-forum.scss
+++ b/packages/synapse-react-client/src/style/components/_discussion-forum.scss
@@ -3,40 +3,16 @@
 
 .ForumTable {
   &__top-level-control {
-    float: right;
     margin-bottom: 16px;
     display: flex;
-  }
-
-  thead {
-    background-color: map.get(SRC.$colors, 'gray-200');
-    th {
-      vertical-align: middle;
-      white-space: nowrap;
-    }
-  }
-
-  th,
-  td {
-    border: none;
+    justify-content: flex-end;
+    gap: 8px;
   }
 
   .avatarContainer {
     display: inline-flex;
     margin: 0 2px;
     vertical-align: middle;
-  }
-  tr td:nth-child(1) {
-    max-width: 14rem;
-  }
-  tr td:nth-child(3) {
-    width: auto;
-  }
-  tr td:nth-child(2),
-  tr td:nth-child(4),
-  tr td:nth-child(5),
-  tr td:nth-child(6) {
-    width: 1px;
   }
 }
 

--- a/packages/synapse-react-client/src/synapse-queries/trash/useTrashCan.ts
+++ b/packages/synapse-react-client/src/synapse-queries/trash/useTrashCan.ts
@@ -8,8 +8,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query'
 import SynapseClient from '../../synapse-client'
-import { SynapseClientError } from '../../utils/SynapseClientError'
-import { useSynapseContext } from '../../utils/context/SynapseContext'
+import { SynapseClientError, useSynapseContext } from '../../utils'
 import {
   PaginatedResults,
   TrashedEntity,
@@ -54,7 +53,7 @@ export function useRestoreEntities(
     UseMutationOptions<
       PromiseSettledResult<void>[],
       SynapseClientError,
-      string | Set<string>
+      string | string[] | Set<string>
     >
   >,
 ) {
@@ -64,10 +63,10 @@ export function useRestoreEntities(
   return useMutation<
     PromiseSettledResult<void>[],
     SynapseClientError,
-    string | Set<string>
+    string | string[] | Set<string>
   >({
     ...options,
-    mutationFn: (ids: string | Set<string>) => {
+    mutationFn: (ids: string | string[] | Set<string>) => {
       if (typeof ids === 'string') {
         ids = new Set([ids])
       }
@@ -92,7 +91,7 @@ export function usePurgeEntities(
     UseMutationOptions<
       PromiseSettledResult<void>[],
       SynapseClientError,
-      string | Set<string>
+      string | string[] | Set<string>
     >
   >,
 ) {
@@ -102,10 +101,10 @@ export function usePurgeEntities(
   return useMutation<
     PromiseSettledResult<void>[],
     SynapseClientError,
-    string | Set<string>
+    string | string[] | Set<string>
   >({
     ...options,
-    mutationFn: (ids: string | Set<string>) => {
+    mutationFn: (ids: string | string[] | Set<string>) => {
       if (typeof ids === 'string') {
         ids = new Set([ids])
       }


### PR DESCRIPTION
SynapseTable
- Extract column header component for reuse

EntityHeaderTable
- Extract table styles into styled component for reuse

TrashCanList, OAuthManagement, ForumTable
- Refactor to use react-table and remove reference to `'react-bootstrap'`

|Component|Screenshot|
|---|---|
|TrashCanList|![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/8e13ce5c-4cf9-4735-841f-4c5440d176d5)|
|OAuthManagement| ![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/e9610bea-d272-4f30-a26f-cf4921ba1443) |
|ForumPage|![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/860e7d8c-d287-4549-b820-226e890c3d2b)|
|SynapseTable (affected by refactoring)|![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/4a1786b6-b9eb-489a-b132-e32834d6d724)|

