### PR TITLE
SWC-6727 / PLFM-8326

### DIFF
--- a/packages/synapse-react-client/src/components/MissingQueryResultsWarning/MissingQueryResultsWarning.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/MissingQueryResultsWarning/MissingQueryResultsWarning.integration.test.tsx
@@ -88,4 +88,20 @@ describe('MissingQueryResultsWarning tests', () => {
       'Files may be unavailable because you do not have permission to see them or the Dataset was misconfigured.',
     )
   })
+
+  it('shows no warning when total results is less than total visible results', () => {
+    // Unlikely edge case -- see PLFM-8326
+    const numberOfVisibleResults = allDatasetItems.length + 1
+    server.use(
+      ...getHandlersForTableQuery({
+        concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
+        queryCount: numberOfVisibleResults,
+      }),
+    )
+
+    renderComponent({ ...mockDatasetEntity, items: allDatasetItems })
+
+    expect(screen.queryByText('Unavailable')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
 })

--- a/packages/synapse-react-client/src/components/MissingQueryResultsWarning/MissingQueryResultsWarning.tsx
+++ b/packages/synapse-react-client/src/components/MissingQueryResultsWarning/MissingQueryResultsWarning.tsx
@@ -53,8 +53,10 @@ const MissingQueryResultsWarning: React.FunctionComponent<
     const totalVisibleResults = queryResult.responseBody!.queryCount!
     const totalResults = entity.items?.length ?? 0
 
-    if (totalVisibleResults === totalResults) {
+    if (totalVisibleResults >= totalResults) {
       // All the results are visible, so there is no need to show a warning.
+      // SWC-6727 / PLFM-8326 - `totalVisibleResults` should never be greater than `totalResults`, but in case it is (e.g. stale cache),
+      // don't show the warning.
       return <></>
     }
 


### PR DESCRIPTION
Do not show MissingQueryResultsWarning if the visible result count is greater than the number of items. The mismatch should never happen, but this safeguards against a case where one of the data sources is outdated.