### PR TITLE
Revert markdown-it-synapse version to 1.1.13

### DIFF
--- a/packages/markdown-it-synapse/package.json
+++ b/packages/markdown-it-synapse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-synapse",
-  "version": "1.1.14",
+  "version": "1.1.13",
   "description": "tag for markdown-it markdown parser.",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
Will cause an error, but allows triggering an automatic release in the next bump