### PR TITLE
SWC-6730b: add components for setting fields specific to basic and managed ARs

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/UploadDocumentField.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/UploadDocumentField.stories.tsx
@@ -1,0 +1,37 @@
+import {
+  FileHandleAssociateType,
+  FileHandleAssociation,
+} from '@sage-bionetworks/synapse-types'
+import { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import { MOCK_MANAGED_ACCESS_REQUIREMENT_ACL } from '../../../mocks/mockAccessRequirementAcls'
+import { MOCK_DUC_TEMPLATE_FILE_HANDLE_ID } from '../../../mocks/mock_file_handle'
+import { UploadDocumentField } from './UploadDocumentField'
+
+const meta: Meta = {
+  title: 'Governance/UploadDocumentField',
+  component: UploadDocumentField,
+  parameters: { stack: 'mock' },
+} satisfies Meta<typeof UploadDocumentField>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const mockDucFileHandleAssociation: FileHandleAssociation = {
+  fileHandleId: MOCK_DUC_TEMPLATE_FILE_HANDLE_ID,
+  associateObjectType: FileHandleAssociateType.AccessRequirementAttachment,
+  associateObjectId: MOCK_MANAGED_ACCESS_REQUIREMENT_ACL.id,
+}
+
+export const Demo: Story = {
+  args: {
+    id: 'duc',
+    isLoading: false,
+    uploadCallback: fn(),
+    documentName: 'Template DUC',
+    fileHandleAssociations: [mockDucFileHandleAssociation],
+    isMultiFileUpload: false,
+    onClearAttachment: null,
+  },
+}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/UploadDocumentField.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/UploadDocumentField.tsx
@@ -3,7 +3,7 @@ import {
   UploadCallbackResp,
 } from '@sage-bionetworks/synapse-types'
 import { useGetFileBatch } from '../../../synapse-queries/file/useFiles'
-import { Box, Button } from '@mui/material'
+import { Box, Button, ButtonProps } from '@mui/material'
 import FileUpload from '../../FileUpload/FileUpload'
 import IconSvg from '../../IconSvg/IconSvg'
 import DirectDownloadButton from '../../DirectDownloadButton'
@@ -18,6 +18,7 @@ type UploadDocumentFieldProps = {
   isMultiFileUpload?: boolean
   onClearAttachment?: (fileHandleId: string) => void
   isLoading?: boolean
+  uploadBtnVariant?: ButtonProps['variant']
 }
 
 export function UploadDocumentField(props: UploadDocumentFieldProps) {
@@ -29,6 +30,7 @@ export function UploadDocumentField(props: UploadDocumentFieldProps) {
     isMultiFileUpload = false,
     onClearAttachment,
     isLoading = false,
+    uploadBtnVariant = 'outlined',
   } = props
   const [isUploading, setIsUploading] = useState(false)
 
@@ -62,7 +64,7 @@ export function UploadDocumentField(props: UploadDocumentFieldProps) {
         label={`Upload ${documentName}`}
         buttonProps={{
           disabled: isLoading,
-          variant: 'outlined',
+          variant: uploadBtnVariant,
           endIcon: <IconSvg icon={'upload'} wrap={false} />,
         }}
       />

--- a/packages/synapse-react-client/src/components/FileUpload/FileUpload.tsx
+++ b/packages/synapse-react-client/src/components/FileUpload/FileUpload.tsx
@@ -76,6 +76,7 @@ export const FileUpload: React.FC<FileUploadProps> = props => {
   return (
     <>
       <input
+        data-testid="file-input"
         type={'file'}
         ref={hiddenFileInput}
         onChange={e => {

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.stories.ts
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.stories.ts
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 import MarkdownSynapse from './MarkdownSynapse'
+import { ObjectType } from '@sage-bionetworks/synapse-types'
 
 const meta = {
   title: 'Markdown/MarkdownSynapse',
@@ -19,6 +20,20 @@ export const WikiPage: Story = {
     ownerId: 'syn12666371',
     wikiId: '585317',
     loadingSkeletonRowCount: 20,
+  },
+}
+
+// Note: this story currently displays an error, but should display a wiki
+// after MarkdownSynapse is updated to handle root WikiPages for ACCESS_REQUIREMENT
+// object types. See https://sagebionetworks.jira.com/browse/SWC-6791.
+export const RootWikiPageAccessRequirement: Story = {
+  args: {
+    ownerId: '9602704',
+    wikiId: undefined,
+    objectType: ObjectType.ACCESS_REQUIREMENT,
+  },
+  parameters: {
+    stack: 'development',
   },
 }
 

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.tsx
@@ -33,6 +33,8 @@ import markdownitInlineComments from 'markdown-it-inline-comments'
 import markdownitBr from 'markdown-it-br'
 import markdownitMath from 'markdown-it-synapse-math'
 
+export const NO_WIKI_CONTENT = 'There is no content.'
+
 export type MarkdownSynapseProps = {
   ownerId?: string
   wikiId?: string
@@ -41,6 +43,7 @@ export type MarkdownSynapseProps = {
   objectType?: ObjectType
   loadingSkeletonRowCount?: number
   onMarkdownProcessingDone?: (textContent: string | null | undefined) => void
+  showPlaceholderIfNoWikiContent?: boolean
 }
 const md = MarkdownIt({ html: true })
 
@@ -241,6 +244,10 @@ class MarkdownSynapse extends React.Component<
       return
     }
     try {
+      /* TODO: when wikiId is undefined, get the root WikiPageKey (SynapseClient.getRootWikiPageKey),
+      then use the key to get the specific WikiPage (SynapseClient.getWikiPage). 
+      See https://sagebionetworks.jira.com/browse/SWC-6791.
+      */
       const wikiPage = await SynapseClient.getEntityWiki(
         this.context.accessToken,
         ownerId,
@@ -344,6 +351,22 @@ class MarkdownSynapse extends React.Component<
       const document = domParser.parseFromString(markup, 'text/html')
       return <>{this.recursiveRender(document.body, markup)}</>
     }
+
+    // If we're still fetching data, then don't show the placeholder yet
+    const isFetchingData =
+      this.props.objectType && this.props.ownerId && this.state.isLoading
+    if (
+      !isFetchingData &&
+      this.props.showPlaceholderIfNoWikiContent &&
+      markup === ''
+    ) {
+      return (
+        <Typography variant="body1Italic" mb={1}>
+          {NO_WIKI_CONTENT}
+        </Typography>
+      )
+    }
+
     return
   }
 
@@ -614,13 +637,17 @@ class MarkdownSynapse extends React.Component<
     )
     if (renderInline) {
       return (
-        <span className="markdown markdown-inline" ref={this.markupRef}>
+        <span
+          aria-label="markdown"
+          className="markdown markdown-inline"
+          ref={this.markupRef}
+        >
           {content}
         </span>
       )
     }
     return (
-      <div className="markdown" ref={this.markupRef}>
+      <div aria-label="markdown" className="markdown" ref={this.markupRef}>
         {content}
       </div>
     )

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.tsx
@@ -638,7 +638,7 @@ class MarkdownSynapse extends React.Component<
     if (renderInline) {
       return (
         <span
-          aria-label="markdown"
+          data-testid="markdown"
           className="markdown markdown-inline"
           ref={this.markupRef}
         >
@@ -647,7 +647,7 @@ class MarkdownSynapse extends React.Component<
       )
     }
     return (
-      <div aria-label="markdown" className="markdown" ref={this.markupRef}>
+      <div data-testid="markdown" className="markdown" ref={this.markupRef}>
         {content}
       </div>
     )

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementTextInstructions.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementTextInstructions.tsx
@@ -1,0 +1,66 @@
+import { Box, Button, Typography } from '@mui/material'
+import {
+  ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  AccessRequirement,
+  TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+} from '@sage-bionetworks/synapse-types'
+import React, { useState } from 'react'
+import ConfirmationDialog from '../ConfirmationDialog'
+import { getOldAccessRequirementInstructions } from './GovernanceUtils'
+
+type AccessRequirementTextInstructionsProps = {
+  accessRequirement: AccessRequirement
+  onConfirmDelete: (updatedAr: AccessRequirement) => void
+}
+
+export const AccessRequirementTextInstructions: React.FunctionComponent<
+  AccessRequirementTextInstructionsProps
+> = (props: AccessRequirementTextInstructionsProps) => {
+  const { accessRequirement, onConfirmDelete } = props
+
+  const [open, setOpen] = useState<boolean>(false)
+  const oldInstructions = getOldAccessRequirementInstructions(accessRequirement)
+
+  return (
+    <>
+      {Boolean(oldInstructions) && (
+        <Box mb={2}>
+          <Typography variant="body1" fontWeight={700} mb={1}>
+            Legacy text-only instructions
+          </Typography>
+          <Typography variant="body1" mb={1}>
+            {oldInstructions}
+          </Typography>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => setOpen(true)}
+          >
+            Delete old instructions
+          </Button>
+          <ConfirmationDialog
+            open={open}
+            title="Are you sure?"
+            content="Deleting the old instructions cannot be undone. Continue?"
+            onCancel={() => setOpen(false)}
+            onConfirm={() => {
+              const clearedInstructionsAr = { ...accessRequirement }
+              if (
+                clearedInstructionsAr.concreteType ===
+                TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+              ) {
+                clearedInstructionsAr.termsOfUse = undefined
+              } else if (
+                clearedInstructionsAr.concreteType ===
+                ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+              ) {
+                clearedInstructionsAr.actContactInfo = undefined
+              }
+              onConfirmDelete(clearedInstructionsAr)
+            }}
+          />
+        </Box>
+      )}
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementTextInstructions.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementTextInstructions.tsx
@@ -11,12 +11,13 @@ import { getOldAccessRequirementInstructions } from './GovernanceUtils'
 type AccessRequirementTextInstructionsProps = {
   accessRequirement: AccessRequirement
   onConfirmDelete: (updatedAr: AccessRequirement) => void
+  allowDelete?: boolean
 }
 
 export const AccessRequirementTextInstructions: React.FunctionComponent<
   AccessRequirementTextInstructionsProps
 > = (props: AccessRequirementTextInstructionsProps) => {
-  const { accessRequirement, onConfirmDelete } = props
+  const { accessRequirement, onConfirmDelete, allowDelete = false } = props
 
   const [open, setOpen] = useState<boolean>(false)
   const oldInstructions = getOldAccessRequirementInstructions(accessRequirement)
@@ -31,34 +32,39 @@ export const AccessRequirementTextInstructions: React.FunctionComponent<
           <Typography variant="body1" mb={1}>
             {oldInstructions}
           </Typography>
-          <Button
-            variant="contained"
-            color="error"
-            onClick={() => setOpen(true)}
-          >
-            Delete old instructions
-          </Button>
-          <ConfirmationDialog
-            open={open}
-            title="Are you sure?"
-            content="Deleting the old instructions cannot be undone. Continue?"
-            onCancel={() => setOpen(false)}
-            onConfirm={() => {
-              const clearedInstructionsAr = { ...accessRequirement }
-              if (
-                clearedInstructionsAr.concreteType ===
-                TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
-              ) {
-                clearedInstructionsAr.termsOfUse = undefined
-              } else if (
-                clearedInstructionsAr.concreteType ===
-                ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
-              ) {
-                clearedInstructionsAr.actContactInfo = undefined
-              }
-              onConfirmDelete(clearedInstructionsAr)
-            }}
-          />
+          {allowDelete && (
+            <>
+              <Button
+                variant="contained"
+                color="error"
+                onClick={() => setOpen(true)}
+              >
+                Delete old instructions
+              </Button>
+              <ConfirmationDialog
+                open={open}
+                title="Are you sure?"
+                content="Deleting the old instructions cannot be undone. Continue?"
+                onCancel={() => setOpen(false)}
+                onConfirm={() => {
+                  const clearedInstructionsAr = { ...accessRequirement }
+                  if (
+                    clearedInstructionsAr.concreteType ===
+                    TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+                  ) {
+                    clearedInstructionsAr.termsOfUse = undefined
+                  } else if (
+                    clearedInstructionsAr.concreteType ===
+                    ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+                  ) {
+                    clearedInstructionsAr.actContactInfo = undefined
+                  }
+                  onConfirmDelete(clearedInstructionsAr)
+                  setOpen(false)
+                }}
+              />
+            </>
+          )}
         </Box>
       )}
     </>

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementWikiInstructions.test.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementWikiInstructions.test.tsx
@@ -15,7 +15,7 @@ import {
   waitForMarkdownSynapseToGetWiki,
 } from '../../testutils/MarkdownSynapseUtils'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
-import { WIKI_PAGE } from '../../utils/APIConstants'
+import { WIKI_PAGE_ID } from '../../utils/APIConstants'
 import { BackendDestinationEnum, getEndpoint } from '../../utils/functions'
 import { NO_WIKI_CONTENT } from '../Markdown/MarkdownSynapse'
 import {
@@ -27,10 +27,11 @@ const createWikiPageSpy = jest.spyOn(SynapseClient, 'createWikiPage')
 const changeGetWikiPageHandlerOnce = (wikiPage: WikiPage) => {
   return server.use(
     rest.get(
-      `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${WIKI_PAGE(
+      `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${WIKI_PAGE_ID(
         ObjectType.ACCESS_REQUIREMENT,
         ':ownerObjectId',
-      )}/:wikiPageId`,
+        ':wikiPageId',
+      )}`,
       async (req, res, ctx) => {
         return res.once(ctx.status(200), ctx.json(wikiPage))
       },

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementWikiInstructions.test.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementWikiInstructions.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import {
+  mockACTAccessRequirement,
+  mockACTAccessRequirementWithWiki,
+} from '../../mocks/mockAccessRequirements'
+import { mockACTAccessRequirementWikiPage } from '../../mocks/mockWiki'
+import { server } from '../../mocks/msw/server'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import { MarkdownSynapse } from '../Markdown'
+import { NO_WIKI_CONTENT } from '../WikiMarkdownEditorButton/WikiMarkdownEditorButton'
+import {
+  AccessRequirementWikiInstructions,
+  AccessRequirementWikiInstructionsProps,
+} from './AccessRequirementWikiInstructions'
+
+const MARKDOWN_SYNAPSE_TEST_ID = 'MarkdownSynapseContent'
+jest.mock('../Markdown/MarkdownSynapse', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+const mockMarkdownSynapse = jest.mocked(MarkdownSynapse)
+mockMarkdownSynapse.mockImplementation(
+  () => (<div data-testid={MARKDOWN_SYNAPSE_TEST_ID} />) as any,
+)
+async function confirmMarkdown(markdown: string) {
+  await screen.findByTestId(MARKDOWN_SYNAPSE_TEST_ID)
+  expect(mockMarkdownSynapse).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      markdown: markdown,
+    }),
+    expect.anything(),
+  )
+}
+
+function renderComponent(props: AccessRequirementWikiInstructionsProps) {
+  return render(<AccessRequirementWikiInstructions {...props} />, {
+    wrapper: createWrapper(),
+  })
+}
+
+function setUp(props: AccessRequirementWikiInstructionsProps) {
+  const user = userEvent.setup()
+  const component = renderComponent(props)
+
+  const editBtn = screen.getByRole('button', { name: 'Edit Instructions' })
+
+  return { component, user, editBtn }
+}
+
+describe('AccessRequirementWikiInstructions', () => {
+  beforeEach(() => jest.clearAllMocks())
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  test('creates and edits new wiki when there is not an existing wiki', async () => {
+    const props: AccessRequirementWikiInstructionsProps = {
+      accessRequirement: mockACTAccessRequirement,
+    }
+    const { user, editBtn } = setUp(props)
+
+    await waitFor(() => {
+      expect(editBtn).not.toBeDisabled()
+      expect(screen.queryByText(NO_WIKI_CONTENT)).not.toBeNull()
+    })
+
+    await user.click(editBtn)
+
+    const editDialog = await screen.findByRole('dialog', {
+      name: 'Edit Wiki Markdown',
+    })
+    const markdownField = await within(editDialog).findByRole('textbox', {
+      name: 'markdown',
+    })
+    expect(markdownField).toHaveValue('')
+
+    const newMarkdown = 'Some new markdown AR instructions'
+    await user.type(markdownField, newMarkdown)
+    expect(markdownField).toHaveValue(newMarkdown)
+
+    const saveBtn = within(editDialog).getByRole('button', { name: 'Save' })
+    await user.click(saveBtn)
+
+    await waitFor(() => {
+      expect(editDialog).not.toBeInTheDocument()
+    })
+
+    await confirmMarkdown(newMarkdown)
+    expect(screen.queryByText(NO_WIKI_CONTENT)).toBeNull()
+  })
+
+  test('edits an existing wiki', async () => {
+    const props: AccessRequirementWikiInstructionsProps = {
+      accessRequirement: mockACTAccessRequirementWithWiki,
+    }
+    const { user, editBtn } = setUp(props)
+
+    await confirmMarkdown(mockACTAccessRequirementWikiPage.markdown)
+    expect(screen.queryByText(NO_WIKI_CONTENT)).toBeNull()
+    expect(editBtn).not.toBeDisabled()
+
+    await user.click(editBtn)
+
+    const editDialog = await screen.findByRole('dialog', {
+      name: 'Edit Wiki Markdown',
+    })
+    const markdownField = await within(editDialog).findByRole('textbox', {
+      name: 'markdown',
+    })
+    expect(markdownField).toHaveValue(mockACTAccessRequirementWikiPage.markdown)
+
+    const newMarkdown = 'Some new markdown AR instructions'
+    await user.clear(markdownField)
+    await user.type(markdownField, newMarkdown)
+    expect(markdownField).toHaveValue(newMarkdown)
+
+    const saveBtn = within(editDialog).getByRole('button', { name: 'Save' })
+    await user.click(saveBtn)
+
+    await waitFor(() => {
+      expect(editDialog).not.toBeInTheDocument()
+    })
+
+    await confirmMarkdown(newMarkdown)
+  })
+})

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementWikiInstructions.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementWikiInstructions.tsx
@@ -1,0 +1,28 @@
+import { Box, Typography } from '@mui/material'
+import { AccessRequirement, ObjectType } from '@sage-bionetworks/synapse-types'
+import React from 'react'
+import WikiMarkdownEditorButton from '../WikiMarkdownEditorButton'
+
+export type AccessRequirementWikiInstructionsProps = {
+  accessRequirement: AccessRequirement
+}
+
+export const AccessRequirementWikiInstructions: React.FunctionComponent<
+  AccessRequirementWikiInstructionsProps
+> = (props: AccessRequirementWikiInstructionsProps) => {
+  const { accessRequirement } = props
+
+  return (
+    <Box mb={2}>
+      <Typography variant="body1" fontWeight={700}>
+        {'Instructions (wiki)'}
+      </Typography>
+      <WikiMarkdownEditorButton
+        ownerObjectType={ObjectType.ACCESS_REQUIREMENT}
+        ownerObjectId={accessRequirement.id.toString()}
+        displayWikiMarkdown={true}
+        buttonProps={{ children: 'Edit Instructions' }}
+      />
+    </Box>
+  )
+}

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessorRequirements.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessorRequirements.tsx
@@ -1,0 +1,64 @@
+import { AccessRequirement } from '@sage-bionetworks/synapse-types'
+import React from 'react'
+import { Checkbox } from '../widgets/Checkbox'
+import { hasAccessorRequirement } from './GovernanceUtils'
+import { MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE } from '@sage-bionetworks/synapse-types'
+import { Box, Typography } from '@mui/material'
+
+type AccessorRequirementsProps = {
+  accessRequirement: AccessRequirement
+  onChange: (updatedAr: AccessRequirement) => void
+}
+
+export const AccessorRequirements: React.FunctionComponent<
+  AccessorRequirementsProps
+> = (props: AccessorRequirementsProps) => {
+  const { accessRequirement, onChange } = props
+
+  return (
+    <>
+      {hasAccessorRequirement(accessRequirement) && (
+        <>
+          <Box mb={2}>
+            <Typography variant="body1" fontWeight={700}>
+              Accessor requirements
+            </Typography>
+            <Checkbox
+              label="Accessors must be certified."
+              checked={accessRequirement.isCertifiedUserRequired}
+              onChange={(checked: boolean) =>
+                onChange({
+                  ...accessRequirement,
+                  isCertifiedUserRequired: checked,
+                })
+              }
+            />
+            <Checkbox
+              label="Accessors must have a validated profile."
+              checked={accessRequirement.isValidatedProfileRequired}
+              onChange={(checked: boolean) =>
+                onChange({
+                  ...accessRequirement,
+                  isValidatedProfileRequired: checked,
+                })
+              }
+            />
+            {accessRequirement.concreteType ===
+              MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE && (
+              <Checkbox
+                label="Accessors must use two-factor authentication (2FA)."
+                checked={accessRequirement.isTwoFaRequired}
+                onChange={(checked: boolean) =>
+                  onChange({
+                    ...accessRequirement,
+                    isTwoFaRequired: checked,
+                  })
+                }
+              />
+            )}
+          </Box>
+        </>
+      )}
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/GovernanceUtils.test.ts
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/GovernanceUtils.test.ts
@@ -1,0 +1,55 @@
+import {
+  mockACTAccessRequirement,
+  mockLockAccessRequirement,
+  mockManagedACTAccessRequirement,
+  mockSelfSignAccessRequirement,
+  mockToUAccessRequirement,
+} from '../../mocks/mockAccessRequirements'
+import {
+  LOCK_ACCESS_REQUIREMENT_TEXT,
+  getOldAccessRequirementInstructions,
+  hasAccessorRequirement,
+} from './GovernanceUtils'
+
+describe('GovernanceUtils', () => {
+  describe('hasAccessorRequirement', () => {
+    test('identifies ARs with accessor requirements', () => {
+      expect(hasAccessorRequirement(mockManagedACTAccessRequirement)).toBe(true)
+      expect(hasAccessorRequirement(mockSelfSignAccessRequirement)).toBe(true)
+    })
+
+    test('identifies ARs without accessor requirements', () => {
+      expect(hasAccessorRequirement(mockToUAccessRequirement)).toBe(false)
+      expect(hasAccessorRequirement(mockACTAccessRequirement)).toBe(false)
+      expect(hasAccessorRequirement(mockLockAccessRequirement)).toBe(false)
+    })
+  })
+
+  describe('getAccessRequirementText', () => {
+    test('Managed AR', () => {
+      expect(
+        getOldAccessRequirementInstructions(mockManagedACTAccessRequirement),
+      ).toBe('')
+    })
+    test('Self Sign AR', () => {
+      expect(
+        getOldAccessRequirementInstructions(mockSelfSignAccessRequirement),
+      ).toBe('')
+    })
+    test('Terms Of Use AR', () => {
+      expect(
+        getOldAccessRequirementInstructions(mockToUAccessRequirement),
+      ).toBe(mockToUAccessRequirement.termsOfUse)
+    })
+    test('ACT AR', () => {
+      expect(
+        getOldAccessRequirementInstructions(mockACTAccessRequirement),
+      ).toBe(mockACTAccessRequirement.actContactInfo)
+    })
+    test('Lock AR', () => {
+      expect(
+        getOldAccessRequirementInstructions(mockLockAccessRequirement),
+      ).toBe(LOCK_ACCESS_REQUIREMENT_TEXT)
+    })
+  })
+})

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/GovernanceUtils.ts
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/GovernanceUtils.ts
@@ -16,6 +16,7 @@ export const getOldAccessRequirementInstructions = (ar: AccessRequirement) => {
   switch (ar.concreteType) {
     case MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
     case SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+      // uses wiki to store instructions
       return ''
     case TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
       return ar.termsOfUse
@@ -26,6 +27,10 @@ export const getOldAccessRequirementInstructions = (ar: AccessRequirement) => {
   }
 }
 
+/**
+ * Returns true iff the access requirement can apply restrictions based on
+ * accessor qualities, such as certification or validation status
+ */
 export const hasAccessorRequirement = (
   ar: AccessRequirement,
 ): ar is SelfSignAccessRequirement | ManagedACTAccessRequirement => {

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/GovernanceUtils.ts
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/GovernanceUtils.ts
@@ -1,0 +1,36 @@
+import {
+  ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  AccessRequirement,
+  LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  ManagedACTAccessRequirement,
+  SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  SelfSignAccessRequirement,
+  TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+} from '@sage-bionetworks/synapse-types'
+
+export const LOCK_ACCESS_REQUIREMENT_TEXT =
+  'Access restricted pending review by Synapse Access and Compliance Team.'
+
+export const getOldAccessRequirementInstructions = (ar: AccessRequirement) => {
+  switch (ar.concreteType) {
+    case MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+    case SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+      return ''
+    case TERMS_OF_USE_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+      return ar.termsOfUse
+    case ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+      return ar.actContactInfo
+    case LOCK_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE:
+      return LOCK_ACCESS_REQUIREMENT_TEXT
+  }
+}
+
+export const hasAccessorRequirement = (
+  ar: AccessRequirement,
+): ar is SelfSignAccessRequirement | ManagedACTAccessRequirement => {
+  return (
+    ar.concreteType === SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE ||
+    ar.concreteType == MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+  )
+}

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/SetBasicAccessRequirementFields.stories.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/SetBasicAccessRequirementFields.stories.tsx
@@ -1,0 +1,68 @@
+import { Button, Paper } from '@mui/material'
+import { Meta, StoryObj } from '@storybook/react'
+import React, { useRef, useState } from 'react'
+import {
+  mockACTAccessRequirement,
+  mockSelfSignAccessRequirement,
+  mockToUAccessRequirement,
+} from '../../mocks/mockAccessRequirements'
+import {
+  SetBasicAccessRequirementFields,
+  SetBasicAccessRequirementFieldsHandle,
+} from './SetBasicAccessRequirementFields'
+
+const meta: Meta<typeof SetBasicAccessRequirementFields> = {
+  title: 'Governance/SetBasicAccessRequirementFields',
+  component: SetBasicAccessRequirementFields,
+  parameters: {
+    stack: 'mock',
+  },
+  render: function RenderFn(args) {
+    const [isSaving, setIsSaving] = useState<boolean>(false)
+    const ref = useRef<SetBasicAccessRequirementFieldsHandle>(null)
+
+    return (
+      <>
+        <Button
+          onClick={() => {
+            setIsSaving(true)
+            ref.current?.save()
+          }}
+          variant="contained"
+          disabled={isSaving}
+        >
+          Save AR
+        </Button>
+        <Paper sx={{ mx: 'auto', p: '44px', maxWidth: '750px' }}>
+          <SetBasicAccessRequirementFields
+            {...args}
+            ref={ref}
+            onSaveComplete={() => setIsSaving(false)}
+          />
+        </Paper>
+      </>
+    )
+  },
+} satisfies Meta<typeof SetBasicAccessRequirementFields>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const MockSelfSign: Story = {
+  args: {
+    accessRequirement: mockSelfSignAccessRequirement,
+  },
+}
+
+export const MockTermsOfUse: Story = {
+  args: {
+    accessRequirement: mockToUAccessRequirement,
+  },
+}
+
+export const MockACTAccessRequirement: Story = {
+  args: {
+    accessRequirement: mockACTAccessRequirement,
+  },
+}

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/SetBasicAccessRequirementFields.stories.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/SetBasicAccessRequirementFields.stories.tsx
@@ -37,7 +37,8 @@ const meta: Meta<typeof SetBasicAccessRequirementFields> = {
           <SetBasicAccessRequirementFields
             {...args}
             ref={ref}
-            onSaveComplete={() => setIsSaving(false)}
+            onSave={() => setIsSaving(false)}
+            onError={() => setIsSaving(false)}
           />
         </Paper>
       </>
@@ -51,18 +52,27 @@ type Story = StoryObj<typeof meta>
 
 export const MockSelfSign: Story = {
   args: {
-    accessRequirement: mockSelfSignAccessRequirement,
+    accessRequirementId: mockSelfSignAccessRequirement.id.toString(),
   },
 }
 
 export const MockTermsOfUse: Story = {
   args: {
-    accessRequirement: mockToUAccessRequirement,
+    accessRequirementId: mockToUAccessRequirement.id.toString(),
   },
 }
 
 export const MockACTAccessRequirement: Story = {
   args: {
-    accessRequirement: mockACTAccessRequirement,
+    accessRequirementId: mockACTAccessRequirement.id.toString(),
+  },
+}
+
+export const DevSelfSign: Story = {
+  args: {
+    accessRequirementId: '9602674',
+  },
+  parameters: {
+    stack: 'development',
   },
 }

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/SetBasicAccessRequirementFields.test.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/SetBasicAccessRequirementFields.test.tsx
@@ -1,0 +1,274 @@
+import { ACTAccessRequirement } from '@sage-bionetworks/synapse-types'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { MOCK_ACCESS_TOKEN } from '../../mocks/MockSynapseContext'
+import {
+  mockACTAccessRequirement,
+  mockACTAccessRequirementWithWiki,
+  mockSelfSignAccessRequirement,
+  mockToUAccessRequirement,
+} from '../../mocks/mockAccessRequirements'
+import {
+  mockACTAccessRequirementWikiPage,
+  mockSelfSignAccessRequirementWikiPage,
+} from '../../mocks/mockWiki'
+import { server } from '../../mocks/msw/server'
+import SynapseClient from '../../synapse-client'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import { MarkdownSynapse } from '../Markdown'
+import {
+  SetBasicAccessRequirementFields,
+  SetBasicAccessRequirementFieldsHandle,
+  SetBasicAccessRequirementFieldsProps,
+} from './SetBasicAccessRequirementFields'
+
+const MARKDOWN_SYNAPSE_TEST_ID = 'MarkdownSynapseContent'
+jest.mock('../Markdown/MarkdownSynapse', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+const mockMarkdownSynapse = jest.mocked(MarkdownSynapse)
+mockMarkdownSynapse.mockImplementation(
+  () => (<div data-testid={MARKDOWN_SYNAPSE_TEST_ID} />) as any,
+)
+async function confirmMarkdown(markdown: string) {
+  await screen.findByTestId(MARKDOWN_SYNAPSE_TEST_ID)
+  expect(mockMarkdownSynapse).toHaveBeenCalledWith(
+    expect.objectContaining({
+      markdown: markdown,
+    }),
+    expect.anything(),
+  )
+}
+
+const onSaveComplete = jest.fn()
+const updateAccessRequirementSpy = jest.spyOn(
+  SynapseClient,
+  'updateAccessRequirement',
+)
+
+function renderComponent(props: SetBasicAccessRequirementFieldsProps) {
+  const ref = React.createRef<SetBasicAccessRequirementFieldsHandle>()
+  const component = render(
+    <SetBasicAccessRequirementFields ref={ref} {...props} />,
+    {
+      wrapper: createWrapper(),
+    },
+  )
+  return { ref, component }
+}
+
+function setUp(props: SetBasicAccessRequirementFieldsProps) {
+  const user = userEvent.setup()
+  const { ref, component } = renderComponent(props)
+
+  const checkboxes = {
+    isCertifiedUserRequired: screen.queryByRole('checkbox', {
+      name: 'Accessors must be certified.',
+    }),
+    isValidatedProfileRequired: screen.queryByRole('checkbox', {
+      name: 'Accessors must have a validated profile.',
+    }),
+  }
+
+  const buttons = {
+    deleteTextInstructions: screen.queryByRole('button', {
+      name: 'Delete old instructions',
+    }),
+    editInstructions: screen.getByRole('button', { name: 'Edit Instructions' }),
+  }
+
+  return {
+    ref,
+    component,
+    user,
+    checkboxes,
+    buttons,
+  }
+}
+
+describe('SetBasicAccessRequirementFields', () => {
+  beforeEach(() => jest.clearAllMocks())
+  beforeAll(() => server.listen())
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  test('does not show text instructions for self-signed AR', () => {
+    const { buttons } = setUp({
+      accessRequirement: mockSelfSignAccessRequirement,
+      onSaveComplete,
+    })
+    expect(buttons.deleteTextInstructions).toBeNull()
+  })
+
+  test('displays existing wiki for self-signed AR', async () => {
+    const { buttons } = setUp({
+      accessRequirement: mockSelfSignAccessRequirement,
+      onSaveComplete,
+    })
+    expect(buttons.editInstructions).toBeVisible()
+    await confirmMarkdown(mockSelfSignAccessRequirementWikiPage.markdown)
+  })
+
+  test('updates accessor requirements for self-signed AR', async () => {
+    const { user, ref, checkboxes } = setUp({
+      accessRequirement: mockSelfSignAccessRequirement,
+      onSaveComplete,
+    })
+
+    expect(checkboxes.isCertifiedUserRequired).not.toBeNull()
+    expect(checkboxes.isValidatedProfileRequired).not.toBeNull()
+    expect(checkboxes.isCertifiedUserRequired).toBeChecked()
+    expect(checkboxes.isValidatedProfileRequired).toBeChecked()
+
+    await user.click(checkboxes.isCertifiedUserRequired!)
+    await user.click(checkboxes.isValidatedProfileRequired!)
+
+    expect(checkboxes.isCertifiedUserRequired).not.toBeChecked()
+    expect(checkboxes.isValidatedProfileRequired).not.toBeChecked()
+    expect(onSaveComplete).not.toHaveBeenCalled()
+
+    // parent calls save
+    ref?.current?.save()
+
+    await waitFor(() => {
+      expect(updateAccessRequirementSpy).toHaveBeenCalledTimes(1)
+      expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
+        MOCK_ACCESS_TOKEN,
+        {
+          ...mockSelfSignAccessRequirement,
+          isCertifiedUserRequired: false,
+          isValidatedProfileRequired: false,
+        },
+      )
+    })
+    expect(onSaveComplete).toHaveBeenCalled()
+  })
+
+  test('does not show accessor requirements for ACT AR', () => {
+    const { checkboxes } = setUp({
+      accessRequirement: mockACTAccessRequirement,
+      onSaveComplete,
+    })
+    expect(checkboxes.isCertifiedUserRequired).toBeNull()
+    expect(checkboxes.isValidatedProfileRequired).toBeNull()
+  })
+
+  test('displays wiki and text instructions for ACT AR', async () => {
+    const mockACTAccessRequirementWithWikiAndTextInstructions: ACTAccessRequirement =
+      {
+        ...mockACTAccessRequirementWithWiki,
+        actContactInfo: 'some contact info',
+      }
+    const { buttons } = setUp({
+      accessRequirement: mockACTAccessRequirementWithWikiAndTextInstructions,
+      onSaveComplete,
+    })
+
+    expect(buttons.editInstructions).toBeVisible()
+    await confirmMarkdown(mockACTAccessRequirementWikiPage.markdown)
+
+    expect(buttons.deleteTextInstructions).not.toBeNull()
+    expect(
+      screen.getByText(
+        mockACTAccessRequirementWithWikiAndTextInstructions.actContactInfo!,
+      ),
+    ).toBeVisible()
+  })
+
+  test('does not delete text instructions from ACT AR when cancelled', async () => {
+    const { user, buttons } = setUp({
+      accessRequirement: mockACTAccessRequirement,
+      onSaveComplete,
+    })
+
+    expect(buttons.deleteTextInstructions).not.toBeNull()
+    await user.click(buttons.deleteTextInstructions!)
+
+    const confirmDialog = await screen.findByRole('dialog')
+    expect(confirmDialog).toHaveTextContent('Are you sure?')
+
+    const cancelBtn = within(confirmDialog).getByRole('button', {
+      name: 'Cancel',
+    })
+    await user.click(cancelBtn)
+
+    expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
+    expect(onSaveComplete).not.toHaveBeenCalled()
+    expect(buttons.deleteTextInstructions).toBeInTheDocument()
+  })
+
+  test('deletes text instructions from ACT AR when confirmed', async () => {
+    const { user, buttons } = setUp({
+      accessRequirement: mockACTAccessRequirement,
+      onSaveComplete,
+    })
+
+    expect(buttons.deleteTextInstructions).not.toBeNull()
+    await user.click(buttons.deleteTextInstructions!)
+
+    const confirmDialog = await screen.findByRole('dialog')
+    expect(confirmDialog).toHaveTextContent('Are you sure?')
+
+    const confirmBtn = within(confirmDialog).getByRole('button', { name: 'OK' })
+    await user.click(confirmBtn)
+
+    await waitFor(() => {
+      expect(updateAccessRequirementSpy).toHaveBeenCalledTimes(1)
+      expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
+        MOCK_ACCESS_TOKEN,
+        {
+          ...mockACTAccessRequirement,
+          actContactInfo: undefined,
+        },
+      )
+      expect(onSaveComplete).not.toHaveBeenCalled()
+    })
+
+    expect(confirmDialog).not.toBeVisible()
+    expect(buttons.deleteTextInstructions).not.toBeInTheDocument()
+  })
+
+  test('does not show accessor requirements for terms of use AR', () => {
+    const { checkboxes } = setUp({
+      accessRequirement: mockToUAccessRequirement,
+      onSaveComplete,
+    })
+    expect(checkboxes.isCertifiedUserRequired).toBeNull()
+    expect(checkboxes.isValidatedProfileRequired).toBeNull()
+  })
+
+  test('deletes text instructions from terms of use AR', async () => {
+    const { user, buttons } = setUp({
+      accessRequirement: mockToUAccessRequirement,
+      onSaveComplete,
+    })
+
+    expect(screen.getByText(mockToUAccessRequirement.termsOfUse!)).toBeVisible()
+    expect(buttons.deleteTextInstructions).not.toBeNull()
+    await user.click(buttons.deleteTextInstructions!)
+
+    const confirmDialog = await screen.findByRole('dialog')
+    expect(confirmDialog).toHaveTextContent('Are you sure?')
+
+    const confirmBtn = within(confirmDialog).getByRole('button', { name: 'OK' })
+    await user.click(confirmBtn)
+
+    await waitFor(() => {
+      expect(updateAccessRequirementSpy).toHaveBeenCalledTimes(1)
+      expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
+        MOCK_ACCESS_TOKEN,
+        {
+          ...mockToUAccessRequirement,
+          termsOfUse: undefined,
+        },
+      )
+      expect(onSaveComplete).not.toHaveBeenCalled()
+    })
+
+    expect(confirmDialog).not.toBeVisible()
+    expect(buttons.deleteTextInstructions).not.toBeInTheDocument()
+    expect(screen.queryByText(mockToUAccessRequirement.termsOfUse!)).toBeNull()
+  })
+})

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/SetBasicAccessRequirementFields.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/SetBasicAccessRequirementFields.tsx
@@ -1,0 +1,103 @@
+import { Alert } from '@mui/material'
+import {
+  AccessRequirement,
+  ManagedACTAccessRequirement,
+} from '@sage-bionetworks/synapse-types'
+import React, { useImperativeHandle, useState } from 'react'
+import { useUpdateAccessRequirement } from '../../synapse-queries'
+import { AccessRequirementTextInstructions } from './AccessRequirementTextInstructions'
+import { AccessorRequirements } from './AccessorRequirements'
+import { SynapseSpinner } from '../LoadingScreen/LoadingScreen'
+import { AccessRequirementWikiInstructions } from './AccessRequirementWikiInstructions'
+
+export type BasicAccessRequirement = Exclude<
+  AccessRequirement,
+  ManagedACTAccessRequirement
+>
+
+export type SetBasicAccessRequirementFieldsHandle = {
+  /* Allow the parent component to trigger saving the AR, so this may be embedded in an arbitrary modal. */
+  save: () => void
+}
+
+export type SetBasicAccessRequirementFieldsProps = {
+  accessRequirement: BasicAccessRequirement
+  onSaveComplete: (
+    /* null when an error has been returned */
+    updatedAr: BasicAccessRequirement | null,
+  ) => void
+}
+
+export const SetBasicAccessRequirementFields = React.forwardRef(
+  function SetBasicAccessRequirementFields(
+    props: SetBasicAccessRequirementFieldsProps,
+    ref: React.ForwardedRef<SetBasicAccessRequirementFieldsHandle>,
+  ) {
+    const { accessRequirement, onSaveComplete } = props
+    const [updatedAr, setUpdatedAr] =
+      useState<BasicAccessRequirement>(accessRequirement)
+
+    const [isDeletingTextInstructions, setIsDeletingTextInstructions] =
+      useState<boolean>(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const { mutate: updateAccessRequirement } =
+      useUpdateAccessRequirement<BasicAccessRequirement>({
+        onSuccess: updatedAr => {
+          setError(null)
+          if (isDeletingTextInstructions) {
+            setUpdatedAr(updatedAr)
+            setIsDeletingTextInstructions(false)
+          } else {
+            onSaveComplete(updatedAr)
+          }
+        },
+        onError: error => {
+          setError(error.reason)
+          setIsDeletingTextInstructions(false)
+          onSaveComplete(null)
+        },
+      })
+
+    useImperativeHandle(
+      ref,
+      () => {
+        return {
+          save() {
+            updateAccessRequirement(updatedAr)
+          },
+        }
+      },
+      [updatedAr, updateAccessRequirement],
+    )
+
+    return (
+      <>
+        {isDeletingTextInstructions ? (
+          <SynapseSpinner />
+        ) : (
+          <AccessRequirementTextInstructions
+            accessRequirement={updatedAr}
+            onConfirmDelete={updatedAr => {
+              setError(null)
+              setIsDeletingTextInstructions(true)
+              updateAccessRequirement(updatedAr as BasicAccessRequirement)
+            }}
+          />
+        )}
+        <AccessRequirementWikiInstructions accessRequirement={updatedAr} />
+        <AccessorRequirements
+          accessRequirement={updatedAr}
+          onChange={updatedAr =>
+            setUpdatedAr(updatedAr as BasicAccessRequirement)
+          }
+        />
+        {error && (
+          <Alert severity="error" sx={{ marginTop: 2 }}>
+            {error}
+          </Alert>
+        )}
+      </>
+    )
+  },
+)

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/index.ts
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/index.ts
@@ -1,0 +1,18 @@
+import { AccessRequirementWikiInstructions } from './AccessRequirementWikiInstructions'
+import { AccessorRequirements } from './AccessorRequirements'
+import type {
+  BasicAccessRequirement,
+  SetBasicAccessRequirementFieldsHandle,
+  SetBasicAccessRequirementFieldsProps,
+} from './SetBasicAccessRequirementFields'
+import { SetBasicAccessRequirementFields } from './SetBasicAccessRequirementFields'
+
+export {
+  AccessRequirementWikiInstructions,
+  AccessorRequirements,
+  BasicAccessRequirement,
+  SetBasicAccessRequirementFields,
+  SetBasicAccessRequirementFieldsHandle,
+  SetBasicAccessRequirementFieldsProps,
+}
+export default SetBasicAccessRequirementFields

--- a/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementFields.test.tsx
+++ b/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementFields.test.tsx
@@ -1,0 +1,568 @@
+import {
+  FileUploadComplete,
+  ManagedACTAccessRequirement,
+} from '@sage-bionetworks/synapse-types'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { noop } from 'lodash-es'
+import React from 'react'
+import { MOCK_ACCESS_TOKEN } from '../../mocks/MockSynapseContext'
+import { mockManagedACTAccessRequirement } from '../../mocks/mockAccessRequirements'
+import { mockManagedACTAccessRequirementWikiPage } from '../../mocks/mockWiki'
+import {
+  mockDucTemplateFileHandle,
+  mockFileHandle,
+} from '../../mocks/mock_file_handle'
+import { rest, server } from '../../mocks/msw/server'
+import SynapseClient from '../../synapse-client'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import { SynapseClientError } from '../../utils'
+import { ACCESS_REQUIREMENT_WIKI_PAGE } from '../../utils/APIConstants'
+import { DAY_IN_MS } from '../../utils/SynapseConstants'
+import { BackendDestinationEnum, getEndpoint } from '../../utils/functions'
+import { MarkdownSynapse } from '../Markdown'
+import { NO_WIKI_CONTENT } from '../WikiMarkdownEditorButton/WikiMarkdownEditorButton'
+import {
+  DUC_TEMPLATE_UPLOAD_ERROR,
+  SetManagedAccessRequirementFields,
+  SetManagedAccessRequirementFieldsHandle,
+  SetManagedAccessRequirementFieldsProps,
+  getValidExpirationPeriodOrErrorMessage,
+} from './SetManagedAccessRequirementFields'
+
+const NEGATIVE_EXPIRATION_PERIOD_ERROR =
+  'Please enter a valid expiration period (in days): If expiration period is set, then it must be greater than 0.'
+
+const MARKDOWN_SYNAPSE_TEST_ID = 'MarkdownSynapseContent'
+jest.mock('../Markdown/MarkdownSynapse', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+const mockMarkdownSynapse = jest.mocked(MarkdownSynapse)
+mockMarkdownSynapse.mockImplementation(
+  () => (<div data-testid={MARKDOWN_SYNAPSE_TEST_ID} />) as any,
+)
+async function confirmMarkdown(markdown: string) {
+  await screen.findByTestId(MARKDOWN_SYNAPSE_TEST_ID)
+  expect(mockMarkdownSynapse).toHaveBeenCalledWith(
+    expect.objectContaining({
+      markdown: markdown,
+    }),
+    expect.anything(),
+  )
+}
+
+const onSaveComplete = jest.fn()
+const updateAccessRequirementSpy = jest.spyOn(
+  SynapseClient,
+  'updateAccessRequirement',
+)
+const getFilesSpy = jest.spyOn(SynapseClient, 'getFiles')
+
+const defaultProps: SetManagedAccessRequirementFieldsProps = {
+  accessRequirement: mockManagedACTAccessRequirement,
+  onSaveComplete: onSaveComplete,
+}
+
+function renderComponent(props: SetManagedAccessRequirementFieldsProps) {
+  const ref = React.createRef<SetManagedAccessRequirementFieldsHandle>()
+  const component = render(
+    <SetManagedAccessRequirementFields ref={ref} {...props} />,
+    {
+      wrapper: createWrapper(),
+    },
+  )
+  return { ref, component }
+}
+
+function setUp(props: SetManagedAccessRequirementFieldsProps = defaultProps) {
+  const user = userEvent.setup()
+  const { ref, component } = renderComponent(props)
+
+  const checkboxes = {
+    isCertifiedUserRequired: screen.getByRole('checkbox', {
+      name: 'Accessors must be certified.',
+    }),
+    isValidatedProfileRequired: screen.getByRole('checkbox', {
+      name: 'Accessors must have a validated profile.',
+    }),
+    isTwoFaRequired: screen.getByRole('checkbox', {
+      name: 'Accessors must use two-factor authentication (2FA).',
+    }),
+    isDUCRequired: screen.getByRole('checkbox', {
+      name: 'DUC is required.',
+    }),
+    isIRBApprovalRequired: screen.getByRole('checkbox', {
+      name: 'IRB approval is required.',
+    }),
+    areOtherAttachmentsRequired: screen.getByRole('checkbox', {
+      name: 'Other documents are required.',
+    }),
+    isIDURequired: screen.getByRole('checkbox', {
+      name: 'Intended Data Use statement is required.',
+    }),
+    isIDUPublic: screen.getByRole('checkbox', {
+      name: 'Intended Data Use statements will be publicly available.',
+    }),
+  }
+
+  const buttons = {
+    uploadDucTemplate: screen.getByRole('button', {
+      name: 'Upload Template DUC',
+    }),
+    editInstructions: screen.getByRole('button', { name: 'Edit Instructions' }),
+  }
+
+  const expirationPeriodInput = screen.getByRole('textbox', {
+    name: 'Expiration period (days)',
+  })
+
+  return {
+    ref,
+    component,
+    user,
+    checkboxes,
+    buttons,
+    expirationPeriodInput,
+  }
+}
+
+const findDucTemplateButton = async (fileName: string) => {
+  return await screen.findByRole('button', { name: fileName })
+}
+
+describe('SetManagedAccessRequirementFields', () => {
+  beforeEach(() => jest.clearAllMocks())
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  test('displays existing managed AR', async () => {
+    const { checkboxes, buttons, expirationPeriodInput } = setUp()
+
+    expect(buttons.editInstructions).toBeVisible()
+    await confirmMarkdown(mockManagedACTAccessRequirementWikiPage.markdown)
+
+    expect(checkboxes.isCertifiedUserRequired).toBeChecked()
+    expect(checkboxes.isValidatedProfileRequired).toBeChecked()
+    expect(checkboxes.isTwoFaRequired).toBeChecked()
+
+    expect(checkboxes.isDUCRequired).toBeChecked()
+    await findDucTemplateButton(mockDucTemplateFileHandle.fileName)
+
+    expect(checkboxes.isIRBApprovalRequired).toBeChecked()
+    expect(checkboxes.areOtherAttachmentsRequired).toBeChecked()
+
+    expect(expirationPeriodInput).toHaveValue(
+      (mockManagedACTAccessRequirement.expirationPeriod / DAY_IN_MS).toString(),
+    )
+
+    expect(checkboxes.isIDURequired).toBeChecked()
+    expect(checkboxes.isIDUPublic).toBeChecked()
+  })
+
+  test('displays managed AR without wiki content', () => {
+    server.use(
+      rest.get(
+        `${getEndpoint(
+          BackendDestinationEnum.REPO_ENDPOINT,
+        )}${ACCESS_REQUIREMENT_WIKI_PAGE(':arId', ':wikiId')}`,
+        async (req, res, ctx) => {
+          return res(
+            ctx.status(200),
+            ctx.json({
+              ...mockManagedACTAccessRequirementWikiPage,
+              markdown: '',
+            }),
+          )
+        },
+      ),
+    )
+
+    setUp()
+
+    expect(mockMarkdownSynapse).not.toHaveBeenCalled()
+    expect(screen.getByText(NO_WIKI_CONTENT)).toBeVisible()
+  })
+
+  test('handles updates to accessor requirements', async () => {
+    const { user, checkboxes, ref } = setUp()
+
+    expect(checkboxes.isCertifiedUserRequired).toBeChecked()
+    expect(checkboxes.isValidatedProfileRequired).toBeChecked()
+    expect(checkboxes.isTwoFaRequired).toBeChecked()
+
+    await user.click(checkboxes.isCertifiedUserRequired)
+    await user.click(checkboxes.isValidatedProfileRequired)
+    await user.click(checkboxes.isTwoFaRequired)
+
+    expect(checkboxes.isCertifiedUserRequired).not.toBeChecked()
+    expect(checkboxes.isValidatedProfileRequired).not.toBeChecked()
+    expect(checkboxes.isTwoFaRequired).not.toBeChecked()
+
+    expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
+
+    // simulate parent clicking save
+    ref.current?.save()
+
+    await waitFor(() => {
+      const updatedAr: ManagedACTAccessRequirement = {
+        ...mockManagedACTAccessRequirement,
+        isCertifiedUserRequired: false,
+        isValidatedProfileRequired: false,
+        isTwoFaRequired: false,
+      }
+      expect(onSaveComplete).toHaveBeenCalledTimes(1)
+      expect(onSaveComplete).toHaveBeenLastCalledWith(updatedAr)
+      expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
+        MOCK_ACCESS_TOKEN,
+        updatedAr,
+      )
+    })
+  })
+
+  test('handles updates to DUC section', async () => {
+    const { user, checkboxes, ref } = setUp()
+
+    expect(checkboxes.isDUCRequired).toBeChecked()
+    expect(checkboxes.isIRBApprovalRequired).toBeChecked()
+    expect(checkboxes.areOtherAttachmentsRequired).toBeChecked()
+
+    await user.click(checkboxes.isDUCRequired)
+    await user.click(checkboxes.isIRBApprovalRequired)
+    await user.click(checkboxes.areOtherAttachmentsRequired)
+
+    expect(checkboxes.isDUCRequired).not.toBeChecked()
+    expect(checkboxes.isIRBApprovalRequired).not.toBeChecked()
+    expect(checkboxes.areOtherAttachmentsRequired).not.toBeChecked()
+
+    expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
+
+    // simulate parent clicking save
+    ref.current?.save()
+
+    await waitFor(() => {
+      const updatedAr: ManagedACTAccessRequirement = {
+        ...mockManagedACTAccessRequirement,
+        isDUCRequired: false,
+        isIRBApprovalRequired: false,
+        areOtherAttachmentsRequired: false,
+      }
+      expect(onSaveComplete).toHaveBeenCalledTimes(1)
+      expect(onSaveComplete).toHaveBeenLastCalledWith(updatedAr)
+      expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
+        MOCK_ACCESS_TOKEN,
+        updatedAr,
+      )
+    })
+  })
+
+  test('displays DUC template download button when there is an existing DUC template', async () => {
+    const { buttons } = setUp()
+    expect(buttons.uploadDucTemplate).toBeVisible()
+
+    const val = document.getElementById('duc-download-0')
+    expect(val).not.toBeNull()
+
+    await findDucTemplateButton(mockDucTemplateFileHandle.fileName)
+    expect(getFilesSpy).toHaveBeenCalled()
+  })
+
+  test('does not display DUC template download button when there is not an existing DUC template', () => {
+    const { buttons } = setUp({
+      ...defaultProps,
+      accessRequirement: {
+        ...mockManagedACTAccessRequirement,
+        ducTemplateFileHandleId: undefined,
+      },
+    })
+    expect(buttons.uploadDucTemplate).toBeVisible()
+    const val = document.getElementById('duc-download-0')
+    expect(val).toBeNull()
+    expect(getFilesSpy).not.toHaveBeenCalled()
+  })
+
+  test('can upload new DUC template file handle', async () => {
+    const newFileName = mockFileHandle.fileName
+    const newFileHandleId = mockFileHandle.id
+    const newFile = new File(['example'], newFileName, {
+      type: 'text/plain',
+    })
+    const fileUploadComplete: FileUploadComplete = {
+      fileHandleId: newFileHandleId,
+      fileName: newFileName,
+    }
+    const mockUploadFile = jest
+      .spyOn(SynapseClient, 'uploadFile')
+      .mockResolvedValue(fileUploadComplete)
+
+    const { user, ref } = setUp()
+    await findDucTemplateButton(mockDucTemplateFileHandle.fileName)
+
+    const fileInput = screen.getByTestId('file-input')
+    await user.upload(fileInput, newFile)
+
+    expect(mockUploadFile).toHaveBeenCalledTimes(1)
+    await findDucTemplateButton(newFileName)
+
+    // simulate parent clicking save
+    ref.current?.save()
+
+    await waitFor(() => {
+      const updatedAr: ManagedACTAccessRequirement = {
+        ...mockManagedACTAccessRequirement,
+        ducTemplateFileHandleId: newFileHandleId,
+      }
+      expect(onSaveComplete).toHaveBeenCalledTimes(1)
+      expect(onSaveComplete).toHaveBeenLastCalledWith(updatedAr)
+      expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
+        MOCK_ACCESS_TOKEN,
+        updatedAr,
+      )
+    })
+  })
+
+  test('handles error when uploading new DUC template file handle', async () => {
+    const newFile = new File(['example'], 'some file', {
+      type: 'text/plain',
+    })
+    const errorReason = 'Some upload error'
+    const mockUploadFile = jest
+      .spyOn(SynapseClient, 'uploadFile')
+      .mockImplementation(() => {
+        throw new SynapseClientError(
+          500,
+          errorReason,
+          expect.getState().currentTestName!,
+        )
+      })
+
+    const { user, ref } = setUp()
+    await findDucTemplateButton(mockDucTemplateFileHandle.fileName)
+
+    // hide console.log output by FileUpload on error
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(noop)
+    const fileInput = screen.getByTestId('file-input')
+    await user.upload(fileInput, newFile)
+    consoleLogSpy.mockRestore()
+
+    expect(mockUploadFile).toHaveBeenCalledTimes(1)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(DUC_TEMPLATE_UPLOAD_ERROR + errorReason)
+
+    // simulate parent clicking save
+    ref.current?.save()
+
+    await waitFor(() => {
+      expect(onSaveComplete).toHaveBeenCalledTimes(1)
+      expect(onSaveComplete).toHaveBeenLastCalledWith(
+        mockManagedACTAccessRequirement,
+      )
+      expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
+        MOCK_ACCESS_TOKEN,
+        mockManagedACTAccessRequirement,
+      )
+    })
+  })
+
+  test('handles valid change to expiration period', async () => {
+    const updatedExpirationPeriodDays = 25
+    const updatedExpirationPeriodMs = updatedExpirationPeriodDays * DAY_IN_MS
+
+    const { user, expirationPeriodInput, ref } = setUp()
+
+    expect(expirationPeriodInput).toHaveValue('1')
+
+    await user.clear(expirationPeriodInput)
+    await user.type(
+      expirationPeriodInput,
+      updatedExpirationPeriodDays.toString(),
+    )
+
+    expect(expirationPeriodInput).toHaveValue(
+      updatedExpirationPeriodDays.toString(),
+    )
+    expect(onSaveComplete).not.toHaveBeenCalled()
+
+    // parent clicking save
+    ref?.current?.save()
+
+    await waitFor(() => {
+      const updatedAr: ManagedACTAccessRequirement = {
+        ...mockManagedACTAccessRequirement,
+        expirationPeriod: updatedExpirationPeriodMs,
+      }
+      expect(updateAccessRequirementSpy).toHaveBeenCalledTimes(1)
+      expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
+        MOCK_ACCESS_TOKEN,
+        updatedAr,
+      )
+      expect(onSaveComplete).toHaveBeenCalledTimes(1)
+      expect(onSaveComplete).toHaveBeenLastCalledWith(updatedAr)
+    })
+  })
+
+  test('defaults to 0 when no expiration period is set', async () => {
+    const updatedExpirationPeriodMs = 0
+    const { user, expirationPeriodInput, ref } = setUp()
+
+    await user.clear(expirationPeriodInput)
+    expect(expirationPeriodInput).toHaveValue('')
+
+    // parent clicking save
+    ref?.current?.save()
+
+    await waitFor(() => {
+      const updatedAr: ManagedACTAccessRequirement = {
+        ...mockManagedACTAccessRequirement,
+        expirationPeriod: updatedExpirationPeriodMs,
+      }
+      expect(updateAccessRequirementSpy).toHaveBeenCalledTimes(1)
+      expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
+        MOCK_ACCESS_TOKEN,
+        updatedAr,
+      )
+      expect(onSaveComplete).toHaveBeenCalledTimes(1)
+      expect(onSaveComplete).toHaveBeenLastCalledWith(updatedAr)
+    })
+  })
+
+  test('displays an error when expiration period is < 0', async () => {
+    const negativeExpirationPeriodDays = '-25'
+    const { user, expirationPeriodInput, ref } = setUp()
+
+    await user.clear(expirationPeriodInput)
+    await user.type(expirationPeriodInput, negativeExpirationPeriodDays)
+
+    expect(expirationPeriodInput).toHaveValue(negativeExpirationPeriodDays)
+
+    // parent clicking save
+    act(() => {
+      ref?.current?.save()
+    })
+
+    await waitFor(() => {
+      expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
+      expect(onSaveComplete).toHaveBeenCalledTimes(1)
+      expect(onSaveComplete).toHaveBeenLastCalledWith(null)
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        NEGATIVE_EXPIRATION_PERIOD_ERROR,
+      )
+    })
+  })
+
+  test('displays an error when a non-number is entered for expiration period', async () => {
+    const nonNumberExpirationPeriod = 'ab23'
+    const { user, expirationPeriodInput, ref } = setUp()
+
+    await user.clear(expirationPeriodInput)
+    await user.type(expirationPeriodInput, nonNumberExpirationPeriod)
+
+    expect(expirationPeriodInput).toHaveValue(nonNumberExpirationPeriod)
+
+    // parent clicking save
+    act(() => {
+      ref?.current?.save()
+    })
+
+    await waitFor(() => {
+      expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
+      expect(onSaveComplete).toHaveBeenCalledTimes(1)
+      expect(onSaveComplete).toHaveBeenLastCalledWith(null)
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        `Please enter a valid expiration period (in days): For input string: "${nonNumberExpirationPeriod}"`,
+      )
+    })
+  })
+
+  test('when isIDURequired is toggled to false, isIDUPublic is disabled and false (even when previously checked)', async () => {
+    const { user, checkboxes, ref } = setUp()
+
+    expect(checkboxes.isIDURequired).toBeChecked()
+    expect(checkboxes.isIDUPublic).toBeChecked()
+    expect(checkboxes.isIDUPublic).not.toBeDisabled()
+
+    await user.click(checkboxes.isIDURequired)
+
+    expect(checkboxes.isIDURequired).not.toBeChecked()
+    expect(checkboxes.isIDUPublic).not.toBeChecked()
+    expect(checkboxes.isIDUPublic).toBeDisabled()
+
+    // parent clicking save
+    act(() => {
+      ref?.current?.save()
+    })
+
+    await waitFor(() => {
+      const updatedAr: ManagedACTAccessRequirement = {
+        ...mockManagedACTAccessRequirement,
+        isIDUPublic: false,
+        isIDURequired: false,
+      }
+      expect(updateAccessRequirementSpy).toHaveBeenCalledTimes(1)
+      expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
+        MOCK_ACCESS_TOKEN,
+        updatedAr,
+      )
+      expect(onSaveComplete).toHaveBeenCalledTimes(1)
+      expect(onSaveComplete).toHaveBeenLastCalledWith(updatedAr)
+    })
+  })
+
+  test('when isIDURequired is toggled to true, isIDUPublic is not disabled', async () => {
+    const accessRequirement: ManagedACTAccessRequirement = {
+      ...mockManagedACTAccessRequirement,
+      isIDURequired: false,
+      isIDUPublic: false,
+    }
+    const { user, checkboxes } = setUp({ accessRequirement, onSaveComplete })
+
+    expect(checkboxes.isIDURequired).not.toBeChecked()
+    expect(checkboxes.isIDUPublic).not.toBeChecked()
+    expect(checkboxes.isIDUPublic).toBeDisabled()
+
+    await user.click(checkboxes.isIDURequired)
+
+    expect(checkboxes.isIDURequired).toBeChecked()
+    expect(checkboxes.isIDUPublic).not.toBeChecked()
+    expect(checkboxes.isIDUPublic).not.toBeDisabled()
+  })
+
+  describe('getValidExpirationPeriodOrErrorMessage', () => {
+    test('empty string is converted to 0', () => {
+      expect(getValidExpirationPeriodOrErrorMessage('')).toBe(0)
+    })
+    test('valid expiration period days are converted ms', () => {
+      expect(getValidExpirationPeriodOrErrorMessage('1')).toBe(DAY_IN_MS)
+      expect(getValidExpirationPeriodOrErrorMessage('0')).toBe(0)
+      expect(getValidExpirationPeriodOrErrorMessage('012')).toBe(12 * DAY_IN_MS)
+      expect(getValidExpirationPeriodOrErrorMessage('25')).toBe(25 * DAY_IN_MS)
+    })
+    test('negative expiration period days return an error message', () => {
+      expect(getValidExpirationPeriodOrErrorMessage('-1')).toBe(
+        NEGATIVE_EXPIRATION_PERIOD_ERROR,
+      )
+      expect(getValidExpirationPeriodOrErrorMessage('-123')).toBe(
+        NEGATIVE_EXPIRATION_PERIOD_ERROR,
+      )
+    })
+    test('invalid input strings return an error message', () => {
+      const errorMsgRegex =
+        /^Please enter a valid expiration period \(in days\): For input string:.*/
+      expect(getValidExpirationPeriodOrErrorMessage('-1.23')).toMatch(
+        errorMsgRegex,
+      )
+      expect(getValidExpirationPeriodOrErrorMessage('0.23')).toMatch(
+        errorMsgRegex,
+      )
+      expect(getValidExpirationPeriodOrErrorMessage('.12')).toMatch(
+        errorMsgRegex,
+      )
+      expect(getValidExpirationPeriodOrErrorMessage('52a')).toMatch(
+        errorMsgRegex,
+      )
+      expect(getValidExpirationPeriodOrErrorMessage('a')).toMatch(errorMsgRegex)
+    })
+  })
+})

--- a/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementFields.tsx
+++ b/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementFields.tsx
@@ -1,0 +1,280 @@
+import { Alert, Box, TextField, Typography } from '@mui/material'
+import {
+  FileHandleAssociateType,
+  FileHandleAssociation,
+  FileUploadComplete,
+  ManagedACTAccessRequirement,
+  UploadCallbackResp,
+} from '@sage-bionetworks/synapse-types'
+import React, { useImperativeHandle, useMemo, useState } from 'react'
+import { useUpdateAccessRequirement } from '../../synapse-queries'
+import { SynapseClientError } from '../../utils'
+import { DAY_IN_MS } from '../../utils/SynapseConstants'
+import { UploadDocumentField } from '../AccessRequirementList/ManagedACTAccessRequirementRequestFlow/UploadDocumentField'
+import {
+  AccessRequirementWikiInstructions,
+  AccessorRequirements,
+} from '../SetBasicAccessRequirementFields'
+import { SynapseErrorBoundary } from '../error/ErrorBanner'
+import { Checkbox } from '../widgets/Checkbox'
+
+export const DUC_TEMPLATE_UPLOAD_ERROR =
+  'There was an error uploading the DUC template. '
+
+export const getValidExpirationPeriodOrErrorMessage = (
+  expirationPeriodDays: string,
+) => {
+  if (expirationPeriodDays === '') return 0
+
+  const msgPrefix = 'Please enter a valid expiration period (in days): '
+  if (/^[-]?\d+$/.test(expirationPeriodDays)) {
+    const num = Number(expirationPeriodDays)
+    if (num < 0) {
+      return `${msgPrefix}If expiration period is set, then it must be greater than 0.`
+    }
+    return num * DAY_IN_MS
+  }
+  return `${msgPrefix}For input string: "${expirationPeriodDays}"`
+}
+
+export type SetManagedAccessRequirementFieldsHandle = {
+  /* Allow the parent component to trigger saving the AR, so this may be embedded in an arbitrary modal. */
+  save: () => void
+}
+
+export type SetManagedAccessRequirementFieldsProps = {
+  accessRequirement: ManagedACTAccessRequirement
+  /* Called when AR has been saved or an error has been returned */
+  onSaveComplete: (
+    /* null when an error has been returned */
+    updatedAr: ManagedACTAccessRequirement | null,
+  ) => void
+}
+
+export const SetManagedAccessRequirementFields = React.forwardRef(
+  function SetManagedAccessRequirementFields(
+    props: SetManagedAccessRequirementFieldsProps,
+    ref: React.ForwardedRef<SetManagedAccessRequirementFieldsHandle>,
+  ) {
+    const { accessRequirement, onSaveComplete } = props
+
+    const [uploadDucTemplateError, setUploadDucTemplateError] = useState<
+      string | null
+    >(null)
+    const [expirationPeriodError, setExpirationPeriodError] = useState<
+      string | null
+    >(null)
+    const [updateArError, setUpdateArError] = useState<string | null>(null)
+
+    const [updatedAr, setUpdatedAr] =
+      useState<ManagedACTAccessRequirement>(accessRequirement)
+    const [expirationPeriodDays, setExpirationPeriodDays] = useState<string>(
+      (accessRequirement.expirationPeriod / DAY_IN_MS).toString(),
+    )
+
+    const ducTemplateFileHandleAssociation = useMemo(() => {
+      if (updatedAr.ducTemplateFileHandleId) {
+        const ducTemplateFileHandleAssociation: FileHandleAssociation = {
+          fileHandleId: updatedAr.ducTemplateFileHandleId,
+          associateObjectType:
+            FileHandleAssociateType.AccessRequirementAttachment,
+          associateObjectId: updatedAr.id.toString(),
+        }
+        return ducTemplateFileHandleAssociation
+      }
+      return undefined
+    }, [updatedAr.ducTemplateFileHandleId, updatedAr.id])
+
+    const uploadDucTemplateCallback = (data: UploadCallbackResp) => {
+      if (data.resp && data.success) {
+        setUploadDucTemplateError(null)
+        // Files are uploaded and synced with the server immediately
+        const uploadResponse: FileUploadComplete = data.resp
+        setUpdatedAr({
+          ...updatedAr,
+          ducTemplateFileHandleId: uploadResponse.fileHandleId,
+        })
+      } else if (!data.success && data.error) {
+        setUploadDucTemplateError(
+          `${DUC_TEMPLATE_UPLOAD_ERROR} ${
+            (data.error as SynapseClientError).reason
+          }`,
+        )
+      }
+    }
+
+    const {
+      mutate: updateAccessRequirement,
+      isPending: isUpdatingAccessRequirement,
+    } = useUpdateAccessRequirement<ManagedACTAccessRequirement>({
+      onSuccess: updatedAr => {
+        setUpdateArError(null)
+        onSaveComplete(updatedAr)
+      },
+      onError: error => {
+        setUpdateArError(error.reason)
+        onSaveComplete(null)
+      },
+    })
+
+    useImperativeHandle(
+      ref,
+      () => {
+        return {
+          save() {
+            const expirationPeriodOrErrorMessage =
+              getValidExpirationPeriodOrErrorMessage(expirationPeriodDays)
+            if (typeof expirationPeriodOrErrorMessage === 'string') {
+              setExpirationPeriodError(expirationPeriodOrErrorMessage)
+              onSaveComplete(null)
+            } else {
+              updateAccessRequirement({
+                ...updatedAr,
+                expirationPeriod: expirationPeriodOrErrorMessage,
+              })
+            }
+          },
+        }
+      },
+      [
+        expirationPeriodDays,
+        updatedAr,
+        updateAccessRequirement,
+        onSaveComplete,
+      ],
+    )
+
+    return (
+      <>
+        <AccessRequirementWikiInstructions accessRequirement={updatedAr} />
+        <Box>
+          <Typography
+            bgcolor="#f5f5f5"
+            borderBottom="1px solid #ddd"
+            color="#333"
+            px={2}
+            py={1}
+          >
+            Data Access Request Parameters
+          </Typography>
+          <Box mt={2} mb={4}>
+            <AccessorRequirements
+              accessRequirement={updatedAr}
+              onChange={updatedAr =>
+                setUpdatedAr(updatedAr as ManagedACTAccessRequirement)
+              }
+            />
+            <Box mb={2}>
+              <Typography variant="body1" fontWeight={700}>
+                DUC
+              </Typography>
+              <Checkbox
+                label="DUC is required."
+                checked={updatedAr.isDUCRequired}
+                onChange={(checked: boolean) =>
+                  setUpdatedAr({
+                    ...updatedAr,
+                    isDUCRequired: checked,
+                  })
+                }
+              />
+              <SynapseErrorBoundary>
+                <UploadDocumentField
+                  id="duc"
+                  isLoading={isUpdatingAccessRequirement}
+                  uploadCallback={resp => uploadDucTemplateCallback(resp)}
+                  documentName="Template DUC"
+                  fileHandleAssociations={
+                    ducTemplateFileHandleAssociation
+                      ? [ducTemplateFileHandleAssociation]
+                      : undefined
+                  }
+                  isMultiFileUpload={false}
+                  uploadBtnVariant="contained"
+                />
+                {uploadDucTemplateError && (
+                  <Alert severity="error" sx={{ marginTop: 2 }}>
+                    {uploadDucTemplateError}
+                  </Alert>
+                )}
+              </SynapseErrorBoundary>
+              <Checkbox
+                label="IRB approval is required."
+                checked={updatedAr.isIRBApprovalRequired}
+                onChange={(checked: boolean) =>
+                  setUpdatedAr({
+                    ...updatedAr,
+                    isIRBApprovalRequired: checked,
+                  })
+                }
+              />
+              <Checkbox
+                label="Other documents are required."
+                checked={updatedAr.areOtherAttachmentsRequired}
+                onChange={(checked: boolean) =>
+                  setUpdatedAr({
+                    ...updatedAr,
+                    areOtherAttachmentsRequired: checked,
+                  })
+                }
+              />
+              <TextField
+                id="expirationPeriod"
+                name="expirationPeriod"
+                label="Expiration period (days)"
+                value={expirationPeriodDays}
+                sx={{ mt: 1 }}
+                fullWidth
+                onChange={event => {
+                  setExpirationPeriodError(null)
+                  setExpirationPeriodDays(event.target.value)
+                }}
+              />
+              {expirationPeriodError && (
+                <Alert severity="error" sx={{ marginTop: 2 }}>
+                  {expirationPeriodError}
+                </Alert>
+              )}
+              <Box mt={1}>
+                <Checkbox
+                  label="Intended Data Use statement is required."
+                  checked={updatedAr.isIDURequired}
+                  onChange={(checked: boolean) => {
+                    if (checked) {
+                      setUpdatedAr({
+                        ...updatedAr,
+                        isIDURequired: true,
+                      })
+                    } else {
+                      setUpdatedAr({
+                        ...updatedAr,
+                        isIDURequired: false,
+                        isIDUPublic: false,
+                      })
+                    }
+                  }}
+                />
+                <Checkbox
+                  label="Intended Data Use statements will be publicly available."
+                  checked={updatedAr.isIDUPublic}
+                  disabled={!updatedAr.isIDURequired}
+                  onChange={(checked: boolean) =>
+                    setUpdatedAr({
+                      ...updatedAr,
+                      isIDUPublic: checked,
+                    })
+                  }
+                />
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+        {updateArError && (
+          <Alert severity="error" sx={{ marginTop: 2 }}>
+            {updateArError}
+          </Alert>
+        )}
+      </>
+    )
+  },
+)

--- a/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementsFields.stories.tsx
+++ b/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementsFields.stories.tsx
@@ -30,7 +30,8 @@ const meta: Meta<typeof SetManagedAccessRequirementFields> = {
           <SetManagedAccessRequirementFields
             {...args}
             ref={ref}
-            onSaveComplete={() => setIsSaving(false)}
+            onSave={() => setIsSaving(false)}
+            onError={() => setIsSaving(false)}
           />
         </Paper>
       </>
@@ -42,11 +43,20 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Demo: Story = {
+export const MockDemo: Story = {
   args: {
-    accessRequirement: mockManagedACTAccessRequirement,
+    accessRequirementId: mockManagedACTAccessRequirement.id.toString(),
   },
   parameters: {
     stack: 'mock',
+  },
+}
+
+export const DevDemo: Story = {
+  args: {
+    accessRequirementId: '9602704',
+  },
+  parameters: {
+    stack: 'development',
   },
 }

--- a/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementsFields.stories.tsx
+++ b/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementsFields.stories.tsx
@@ -1,0 +1,52 @@
+import { Button, Paper } from '@mui/material'
+import { Meta, StoryObj } from '@storybook/react'
+import React, { useRef, useState } from 'react'
+import { mockManagedACTAccessRequirement } from '../../mocks/mockAccessRequirements'
+import {
+  SetManagedAccessRequirementFields,
+  SetManagedAccessRequirementFieldsHandle,
+} from './SetManagedAccessRequirementFields'
+
+const meta: Meta<typeof SetManagedAccessRequirementFields> = {
+  title: 'Governance/SetManagedAccessRequirementFields',
+  component: SetManagedAccessRequirementFields,
+  render: function RenderFn(args) {
+    const [isSaving, setIsSaving] = useState<boolean>(false)
+    const ref = useRef<SetManagedAccessRequirementFieldsHandle>(null)
+
+    return (
+      <>
+        <Button
+          onClick={() => {
+            setIsSaving(true)
+            ref.current?.save()
+          }}
+          variant="contained"
+          disabled={isSaving}
+        >
+          Save AR
+        </Button>
+        <Paper sx={{ mx: 'auto', p: '44px', maxWidth: '750px' }}>
+          <SetManagedAccessRequirementFields
+            {...args}
+            ref={ref}
+            onSaveComplete={() => setIsSaving(false)}
+          />
+        </Paper>
+      </>
+    )
+  },
+} satisfies Meta<typeof SetManagedAccessRequirementFields>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  args: {
+    accessRequirement: mockManagedACTAccessRequirement,
+  },
+  parameters: {
+    stack: 'mock',
+  },
+}

--- a/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/index.ts
+++ b/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/index.ts
@@ -1,0 +1,12 @@
+import type {
+  SetManagedAccessRequirementFieldsHandle,
+  SetManagedAccessRequirementFieldsProps,
+} from './SetManagedAccessRequirementFields'
+import { SetManagedAccessRequirementFields } from './SetManagedAccessRequirementFields'
+
+export {
+  SetManagedAccessRequirementFields,
+  SetManagedAccessRequirementFieldsHandle,
+  SetManagedAccessRequirementFieldsProps,
+}
+export default SetManagedAccessRequirementFields

--- a/packages/synapse-react-client/src/components/WikiMarkdownEditor/WikiMarkdownEditor.test.tsx
+++ b/packages/synapse-react-client/src/components/WikiMarkdownEditor/WikiMarkdownEditor.test.tsx
@@ -14,7 +14,7 @@ import {
 import { rest, server } from '../../mocks/msw/server'
 import SynapseClient from '../../synapse-client'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
-import { WIKI_PAGE } from '../../utils/APIConstants'
+import { WIKI_PAGE_ID } from '../../utils/APIConstants'
 import { BackendDestinationEnum, getEndpoint } from '../../utils/functions'
 import {
   ERROR_SAVING_WIKI,
@@ -226,10 +226,11 @@ describe('WikiMarkdownEditor', () => {
     }
     server.use(
       rest.put(
-        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${WIKI_PAGE(
+        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${WIKI_PAGE_ID(
           defaultSubWikiPageProps.ownerObjectType,
           ':ownerObjectId',
-        )}/:wikiPageId`,
+          ':wikiPageId',
+        )}`,
         async (req, res, ctx) => {
           return res(ctx.status(403), ctx.json(errorResponse))
         },

--- a/packages/synapse-react-client/src/components/WikiMarkdownEditorButton/WikiMarkdownEditorButton.tsx
+++ b/packages/synapse-react-client/src/components/WikiMarkdownEditorButton/WikiMarkdownEditorButton.tsx
@@ -1,4 +1,6 @@
+import { Alert, Button, ButtonProps, Typography } from '@mui/material'
 import { ObjectType, WikiPageKey } from '@sage-bionetworks/synapse-types'
+import { defaults } from 'lodash-es'
 import React, { useMemo, useState } from 'react'
 import {
   CreateWikiPageInput,
@@ -6,10 +8,10 @@ import {
   useGetRootWikiPageKey,
   useGetWikiPage,
 } from '../../synapse-queries'
-import { Alert, Button, ButtonProps } from '@mui/material'
-import { defaults } from 'lodash-es'
+import { MarkdownSynapse } from '../Markdown'
 import WikiMarkdownEditor from '../WikiMarkdownEditor/WikiMarkdownEditor'
 
+export const NO_WIKI_CONTENT = 'There is no content.'
 export const ERROR_LOADING_WIKI_FAILED = 'Failed to load the wiki page: '
 export const DEFAULT_BUTTON_TEXT = 'Edit Wiki Page'
 const DEFAULT_BUTTON_PROPS: Omit<ButtonProps, 'onClick'> = {
@@ -25,6 +27,7 @@ export type WikiMarkdownEditorButtonProps = {
   // otherwise, will get the WikiPage with the specified wikiPageId
   wikiPageId?: string
   buttonProps?: Omit<ButtonProps, 'onClick' | 'disabled'>
+  displayWikiMarkdown?: boolean
 }
 
 export const WikiMarkdownEditorButton: React.FunctionComponent<
@@ -34,6 +37,7 @@ export const WikiMarkdownEditorButton: React.FunctionComponent<
     ownerObjectType,
     ownerObjectId,
     wikiPageId: initialWikiPageId,
+    displayWikiMarkdown = false,
   } = props
 
   const buttonProps: Omit<ButtonProps, 'onClick' | 'disabled'> = defaults(
@@ -124,6 +128,20 @@ export const WikiMarkdownEditorButton: React.FunctionComponent<
 
   return (
     <>
+      {displayWikiMarkdown && (
+        <>
+          {wikiPage && wikiPage.markdown !== '' ? (
+            <MarkdownSynapse
+              key={wikiPage.markdown}
+              markdown={wikiPage.markdown}
+            />
+          ) : (
+            <Typography variant="body1Italic" mb={1}>
+              {NO_WIKI_CONTENT}
+            </Typography>
+          )}
+        </>
+      )}
       <Button
         onClick={handleClick}
         disabled={

--- a/packages/synapse-react-client/src/components/WikiMarkdownEditorButton/WikiMarkdownEditorButton.tsx
+++ b/packages/synapse-react-client/src/components/WikiMarkdownEditorButton/WikiMarkdownEditorButton.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, ButtonProps } from '@mui/material'
+import { Alert, Box, Button, ButtonProps } from '@mui/material'
 import { ObjectType, WikiPageKey } from '@sage-bionetworks/synapse-types'
 import { defaults } from 'lodash-es'
 import React, { useMemo, useState } from 'react'
@@ -150,7 +150,7 @@ export const WikiMarkdownEditorButton: React.FunctionComponent<
   return (
     <>
       {displayWikiMarkdown && (
-        <>
+        <Box mb={1}>
           {isLoadingWikiPage || isLoadingRootWikiPageKey ? (
             <SynapseSpinner />
           ) : (
@@ -160,7 +160,7 @@ export const WikiMarkdownEditorButton: React.FunctionComponent<
               {...markdownSynapseProps}
             />
           )}
-        </>
+        </Box>
       )}
       <Button
         onClick={handleClick}

--- a/packages/synapse-react-client/src/mocks/mockAccessRequirements.ts
+++ b/packages/synapse-react-client/src/mocks/mockAccessRequirements.ts
@@ -25,6 +25,7 @@ import {
   mockToUAccessRequirementWikiPage,
 } from './mockWiki'
 import { mockDucTemplateFileHandle } from './mock_file_handle'
+import { DAY_IN_MS } from '../utils/SynapseConstants'
 
 const MOCK_PROJECT_ID = mockProjectData.id
 
@@ -56,7 +57,7 @@ export const mockManagedACTAccessRequirement: ManagedACTAccessRequirement = {
   isIDUPublic: true,
   isIDURequired: true,
   ducTemplateFileHandleId: mockDucTemplateFileHandle.id,
-  expirationPeriod: 1000 * 60 * 60 * 24, // 1 day
+  expirationPeriod: DAY_IN_MS, // 1 day
   isIRBApprovalRequired: true,
   isValidatedProfileRequired: true,
   isTwoFaRequired: true,

--- a/packages/synapse-react-client/src/mocks/mockWiki.ts
+++ b/packages/synapse-react-client/src/mocks/mockWiki.ts
@@ -54,7 +54,7 @@ export const mockACTAccessRequirementWikiPage: WikiPage = {
   modifiedBy: MOCK_USER_ID_2.toString(),
   title: '',
   markdown:
-    'This is a wiki page.  You must request access using this legacy ACT access requirement.  Access to these data is controlled at the request of the data contributor(s) and due to the sensitive nature of the data.',
+    'This is a wiki page. You must request access using this legacy ACT access requirement. Access to these data is controlled at the request of the data contributor(s) and due to the sensitive nature of the data.',
   attachmentFileHandleIds: [],
 }
 

--- a/packages/synapse-react-client/src/mocks/mockWiki.ts
+++ b/packages/synapse-react-client/src/mocks/mockWiki.ts
@@ -66,7 +66,7 @@ export const mockEntityRootWikiPage: WikiPage = {
   modifiedOn: '2022-12-06T23:18:27.877Z',
   modifiedBy: MOCK_USER_ID_2.toString(),
   title: '',
-  markdown: 'This is the **root** page for an Entity wiki',
+  markdown: 'This is the root page for an Entity wiki',
   attachmentFileHandleIds: [],
 }
 
@@ -78,7 +78,7 @@ export const mockEntityWikiPage: WikiPage = {
   modifiedOn: '2022-12-06T23:18:27.877Z',
   modifiedBy: MOCK_USER_ID_2.toString(),
   title: 'Some title',
-  markdown: 'This is a a **subpage** for an Entity wiki',
+  markdown: 'This is a a subpage for an Entity wiki',
   attachmentFileHandleIds: [MOCK_FILE_HANDLE_ID],
   parentWikiId: mockEntityRootWikiPage.id,
 }

--- a/packages/synapse-react-client/src/mocks/msw/handlers/accessRequirementHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/accessRequirementHandlers.ts
@@ -71,6 +71,16 @@ export const getAccessRequirementHandlers = (backendOrigin: string) => [
     },
   ),
 ]
+export function updateAccessRequirement(backendOrigin: string) {
+  return rest.put(
+    `${backendOrigin}${ACCESS_REQUIREMENT_BY_ID(':id')}`,
+    async (req, res, ctx) => {
+      const requestBody: AccessRequirement = await req.json()
+      return res(ctx.status(200), ctx.json(requestBody))
+    },
+  )
+}
+
 export const getAccessRequirementEntityBindingHandlers = (
   backendOrigin: string,
   entityId = ':entityId',
@@ -191,6 +201,7 @@ export function getCreateAccessApprovalHandler(backendOrigin: string) {
 export function getAllAccessRequirementHandlers(backendOrigin: string) {
   return [
     ...getAccessRequirementHandlers(backendOrigin),
+    updateAccessRequirement(backendOrigin),
     ...getAccessRequirementEntityBindingHandlers(backendOrigin),
     getAccessRequirementsBoundToTeamHandler(backendOrigin),
     ...getAccessRequirementStatusHandlers(backendOrigin),

--- a/packages/synapse-react-client/src/mocks/msw/handlers/wikiHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/wikiHandlers.ts
@@ -5,7 +5,11 @@ import {
   WikiPageKey,
 } from '@sage-bionetworks/synapse-types'
 import { rest } from 'msw'
-import { WIKI_OBJECT_TYPE, WIKI_PAGE } from '../../../utils/APIConstants'
+import {
+  WIKI_OBJECT_TYPE,
+  WIKI_PAGE,
+  WIKI_PAGE_ID,
+} from '../../../utils/APIConstants'
 import { MOCK_WIKI_ETAG, NEW_WIKI_PAGE_ID, mockWikiPages } from '../../mockWiki'
 import { mockWikiPageKeys } from '../../mockWikiPageKey'
 import { MOCK_USER_ID } from '../../user/mock_user_profile'
@@ -20,10 +24,11 @@ const wikiOwnerObjectTypes = [
 export function getWikiPage(backendOrigin: string) {
   return wikiOwnerObjectTypes.map(ownerObjectType => {
     return rest.get(
-      `${backendOrigin}${WIKI_PAGE(
+      `${backendOrigin}${WIKI_PAGE_ID(
         ownerObjectType,
         ':ownerObjectId',
-      )}/:wikiPageId`,
+        ':wikiPageId',
+      )}`,
       async (req, res, ctx) => {
         let status = 404
         let response: SynapseApiResponse<WikiPage> = {
@@ -111,10 +116,11 @@ export function createWikiPage(backendOrigin: string) {
 export function updateWikiPage(backendOrigin: string) {
   return wikiOwnerObjectTypes.map(ownerObjectType => {
     return rest.put(
-      `${backendOrigin}${WIKI_PAGE(
+      `${backendOrigin}${WIKI_PAGE_ID(
         ownerObjectType,
         ':ownerObjectId',
-      )}/:wikiPageId`,
+        ':wikiPageId',
+      )}`,
       async (req, res, ctx) => {
         const requestBody: WikiPage = await req.json()
         return res(ctx.status(201), ctx.json(requestBody))

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -6,6 +6,7 @@ import {
   ACCESS_APPROVAL,
   ACCESS_APPROVAL_BY_ID,
   ACCESS_REQUEST_SUBMISSION_SEARCH,
+  ACCESS_REQUIREMENT,
   ACCESS_REQUIREMENT_ACL,
   ACCESS_REQUIREMENT_BY_ID,
   ACCESS_REQUIREMENT_DATA_ACCESS_REQUEST_FOR_UPDATE,
@@ -3085,6 +3086,28 @@ export const getAccessRequirementById = <T extends AccessRequirement>(
 ): Promise<T> => {
   return doGet<T>(
     ACCESS_REQUIREMENT_BY_ID(id),
+    accessToken,
+    BackendDestinationEnum.REPO_ENDPOINT,
+  )
+}
+
+/**
+ * Modify an existing Access Requirement. This service may only be used by the
+ * Synapse Access and Compliance Team.
+ *
+ * See https://rest-docs.synapse.org/rest/PUT/accessRequirement/requirementId.html
+ *
+ * @param accessToken token of user
+ * @param accessRequirement access requirement to update
+ * @returns updated access requirement
+ */
+export const updateAccessRequirement = <T extends AccessRequirement>(
+  accessToken: string | undefined,
+  accessRequirement: T,
+): Promise<T> => {
+  return doPut<T>(
+    `${ACCESS_REQUIREMENT}/${accessRequirement.id}`,
+    accessRequirement,
     accessToken,
     BackendDestinationEnum.REPO_ENDPOINT,
   )

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -80,6 +80,7 @@ import {
   VERIFICATION_SUBMISSION,
   WIKI_OBJECT_TYPE,
   WIKI_PAGE,
+  WIKI_PAGE_ID,
 } from '../utils/APIConstants'
 import { dispatchDownloadListChangeEvent } from '../utils/functions/dispatchDownloadListChangeEvent'
 import { BackendDestinationEnum, getEndpoint } from '../utils/functions'
@@ -1747,10 +1748,11 @@ export const getWikiPage = (
   accessToken: string | undefined,
   wikiPageKey: WikiPageKey,
 ): Promise<WikiPage> => {
-  const url = `${WIKI_PAGE(
+  const url = `${WIKI_PAGE_ID(
     wikiPageKey.ownerObjectType,
     wikiPageKey.ownerObjectId,
-  )}/${wikiPageKey.wikiPageId}`
+    wikiPageKey.wikiPageId,
+  )}`
   return doGet<WikiPage>(url, accessToken, BackendDestinationEnum.REPO_ENDPOINT)
 }
 
@@ -1801,7 +1803,7 @@ export const updateWikiPage = (
   ownerObjectId: string,
   wikiPage: WikiPage,
 ): Promise<WikiPage> => {
-  const url = `${WIKI_PAGE(ownerObjectType, ownerObjectId)}/${wikiPage.id}`
+  const url = `${WIKI_PAGE_ID(ownerObjectType, ownerObjectId, wikiPage.id)}`
   return doPut<WikiPage>(
     url,
     wikiPage,

--- a/packages/synapse-react-client/src/synapse-queries/dataaccess/useAccessRequirements.ts
+++ b/packages/synapse-react-client/src/synapse-queries/dataaccess/useAccessRequirements.ts
@@ -13,6 +13,7 @@ import {
 import SynapseClient, {
   createAccessRequirementAcl,
   deleteAccessRequirementAcl,
+  updateAccessRequirement,
   updateAccessRequirementAcl,
 } from '../../synapse-client'
 import { SynapseClientError, useSynapseContext } from '../../utils'
@@ -94,6 +95,28 @@ export function useGetAccessRequirementWikiPageKey(
         accessToken,
         accessRequirementId,
       ),
+  })
+}
+
+export function useUpdateAccessRequirement<T extends AccessRequirement>(
+  options?: UseMutationOptions<T, SynapseClientError, T>,
+) {
+  const queryClient = useQueryClient()
+  const { accessToken, keyFactory } = useSynapseContext()
+  return useMutation<T, SynapseClientError, T>({
+    ...options,
+    mutationFn: ar => updateAccessRequirement<T>(accessToken, ar),
+    onSuccess: async (newAr, ar, ctx) => {
+      const accessRequirementQueryKey = keyFactory.getAccessRequirementQueryKey(
+        newAr.id.toString(),
+      )
+      queryClient.setQueryData(accessRequirementQueryKey, newAr)
+
+      if (options?.onSuccess) {
+        return await options.onSuccess(newAr, ar, ctx)
+      }
+      return
+    },
   })
 }
 

--- a/packages/synapse-react-client/src/testutils/MarkdownSynapseUtils.ts
+++ b/packages/synapse-react-client/src/testutils/MarkdownSynapseUtils.ts
@@ -1,0 +1,27 @@
+import { screen, waitFor } from '@testing-library/react'
+import SynapseClient from '../synapse-client'
+
+const getEntityWikiSpy = jest.spyOn(SynapseClient, 'getEntityWiki')
+const getWikiAttachmentsFromEntitySpy = jest.spyOn(
+  SynapseClient,
+  'getWikiAttachmentsFromEntity',
+)
+
+export function expectMarkdownSynapseNotToGetWiki() {
+  expect(getEntityWikiSpy).toHaveBeenCalledTimes(0)
+  expect(getWikiAttachmentsFromEntitySpy).toHaveBeenCalledTimes(0)
+}
+
+export async function waitForMarkdownSynapseToGetWiki(times: number = 1) {
+  await waitFor(() => {
+    expect(getEntityWikiSpy).toHaveBeenCalledTimes(times)
+    expect(getWikiAttachmentsFromEntitySpy).toHaveBeenCalledTimes(times)
+  })
+}
+
+// Note - matches text content rendered by MarkdownSynapse, but does not
+// confirm that formatting was applied or widgets embedded
+export async function confirmMarkdownSynapseTextContent(textContent: string) {
+  const markdownField = await screen.findByLabelText('markdown')
+  expect(markdownField).toHaveTextContent(textContent)
+}

--- a/packages/synapse-react-client/src/testutils/MarkdownSynapseUtils.ts
+++ b/packages/synapse-react-client/src/testutils/MarkdownSynapseUtils.ts
@@ -22,6 +22,6 @@ export async function waitForMarkdownSynapseToGetWiki(times: number = 1) {
 // Note - matches text content rendered by MarkdownSynapse, but does not
 // confirm that formatting was applied or widgets embedded
 export async function confirmMarkdownSynapseTextContent(textContent: string) {
-  const markdownField = await screen.findByLabelText('markdown')
+  const markdownField = await screen.findByTestId('markdown')
   expect(markdownField).toHaveTextContent(textContent)
 }

--- a/packages/synapse-react-client/src/utils/APIConstants.ts
+++ b/packages/synapse-react-client/src/utils/APIConstants.ts
@@ -98,11 +98,12 @@ export const SIGN_TERMS_OF_USE = `${AUTH}/termsOfUse2`
 export const VERIFICATION_SUBMISSION = `${REPO}/verificationSubmission`
 export const CHANGE_PASSWORD = `${AUTH}/user/changePassword`
 
-export const ACCESS_REQUIREMENT_SEARCH = `${REPO}/accessRequirement/search`
+export const ACCESS_REQUIREMENT = `${REPO}/accessRequirement`
+export const ACCESS_REQUIREMENT_SEARCH = `${ACCESS_REQUIREMENT}/search`
 export const ACCESS_REQUEST_SUBMISSION_SEARCH = `${REPO}/dataAccessSubmission/search`
 
 export const ACCESS_REQUIREMENT_BY_ID = (id: string | number) =>
-  `${REPO}/accessRequirement/${id}`
+  `${ACCESS_REQUIREMENT}/${id}`
 
 export const ACCESS_REQUIREMENT_ACL = (id: string | number) =>
   ACCESS_REQUIREMENT_BY_ID(id) + '/acl'

--- a/packages/synapse-react-client/src/utils/APIConstants.ts
+++ b/packages/synapse-react-client/src/utils/APIConstants.ts
@@ -115,13 +115,6 @@ export const ACCESS_REQUIREMENT_WIKI_PAGE_KEY = (id: string | number) =>
   // Note that this is `access_requirement` not `accessRequirement`!
   `${REPO}/access_requirement/${id}/wikikey`
 
-export const ACCESS_REQUIREMENT_WIKI_PAGE = (
-  accessRequirementId: string | number,
-  wikiId: string | number,
-) =>
-  // Note that this is `access_requirement` not `accessRequirement`!
-  `${REPO}/access_requirement/${accessRequirementId}/wiki/${wikiId}`
-
 export const FAVORITES = `${REPO}/favorite`
 
 export const USER_GROUP_HEADERS = `${REPO}/userGroupHeaders`
@@ -217,4 +210,11 @@ export const WIKI_PAGE = (
   ownerObjectId: string,
 ) => {
   return `${WIKI_OBJECT_TYPE(ownerObjectType)}/${ownerObjectId}/wiki`
+}
+export const WIKI_PAGE_ID = (
+  ownerObjectType: ObjectType,
+  ownerObjectId: string,
+  wikiPageId: string,
+) => {
+  return `${WIKI_PAGE(ownerObjectType, ownerObjectId)}/${wikiPageId}`
 }

--- a/packages/synapse-react-client/src/utils/SynapseConstants.ts
+++ b/packages/synapse-react-client/src/utils/SynapseConstants.ts
@@ -123,6 +123,8 @@ export const BASE = 1024,
   GB = MB * BASE,
   TB = GB * BASE
 
+export const DAY_IN_MS = 1000 * 60 * 60 * 24
+
 export const NETWORK_UNAVAILABLE_MESSAGE =
   'This site cannot be reached. Either a connection is unavailable, or your network administrator has blocked you from accessing this site.'
 

--- a/packages/synapse-react-client/test/containers/markdown/MarkdownSynapse.integration.test.tsx
+++ b/packages/synapse-react-client/test/containers/markdown/MarkdownSynapse.integration.test.tsx
@@ -149,7 +149,7 @@ describe('MarkdownSynapse tests', () => {
       }
       renderComponent(props)
 
-      const markdownField = screen.getByLabelText('markdown')
+      const markdownField = screen.getByTestId('markdown')
       expect(markdownField).toHaveTextContent('')
     })
 
@@ -161,7 +161,7 @@ describe('MarkdownSynapse tests', () => {
       mockGetEntityWiki('')
       renderComponent(props)
 
-      const markdownField = screen.getByLabelText('markdown')
+      const markdownField = screen.getByTestId('markdown')
       expect(markdownField).toHaveTextContent('')
     })
 

--- a/packages/synapse-react-client/test/containers/markdown/MarkdownSynapse.integration.test.tsx
+++ b/packages/synapse-react-client/test/containers/markdown/MarkdownSynapse.integration.test.tsx
@@ -4,6 +4,7 @@ import * as MarkdownSynapseImageModule from '../../../src/components/Markdown/wi
 import * as MarkdownPlotModule from '../../../src/components/Markdown/widget/MarkdownSynapsePlot'
 import MarkdownSynapse, {
   MarkdownSynapseProps,
+  NO_WIKI_CONTENT,
 } from '../../../src/components/Markdown/MarkdownSynapse'
 import { createWrapper } from '../../../src/testutils/TestingLibraryUtils'
 import SynapseClient from '../../../src/synapse-client'
@@ -138,6 +139,50 @@ describe('MarkdownSynapse tests', () => {
       }
       renderComponent(props)
       await screen.findByRole('link')
+    })
+  })
+
+  describe('it conditonally renders no content placeholder', () => {
+    it('by default, displays empty string when wiki markdown is undefined', () => {
+      const props: MarkdownSynapseProps = {
+        markdown: undefined,
+      }
+      renderComponent(props)
+
+      const markdownField = screen.getByLabelText('markdown')
+      expect(markdownField).toHaveTextContent('')
+    })
+
+    it('by default, displays empty string when wiki markdown is empty string', () => {
+      const props: MarkdownSynapseProps = {
+        wikiId: 'xxx', // placeholder
+        ownerId: 'xxx', // placeholder
+      }
+      mockGetEntityWiki('')
+      renderComponent(props)
+
+      const markdownField = screen.getByLabelText('markdown')
+      expect(markdownField).toHaveTextContent('')
+    })
+
+    it('when specified, displays no content placeholder when wiki markdown is undefined', () => {
+      const props: MarkdownSynapseProps = {
+        markdown: undefined,
+        showPlaceholderIfNoWikiContent: true,
+      }
+      renderComponent(props)
+      screen.getByText(NO_WIKI_CONTENT)
+    })
+
+    it('when specified, displays no content placeholder when wiki markdown is empty string', () => {
+      const props: MarkdownSynapseProps = {
+        wikiId: 'xxx', // placeholder
+        ownerId: 'xxx', // placeholder
+        showPlaceholderIfNoWikiContent: true,
+      }
+      mockGetEntityWiki('')
+      renderComponent(props)
+      screen.getByText(NO_WIKI_CONTENT)
     })
   })
 

--- a/packages/synapse-react-client/test/containers/markdown/__snapshots__/MarkdownSynapse.integration.test.tsx.snap
+++ b/packages/synapse-react-client/test/containers/markdown/__snapshots__/MarkdownSynapse.integration.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`MarkdownSynapse tests Snapshot tests works with a br statement and loose text 1`] = `
 <div>
   <div
+    aria-label="markdown"
     class="markdown"
   >
     <span
@@ -39,6 +40,7 @@ exports[`MarkdownSynapse tests Snapshot tests works with a br statement and loos
 exports[`MarkdownSynapse tests Snapshot tests works with header and a link 1`] = `
 <div>
   <div
+    aria-label="markdown"
     class="markdown"
   >
     <span
@@ -68,6 +70,7 @@ exports[`MarkdownSynapse tests Snapshot tests works with header and a link 1`] =
 exports[`MarkdownSynapse tests Snapshot tests works with two inline widgets 1`] = `
 <div>
   <div
+    aria-label="markdown"
     class="markdown"
   >
     <span

--- a/packages/synapse-react-client/test/containers/markdown/__snapshots__/MarkdownSynapse.integration.test.tsx.snap
+++ b/packages/synapse-react-client/test/containers/markdown/__snapshots__/MarkdownSynapse.integration.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`MarkdownSynapse tests Snapshot tests works with a br statement and loose text 1`] = `
 <div>
   <div
-    aria-label="markdown"
     class="markdown"
+    data-testid="markdown"
   >
     <span
       class="MuiTypography-root MuiTypography-body1 css-4ozm06-MuiTypography-root"
@@ -40,8 +40,8 @@ exports[`MarkdownSynapse tests Snapshot tests works with a br statement and loos
 exports[`MarkdownSynapse tests Snapshot tests works with header and a link 1`] = `
 <div>
   <div
-    aria-label="markdown"
     class="markdown"
+    data-testid="markdown"
   >
     <span
       class="MuiTypography-root MuiTypography-body1 css-4ozm06-MuiTypography-root"
@@ -70,8 +70,8 @@ exports[`MarkdownSynapse tests Snapshot tests works with header and a link 1`] =
 exports[`MarkdownSynapse tests Snapshot tests works with two inline widgets 1`] = `
 <div>
   <div
-    aria-label="markdown"
     class="markdown"
+    data-testid="markdown"
   >
     <span
       class="MuiTypography-root MuiTypography-body1 css-4ozm06-MuiTypography-root"

--- a/packages/synapse-types/src/AccessRequirement/ManagedACTAccessRequirement.ts
+++ b/packages/synapse-types/src/AccessRequirement/ManagedACTAccessRequirement.ts
@@ -41,7 +41,7 @@ export type ManagedACTAccessRequirement = {
   /* If true, then accessor needs to fill, sign, and submit a Data Use Certificate (DUC) to gain access to the data. */
   isDUCRequired: boolean
   /* If the Data Use Certificate (DUC) is required, creator of this requirement needs to upload a Data Use Certificate (DUC) template. Users have to download this template, fill out, sign and submit it. */
-  ducTemplateFileHandleId: string
+  ducTemplateFileHandleId?: string
   /* If true, then accessor needs to submit an Institutional Review Board (IRB) Approval document to gain access to the data. */
   isIRBApprovalRequired: boolean
   /* If true, then accessor needs to upload attachment(s) other than Data Use Certificate (DUC) and Institutional Review Board (IRB) Approval document to gain access to the data. */


### PR DESCRIPTION
type | SWC | SRC
:---:|:---:|:---:
Basic AR (self-sign) | <img width="747" alt="SWC-6730_basicSelfSignAR_SWC" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/fe801cb3-61d1-4491-8592-ba1db0fa8b9b"> | <img width="791" alt="SWC-6730_basicSelfSignAR" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/17b8bf42-ec15-4e1c-87a8-287b221b78e9">
Managed AR | <img width="678" alt="SWC-6730_managedAR_SWC" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/b1cad4ea-8ffa-460b-afb0-e10204afe793"> | <img width="702" alt="SWC-6730_managedAR" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/f683799d-812d-4d43-924d-f3cad599beb1">

