### PR TITLE
SWC-6766 - Add ChangePasswordWithToken component, use in SageAccountWeb

### DIFF
--- a/apps/SageAccountWeb/src/components/ResetPassword.tsx
+++ b/apps/SageAccountWeb/src/components/ResetPassword.tsx
@@ -42,8 +42,8 @@ export const ResetPassword = (props: ResetPasswordProps) => {
         'If a matching account was found, then your password reset request has been sent. Please check your email.',
         'success',
       )
-    } catch (err: SynapseClientError) {
-      displayToast(err.reason, 'danger')
+    } catch (err: unknown) {
+      displayToast((err as SynapseClientError).reason, 'danger')
     }
   }
 

--- a/apps/SageAccountWeb/src/components/ResetPassword.tsx
+++ b/apps/SageAccountWeb/src/components/ResetPassword.tsx
@@ -1,12 +1,13 @@
-import { Box, Button, TextField, Typography } from '@mui/material'
-import { StyledFormControl } from '../components/StyledComponents'
-import React, { useEffect, useState } from 'react'
+import { Box, Button, SxProps, TextField, Typography } from '@mui/material'
+import React, { useMemo, useState } from 'react'
 import { useHistory } from 'react-router-dom'
-import { displayToast, SynapseClient } from 'synapse-react-client'
 import {
   ChangePasswordWithToken,
-  PasswordResetSignedToken,
-} from '@sage-bionetworks/synapse-types'
+  displayToast,
+  SynapseClient,
+  SynapseClientError,
+} from 'synapse-react-client'
+import { PasswordResetSignedToken } from '@sage-bionetworks/synapse-types'
 import { getSearchParam, hexDecodeAndDeserialize } from '../URLUtils'
 import { BackButton } from './BackButton'
 import { LeftRightPanel } from './LeftRightPanel'
@@ -19,20 +20,17 @@ export type ResetPasswordProps = {
 export const ResetPassword = (props: ResetPasswordProps) => {
   const history = useHistory()
   const [userName, setUserName] = useState('')
-  const [token, setToken] = useState<PasswordResetSignedToken | undefined>()
-  const [newPassword, setNewPassword] = useState<string>('')
-  const [confirmPassword, setConfirmPassword] = useState<string>('')
 
   const passwordResetTokenValue = getSearchParam('passwordResetToken')
 
-  useEffect(() => {
+  const token = useMemo(() => {
     if (passwordResetTokenValue) {
-      const hexDecodedPasswordResetToken = hexDecodeAndDeserialize(
+      return hexDecodeAndDeserialize(
         passwordResetTokenValue,
-      )
-      setToken(hexDecodedPasswordResetToken)
+      ) as PasswordResetSignedToken
     }
-  }, [])
+    return undefined
+  }, [passwordResetTokenValue])
 
   const handleResetPassword = async (
     clickEvent: React.FormEvent<HTMLElement>,
@@ -40,48 +38,17 @@ export const ResetPassword = (props: ResetPasswordProps) => {
     clickEvent.preventDefault()
     try {
       await SynapseClient.resetPassword(userName)
-        .then(() => {
-          displayToast(
-            'If a matching account was found, then your password reset request has been sent. Please check your email.',
-            'success',
-          )
-        })
-        .catch((err: any) => {
-          displayToast(err.reason as string, 'danger')
-        })
-    } catch (err: any) {
-      displayToast(err.reason as string, 'danger')
+      displayToast(
+        'If a matching account was found, then your password reset request has been sent. Please check your email.',
+        'success',
+      )
+    } catch (err: SynapseClientError) {
+      displayToast(err.reason, 'danger')
     }
   }
 
-  const handleChangePasswordWithToken = async (
-    clickEvent: React.FormEvent<HTMLElement>,
-  ) => {
-    clickEvent.preventDefault()
-    try {
-      if (newPassword !== confirmPassword) {
-        displayToast('Passwords do not match', 'danger')
-      } else {
-        const changeRequest: ChangePasswordWithToken = {
-          newPassword,
-          concreteType:
-            'org.sagebionetworks.repo.model.auth.ChangePasswordWithToken',
-          passwordChangeToken: token as PasswordResetSignedToken,
-        }
-        await SynapseClient.changePasswordWithToken(changeRequest)
-          .then(() => {
-            displayToast('Successfully changed', 'success')
-          })
-          .then(() => window.location.replace(props.returnToUrl))
-      }
-    } catch (err: any) {
-      displayToast(err.reason as string, 'danger')
-    }
-  }
-
-  const formControlSx = {
-    marginTop: '0px',
-    marginBottom: '10px',
+  const formControlSx: SxProps = {
+    mb: 2,
   }
 
   const buttonSx = {
@@ -96,55 +63,12 @@ export const ResetPassword = (props: ResetPasswordProps) => {
           token ? (
             <>
               <SourceAppLogo />
-              <form onSubmit={handleChangePasswordWithToken}>
-                <StyledFormControl
-                  fullWidth
-                  required
-                  variant="standard"
-                  margin="normal"
-                  sx={formControlSx}
-                >
-                  <TextField
-                    fullWidth
-                    required
-                    type="password"
-                    id="newPassword"
-                    name="newPassword"
-                    label={'New password'}
-                    onChange={e => setNewPassword(e.target.value)}
-                    value={newPassword || ''}
-                  />
-                </StyledFormControl>
-                <StyledFormControl
-                  fullWidth
-                  required
-                  variant="standard"
-                  margin="normal"
-                  sx={formControlSx}
-                >
-                  <TextField
-                    fullWidth
-                    required
-                    type="password"
-                    id="confirmPassword"
-                    name="confirmPassword"
-                    label={'Confirm password'}
-                    onChange={e => setConfirmPassword(e.target.value)}
-                    value={confirmPassword || ''}
-                  />
-                </StyledFormControl>
-                <Button
-                  className="btn-container"
-                  variant="contained"
-                  type="submit"
-                  fullWidth
-                  onSubmit={handleChangePasswordWithToken}
-                  sx={buttonSx}
-                  disabled={!newPassword || !confirmPassword}
-                >
-                  Change Password
-                </Button>
-              </form>
+              <ChangePasswordWithToken
+                passwordChangeToken={token}
+                onSuccess={() => {
+                  window.location.replace(props.returnToUrl)
+                }}
+              />
             </>
           ) : (
             <Box>
@@ -154,27 +78,22 @@ export const ResetPassword = (props: ResetPasswordProps) => {
                 }}
               />
               <SourceAppLogo />
-              <StyledFormControl
+              <TextField
                 fullWidth
                 required
-                variant="standard"
-                margin="normal"
+                label={'Email address or username'}
+                id="username"
+                name="username"
+                onChange={e => setUserName(e.target.value)}
+                value={userName || ''}
                 sx={formControlSx}
-              >
-                <TextField
-                  fullWidth
-                  required
-                  label={'Email address or username'}
-                  id="username"
-                  name="username"
-                  onChange={e => setUserName(e.target.value)}
-                  value={userName || ''}
-                />
-              </StyledFormControl>
+              />
               <Button
                 variant="contained"
                 fullWidth
-                onClick={handleResetPassword}
+                onClick={e => {
+                  void handleResetPassword(e)
+                }}
                 sx={buttonSx}
                 type="button"
                 disabled={!userName}
@@ -198,8 +117,8 @@ export const ResetPassword = (props: ResetPasswordProps) => {
             <div>
               <Typography variant="headline2">Reset your password</Typography>
               <Typography variant="subtitle1">
-                Please enter your email address or username and we'll send you
-                instructions to reset your password
+                Please enter your email address or username and we&apos;ll send
+                you instructions to reset your password
               </Typography>
             </div>
           )

--- a/apps/SageAccountWeb/src/style/_core.scss
+++ b/apps/SageAccountWeb/src/style/_core.scss
@@ -56,10 +56,4 @@
       background-color: #f4f4f4;
     }
   }
-  .btn-container {
-    padding: 10px 30px;
-    box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
-    min-width: 190px;
-    margin-right: 16px;
-  }
 }

--- a/packages/synapse-react-client/src/components/ChangePassword/ChangePassword.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/ChangePassword.tsx
@@ -15,7 +15,7 @@ export default function ChangePassword() {
 
   const {
     promptForTwoFactorAuth,
-    twoFactorAuthPrompt,
+    TwoFactorAuthPrompt,
     isPending: changePasswordIsPending,
     handleChangePasswordWithCurrentPassword,
     error,
@@ -44,7 +44,7 @@ export default function ChangePassword() {
   return (
     <div>
       {promptForTwoFactorAuth ? (
-        twoFactorAuthPrompt
+        <TwoFactorAuthPrompt />
       ) : (
         <form
           onSubmit={e => {

--- a/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.integration.test.tsx
@@ -1,0 +1,401 @@
+import React from 'react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import userEvent from '@testing-library/user-event'
+import { server } from '../../mocks/msw/server'
+import { noop } from 'lodash-es'
+import * as ToastMessage from '../ToastMessage/ToastMessage'
+import { MemoryRouter } from 'react-router-dom'
+import SynapseClient from '../../synapse-client'
+import { MOCK_USER_ID } from '../../mocks/user/mock_user_profile'
+import {
+  getBadRequestChangePasswordHandler,
+  getRequires2FAChangePasswordHandler,
+  getSuccessfulChangePasswordHandler,
+} from '../../mocks/msw/handlers/changePasswordHandlers'
+import { BackendDestinationEnum, getEndpoint } from '../../utils/functions'
+import ChangePasswordWithToken from './ChangePasswordWithToken'
+import { PasswordResetSignedToken } from '@sage-bionetworks/synapse-types'
+
+const mockDisplayToast = jest
+  .spyOn(ToastMessage, 'displayToast')
+  .mockImplementation(() => noop)
+
+const changePasswordSpy = jest.spyOn(SynapseClient, 'changePassword')
+
+const passwordResetSignedToken: PasswordResetSignedToken = {
+  concreteType: 'org.sagebionetworks.repo.model.auth.PasswordResetSignedToken',
+  hmac: 'foo',
+  version: 3,
+  expiresOn: 'later',
+  createdOn: 'now',
+  userId: String(MOCK_USER_ID),
+  validity: 'valid',
+}
+
+const mockOnSuccess = jest.fn()
+
+function renderComponent() {
+  return render(
+    <MemoryRouter>
+      <ChangePasswordWithToken
+        passwordChangeToken={passwordResetSignedToken}
+        onSuccess={mockOnSuccess}
+      />
+    </MemoryRouter>,
+    { wrapper: createWrapper() },
+  )
+}
+
+function getNewPasswordField() {
+  return screen.getByLabelText(/New password/i)
+}
+
+function getConfirmPasswordField() {
+  return screen.getByLabelText(/Confirm password/i)
+}
+
+function setUp() {
+  const user = userEvent.setup()
+  const result = renderComponent()
+  const newPasswordField = getNewPasswordField()
+  const confirmPasswordField = getConfirmPasswordField()
+  const submitButton = screen.getByRole('button', { name: 'Change Password' })
+
+  return {
+    user,
+    result,
+    newPasswordField,
+    confirmPasswordField,
+    submitButton,
+  }
+}
+
+async function getTOTPInputs() {
+  let otpInputs: HTMLElement[] = []
+  await waitFor(() => {
+    otpInputs = screen.getAllByRole('textbox')
+    expect(otpInputs).toHaveLength(6)
+  })
+  return otpInputs
+}
+
+async function typeAndSubmitTOTP(
+  newPasswordField: HTMLElement,
+  confirmPasswordField: HTMLElement,
+  newPassword: string,
+  user: ReturnType<typeof userEvent.setup>,
+) {
+  const otpInputs: HTMLElement[] = await getTOTPInputs()
+
+  await waitFor(() => {
+    const alert = screen.getByRole('alert')
+    within(alert).getByText(
+      'Two-factor authentication is required to change your password.',
+    )
+
+    expect(mockDisplayToast).not.toHaveBeenCalled()
+    expect(newPasswordField).not.toBeInTheDocument()
+    expect(confirmPasswordField).not.toBeInTheDocument()
+
+    expect(changePasswordSpy).toHaveBeenCalledTimes(1)
+    expect(changePasswordSpy).toHaveBeenCalledWith({
+      concreteType:
+        'org.sagebionetworks.repo.model.auth.ChangePasswordWithToken',
+      newPassword: newPassword,
+      passwordChangeToken: passwordResetSignedToken,
+    })
+  })
+
+  // Type the code. Once the code is entered, the form should submit automatically
+  for (let i = 0; i < otpInputs.length; i++) {
+    await user.type(otpInputs[i], String(i + 1))
+  }
+}
+
+describe('ChangePassword tests', () => {
+  beforeAll(() => server.listen())
+  beforeEach(() => jest.clearAllMocks())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('allows changing password', async () => {
+    server.use(
+      getSuccessfulChangePasswordHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+      ),
+    )
+
+    const newPassword = 'newPassword'
+
+    const { user, newPasswordField, confirmPasswordField, submitButton } =
+      setUp()
+
+    await user.type(newPasswordField, newPassword)
+    await user.type(confirmPasswordField, newPassword)
+
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+      expect(mockDisplayToast).toHaveBeenCalledWith(
+        'Password successfully changed.',
+        'success',
+      )
+      expect(newPasswordField).toHaveValue('')
+      expect(confirmPasswordField).toHaveValue('')
+      expect(changePasswordSpy).toHaveBeenCalledTimes(1)
+      expect(changePasswordSpy).toHaveBeenCalledWith({
+        concreteType:
+          'org.sagebionetworks.repo.model.auth.ChangePasswordWithToken',
+        newPassword: newPassword,
+        passwordChangeToken: passwordResetSignedToken,
+      })
+    })
+  })
+
+  it('shows error when the confirm password does not match the new password', async () => {
+    const newPassword = 'newPassword'
+    const confirmPassword = 'mismatched'
+
+    const { user, newPasswordField, confirmPasswordField, submitButton } =
+      setUp()
+
+    await user.type(newPasswordField, newPassword)
+    await user.type(confirmPasswordField, confirmPassword)
+
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockDisplayToast).toHaveBeenCalledWith(
+        'Passwords do not match.',
+        'danger',
+      )
+
+      expect(newPasswordField).toHaveValue(newPassword)
+      expect(confirmPasswordField).toHaveValue(confirmPassword)
+
+      expect(changePasswordSpy).not.toHaveBeenCalled()
+      expect(mockOnSuccess).not.toHaveBeenCalled()
+    })
+  })
+
+  it('shows error when the server returns an error', async () => {
+    const errorMessage =
+      'The provided username/password combination is incorrect'
+    server.use(
+      getBadRequestChangePasswordHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        errorMessage,
+      ),
+    )
+
+    const newPassword = 'newPassword'
+
+    const { user, newPasswordField, confirmPasswordField, submitButton } =
+      setUp()
+
+    await user.type(newPasswordField, newPassword)
+    await user.type(confirmPasswordField, newPassword)
+
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      const alert = screen.getByRole('alert')
+      within(alert).getByText(errorMessage)
+
+      expect(mockOnSuccess).not.toHaveBeenCalled()
+      expect(mockDisplayToast).not.toHaveBeenCalled()
+      expect(newPasswordField).toHaveValue(newPassword)
+      expect(confirmPasswordField).toHaveValue(newPassword)
+
+      expect(changePasswordSpy).toHaveBeenCalledTimes(1)
+      expect(changePasswordSpy).toHaveBeenCalledWith({
+        concreteType:
+          'org.sagebionetworks.repo.model.auth.ChangePasswordWithToken',
+        newPassword: newPassword,
+        passwordChangeToken: passwordResetSignedToken,
+      })
+    })
+  })
+
+  it('supports entering a TOTP if the server requires 2FA', async () => {
+    const userId = MOCK_USER_ID
+    const twoFaToken = 'mock-2fa-token'
+    server.use(
+      // The first call will indicate that 2FA is required
+      getRequires2FAChangePasswordHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        userId,
+        twoFaToken,
+      ),
+      // Update the mock server so the second request will succeed
+      getSuccessfulChangePasswordHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+      ),
+    )
+
+    const newPassword = 'newPassword'
+
+    const { user, newPasswordField, confirmPasswordField, submitButton } =
+      setUp()
+
+    await user.type(newPasswordField, newPassword)
+    await user.type(confirmPasswordField, newPassword)
+
+    await user.click(submitButton)
+
+    // TOTP form should pop up
+    await typeAndSubmitTOTP(
+      newPasswordField,
+      confirmPasswordField,
+      newPassword,
+      user,
+    )
+    await waitFor(() => {
+      expect(changePasswordSpy).toHaveBeenCalledTimes(2)
+      expect(changePasswordSpy).toHaveBeenLastCalledWith({
+        concreteType:
+          'org.sagebionetworks.repo.model.auth.ChangePasswordWithTwoFactorAuthToken',
+        newPassword: newPassword,
+        twoFaToken: twoFaToken,
+        userId: userId,
+        otpCode: '123456',
+        otpType: 'TOTP',
+      })
+
+      expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+      expect(mockDisplayToast).toHaveBeenCalledWith(
+        'Password successfully changed.',
+        'success',
+      )
+    })
+
+    // The form should be reset
+    expect(getNewPasswordField()).toHaveValue('')
+    expect(getConfirmPasswordField()).toHaveValue('')
+  })
+
+  it('supports entering a recovery code if the server requires 2FA', async () => {
+    const userId = MOCK_USER_ID
+    const twoFaToken = 'mock-2fa-token'
+    server.use(
+      // The first call will indicate that 2FA is required
+      getRequires2FAChangePasswordHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        userId,
+        twoFaToken,
+      ),
+      // Update the mock server so the second request will succeed
+      getSuccessfulChangePasswordHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+      ),
+    )
+
+    const newPassword = 'newPassword'
+
+    const { user, newPasswordField, confirmPasswordField, submitButton } =
+      setUp()
+
+    await user.type(newPasswordField, newPassword)
+    await user.type(confirmPasswordField, newPassword)
+
+    await user.click(submitButton)
+
+    const useRecoveryCodeButton = await screen.findByText(
+      'Use a backup code instead',
+    )
+    await user.click(useRecoveryCodeButton)
+
+    // Type the backup code and submit it
+    const recoveryCode = '1234-5678-abcd-edcb'
+    const recoveryCodeTextbox = await screen.findByPlaceholderText(
+      'Enter backup code',
+    )
+    await user.type(recoveryCodeTextbox, recoveryCode)
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+    await waitFor(() => {
+      expect(changePasswordSpy).toHaveBeenCalledTimes(2)
+      expect(changePasswordSpy).toHaveBeenLastCalledWith({
+        concreteType:
+          'org.sagebionetworks.repo.model.auth.ChangePasswordWithTwoFactorAuthToken',
+        newPassword: newPassword,
+        twoFaToken: twoFaToken,
+        userId: userId,
+        otpCode: recoveryCode,
+        otpType: 'RECOVERY_CODE',
+      })
+
+      expect(mockOnSuccess).toHaveBeenCalledTimes(1)
+      expect(mockDisplayToast).toHaveBeenCalledWith(
+        'Password successfully changed.',
+        'success',
+      )
+
+      // The form should be reset
+      expect(getNewPasswordField()).toHaveValue('')
+      expect(getConfirmPasswordField()).toHaveValue('')
+    })
+  })
+
+  it('shows an error when the 2FA submission is invalid', async () => {
+    const userId = MOCK_USER_ID
+    const twoFaToken = 'mock-2fa-token'
+    const errorMessage = 'The provided code is invalid.'
+    server.use(
+      // The first call will indicate that 2FA is required
+      getRequires2FAChangePasswordHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        userId,
+        twoFaToken,
+      ),
+      // Update the mock server so the next request will fail with a meaningful error
+      getBadRequestChangePasswordHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        errorMessage,
+      ),
+    )
+
+    const newPassword = 'newPassword'
+
+    const { user, newPasswordField, confirmPasswordField, submitButton } =
+      setUp()
+
+    await user.type(newPasswordField, newPassword)
+    await user.type(confirmPasswordField, newPassword)
+
+    await user.click(submitButton)
+
+    // TOTP form should pop up
+    await typeAndSubmitTOTP(
+      newPasswordField,
+      confirmPasswordField,
+      newPassword,
+      user,
+    )
+
+    await waitFor(() => {
+      // The error should be shown on the screen
+      screen.getByText(errorMessage)
+
+      expect(changePasswordSpy).toHaveBeenCalledTimes(2)
+      expect(changePasswordSpy).toHaveBeenLastCalledWith({
+        concreteType:
+          'org.sagebionetworks.repo.model.auth.ChangePasswordWithTwoFactorAuthToken',
+        newPassword: newPassword,
+        twoFaToken: twoFaToken,
+        userId: userId,
+        otpCode: '123456',
+        otpType: 'TOTP',
+      })
+
+      expect(mockOnSuccess).not.toHaveBeenCalled()
+      expect(mockDisplayToast).not.toHaveBeenCalled()
+    })
+
+    // The TOTP form should still be shown
+    const otpInputs = await getTOTPInputs()
+    expect(otpInputs).toHaveLength(6)
+  })
+})

--- a/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.integration.test.tsx
@@ -113,7 +113,7 @@ async function typeAndSubmitTOTP(
   }
 }
 
-describe('ChangePassword tests', () => {
+describe('ChangePasswordWithToken tests', () => {
   beforeAll(() => server.listen())
   beforeEach(() => jest.clearAllMocks())
   afterEach(() => server.resetHandlers())

--- a/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.stories.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Meta, StoryObj } from '@storybook/react'
-import ChangePassword from './ChangePassword'
 import { Paper } from '@mui/material'
 import {
   getRequires2FAChangePasswordHandler,
@@ -8,10 +7,11 @@ import {
 } from '../../mocks/msw/handlers/changePasswordHandlers'
 import { MOCK_REPO_ORIGIN } from '../../utils/functions/getEndpoint'
 import { MOCK_USER_ID } from '../../mocks/user/mock_user_profile'
+import ChangePasswordWithToken from './ChangePasswordWithToken'
 
-const meta: Meta<typeof ChangePassword> = {
-  title: 'Authentication/ChangePassword/WithCurrentPassword',
-  component: ChangePassword,
+const meta: Meta<typeof ChangePasswordWithToken> = {
+  title: 'Authentication/ChangePassword/ResetWithToken',
+  component: ChangePasswordWithToken,
   parameters: {
     stack: 'mock',
   },

--- a/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.tsx
@@ -18,7 +18,7 @@ export default function ChangePasswordWithToken(
 
   const {
     promptForTwoFactorAuth,
-    twoFactorAuthPrompt,
+    TwoFactorAuthPrompt,
     isPending: changePasswordIsPending,
     handleChangePasswordWithResetToken,
     error,
@@ -43,7 +43,7 @@ export default function ChangePasswordWithToken(
   return (
     <div>
       {promptForTwoFactorAuth ? (
-        twoFactorAuthPrompt
+        <TwoFactorAuthPrompt />
       ) : (
         <form
           onSubmit={e => {

--- a/packages/synapse-react-client/src/components/ChangePassword/index.ts
+++ b/packages/synapse-react-client/src/components/ChangePassword/index.ts
@@ -1,4 +1,8 @@
 import ChangePassword from './ChangePassword'
+import ChangePasswordWithToken, {
+  ChangePasswordWithTokenProps,
+} from './ChangePasswordWithToken'
 
-export { ChangePassword }
+export { ChangePassword, ChangePasswordWithToken }
+export { type ChangePasswordWithTokenProps }
 export default ChangePassword

--- a/packages/synapse-react-client/src/components/ChangePassword/useChangePasswordFormState.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/useChangePasswordFormState.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import {
   ChangePasswordWithCurrentPassword,
   ChangePasswordWithToken as ChangePasswordWithTokenObject,
@@ -100,9 +100,13 @@ export default function useChangePasswordFormState(
       changePassword(changeRequest)
     }
   }
+  const promptForTwoFactorAuth = Boolean(twoFactorAuthErrorResponse)
 
-  const twoFactorAuthPrompt: React.ReactNode = useMemo(
-    () => (
+  const TwoFactorAuthPrompt = useCallback(() => {
+    if (!promptForTwoFactorAuth) {
+      return <></>
+    }
+    return (
       <>
         {otpStep === 'VERIFICATION_CODE' && (
           <Typography variant={'body1'} sx={{ my: 2 }} align={'center'}>
@@ -131,15 +135,20 @@ export default function useChangePasswordFormState(
           Two-factor authentication is required to change your password.
         </Alert>
       </>
-    ),
-    [handleChangePasswordWithOtp, isPending, newPassword, otpStep],
-  )
+    )
+  }, [
+    handleChangePasswordWithOtp,
+    isPending,
+    newPassword,
+    otpStep,
+    promptForTwoFactorAuth,
+  ])
 
   return {
     isPending,
     error,
-    promptForTwoFactorAuth: Boolean(twoFactorAuthErrorResponse),
-    twoFactorAuthPrompt,
+    promptForTwoFactorAuth,
+    TwoFactorAuthPrompt: TwoFactorAuthPrompt,
     handleChangePasswordWithCurrentPassword,
     handleChangePasswordWithResetToken,
   }

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -4089,6 +4089,7 @@ export const createProfileVerificationSubmission = (
 // https://rest-docs.synapse.org/rest/POST/user/changePassword.html
 export const changePassword = (
   request:
+    | ChangePasswordWithToken
     | ChangePasswordWithCurrentPassword
     | ChangePasswordWithTwoFactorAuthToken,
 ): Promise<TwoFactorAuthErrorResponse | ''> => {
@@ -4099,18 +4100,6 @@ export const changePassword = (
       undefined,
       BackendDestinationEnum.REPO_ENDPOINT,
     ),
-  )
-}
-
-// https://rest-docs.synapse.org/rest/POST/user/changePassword.html
-export const changePasswordWithToken = (
-  newPassword: ChangePasswordWithToken,
-) => {
-  return doPost<ChangePasswordWithToken>(
-    CHANGE_PASSWORD,
-    newPassword,
-    undefined,
-    BackendDestinationEnum.REPO_ENDPOINT,
   )
 }
 

--- a/packages/synapse-react-client/src/synapse-queries/auth/useChangePassword.ts
+++ b/packages/synapse-react-client/src/synapse-queries/auth/useChangePassword.ts
@@ -1,6 +1,7 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 import {
   ChangePasswordWithCurrentPassword,
+  ChangePasswordWithToken,
   ChangePasswordWithTwoFactorAuthToken,
   TwoFactorAuthErrorResponse,
 } from '@sage-bionetworks/synapse-types'
@@ -12,7 +13,9 @@ export function useChangePassword(
     UseMutationOptions<
       '' | TwoFactorAuthErrorResponse,
       SynapseClientError,
-      ChangePasswordWithCurrentPassword | ChangePasswordWithTwoFactorAuthToken
+      | ChangePasswordWithToken
+      | ChangePasswordWithCurrentPassword
+      | ChangePasswordWithTwoFactorAuthToken
     >
   >,
 ) {


### PR DESCRIPTION
- Add component to support changing password with a reset token
- Refactor existing ChangePassword component to share logic for 2FA via custom hook