### PR TITLE
Add thumbnail column preview to mc2supplement.ts

### DIFF
--- a/apps/portals/src/configurations/cancercomplexity/synapseConfigs/mc2supplement.ts
+++ b/apps/portals/src/configurations/cancercomplexity/synapseConfigs/mc2supplement.ts
@@ -16,6 +16,10 @@ export const mc2SupplementTable: SynapseConfig = {
         matchColumnName: 'fuse_mask',
         isEntityImage: true,
       },
+      {
+        matchColumnName: 'thumb',
+        isEntityImage: true,
+      },
     ],
   },
 }


### PR DESCRIPTION
Following work by @jay-hodgson to add a hidden page to CCKP to share results from the M2 Digital Pathology supplement, this PR makes a minor adjustment to also preview the image thumbnail as well as the fuse mask.

This is an initial PR to scope a further change to this page to optimise for digital pathology qc data sharing.