### PR TITLE
Bump markdown-it-synapse to v1.1.14

### DIFF
--- a/packages/markdown-it-synapse/package.json
+++ b/packages/markdown-it-synapse/package.json
@@ -15,6 +15,7 @@
     "markdown-it-plugin",
     "markdown-it",
     "markdown",
+    "markdownitSynapse",
     "synapse"
   ],
   "files": [


### PR DESCRIPTION
Attempt to trigger auto-release without changing version