### PR TITLE
GENIE: set the visible column count to hide the currentVersion column

### DIFF
--- a/apps/portals/src/configurations/genie/synapseConfigs/genieBPCData.ts
+++ b/apps/portals/src/configurations/genie/synapseConfigs/genieBPCData.ts
@@ -12,6 +12,7 @@ const genieBPCData: SynapseConfig = {
     showExportToCavatica: true,
     isRowSelectionVisible: true,
     rowSelectionPrimaryKey: ['id'],
+    visibleColumnCount: 6,
     tableConfiguration: {
       showAccessColumn: true,
       // set the entity ID column and version column to use (instead of the Row ID and Version)

--- a/apps/portals/src/configurations/genie/synapseConfigs/genieData.ts
+++ b/apps/portals/src/configurations/genie/synapseConfigs/genieData.ts
@@ -12,6 +12,7 @@ const genieData: SynapseConfig = {
     showExportToCavatica: true,
     isRowSelectionVisible: true,
     rowSelectionPrimaryKey: ['id'],
+    visibleColumnCount: 6,
     tableConfiguration: {
       showAccessColumn: true,
       // set the entity ID column and version column to use (instead of the Row ID and Version)


### PR DESCRIPTION
since it might be confused with the dataset version