### PR TITLE
SWC-6753: prevent Available Evaluation Lists from collapsing twice

### DIFF
--- a/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.stories.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.stories.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import {
   generatedEvaulations,
   mockEvaluationQueue,
+  sevenGeneratedEvaulations,
 } from '../../mocks/entity/mockEvaluationQueue'
 import AvailableEvaluationQueueList from './AvailableEvaluationQueueList'
 
@@ -33,6 +34,12 @@ export const OneAvailable: Story = {
     evaluations: [
       { ...mockEvaluationQueue, submissionInstructionsMessage: markdownText },
     ],
+  },
+}
+
+export const SevenAvailable: Story = {
+  args: {
+    evaluations: sevenGeneratedEvaulations,
   },
 }
 

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.test.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.test.tsx
@@ -40,15 +40,11 @@ function setUp(props: AvailableEvaluationQueueListProps) {
   const user = userEvent.setup()
   const component = renderComponent(props)
   const selectInput = screen.queryByLabelText('Selected Evaluation Queue')
-  const showStaticListButton = screen.queryByRole('button', {
-    name: /all available evaluation queues/i,
-  })
   const staticListHeading = screen.queryByText('Available Evaluation Queues:')
   return {
     component,
     user,
     selectInput,
-    showStaticListButton,
     staticListHeading,
   }
 }
@@ -59,22 +55,20 @@ describe('AvailableEvaluationQueueList', () => {
   })
 
   it('handles 0 available evaluations', () => {
-    const { selectInput, showStaticListButton } = setUp(defaultProps)
+    const { selectInput } = setUp(defaultProps)
 
     screen.getByText('No evaluations found')
     expect(selectInput).toBeNull()
-    expect(showStaticListButton).toBeNull()
   })
 
   it('handles 1 available evaluation', () => {
-    const { selectInput, showStaticListButton, staticListHeading } = setUp({
+    const { selectInput, staticListHeading } = setUp({
       ...defaultProps,
       evaluations: [mockEvaluationQueue],
     })
 
     screen.getByText(mockEvaluationQueue.name!)
     expect(selectInput).toBeNull()
-    expect(showStaticListButton).toBeNull()
     expect(staticListHeading).toBeNull()
 
     expect(onChangeSelectedEvaluation).toHaveBeenCalledTimes(1)
@@ -82,7 +76,7 @@ describe('AvailableEvaluationQueueList', () => {
   })
 
   it('handles 1 available evaluation that is not selectable', () => {
-    const { selectInput, showStaticListButton, staticListHeading } = setUp({
+    const { selectInput, staticListHeading } = setUp({
       ...defaultProps,
       evaluations: [mockEvaluationQueue],
       isSelectable: false,
@@ -90,26 +84,17 @@ describe('AvailableEvaluationQueueList', () => {
 
     screen.getByText(mockEvaluationQueue.name!)
     expect(staticListHeading).toBeNull()
-    expect(showStaticListButton).toBeNull()
     expect(selectInput).toBeNull()
     expect(onChangeSelectedEvaluation).not.toHaveBeenCalled()
   })
 
   it('handles >1 available evaluations', async () => {
-    const { selectInput, showStaticListButton, staticListHeading, user } =
-      setUp({
-        ...defaultProps,
-        evaluations: [mockEvaluationQueue, secondEvaluation],
-      })
+    const { selectInput, staticListHeading, user } = setUp({
+      ...defaultProps,
+      evaluations: [mockEvaluationQueue, secondEvaluation],
+    })
 
     expect(selectInput).not.toBeNull()
-    expect(showStaticListButton).not.toBeNull()
-    expect(showStaticListButton?.textContent).toContain('Show')
-    expect(staticListHeading).not.toBeVisible()
-
-    await user.click(showStaticListButton!)
-
-    expect(showStaticListButton?.textContent).toContain('Hide')
     expect(staticListHeading).toBeVisible()
     expect(screen.getByText(mockEvaluationQueue.name!)).toBeVisible()
     expect(screen.getByText(secondEvaluation.name)).toBeVisible()
@@ -122,18 +107,13 @@ describe('AvailableEvaluationQueueList', () => {
   })
 
   it('handles >1 available evaluations that are not selectable', async () => {
-    const { selectInput, staticListHeading, showStaticListButton, user } =
-      setUp({
-        ...defaultProps,
-        evaluations: [mockEvaluationQueue, secondEvaluation],
-        isSelectable: false,
-      })
+    const { selectInput, staticListHeading } = setUp({
+      ...defaultProps,
+      evaluations: [mockEvaluationQueue, secondEvaluation],
+      isSelectable: false,
+    })
 
     expect(selectInput).toBeNull()
-    expect(showStaticListButton).not.toBeNull()
-    expect(staticListHeading).not.toBeVisible()
-
-    await user.click(showStaticListButton!)
 
     expect(staticListHeading).toBeVisible()
     expect(screen.getByText(mockEvaluationQueue.name!)).toBeVisible()

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.test.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.test.tsx
@@ -106,7 +106,7 @@ describe('AvailableEvaluationQueueList', () => {
     expect(onChangeSelectedEvaluation).toHaveBeenCalledWith(secondEvaluation)
   })
 
-  it('handles >1 available evaluations that are not selectable', async () => {
+  it('handles >1 available evaluations that are not selectable', () => {
     const { selectInput, staticListHeading } = setUp({
       ...defaultProps,
       evaluations: [mockEvaluationQueue, secondEvaluation],

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.test.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.test.tsx
@@ -64,14 +64,15 @@ describe('AvailableEvaluationQueueList', () => {
   })
 
   it('handles 0 available evaluations', () => {
-    const { selectInput } = setUp(defaultProps)
+    const { selectInput, showStaticListButton } = setUp(defaultProps)
 
     screen.getByText('No evaluations found')
     expect(selectInput).toBeNull()
+    expect(showStaticListButton).toBeNull()
   })
 
   it('handles 1 available evaluation', () => {
-    const { selectInput, staticListHeading } = setUp({
+    const { selectInput, staticListHeading, showStaticListButton } = setUp({
       ...defaultProps,
       evaluations: [mockEvaluationQueue],
     })
@@ -79,13 +80,14 @@ describe('AvailableEvaluationQueueList', () => {
     screen.getByText(mockEvaluationQueue.name!)
     expect(selectInput).toBeNull()
     expect(staticListHeading).toBeNull()
+    expect(showStaticListButton).toBeNull()
 
     expect(onChangeSelectedEvaluation).toHaveBeenCalledTimes(1)
     expect(onChangeSelectedEvaluation).toHaveBeenCalledWith(mockEvaluationQueue)
   })
 
   it('handles 1 available evaluation that is not selectable', () => {
-    const { selectInput, staticListHeading } = setUp({
+    const { selectInput, staticListHeading, showStaticListButton } = setUp({
       ...defaultProps,
       evaluations: [mockEvaluationQueue],
       isSelectable: false,
@@ -93,11 +95,12 @@ describe('AvailableEvaluationQueueList', () => {
 
     screen.getByText(mockEvaluationQueue.name!)
     expect(staticListHeading).toBeNull()
+    expect(showStaticListButton).toBeNull()
     expect(selectInput).toBeNull()
     expect(onChangeSelectedEvaluation).not.toHaveBeenCalled()
   })
 
-  it('handles >1 available evaluations', async () => {
+  it('displays collapsed list for <8 selectable available evaluations', async () => {
     const { selectInput, staticListHeading, showStaticListButton, user } =
       setUp({
         ...defaultProps,
@@ -106,6 +109,7 @@ describe('AvailableEvaluationQueueList', () => {
 
     expect(selectInput).not.toBeNull()
     expect(staticListHeading).not.toBeNull()
+    expect(showStaticListButton).not.toBeNull()
     expect(showStaticListButton?.textContent).toContain('Show')
     expect(staticListHeading).not.toBeVisible()
 
@@ -123,8 +127,8 @@ describe('AvailableEvaluationQueueList', () => {
     expect(onChangeSelectedEvaluation).toHaveBeenCalledWith(secondEvaluation)
   })
 
-  it('handles >1 available evaluations that are not selectable', () => {
-    const { selectInput, staticListHeading } = setUp({
+  it('displays static list for <8 available evaluations that are not selectable', () => {
+    const { selectInput, staticListHeading, showStaticListButton } = setUp({
       ...defaultProps,
       evaluations: [mockEvaluationQueue, secondEvaluation],
       isSelectable: false,
@@ -132,13 +136,14 @@ describe('AvailableEvaluationQueueList', () => {
 
     expect(selectInput).toBeNull()
     expect(staticListHeading).toBeVisible()
+    expect(showStaticListButton).toBeNull()
     expect(screen.getByText(mockEvaluationQueue.name!)).toBeVisible()
     expect(screen.getByText(secondEvaluation.name)).toBeVisible()
 
     expect(onChangeSelectedEvaluation).not.toHaveBeenCalled()
   })
 
-  it('handles >7 available evaluations', async () => {
+  it('displays collapsed list for >8 selectable available evaluations', async () => {
     const { selectInput, showStaticListButton, staticListHeading, user } =
       setUp({
         ...defaultProps,
@@ -173,7 +178,7 @@ describe('AvailableEvaluationQueueList', () => {
     )
   })
 
-  it('handles >7 available evaluations that are not selectable', async () => {
+  it('displays collapsed list for >8 available evaluations that are not selectable', async () => {
     const { selectInput, showStaticListButton, staticListHeading, user } =
       setUp({
         ...defaultProps,
@@ -183,10 +188,12 @@ describe('AvailableEvaluationQueueList', () => {
 
     expect(selectInput).toBeNull()
     expect(showStaticListButton).not.toBeNull()
+    expect(showStaticListButton?.textContent).toContain('Show')
     expect(staticListHeading).not.toBeVisible()
 
     await user.click(showStaticListButton!)
 
+    expect(showStaticListButton?.textContent).toContain('Hide')
     expect(staticListHeading).toBeVisible()
     eightEvaluationQueues.forEach((queue, index) => {
       expect(screen.getByText(queue.name)).toBeVisible()

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.tsx
@@ -83,11 +83,12 @@ function AvailableEvaluationQueueCollapsableList(
 ) {
   const { evaluations, isSelectable } = props
   const [showList, setShowList] = useState<boolean>(false)
-  const collapseBound = isSelectable ? 2 : 8
+  const nEvaluationsCollapseLimit = isSelectable ? 2 : 8
+  const shouldCollapse = evaluations.length >= nEvaluationsCollapseLimit
 
   return (
     <Box mt={2}>
-      {evaluations.length >= (collapseBound as number) ? (
+      {shouldCollapse ? (
         <>
           <Button
             variant="contained"

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.tsx
@@ -2,8 +2,6 @@ import { HelpOutlineTwoTone } from '@mui/icons-material'
 import {
   Autocomplete,
   Box,
-  Button,
-  Collapse,
   List,
   ListItem,
   MenuItem,
@@ -57,32 +55,22 @@ function AvailableEvaluationQueueStaticList(
   props: AvailableEvaluationQueueStaticListProps,
 ) {
   const { evaluations } = props
-  const [showList, setShowList] = useState<boolean>(false)
 
   return (
     <Box mt={2}>
-      <Button
-        variant="contained"
-        sx={{ mb: 1 }}
-        onClick={() => setShowList(!showList)}
-      >
-        {`${showList ? 'Hide' : 'Show'} All Available Evaluation Queues`}
-      </Button>
-      <Collapse in={showList}>
-        <Typography variant="body1">Available Evaluation Queues:</Typography>
-        <List dense={true}>
-          {evaluations.map(evaluation => {
-            return (
-              <ListItem key={evaluation.id}>
-                <TextWithHelpIcon
-                  text={evaluation.name!}
-                  tooltipMarkdownText={evaluation.submissionInstructionsMessage}
-                />
-              </ListItem>
-            )
-          })}
-        </List>
-      </Collapse>
+      <Typography variant="body1">Available Evaluation Queues:</Typography>
+      <List dense={true}>
+        {evaluations.map(evaluation => {
+          return (
+            <ListItem key={evaluation.id}>
+              <TextWithHelpIcon
+                text={evaluation.name!}
+                tooltipMarkdownText={evaluation.submissionInstructionsMessage}
+              />
+            </ListItem>
+          )
+        })}
+      </List>
     </Box>
   )
 }

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/AvailableEvaluationQueueList.tsx
@@ -2,6 +2,8 @@ import { HelpOutlineTwoTone } from '@mui/icons-material'
 import {
   Autocomplete,
   Box,
+  Button,
+  Collapse,
   List,
   ListItem,
   MenuItem,
@@ -50,27 +52,59 @@ type AvailableEvaluationQueueStaticListProps = Pick<
   AvailableEvaluationQueueListProps,
   'evaluations'
 >
-
 function AvailableEvaluationQueueStaticList(
   props: AvailableEvaluationQueueStaticListProps,
 ) {
   const { evaluations } = props
+  return (
+    <>
+      <Typography variant="body1">Available Evaluation Queues:</Typography>
+      <List dense={true}>
+        {evaluations.map(evaluation => (
+          <ListItem key={evaluation.id}>
+            <TextWithHelpIcon
+              text={evaluation.name!}
+              tooltipMarkdownText={evaluation.submissionInstructionsMessage}
+            />
+          </ListItem>
+        ))}
+      </List>
+    </>
+  )
+}
+
+type AvailableEvaluationQueueCollapsableListProps = Pick<
+  AvailableEvaluationQueueListProps,
+  'evaluations' | 'isSelectable'
+>
+
+function AvailableEvaluationQueueCollapsableList(
+  props: AvailableEvaluationQueueCollapsableListProps,
+) {
+  const { evaluations, isSelectable } = props
+  const [showList, setShowList] = useState<boolean>(false)
+  const collapseBound = isSelectable ? 2 : 8
 
   return (
     <Box mt={2}>
-      <Typography variant="body1">Available Evaluation Queues:</Typography>
-      <List dense={true}>
-        {evaluations.map(evaluation => {
-          return (
-            <ListItem key={evaluation.id}>
-              <TextWithHelpIcon
-                text={evaluation.name!}
-                tooltipMarkdownText={evaluation.submissionInstructionsMessage}
-              />
-            </ListItem>
-          )
-        })}
-      </List>
+      {evaluations.length >= (collapseBound as number) ? (
+        <>
+          <Button
+            variant="contained"
+            sx={{ mb: 1 }}
+            onClick={() => setShowList(!showList)}
+          >
+            {`${showList ? 'Hide' : 'Show'} All Available Evaluation Queues`}
+          </Button>
+          <Collapse in={showList}>
+            <AvailableEvaluationQueueStaticList {...props} />
+          </Collapse>
+        </>
+      ) : (
+        <>
+          <AvailableEvaluationQueueStaticList {...props} />
+        </>
+      )}
     </Box>
   )
 }
@@ -160,7 +194,7 @@ function AvailableEvaluationQueueList(
       className="AvailableEvaluationQueueList"
     >
       {isSelectable && <AvailableEvaluationQueueAutocompleteList {...props} />}
-      <AvailableEvaluationQueueStaticList {...props} />
+      <AvailableEvaluationQueueCollapsableList {...props} />
     </Box>
   )
 }

--- a/packages/synapse-react-client/src/mocks/entity/mockEvaluationQueue.ts
+++ b/packages/synapse-react-client/src/mocks/entity/mockEvaluationQueue.ts
@@ -30,3 +30,7 @@ export const mockEvaluations: Evaluation[] = [mockEvaluationQueue]
 export const generatedEvaulations: Evaluation[] = times(10, () =>
   generateEvaluation(),
 )
+
+export const sevenGeneratedEvaulations: Evaluation[] = times(7, () =>
+  generateEvaluation(),
+)


### PR DESCRIPTION
In production
![Screenshot 2024-04-05 at 12 32 28 PM](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/83617519/2f3b738e-dc65-4468-a7fb-00d2dcec2dcb)

In feature
![Screenshot 2024-04-05 at 12 31 46 PM](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/83617519/0dbb97f3-0acf-40ad-b965-dad93b28a900)
