### PR TITLE
SWC-6730c: add step to set common AR fields

### DIFF
--- a/packages/synapse-react-client/src/components/EntitySubjectsSelector/EntitySubjectsSelector.stories.tsx
+++ b/packages/synapse-react-client/src/components/EntitySubjectsSelector/EntitySubjectsSelector.stories.tsx
@@ -1,0 +1,55 @@
+import {
+  RestrictableObjectDescriptor,
+  RestrictableObjectType,
+} from '@sage-bionetworks/synapse-types'
+import { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import React, { useState } from 'react'
+import EntitySubjectsSelector from './EntitySubjectsSelector'
+
+const meta: Meta<typeof EntitySubjectsSelector> = {
+  title: 'Governance/EntitySubjectsSelector',
+  component: EntitySubjectsSelector,
+  parameters: {
+    stack: 'development',
+  },
+  render: function RenderFn(args) {
+    const [subjects, setSubjects] = useState<RestrictableObjectDescriptor[]>(
+      args.subjects,
+    )
+
+    return (
+      <>
+        <EntitySubjectsSelector
+          subjects={subjects}
+          onUpdate={subjects => setSubjects(subjects)}
+          onUpdateEntityIDsTextbox={fn()}
+        />
+      </>
+    )
+  },
+} satisfies Meta<typeof EntitySubjectsSelector>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  args: {
+    subjects: [
+      {
+        id: 'syn5550376',
+        type: RestrictableObjectType.ENTITY,
+      },
+      {
+        id: 'syn12177273',
+        type: RestrictableObjectType.ENTITY,
+      },
+      {
+        id: '3429759',
+        type: RestrictableObjectType.TEAM,
+      },
+    ],
+    onUpdate: fn(),
+  },
+}

--- a/packages/synapse-react-client/src/components/EntitySubjectsSelector/EntitySubjectsSelector.test.tsx
+++ b/packages/synapse-react-client/src/components/EntitySubjectsSelector/EntitySubjectsSelector.test.tsx
@@ -1,0 +1,160 @@
+import {
+  RestrictableObjectDescriptor,
+  RestrictableObjectType,
+} from '@sage-bionetworks/synapse-types'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import {
+  MOCK_FILE_ENTITY_ID,
+  MOCK_FILE_NAME,
+} from '../../mocks/entity/mockFileEntity'
+import { MOCK_FILE_VIEW_ENTITY_ID } from '../../mocks/entity/mockFileView'
+import { MOCK_PROJECT_VIEW_ENTITY_ID } from '../../mocks/entity/mockProjectView'
+import { server } from '../../mocks/msw/server'
+import { MOCK_TEAM_ID } from '../../mocks/team/mockTeam'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import EntitySubjectsSelector, {
+  EntitySubjectsSelectorProps,
+  NO_ENTITIES_SELECTED,
+  REMOVE_BUTTON_TEXT,
+} from './EntitySubjectsSelector'
+
+const onUpdate = jest.fn()
+const onUpdateEntityIDsTextbox = jest.fn()
+
+const teamSubject: RestrictableObjectDescriptor = {
+  id: MOCK_TEAM_ID.toString(),
+  type: RestrictableObjectType.TEAM,
+}
+const entitySubject: RestrictableObjectDescriptor = {
+  id: MOCK_FILE_ENTITY_ID.toString(),
+  type: RestrictableObjectType.ENTITY,
+}
+
+const defaultProps: EntitySubjectsSelectorProps = {
+  subjects: [entitySubject, teamSubject],
+  onUpdate,
+  onUpdateEntityIDsTextbox,
+}
+
+const defaultRowsCount = 1
+
+function renderComponent(props: EntitySubjectsSelectorProps) {
+  return render(<EntitySubjectsSelector {...props} />, {
+    wrapper: createWrapper(),
+  })
+}
+
+async function setUp(
+  props: EntitySubjectsSelectorProps = defaultProps,
+  rowsCount: number = defaultRowsCount,
+) {
+  const user = userEvent.setup()
+  const component = renderComponent(props)
+
+  await waitFor(() => {
+    // account for the header row
+    expect(screen.getAllByRole('row')).toHaveLength(rowsCount + 1)
+  })
+
+  return { component, user }
+}
+
+describe('EntitySubjectsSelector', () => {
+  beforeEach(() => jest.clearAllMocks())
+  beforeAll(() => server.listen())
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  test('displays selected entities', async () => {
+    await setUp()
+
+    expect(screen.getByText(MOCK_FILE_NAME)).toBeVisible()
+
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(onUpdateEntityIDsTextbox).not.toHaveBeenCalled()
+  })
+
+  test('displays placeholder when no entities selected', () => {
+    renderComponent({ ...defaultProps, subjects: [] })
+
+    expect(screen.getByText(NO_ENTITIES_SELECTED)).toBeVisible()
+
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(onUpdateEntityIDsTextbox).not.toHaveBeenCalled()
+  })
+
+  test('removes entity and drops any team subjects', async () => {
+    const { user } = await setUp()
+
+    const row = screen.getAllByRole('row')[1]
+    const checkbox = within(row).getByRole('checkbox')
+    await user.click(checkbox)
+
+    const removeButton = await screen.findByRole('button', {
+      name: REMOVE_BUTTON_TEXT,
+    })
+    await user.click(removeButton)
+
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+    expect(onUpdate).toHaveBeenLastCalledWith([])
+    expect(screen.queryAllByRole('row')).toHaveLength(0)
+  })
+
+  test('adds entities and drops any team subjects', async () => {
+    const { user } = await setUp()
+
+    const newEntityIds = `${MOCK_FILE_VIEW_ENTITY_ID}, ${MOCK_PROJECT_VIEW_ENTITY_ID}`
+    const input = screen.getByRole('textbox', { name: 'Add Synapse IDs' })
+    await user.type(input, newEntityIds)
+
+    expect(input).toHaveValue(newEntityIds)
+    expect(onUpdateEntityIDsTextbox).toHaveBeenLastCalledWith(newEntityIds)
+
+    const addButton = screen.getByRole('button', { name: 'Add Entities' })
+    await user.click(addButton)
+
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+    expect(onUpdate).toHaveBeenCalledWith([
+      entitySubject,
+      {
+        id: MOCK_FILE_VIEW_ENTITY_ID,
+        type: RestrictableObjectType.ENTITY,
+      },
+      {
+        id: MOCK_PROJECT_VIEW_ENTITY_ID,
+        type: RestrictableObjectType.ENTITY,
+      },
+    ])
+    expect(onUpdateEntityIDsTextbox).toHaveBeenLastCalledWith('')
+  })
+
+  test('drops duplicates when adding entities', async () => {
+    const { user } = await setUp()
+
+    // add 1 new ID, 1 duplicate of the new ID, and 1 duplicate of the ID that selector was configured with
+    const newEntityId = MOCK_PROJECT_VIEW_ENTITY_ID
+    const newEntityIdsString = `${entitySubject.id}, ${newEntityId}, ${newEntityId}`
+    const input = screen.getByRole('textbox', { name: 'Add Synapse IDs' })
+    await user.type(input, newEntityIdsString)
+
+    expect(input).toHaveValue(newEntityIdsString)
+    expect(onUpdateEntityIDsTextbox).toHaveBeenLastCalledWith(
+      newEntityIdsString,
+    )
+
+    const addButton = screen.getByRole('button', { name: 'Add Entities' })
+    await user.click(addButton)
+
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+    expect(onUpdate).toHaveBeenCalledWith([
+      entitySubject,
+      {
+        id: newEntityId,
+        type: RestrictableObjectType.ENTITY,
+      },
+    ])
+    expect(onUpdateEntityIDsTextbox).toHaveBeenLastCalledWith('')
+  })
+})

--- a/packages/synapse-react-client/src/components/EntitySubjectsSelector/EntitySubjectsSelector.tsx
+++ b/packages/synapse-react-client/src/components/EntitySubjectsSelector/EntitySubjectsSelector.tsx
@@ -1,0 +1,74 @@
+import { Box, Typography } from '@mui/material'
+import {
+  Reference,
+  ReferenceList,
+  RestrictableObjectDescriptor,
+  RestrictableObjectType,
+} from '@sage-bionetworks/synapse-types'
+import { isEqual, uniqWith } from 'lodash-es'
+import React, { useMemo } from 'react'
+import EntityHeaderTable, { EntityHeaderTableProps } from '../EntityHeaderTable'
+
+export const REMOVE_BUTTON_TEXT = 'Mark for Removal from AR'
+export const NO_ENTITIES_SELECTED = 'No entities selected.'
+
+export type EntitySubjectsSelectorProps = {
+  // will be filtered to only entity subjects
+  subjects: RestrictableObjectDescriptor[]
+  onUpdate?: (subjects: RestrictableObjectDescriptor[]) => void
+  onUpdateEntityIDsTextbox: EntityHeaderTableProps['onUpdateEntityIDsTextbox']
+}
+
+const EntitySubjectsSelector: React.FunctionComponent<
+  EntitySubjectsSelectorProps
+> = (props: EntitySubjectsSelectorProps) => {
+  const { subjects, onUpdate, onUpdateEntityIDsTextbox } = props
+
+  const references = useMemo(() => {
+    return subjects
+      .filter(subject => {
+        return subject.type === RestrictableObjectType.ENTITY
+      })
+      .map(subject => {
+        const ref: Reference = {
+          targetId: subject.id,
+        }
+        return ref
+      })
+  }, [subjects])
+
+  const handleChange = (updatedReferences: ReferenceList) => {
+    if (onUpdate) {
+      const dedupedReferences = uniqWith(updatedReferences, isEqual)
+      const updatedSubjects = dedupedReferences.map(reference => {
+        const subject: RestrictableObjectDescriptor = {
+          id: reference.targetId,
+          type: RestrictableObjectType.ENTITY,
+        }
+        return subject
+      })
+      onUpdate(updatedSubjects)
+    }
+  }
+
+  return (
+    <Box mb={2}>
+      {references.length === 0 && (
+        <Typography variant="body1Italic" mb={-4}>
+          {NO_ENTITIES_SELECTED}
+        </Typography>
+      )}
+      <EntityHeaderTable
+        references={references}
+        isEditable={Boolean(onUpdate)}
+        onUpdate={newReferences => {
+          handleChange(newReferences)
+        }}
+        removeSelectedRowsButtonText={REMOVE_BUTTON_TEXT}
+        onUpdateEntityIDsTextbox={onUpdateEntityIDsTextbox}
+      />
+    </Box>
+  )
+}
+
+export default EntitySubjectsSelector

--- a/packages/synapse-react-client/src/components/EntitySubjectsSelector/index.ts
+++ b/packages/synapse-react-client/src/components/EntitySubjectsSelector/index.ts
@@ -1,0 +1,4 @@
+import type { EntitySubjectsSelectorProps } from './EntitySubjectsSelector'
+import EntitySubjectsSelector from './EntitySubjectsSelector'
+export { EntitySubjectsSelector, EntitySubjectsSelectorProps }
+export default EntitySubjectsSelector

--- a/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.stories.tsx
+++ b/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.stories.tsx
@@ -1,0 +1,77 @@
+import { Meta, StoryObj } from '@storybook/react'
+import React, { useRef, useState } from 'react'
+import {
+  SetAccessRequirementCommonFields,
+  SetAccessRequirementCommonFieldsHandle,
+} from './SetAccessRequirementCommonFields'
+import { Button, Paper } from '@mui/material'
+import { RestrictableObjectType } from '@sage-bionetworks/synapse-types'
+
+const meta: Meta<typeof SetAccessRequirementCommonFields> = {
+  title: 'Governance/SetAccessRequirementCommonFields',
+  component: SetAccessRequirementCommonFields,
+  parameters: {
+    stack: 'development',
+  },
+  render: function RenderFn(args) {
+    const [isSaving, setIsSaving] = useState<boolean>(false)
+    const ref = useRef<SetAccessRequirementCommonFieldsHandle>(null)
+
+    return (
+      <>
+        <Button
+          onClick={() => {
+            setIsSaving(true)
+            ref.current?.save()
+          }}
+          variant="contained"
+          disabled={isSaving}
+        >
+          Save AR
+        </Button>
+        <Paper sx={{ mx: 'auto', p: '44px', maxWidth: '750px' }}>
+          <SetAccessRequirementCommonFields
+            {...args}
+            ref={ref}
+            onSave={() => setIsSaving(false)}
+            onError={() => setIsSaving(false)}
+          />
+        </Paper>
+      </>
+    )
+  },
+} satisfies Meta<typeof SetAccessRequirementCommonFields>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const DemoCreateTeamAr: Story = {
+  args: {
+    subject: {
+      id: '3429759',
+      type: RestrictableObjectType.TEAM,
+    },
+  },
+}
+
+export const DemoExistingTeamAr: Story = {
+  args: {
+    accessRequirementId: '9602672',
+  },
+}
+
+export const DemoCreateEntityAr: Story = {
+  args: {
+    subject: {
+      id: 'syn12714410',
+      type: RestrictableObjectType.ENTITY,
+    },
+  },
+}
+
+export const DemoExistingEntityAr: Story = {
+  args: {
+    accessRequirementId: '9602704',
+  },
+}

--- a/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.test.tsx
+++ b/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.test.tsx
@@ -24,7 +24,7 @@ import {
   mockACTAccessRequirement,
   mockManagedACTAccessRequirement,
   mockSelfSignAccessRequirement,
-  mockTeamManagedACTAccessRequirement,
+  mockTeamSelfSignAccessRequirement,
   mockToUAccessRequirement,
 } from '../../mocks/mockAccessRequirements'
 import { server } from '../../mocks/msw/server'
@@ -63,7 +63,7 @@ const newEntityArProps: SetAccessRequirementCommonFieldsProps = {
   onError,
 }
 const existingTeamArProps: SetAccessRequirementCommonFieldsProps = {
-  accessRequirementId: mockTeamManagedACTAccessRequirement.id.toString(),
+  accessRequirementId: mockTeamSelfSignAccessRequirement.id.toString(),
   onSave,
   onError,
 }
@@ -199,7 +199,24 @@ describe('SetAccessRequirementCommonFields', () => {
     })
   })
 
-  test('creates a new managed team AR', async () => {
+  test('does not show AR type options when creating new team AR', async () => {
+    const props: SetAccessRequirementCommonFieldsProps = {
+      subject: teamSubject,
+      onSave,
+      onError,
+    }
+    await setUp(props)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: mockTeamData.name }),
+      ).toBeVisible()
+    })
+
+    expect(screen.queryByRole('radiogroup')).toBeNull()
+  })
+
+  test('creates a new self-signed team AR', async () => {
     const props: SetAccessRequirementCommonFieldsProps = {
       subject: teamSubject,
       onSave,
@@ -217,10 +234,6 @@ describe('SetAccessRequirementCommonFields', () => {
     const name = 'some name'
     await user.type(nameInput, name)
 
-    const radioButtons = getRadioButtons()
-    expect(radioButtons.managed).toBeChecked()
-    expect(radioButtons.selfSign).not.toBeChecked()
-
     expect(onSave).not.toHaveBeenCalled()
     expect(onError).not.toHaveBeenCalled()
 
@@ -228,11 +241,11 @@ describe('SetAccessRequirementCommonFields', () => {
     ref.current?.save()
 
     await waitFor(() => {
-      const managedAr: Pick<
-        ManagedACTAccessRequirement,
+      const selfSignAr: Pick<
+        SelfSignAccessRequirement,
         'concreteType' | 'name' | 'subjectIds' | 'accessType'
       > = {
-        concreteType: MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+        concreteType: SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
         name: name,
         subjectIds: [teamSubject],
         accessType: ACCESS_TYPE.PARTICIPATE,
@@ -240,27 +253,27 @@ describe('SetAccessRequirementCommonFields', () => {
 
       expect(createAccessRequirementSpy).toHaveBeenCalledWith(
         MOCK_ACCESS_TOKEN,
-        managedAr,
+        selfSignAr,
       )
       expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
 
       expect(onSave).toHaveBeenCalledTimes(1)
       expect(onSave).toHaveBeenLastCalledWith(
         MOCK_NEWLY_CREATED_AR_ID.toString(),
-        MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+        SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
       )
       expect(onError).not.toHaveBeenCalled()
     })
   })
 
-  test('updates an existing managed team AR', async () => {
+  test('updates an existing self-sign team AR', async () => {
     const { ref, user, nameInput } = await setUp(existingTeamArProps)
 
     await waitFor(() => {
       expect(
         screen.getByRole('link', { name: mockTeamData.name }),
       ).toBeVisible()
-      expect(nameInput).toHaveValue(mockTeamManagedACTAccessRequirement.name)
+      expect(nameInput).toHaveValue(mockTeamSelfSignAccessRequirement.name)
       // cannot select access type for existing AR
       expect(screen.queryByRole('radiogroup')).toBeNull()
     })
@@ -277,8 +290,8 @@ describe('SetAccessRequirementCommonFields', () => {
     ref.current?.save()
 
     await waitFor(() => {
-      const updatedAr: ManagedACTAccessRequirement = {
-        ...mockTeamManagedACTAccessRequirement,
+      const updatedAr: SelfSignAccessRequirement = {
+        ...mockTeamSelfSignAccessRequirement,
         name: updatedName,
       }
       expect(onSave).toHaveBeenCalledTimes(1)
@@ -397,14 +410,14 @@ describe('SetAccessRequirementCommonFields', () => {
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledTimes(1)
       expect(onSave).toHaveBeenLastCalledWith(
-        mockTeamManagedACTAccessRequirement.id.toString(),
-        MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+        mockTeamSelfSignAccessRequirement.id.toString(),
+        SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
       )
       expect(onError).not.toHaveBeenCalled()
       expect(updateAccessRequirementSpy).toHaveBeenCalledTimes(1)
       expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
         MOCK_ACCESS_TOKEN,
-        mockTeamManagedACTAccessRequirement,
+        mockTeamSelfSignAccessRequirement,
       )
     })
 

--- a/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.test.tsx
+++ b/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.test.tsx
@@ -34,7 +34,6 @@ import { createWrapper } from '../../testutils/TestingLibraryUtils'
 import { REMOVE_TEXT } from '../TeamSubjectsSelector/TeamSubjectsSelector'
 import {
   EMPTY_SUBJECT_LIST_ERROR_MESSAGE,
-  MISSING_NAME_ERROR_MESSAGE,
   UNSAVED_SUBJECTS_ERROR_MESSAGE,
 } from './SetAccessRequirementCommonFields'
 
@@ -350,27 +349,6 @@ describe('SetAccessRequirementCommonFields', () => {
       })
     })
   }
-
-  test('displays error when name is not provided', async () => {
-    const { ref, nameInput } = await setUp(newEntityArProps)
-
-    await waitFor(() => {
-      expect(screen.getByText(MOCK_FILE_NAME)).toBeVisible()
-      expect(nameInput).toHaveValue('')
-    })
-
-    // parent calls save
-    act(() => ref.current?.save())
-
-    await waitFor(() => {
-      expect(onError).toHaveBeenCalledTimes(1)
-      expect(onSave).not.toHaveBeenCalled()
-      expect(createAccessRequirementSpy).not.toHaveBeenCalled()
-      expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
-    })
-
-    expect(screen.getByText(MISSING_NAME_ERROR_MESSAGE)).toBeVisible()
-  })
 
   test('displays error when there are pending subjects', async () => {
     const { ref, user } = await setUp(existingTeamArProps)

--- a/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.test.tsx
+++ b/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.test.tsx
@@ -1,0 +1,461 @@
+import {
+  ACCESS_TYPE,
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  ManagedACTAccessRequirement,
+  RestrictableObjectDescriptor,
+  RestrictableObjectType,
+  SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  SelfSignAccessRequirement,
+} from '@sage-bionetworks/synapse-types'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import SetAccessRequirementCommonFields, {
+  SetAccessRequirementCommonFieldsHandle,
+  SetAccessRequirementCommonFieldsProps,
+} from '.'
+import { MOCK_ACCESS_TOKEN } from '../../mocks/MockSynapseContext'
+import {
+  MOCK_FILE_ENTITY_ID,
+  MOCK_FILE_NAME,
+} from '../../mocks/entity/mockFileEntity'
+import {
+  MOCK_NEWLY_CREATED_AR_ID,
+  mockACTAccessRequirement,
+  mockManagedACTAccessRequirement,
+  mockSelfSignAccessRequirement,
+  mockTeamManagedACTAccessRequirement,
+  mockToUAccessRequirement,
+} from '../../mocks/mockAccessRequirements'
+import { server } from '../../mocks/msw/server'
+import { MOCK_TEAM_ID, mockTeamData } from '../../mocks/team/mockTeam'
+import SynapseClient from '../../synapse-client'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import { REMOVE_TEXT } from '../TeamSubjectsSelector/TeamSubjectsSelector'
+import {
+  EMPTY_SUBJECT_LIST_ERROR_MESSAGE,
+  MISSING_NAME_ERROR_MESSAGE,
+  UNSAVED_SUBJECTS_ERROR_MESSAGE,
+} from './SetAccessRequirementCommonFields'
+
+const onSave = jest.fn()
+const onError = jest.fn()
+const createAccessRequirementSpy = jest.spyOn(
+  SynapseClient,
+  'createAccessRequirement',
+)
+const updateAccessRequirementSpy = jest.spyOn(
+  SynapseClient,
+  'updateAccessRequirement',
+)
+
+const entitySubject: RestrictableObjectDescriptor = {
+  id: MOCK_FILE_ENTITY_ID,
+  type: RestrictableObjectType.ENTITY,
+}
+const teamSubject: RestrictableObjectDescriptor = {
+  id: MOCK_TEAM_ID.toString(),
+  type: RestrictableObjectType.TEAM,
+}
+
+const newEntityArProps: SetAccessRequirementCommonFieldsProps = {
+  subject: entitySubject,
+  onSave,
+  onError,
+}
+const existingTeamArProps: SetAccessRequirementCommonFieldsProps = {
+  accessRequirementId: mockTeamManagedACTAccessRequirement.id.toString(),
+  onSave,
+  onError,
+}
+
+function renderComponent(props: SetAccessRequirementCommonFieldsProps) {
+  const ref = React.createRef<SetAccessRequirementCommonFieldsHandle>()
+  const component = render(
+    <SetAccessRequirementCommonFields ref={ref} {...props} />,
+    {
+      wrapper: createWrapper(),
+    },
+  )
+  return { ref, component }
+}
+
+async function setUp(props: SetAccessRequirementCommonFieldsProps) {
+  const user = userEvent.setup()
+  const { ref, component } = renderComponent(props)
+
+  const nameInput = await screen.findByRole('textbox', { name: 'Name' })
+
+  return { ref, component, user, nameInput }
+}
+
+function getRadioButtons() {
+  const radioGroup = screen.getByRole('radiogroup')
+  return {
+    managed: within(radioGroup).getByRole('radio', {
+      name: 'Controlled - requests are in Synapse',
+    }),
+    selfSign: within(radioGroup).getByRole('radio', { name: 'Click wrap' }),
+  }
+}
+
+describe('SetAccessRequirementCommonFields', () => {
+  beforeEach(() => jest.clearAllMocks())
+  beforeAll(() => server.listen())
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  test('creates a new managed entity AR', async () => {
+    const { ref, user, nameInput } = await setUp(newEntityArProps)
+
+    await waitFor(() => {
+      expect(screen.getByText(MOCK_FILE_NAME)).toBeVisible()
+      expect(nameInput).toHaveValue('')
+    })
+
+    const radioButtons = getRadioButtons()
+    expect(radioButtons.managed).toBeChecked()
+    expect(radioButtons.selfSign).not.toBeChecked()
+
+    const name = 'some name'
+    await user.type(nameInput, name)
+    expect(nameInput).toHaveValue(name)
+    expect(onSave).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+
+    // parent calls save
+    ref.current?.save()
+
+    await waitFor(() => {
+      const managedAr: Pick<
+        ManagedACTAccessRequirement,
+        'concreteType' | 'name' | 'subjectIds' | 'accessType'
+      > = {
+        concreteType: MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+        name: name,
+        subjectIds: [entitySubject],
+        accessType: ACCESS_TYPE.DOWNLOAD,
+      }
+
+      expect(createAccessRequirementSpy).toHaveBeenCalledWith(
+        MOCK_ACCESS_TOKEN,
+        managedAr,
+      )
+      expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
+
+      expect(onSave).toHaveBeenCalledTimes(1)
+      expect(onSave).toHaveBeenLastCalledWith(
+        MOCK_NEWLY_CREATED_AR_ID.toString(),
+        MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+      )
+      expect(onError).not.toHaveBeenCalled()
+    })
+  })
+
+  test('creates a new self-sign entity AR', async () => {
+    const { ref, user, nameInput } = await setUp(newEntityArProps)
+
+    await waitFor(() => {
+      expect(screen.getByText(MOCK_FILE_NAME)).toBeVisible()
+      expect(nameInput).toHaveValue('')
+    })
+
+    const name = 'some name'
+    await user.type(nameInput, name)
+
+    const radioButtons = getRadioButtons()
+    await user.click(radioButtons.selfSign)
+    expect(radioButtons.managed).not.toBeChecked()
+    expect(radioButtons.selfSign).toBeChecked()
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+
+    // parent calls save
+    ref.current?.save()
+
+    await waitFor(() => {
+      const selfSignAr: Pick<
+        SelfSignAccessRequirement,
+        'concreteType' | 'name' | 'subjectIds' | 'accessType'
+      > = {
+        concreteType: SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+        name: name,
+        subjectIds: [entitySubject],
+        accessType: ACCESS_TYPE.DOWNLOAD,
+      }
+
+      expect(createAccessRequirementSpy).toHaveBeenCalledWith(
+        MOCK_ACCESS_TOKEN,
+        selfSignAr,
+      )
+      expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
+
+      expect(onSave).toHaveBeenCalledTimes(1)
+      expect(onSave).toHaveBeenLastCalledWith(
+        MOCK_NEWLY_CREATED_AR_ID.toString(),
+        SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+      )
+      expect(onError).not.toHaveBeenCalled()
+    })
+  })
+
+  test('creates a new managed team AR', async () => {
+    const props: SetAccessRequirementCommonFieldsProps = {
+      subject: teamSubject,
+      onSave,
+      onError,
+    }
+    const { ref, user, nameInput } = await setUp(props)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: mockTeamData.name }),
+      ).toBeVisible()
+      expect(nameInput).toHaveValue('')
+    })
+
+    const name = 'some name'
+    await user.type(nameInput, name)
+
+    const radioButtons = getRadioButtons()
+    expect(radioButtons.managed).toBeChecked()
+    expect(radioButtons.selfSign).not.toBeChecked()
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+
+    // parent calls save
+    ref.current?.save()
+
+    await waitFor(() => {
+      const managedAr: Pick<
+        ManagedACTAccessRequirement,
+        'concreteType' | 'name' | 'subjectIds' | 'accessType'
+      > = {
+        concreteType: MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+        name: name,
+        subjectIds: [teamSubject],
+        accessType: ACCESS_TYPE.PARTICIPATE,
+      }
+
+      expect(createAccessRequirementSpy).toHaveBeenCalledWith(
+        MOCK_ACCESS_TOKEN,
+        managedAr,
+      )
+      expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
+
+      expect(onSave).toHaveBeenCalledTimes(1)
+      expect(onSave).toHaveBeenLastCalledWith(
+        MOCK_NEWLY_CREATED_AR_ID.toString(),
+        MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+      )
+      expect(onError).not.toHaveBeenCalled()
+    })
+  })
+
+  test('updates an existing managed team AR', async () => {
+    const { ref, user, nameInput } = await setUp(existingTeamArProps)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: mockTeamData.name }),
+      ).toBeVisible()
+      expect(nameInput).toHaveValue(mockTeamManagedACTAccessRequirement.name)
+      // cannot select access type for existing AR
+      expect(screen.queryByRole('radiogroup')).toBeNull()
+    })
+
+    const updatedName = 'a new name'
+    await user.clear(nameInput)
+    await user.type(nameInput, updatedName)
+
+    expect(nameInput).toHaveValue(updatedName)
+    expect(onSave).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+
+    // parent calls save
+    ref.current?.save()
+
+    await waitFor(() => {
+      const updatedAr: ManagedACTAccessRequirement = {
+        ...mockTeamManagedACTAccessRequirement,
+        name: updatedName,
+      }
+      expect(onSave).toHaveBeenCalledTimes(1)
+      expect(onSave).toHaveBeenLastCalledWith(
+        updatedAr.id.toString(),
+        updatedAr.concreteType,
+      )
+      expect(onError).not.toHaveBeenCalled()
+      expect(createAccessRequirementSpy).not.toHaveBeenCalled()
+      expect(updateAccessRequirementSpy).toHaveBeenCalledWith(
+        MOCK_ACCESS_TOKEN,
+        updatedAr,
+      )
+    })
+  })
+
+  const existingEntityArs = [
+    // Lock ARs can only be deleted by ACT, so will not be managed with this component
+    // ...so will not be included in this test.
+    // mockLockAccessRequirement,
+    mockSelfSignAccessRequirement,
+    mockManagedACTAccessRequirement,
+    mockToUAccessRequirement,
+    mockACTAccessRequirement,
+  ]
+  for (const ar of existingEntityArs) {
+    test(`updates an existing entity AR - ${ar.name}`, async () => {
+      const props: SetAccessRequirementCommonFieldsProps = {
+        onSave,
+        onError,
+        accessRequirementId: ar.id.toString(),
+      }
+      const { ref, user, nameInput } = await setUp(props)
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', { name: ar.subjectIds[0].id }),
+        ).toBeVisible()
+        expect(nameInput).toHaveValue(ar.name)
+        // cannot select access type for existing AR
+        expect(screen.queryByRole('radiogroup')).toBeNull()
+      })
+
+      const updatedName = 'a new name'
+      await user.clear(nameInput)
+      await user.type(nameInput, updatedName)
+
+      expect(nameInput).toHaveValue(updatedName)
+      expect(onSave).not.toHaveBeenCalled()
+      expect(onError).not.toHaveBeenCalled()
+
+      // parent calls save
+      ref.current?.save()
+
+      await waitFor(() => {
+        const updatedAr = { ...ar, name: updatedName }
+        expect(onSave).toHaveBeenCalledTimes(1)
+        expect(onSave).toHaveBeenLastCalledWith(
+          updatedAr.id.toString(),
+          updatedAr.concreteType,
+        )
+        expect(onError).not.toHaveBeenCalled()
+        expect(createAccessRequirementSpy).not.toHaveBeenCalled()
+        expect(updateAccessRequirementSpy).toHaveBeenCalledWith(
+          MOCK_ACCESS_TOKEN,
+          updatedAr,
+        )
+      })
+    })
+  }
+
+  test('displays error when name is not provided', async () => {
+    const { ref, nameInput } = await setUp(newEntityArProps)
+
+    await waitFor(() => {
+      expect(screen.getByText(MOCK_FILE_NAME)).toBeVisible()
+      expect(nameInput).toHaveValue('')
+    })
+
+    // parent calls save
+    act(() => ref.current?.save())
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onSave).not.toHaveBeenCalled()
+      expect(createAccessRequirementSpy).not.toHaveBeenCalled()
+      expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
+    })
+
+    expect(screen.getByText(MISSING_NAME_ERROR_MESSAGE)).toBeVisible()
+  })
+
+  test('displays error when there are pending subjects', async () => {
+    const { ref, user } = await setUp(existingTeamArProps)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: mockTeamData.name }),
+      ).toBeVisible()
+    })
+
+    const teamInput = screen.getByRole('textbox', { name: 'Add Team IDs' })
+    expect(teamInput).toHaveValue('')
+    await user.type(teamInput, '123, 456')
+
+    // parent calls save
+    act(() => ref.current?.save())
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onSave).not.toHaveBeenCalled()
+      expect(createAccessRequirementSpy).not.toHaveBeenCalled()
+      expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      UNSAVED_SUBJECTS_ERROR_MESSAGE(RestrictableObjectType.TEAM),
+    )
+  })
+
+  test('does not display error when pending subjects string only contains whitespace', async () => {
+    const { ref, user } = await setUp(existingTeamArProps)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: mockTeamData.name }),
+      ).toBeVisible()
+    })
+
+    const teamInput = screen.getByRole('textbox', { name: 'Add Team IDs' })
+    expect(teamInput).toHaveValue('')
+    await user.type(teamInput, '    ')
+
+    // parent calls save
+    act(() => ref.current?.save())
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1)
+      expect(onSave).toHaveBeenLastCalledWith(
+        mockTeamManagedACTAccessRequirement.id.toString(),
+        MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+      )
+      expect(onError).not.toHaveBeenCalled()
+      expect(updateAccessRequirementSpy).toHaveBeenCalledTimes(1)
+      expect(updateAccessRequirementSpy).toHaveBeenLastCalledWith(
+        MOCK_ACCESS_TOKEN,
+        mockTeamManagedACTAccessRequirement,
+      )
+    })
+
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  test('displays error when there are no subjects', async () => {
+    const { ref, user } = await setUp(existingTeamArProps)
+
+    const link = await screen.findByRole('link', { name: mockTeamData.name })
+
+    const removeButton = screen.getByRole('button', {
+      name: REMOVE_TEXT,
+    })
+    await user.click(removeButton)
+    expect(link).not.toBeVisible()
+
+    // parent calls save
+    act(() => ref.current?.save())
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onSave).not.toHaveBeenCalled()
+      expect(createAccessRequirementSpy).not.toHaveBeenCalled()
+      expect(updateAccessRequirementSpy).not.toHaveBeenCalled()
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      EMPTY_SUBJECT_LIST_ERROR_MESSAGE,
+    )
+  })
+})

--- a/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.tsx
+++ b/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.tsx
@@ -157,33 +157,31 @@ export const SetAccessRequirementCommonFields = React.forwardRef(
     const selectorContent = useMemo(() => {
       if (!subjectsType) return <></>
 
+      function onUpdate(subjects: RestrictableObjectDescriptor[]) {
+        setSubjectsError(null)
+        setSubjects(subjects)
+      }
+
+      function onUpdateIdsTextbox(value: string) {
+        setSubjectsError(null)
+        setHasPendingSubjects(value.trim() !== '')
+      }
+
       switch (subjectsType) {
         case RestrictableObjectType.TEAM:
           return (
             <TeamSubjectsSelector
               subjects={subjects}
-              onUpdate={subjects => {
-                setSubjectsError(null)
-                setSubjects(subjects)
-              }}
-              onUpdateTeamIDsTextbox={value => {
-                setSubjectsError(null)
-                setHasPendingSubjects(value.trim() !== '')
-              }}
+              onUpdate={subjects => onUpdate(subjects)}
+              onUpdateTeamIDsTextbox={value => onUpdateIdsTextbox(value)}
             />
           )
         case RestrictableObjectType.ENTITY:
           return (
             <EntitySubjectsSelector
               subjects={subjects}
-              onUpdate={subjects => {
-                setSubjectsError(null)
-                setSubjects(subjects)
-              }}
-              onUpdateEntityIDsTextbox={value => {
-                setSubjectsError(null)
-                setHasPendingSubjects(value.trim() !== '')
-              }}
+              onUpdate={subjects => onUpdate(subjects)}
+              onUpdateEntityIDsTextbox={value => onUpdateIdsTextbox(value)}
             />
           )
         default:

--- a/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.tsx
+++ b/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.tsx
@@ -42,8 +42,6 @@ export const UNSAVED_SUBJECTS_ERROR_MESSAGE = (
     typeText,
   )} button.`
 }
-export const MISSING_NAME_ERROR_MESSAGE =
-  'Please enter a name for this Access Requirement.'
 const NAME_HELP_TEXT =
   "Enter access requirement name. This will also be used when sending notifications for expiring or revoked approval. For example, 'The approval for the name access requirement was revoked...'"
 
@@ -99,7 +97,6 @@ export const SetAccessRequirementCommonFields = React.forwardRef(
     const [hasPendingSubjects, setHasPendingSubjects] = useState<boolean>(false)
     const [subjectsError, setSubjectsError] = useState<string | null>(null)
     const [name, setName] = useState<string>('')
-    const [nameError, setNameError] = useState<string | null>(null)
     const [arType, setArType] = useState<ACCESS_REQUIREMENT_CONCRETE_TYPE>(
       MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
     )
@@ -200,13 +197,8 @@ export const SetAccessRequirementCommonFields = React.forwardRef(
             const isStillLoading =
               (isEditing && !accessRequirement) || !subjectsType
             const hasSubjectsError = hasPendingSubjects || subjects.length === 0
-            const hasNameError = name === ''
 
-            if (isStillLoading || hasSubjectsError || hasNameError) {
-              if (hasNameError) {
-                setNameError(MISSING_NAME_ERROR_MESSAGE)
-              }
-
+            if (isStillLoading || hasSubjectsError) {
               if (hasSubjectsError && !isStillLoading) {
                 if (hasPendingSubjects) {
                   setSubjectsError(UNSAVED_SUBJECTS_ERROR_MESSAGE(subjectsType))
@@ -281,15 +273,7 @@ export const SetAccessRequirementCommonFields = React.forwardRef(
           value={name}
           placeholder="Access requirement name"
           fullWidth
-          error={Boolean(nameError)}
-          helperText={nameError}
-          onChange={event => {
-            setNameError(null)
-            setName(event.target.value)
-          }}
-          onBlur={() => {
-            if (name === '') setNameError(MISSING_NAME_ERROR_MESSAGE)
-          }}
+          onChange={event => setName(event.target.value)}
         />
         {!isEditing && (
           <>

--- a/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.tsx
+++ b/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.tsx
@@ -98,7 +98,9 @@ export const SetAccessRequirementCommonFields = React.forwardRef(
     const [subjectsError, setSubjectsError] = useState<string | null>(null)
     const [name, setName] = useState<string>('')
     const [arType, setArType] = useState<ACCESS_REQUIREMENT_CONCRETE_TYPE>(
-      MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+      subject?.type === RestrictableObjectType.TEAM
+        ? SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE
+        : MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
     )
     const [clientError, setClientError] = useState<string | null>(null)
 
@@ -275,7 +277,7 @@ export const SetAccessRequirementCommonFields = React.forwardRef(
           fullWidth
           onChange={event => setName(event.target.value)}
         />
-        {!isEditing && (
+        {!isEditing && subjectsType !== RestrictableObjectType.TEAM && (
           <>
             <Typography {...headerProps} mt={2}>
               Access requirement type

--- a/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.tsx
+++ b/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.tsx
@@ -1,0 +1,327 @@
+import { HelpOutlineTwoTone } from '@mui/icons-material'
+import {
+  Alert,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+  TypographyProps,
+} from '@mui/material'
+import {
+  ACCESS_REQUIREMENT_CONCRETE_TYPE,
+  ACCESS_TYPE,
+  AccessRequirement,
+  MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+  RestrictableObjectDescriptor,
+  RestrictableObjectType,
+  SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+} from '@sage-bionetworks/synapse-types'
+import pluralize from 'pluralize'
+import React, { useEffect, useImperativeHandle, useMemo, useState } from 'react'
+import {
+  useCreateAccessRequirement,
+  useGetAccessRequirements,
+  useUpdateAccessRequirement,
+} from '../../synapse-queries'
+import { SynapseClientError } from '../../utils/SynapseClientError'
+import EntitySubjectsSelector from '../EntitySubjectsSelector'
+import { SynapseSpinner } from '../LoadingScreen/LoadingScreen'
+import TeamSubjectsSelector from '../TeamSubjectsSelector'
+import { RadioGroup } from '../widgets/RadioGroup'
+
+export const EMPTY_SUBJECT_LIST_ERROR_MESSAGE =
+  'Please select at least one resource for this Access Requirement to be associated with.'
+export const UNSAVED_SUBJECTS_ERROR_MESSAGE = (
+  subjectsType: RestrictableObjectType,
+) => {
+  const idsText =
+    subjectsType === RestrictableObjectType.ENTITY ? 'Synapse' : 'Team'
+  const typeText =
+    subjectsType[0].toUpperCase() + subjectsType.slice(1).toLowerCase()
+  return `${idsText} IDs were specified but not added to the subjects list. Please either clear out the Add ${idsText} IDs textbox or click the Add ${pluralize(
+    typeText,
+  )} button.`
+}
+export const MISSING_NAME_ERROR_MESSAGE =
+  'Please enter a name for this Access Requirement.'
+const NAME_HELP_TEXT =
+  "Enter access requirement name. This will also be used when sending notifications for expiring or revoked approval. For example, 'The approval for the name access requirement was revoked...'"
+
+const headerProps: Partial<TypographyProps> = {
+  variant: 'body1',
+  fontWeight: 700,
+}
+
+function getAccessType(subject: RestrictableObjectDescriptor) {
+  switch (subject.type) {
+    case RestrictableObjectType.ENTITY:
+      return ACCESS_TYPE.DOWNLOAD
+    case RestrictableObjectType.TEAM:
+      return ACCESS_TYPE.PARTICIPATE
+    default:
+      throw new Error(
+        `RestrictableObjectType ${subject.type} does not have an access type specified.`,
+      )
+  }
+}
+
+export type SetAccessRequirementCommonFieldsHandle = {
+  /* Allow the parent component to trigger saving the AR, so this may be embedded in an arbitrary modal. */
+  save: () => void
+}
+
+export type SetAccessRequirementCommonFieldsProps = {
+  /* Provided when creating a new AR */
+  subject?: RestrictableObjectDescriptor
+  /* Provided when editing an existing AR */
+  accessRequirementId?: string
+  /* Called when AR has been saved successfully */
+  onSave: (
+    accessRequirementId: string,
+    accessRequirementConreteType: ACCESS_REQUIREMENT_CONCRETE_TYPE,
+  ) => void
+  /* Called when error saving AR */
+  onError: () => void
+}
+
+export const SetAccessRequirementCommonFields = React.forwardRef(
+  function SetAccessRequirementCommonFields(
+    props: SetAccessRequirementCommonFieldsProps,
+    ref: React.ForwardedRef<SetAccessRequirementCommonFieldsHandle>,
+  ) {
+    const { subject, accessRequirementId, onSave, onError } = props
+
+    const isEditing = !subject
+
+    const [subjects, setSubjects] = useState<RestrictableObjectDescriptor[]>(
+      subject ? [subject] : [],
+    )
+    const [hasPendingSubjects, setHasPendingSubjects] = useState<boolean>(false)
+    const [subjectsError, setSubjectsError] = useState<string | null>(null)
+    const [name, setName] = useState<string>('')
+    const [nameError, setNameError] = useState<string | null>(null)
+    const [arType, setArType] = useState<ACCESS_REQUIREMENT_CONCRETE_TYPE>(
+      MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+    )
+    const [clientError, setClientError] = useState<string | null>(null)
+
+    const onMutationSuccess = (ar: AccessRequirement) => {
+      setClientError(null)
+      onSave(ar.id.toString(), ar.concreteType)
+    }
+
+    const onMutationError = (error: SynapseClientError) => {
+      setClientError(error.reason)
+      onError()
+    }
+
+    const { mutate: createAccessRequirement } = useCreateAccessRequirement({
+      onSuccess: newAr => onMutationSuccess(newAr),
+      onError: error => onMutationError(error),
+    })
+
+    const { mutate: updateAccessRequirement } = useUpdateAccessRequirement({
+      onSuccess: updatedAr => onMutationSuccess(updatedAr),
+      onError: error => onMutationError(error),
+    })
+
+    const {
+      data: accessRequirement,
+      isLoading: isLoadingAr,
+      error: getArError,
+    } = useGetAccessRequirements(accessRequirementId!, {
+      enabled: Boolean(accessRequirementId),
+    })
+
+    useEffect(() => {
+      if (accessRequirement) {
+        setArType(accessRequirement.concreteType)
+        setName(accessRequirement.name)
+        setSubjects(accessRequirement.subjectIds)
+      }
+    }, [accessRequirement])
+
+    const subjectsType = useMemo(() => {
+      if (subject) {
+        return subject.type
+      }
+      if (accessRequirement) {
+        const initialSubjects = accessRequirement.subjectIds
+        if (initialSubjects.length > 0) {
+          return initialSubjects[0].type
+        }
+      }
+      return null
+    }, [subject, accessRequirement])
+
+    const selectorContent = useMemo(() => {
+      if (!subjectsType) return <></>
+
+      switch (subjectsType) {
+        case RestrictableObjectType.TEAM:
+          return (
+            <TeamSubjectsSelector
+              subjects={subjects}
+              onUpdate={subjects => {
+                setSubjectsError(null)
+                setSubjects(subjects)
+              }}
+              onUpdateTeamIDsTextbox={value => {
+                setSubjectsError(null)
+                setHasPendingSubjects(value.trim() !== '')
+              }}
+            />
+          )
+        case RestrictableObjectType.ENTITY:
+          return (
+            <EntitySubjectsSelector
+              subjects={subjects}
+              onUpdate={subjects => {
+                setSubjectsError(null)
+                setSubjects(subjects)
+              }}
+              onUpdateEntityIDsTextbox={value => {
+                setSubjectsError(null)
+                setHasPendingSubjects(value.trim() !== '')
+              }}
+            />
+          )
+        default:
+          console.error(
+            `RestrictableObjectType ${subjectsType} does not have a selector implemented.`,
+          )
+          return <></>
+      }
+    }, [subjectsType, subjects])
+
+    useImperativeHandle(
+      ref,
+      () => {
+        return {
+          save() {
+            const isStillLoading =
+              (isEditing && !accessRequirement) || !subjectsType
+            const hasSubjectsError = hasPendingSubjects || subjects.length === 0
+            const hasNameError = name === ''
+
+            if (isStillLoading || hasSubjectsError || hasNameError) {
+              if (hasNameError) {
+                setNameError(MISSING_NAME_ERROR_MESSAGE)
+              }
+
+              if (hasSubjectsError && !isStillLoading) {
+                if (hasPendingSubjects) {
+                  setSubjectsError(UNSAVED_SUBJECTS_ERROR_MESSAGE(subjectsType))
+                } else if (subjects.length === 0) {
+                  setSubjectsError(EMPTY_SUBJECT_LIST_ERROR_MESSAGE)
+                }
+              }
+
+              onError()
+              return
+            }
+
+            if (!isEditing) {
+              const newAr: Partial<AccessRequirement> = {
+                concreteType: arType,
+                subjectIds: subjects,
+                name: name,
+                accessType: getAccessType(subjects[0]),
+              }
+              createAccessRequirement(newAr)
+            }
+
+            if (isEditing && accessRequirement) {
+              updateAccessRequirement({
+                ...accessRequirement,
+                subjectIds: subjects,
+                name: name,
+                accessType: getAccessType(subjects[0]),
+              })
+            }
+          },
+        }
+      },
+      [
+        hasPendingSubjects,
+        subjectsType,
+        subjects,
+        name,
+        arType,
+        accessRequirement,
+        isEditing,
+        onError,
+        createAccessRequirement,
+        updateAccessRequirement,
+      ],
+    )
+
+    if (isLoadingAr || !subjectsType) {
+      return <SynapseSpinner />
+    }
+
+    if (getArError) {
+      return <Alert severity="error">{getArError.reason}</Alert>
+    }
+
+    return (
+      <>
+        <Typography {...headerProps}>Resources</Typography>
+        {selectorContent}
+        {subjectsError && <Alert severity="error">{subjectsError}</Alert>}
+        <Stack direction="row" gap={1} alignItems="center" mb={1} mt={2}>
+          <Typography component="label" htmlFor="arName" {...headerProps}>
+            Name
+          </Typography>
+          <Tooltip title={NAME_HELP_TEXT} placement="right">
+            <HelpOutlineTwoTone sx={{ color: 'grey.600' }} />
+          </Tooltip>
+        </Stack>
+        <TextField
+          id="arName"
+          name="arName"
+          value={name}
+          placeholder="Access requirement name"
+          fullWidth
+          error={Boolean(nameError)}
+          helperText={nameError}
+          onChange={event => {
+            setNameError(null)
+            setName(event.target.value)
+          }}
+          onBlur={() => {
+            if (name === '') setNameError(MISSING_NAME_ERROR_MESSAGE)
+          }}
+        />
+        {!isEditing && (
+          <>
+            <Typography {...headerProps} mt={2}>
+              Access requirement type
+            </Typography>
+            <RadioGroup
+              value={arType}
+              options={[
+                {
+                  label: 'Controlled - requests are in Synapse',
+                  value: MANAGED_ACT_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+                },
+                {
+                  label: 'Click wrap',
+                  value: SELF_SIGN_ACCESS_REQUIREMENT_CONCRETE_TYPE_VALUE,
+                },
+              ]}
+              onChange={(value: string) =>
+                setArType(value as ACCESS_REQUIREMENT_CONCRETE_TYPE)
+              }
+            />
+          </>
+        )}
+        {clientError && (
+          <Alert severity="error" sx={{ marginTop: 2 }}>
+            {clientError}
+          </Alert>
+        )}
+      </>
+    )
+  },
+)

--- a/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.tsx
+++ b/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/SetAccessRequirementCommonFields.tsx
@@ -1,6 +1,7 @@
 import { HelpOutlineTwoTone } from '@mui/icons-material'
 import {
   Alert,
+  Skeleton,
   Stack,
   TextField,
   Tooltip,
@@ -25,7 +26,6 @@ import {
 } from '../../synapse-queries'
 import { SynapseClientError } from '../../utils/SynapseClientError'
 import EntitySubjectsSelector from '../EntitySubjectsSelector'
-import { SynapseSpinner } from '../LoadingScreen/LoadingScreen'
 import TeamSubjectsSelector from '../TeamSubjectsSelector'
 import { RadioGroup } from '../widgets/RadioGroup'
 
@@ -249,7 +249,19 @@ export const SetAccessRequirementCommonFields = React.forwardRef(
     )
 
     if (isLoadingAr || !subjectsType) {
-      return <SynapseSpinner />
+      return (
+        <>
+          <Skeleton width={100} height={30} />
+          <Skeleton width={125} height={30} />
+          <Skeleton width="100%">
+            <TextField />
+          </Skeleton>
+          <Skeleton width={100} height={30} />
+          <Skeleton width="100%">
+            <TextField />
+          </Skeleton>
+        </>
+      )
     }
 
     if (getArError) {

--- a/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/index.ts
+++ b/packages/synapse-react-client/src/components/SetAccessRequirementCommonFields/index.ts
@@ -1,0 +1,12 @@
+import { SetAccessRequirementCommonFields } from './SetAccessRequirementCommonFields'
+import type {
+  SetAccessRequirementCommonFieldsProps,
+  SetAccessRequirementCommonFieldsHandle,
+} from './SetAccessRequirementCommonFields'
+
+export {
+  SetAccessRequirementCommonFields,
+  SetAccessRequirementCommonFieldsProps,
+  SetAccessRequirementCommonFieldsHandle,
+}
+export default SetAccessRequirementCommonFields

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementWikiInstructions.test.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementWikiInstructions.test.tsx
@@ -89,6 +89,10 @@ describe('AccessRequirementWikiInstructions', () => {
     await user.type(markdownField, newMarkdown)
     expect(markdownField).toHaveValue(newMarkdown)
 
+    // change getGetWikiPage since MarkdownSynapse will GET wiki rather than
+    // ...reading from react query cache
+    changeGetWikiPageHandlerOnce({ ...createdWikiPage, markdown: newMarkdown })
+
     const saveBtn = within(editDialog).getByRole('button', { name: 'Save' })
     await user.click(saveBtn)
 
@@ -96,7 +100,6 @@ describe('AccessRequirementWikiInstructions', () => {
       expect(editDialog).not.toBeInTheDocument()
     })
 
-    changeGetWikiPageHandlerOnce({ ...createdWikiPage, markdown: newMarkdown })
     await waitForMarkdownSynapseToGetWiki(2)
     await confirmMarkdownSynapseTextContent(newMarkdown)
   })
@@ -129,6 +132,13 @@ describe('AccessRequirementWikiInstructions', () => {
     await user.type(markdownField, newMarkdown)
     expect(markdownField).toHaveValue(newMarkdown)
 
+    // change getGetWikiPage since MarkdownSynapse will GET wiki rather than
+    // ...reading from react query cache
+    changeGetWikiPageHandlerOnce({
+      ...mockToUAccessRequirementWikiPage,
+      markdown: newMarkdown,
+    })
+
     const saveBtn = within(editDialog).getByRole('button', { name: 'Save' })
     await user.click(saveBtn)
 
@@ -136,10 +146,6 @@ describe('AccessRequirementWikiInstructions', () => {
       expect(editDialog).not.toBeInTheDocument()
     })
 
-    changeGetWikiPageHandlerOnce({
-      ...mockToUAccessRequirementWikiPage,
-      markdown: newMarkdown,
-    })
     await waitForMarkdownSynapseToGetWiki(2)
     await confirmMarkdownSynapseTextContent(newMarkdown)
   })

--- a/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementWikiInstructions.test.tsx
+++ b/packages/synapse-react-client/src/components/SetBasicAccessRequirementFields/AccessRequirementWikiInstructions.test.tsx
@@ -111,11 +111,14 @@ describe('AccessRequirementWikiInstructions', () => {
     const { user, editBtn } = setUp(props)
 
     await waitForMarkdownSynapseToGetWiki()
+    await waitFor(() => {
+      expect(screen.queryByText(NO_WIKI_CONTENT)).toBeNull()
+      expect(editBtn).not.toBeDisabled()
+    })
+
     await confirmMarkdownSynapseTextContent(
       mockToUAccessRequirementWikiPage.markdown,
     )
-    expect(screen.queryByText(NO_WIKI_CONTENT)).toBeNull()
-    expect(editBtn).not.toBeDisabled()
 
     await user.click(editBtn)
 

--- a/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamBadgeOrError.tsx
+++ b/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamBadgeOrError.tsx
@@ -1,0 +1,37 @@
+import React, { useMemo } from 'react'
+import { useGetTeamList } from '../../synapse-queries'
+import { Skeleton, Stack, Typography } from '@mui/material'
+import { ErrorTwoTone } from '@mui/icons-material'
+import TeamBadge from '../TeamBadge'
+
+export type TeamBadgeOrErrorProps = {
+  teamId: string
+}
+
+export const TeamBadgeOrError: React.FunctionComponent<
+  TeamBadgeOrErrorProps
+> = (props: TeamBadgeOrErrorProps) => {
+  const { teamId } = props
+
+  const { data: teamList, isLoading, error } = useGetTeamList([teamId])
+  const team = useMemo(() => {
+    if (teamList && teamList.list.length === 1) {
+      return teamList.list[0]
+    }
+    return undefined
+  }, [teamList])
+
+  if (error) {
+    return (
+      <Stack gap="5px" direction="row" alignItems="center" role="alert">
+        <ErrorTwoTone color="error" />
+        <Typography variant="smallText1" color="error">
+          {error?.reason || `Error: ${teamId}`}
+        </Typography>
+      </Stack>
+    )
+  } else if (isLoading || !team) {
+    return <Skeleton width={125} height={30} />
+  }
+  return <TeamBadge teamId={team.id} teamName={team.name} />
+}

--- a/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamBadgeOrError.tsx
+++ b/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamBadgeOrError.tsx
@@ -1,7 +1,7 @@
-import React, { useMemo } from 'react'
-import { useGetTeamList } from '../../synapse-queries'
-import { Skeleton, Stack, Typography } from '@mui/material'
 import { ErrorTwoTone } from '@mui/icons-material'
+import { Skeleton, Stack, Typography } from '@mui/material'
+import React from 'react'
+import { useGetTeam } from '../../synapse-queries'
 import TeamBadge from '../TeamBadge'
 
 export type TeamBadgeOrErrorProps = {
@@ -13,13 +13,7 @@ export const TeamBadgeOrError: React.FunctionComponent<
 > = (props: TeamBadgeOrErrorProps) => {
   const { teamId } = props
 
-  const { data: teamList, isLoading, error } = useGetTeamList([teamId])
-  const team = useMemo(() => {
-    if (teamList && teamList.list.length === 1) {
-      return teamList.list[0]
-    }
-    return undefined
-  }, [teamList])
+  const { data: team, isLoading, error } = useGetTeam(teamId)
 
   if (error) {
     return (

--- a/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamSubjectsSelector.stories.tsx
+++ b/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamSubjectsSelector.stories.tsx
@@ -1,0 +1,49 @@
+import { Paper } from '@mui/material'
+import {
+  RestrictableObjectDescriptor,
+  RestrictableObjectType,
+} from '@sage-bionetworks/synapse-types'
+import { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import React, { useState } from 'react'
+import TeamSubjectsSelector from './TeamSubjectsSelector'
+
+const meta: Meta<typeof TeamSubjectsSelector> = {
+  title: 'Governance/TeamSubjectsSelector',
+  component: TeamSubjectsSelector,
+  parameters: {
+    stack: 'development',
+  },
+  render: function RenderFn(args) {
+    const [subjects, setSubjects] = useState<RestrictableObjectDescriptor[]>(
+      args.subjects,
+    )
+
+    return (
+      <>
+        <Paper sx={{ mx: 'auto', p: '44px', maxWidth: '750px' }}>
+          <TeamSubjectsSelector
+            subjects={subjects}
+            onUpdate={subjects => setSubjects(subjects)}
+          />
+        </Paper>
+      </>
+    )
+  },
+} satisfies Meta<typeof TeamSubjectsSelector>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  args: {
+    subjects: [
+      {
+        id: '3429759',
+        type: RestrictableObjectType.TEAM,
+      },
+    ],
+    onUpdate: fn(),
+  },
+}

--- a/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamSubjectsSelector.test.tsx
+++ b/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamSubjectsSelector.test.tsx
@@ -193,7 +193,7 @@ describe('TeamSubjectsSelector', () => {
 
     const alert = await screen.findByRole('alert')
     expect(alert).toHaveTextContent(
-      `Team with id ${nonTeamSubject.id} not found`,
+      `Team id: '${nonTeamSubject.id}' does not exist`,
     )
   })
 })

--- a/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamSubjectsSelector.test.tsx
+++ b/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamSubjectsSelector.test.tsx
@@ -1,0 +1,199 @@
+import {
+  RestrictableObjectDescriptor,
+  RestrictableObjectType,
+} from '@sage-bionetworks/synapse-types'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { MOCK_FILE_ENTITY_ID } from '../../mocks/entity/mockFileEntity'
+import { server } from '../../mocks/msw/server'
+import {
+  MOCK_TEAM_ID,
+  MOCK_TEAM_ID_2,
+  MOCK_TEAM_ID_3,
+  mockTeamData,
+} from '../../mocks/team/mockTeam'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import TeamSubjectsSelector, {
+  HELP_TEXT,
+  NO_TEAMS_SELECTED,
+  REMOVE_TEXT,
+  TEAM_ALREADY_SELECTED,
+  TEAM_PARSING_ERROR,
+  TeamSubjectsSelectorProps,
+} from './TeamSubjectsSelector'
+import { MOCK_USER_ID } from '../../mocks/user/mock_user_profile'
+
+const onUpdate = jest.fn()
+const onUpdateTeamIDsTextbox = jest.fn()
+
+const teamSubject: RestrictableObjectDescriptor = {
+  id: MOCK_TEAM_ID.toString(),
+  type: RestrictableObjectType.TEAM,
+}
+const entitySubject: RestrictableObjectDescriptor = {
+  id: MOCK_FILE_ENTITY_ID.toString(),
+  type: RestrictableObjectType.ENTITY,
+}
+
+const defaultProps: TeamSubjectsSelectorProps = {
+  subjects: [entitySubject, teamSubject],
+  onUpdate,
+  onUpdateTeamIDsTextbox,
+}
+const defaultTeamCount = 1
+
+function renderComponent(props: TeamSubjectsSelectorProps) {
+  return render(<TeamSubjectsSelector {...props} />, {
+    wrapper: createWrapper(),
+  })
+}
+
+async function setUp(
+  props: TeamSubjectsSelectorProps = defaultProps,
+  expectedTeamCount: number = defaultTeamCount,
+) {
+  const user = userEvent.setup()
+  const component = renderComponent(props)
+
+  // wait for team badge(s) to finish loading
+  await waitFor(() => {
+    expect(screen.queryAllByRole('link')).toHaveLength(expectedTeamCount)
+  })
+
+  const items = screen.queryAllByTestId('selected-team')
+  expect(items).toHaveLength(expectedTeamCount)
+
+  return { component, items, user }
+}
+
+async function addTeams(
+  teamIdsString: string,
+  user: ReturnType<(typeof userEvent)['setup']>,
+) {
+  const input = screen.getByPlaceholderText(HELP_TEXT)
+  await user.type(input, teamIdsString)
+  expect(onUpdateTeamIDsTextbox).toHaveBeenLastCalledWith(teamIdsString)
+
+  expect(input).toHaveValue(teamIdsString)
+
+  const addButton = screen.getByRole('button', { name: 'Add Teams' })
+  await user.click(addButton)
+}
+
+describe('TeamSubjectsSelector', () => {
+  beforeEach(() => jest.clearAllMocks())
+  beforeAll(() => server.listen())
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  test('displays selected teams', async () => {
+    await setUp()
+
+    expect(screen.getByRole('link', { name: mockTeamData.name })).toBeVisible()
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  test('displays placeholder when no teams are selected', () => {
+    renderComponent({
+      ...defaultProps,
+      subjects: [],
+    })
+    expect(screen.getByText(NO_TEAMS_SELECTED)).toBeVisible()
+  })
+
+  test('removes a team and drops any entity subjects', async () => {
+    const { user } = await setUp()
+
+    const removeButton = screen.getByRole('button', { name: REMOVE_TEXT })
+    await user.click(removeButton)
+
+    // entity subject is not included
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+    expect(onUpdate).toHaveBeenCalledWith([])
+  })
+
+  test('adds teams and drops any entity subjects', async () => {
+    const { user } = await setUp()
+
+    const newTeamIds = `${MOCK_TEAM_ID_2}, ${MOCK_TEAM_ID_3}`
+    await addTeams(newTeamIds, user)
+
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+    expect(onUpdate).toHaveBeenCalledWith([
+      teamSubject,
+      { id: MOCK_TEAM_ID_2.toString(), type: RestrictableObjectType.TEAM },
+      { id: MOCK_TEAM_ID_3.toString(), type: RestrictableObjectType.TEAM },
+    ])
+
+    const input = screen.getByPlaceholderText(HELP_TEXT)
+    expect(input).toHaveValue('')
+    expect(onUpdateTeamIDsTextbox).toHaveBeenLastCalledWith('')
+  })
+
+  test('drops duplicates when adding new teams', async () => {
+    const { user } = await setUp()
+
+    // add 2 new IDs, 1 duplicate of a new ID
+    const newTeamIds = `${MOCK_TEAM_ID_2}, ${MOCK_TEAM_ID_3}, ${MOCK_TEAM_ID_2}`
+    await addTeams(newTeamIds, user)
+
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+    expect(onUpdate).toHaveBeenCalledWith([
+      teamSubject,
+      { id: MOCK_TEAM_ID_2.toString(), type: RestrictableObjectType.TEAM },
+      { id: MOCK_TEAM_ID_3.toString(), type: RestrictableObjectType.TEAM },
+    ])
+
+    const input = screen.getByPlaceholderText(HELP_TEXT)
+    expect(input).toHaveValue('')
+    expect(onUpdateTeamIDsTextbox).toHaveBeenLastCalledWith('')
+  })
+
+  test('displays an error when attempting to add a team that was previously added', async () => {
+    const { user } = await setUp()
+
+    const newTeamIds = `${MOCK_TEAM_ID_2}, ${MOCK_TEAM_ID}`
+    await addTeams(newTeamIds, user)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(
+      TEAM_ALREADY_SELECTED(MOCK_TEAM_ID.toString()),
+    )
+
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(onUpdateTeamIDsTextbox).toHaveBeenLastCalledWith(newTeamIds)
+  })
+
+  test('displays an error when error parsing team ids', async () => {
+    const { user } = await setUp()
+
+    const invalidTeamId = 'abc'
+    const newTeamIds = `${MOCK_TEAM_ID_2}, ${invalidTeamId}`
+    await addTeams(newTeamIds, user)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(TEAM_PARSING_ERROR(invalidTeamId))
+
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(onUpdateTeamIDsTextbox).toHaveBeenLastCalledWith(newTeamIds)
+  })
+
+  test('displays an error when team is not found', async () => {
+    const nonTeamSubject: RestrictableObjectDescriptor = {
+      id: MOCK_USER_ID.toString(),
+      type: RestrictableObjectType.TEAM,
+    }
+    renderComponent({
+      ...defaultProps,
+      subjects: [teamSubject, nonTeamSubject],
+    })
+
+    await screen.findByRole('link', { name: mockTeamData.name })
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(
+      `Team with id ${nonTeamSubject.id} not found`,
+    )
+  })
+})

--- a/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamSubjectsSelector.tsx
+++ b/packages/synapse-react-client/src/components/TeamSubjectsSelector/TeamSubjectsSelector.tsx
@@ -1,0 +1,153 @@
+import { AddCircleTwoTone, HelpOutlineTwoTone } from '@mui/icons-material'
+import {
+  Alert,
+  Box,
+  Button,
+  IconButton,
+  InputLabel,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import {
+  RestrictableObjectDescriptor,
+  RestrictableObjectType,
+} from '@sage-bionetworks/synapse-types'
+import { noop } from 'lodash-es'
+import React, { useMemo, useState } from 'react'
+import IconSvg from '../IconSvg'
+import { TeamBadgeOrError } from './TeamBadgeOrError'
+
+export type TeamSubjectsSelectorProps = {
+  // will be filtered to only team subjects
+  subjects: RestrictableObjectDescriptor[]
+  onUpdate: (subjects: RestrictableObjectDescriptor[]) => void
+  onUpdateTeamIDsTextbox?: (value: string) => void // called when the team IDs text box is updated
+}
+
+export const TEAM_ALREADY_SELECTED = (teamId: string) =>
+  `Team ${teamId} has already been added to this AR.`
+export const TEAM_PARSING_ERROR = (teamId: string) =>
+  `Parsing errors encountered. Invalid Team ID: ${teamId}`
+export const NO_TEAMS_SELECTED = 'No teams selected.'
+export const REMOVE_TEXT = 'Remove from Access Requirement'
+export const HELP_TEXT = 'Enter Team IDs (i.e. 123, 456)'
+const teamIdsStringDefault = ''
+
+const TeamSubjectsSelector: React.FunctionComponent<
+  TeamSubjectsSelectorProps
+> = (props: TeamSubjectsSelectorProps) => {
+  const { subjects, onUpdate, onUpdateTeamIDsTextbox = noop } = props
+  const [teamIdsString, setTeamIdsString] =
+    useState<string>(teamIdsStringDefault)
+  const [error, setError] = useState<string | null>(null)
+
+  const teamSubjects = useMemo(() => {
+    return subjects.filter(subject => {
+      return subject.type === RestrictableObjectType.TEAM ? subject : null
+    })
+  }, [subjects])
+
+  const onChangeTeamIdsTextbox = (value: string) => {
+    setTeamIdsString(value)
+    onUpdateTeamIDsTextbox(value)
+  }
+
+  const onRemove = (subjectId: string) => {
+    const updatedSubjects = teamSubjects.filter(subject => {
+      return subject.id !== subjectId
+    })
+    onUpdate(updatedSubjects)
+  }
+
+  const onAddTeams = (teamIdsString: string | null) => {
+    const teamIds = teamIdsString?.split(',').map(item => item.trim())
+    const dedupedTeamIds = [...new Set(teamIds)]
+    if (dedupedTeamIds && dedupedTeamIds.length > 0) {
+      const updatedTeamSubjects = [...teamSubjects]
+      for (const teamId of dedupedTeamIds) {
+        const validId = /^\d+$/.test(teamId)
+        const alreadyAdded = teamSubjects.some(subject => subject.id === teamId)
+        if (!validId) {
+          setError(TEAM_PARSING_ERROR(teamId))
+          return
+        } else if (alreadyAdded) {
+          setError(TEAM_ALREADY_SELECTED(teamId))
+          return
+        } else {
+          const newSubject: RestrictableObjectDescriptor = {
+            id: teamId,
+            type: RestrictableObjectType.TEAM,
+          }
+          updatedTeamSubjects.push(newSubject)
+        }
+      }
+      onChangeTeamIdsTextbox(teamIdsStringDefault)
+      onUpdate(updatedTeamSubjects)
+    }
+    setError(null)
+  }
+
+  return (
+    <>
+      <Box display="flex" flexWrap="wrap" gap="0px 15px" pb="10px">
+        {teamSubjects.length === 0 && (
+          <Typography variant="body1Italic" pb={2}>
+            {NO_TEAMS_SELECTED}
+          </Typography>
+        )}
+        {teamSubjects.map(subject => {
+          return (
+            <Stack
+              key={subject.id}
+              direction="row"
+              alignItems="center"
+              pb={1}
+              data-testid="selected-team"
+            >
+              <TeamBadgeOrError teamId={subject.id} />
+              <IconButton
+                aria-label={REMOVE_TEXT}
+                onClick={() => onRemove(subject.id)}
+                sx={{
+                  '&:hover': {
+                    color: 'error.main',
+                  },
+                }}
+              >
+                <IconSvg icon={'delete'} fontSize={'inherit'} wrap={false} />
+              </IconButton>
+            </Stack>
+          )
+        })}
+      </Box>
+      <InputLabel htmlFor="teamIDs">Add Team IDs</InputLabel>
+      <Stack direction="row" gap={1} alignItems="center" mb={2}>
+        <TextField
+          id="teamIDs"
+          name="teamIDs"
+          placeholder={HELP_TEXT}
+          value={teamIdsString}
+          onChange={event => onChangeTeamIdsTextbox(event.target.value)}
+          fullWidth
+        />
+        <Button
+          startIcon={<AddCircleTwoTone />}
+          variant="outlined"
+          sx={{ flexShrink: 0, height: '53px' }}
+          onClick={() => onAddTeams(teamIdsString)}
+          disabled={teamIdsString === ''}
+        >
+          Add Teams
+        </Button>
+        <Tooltip title={HELP_TEXT} placement="right">
+          <HelpOutlineTwoTone sx={{ color: 'grey.600' }} />
+        </Tooltip>
+      </Stack>
+      {error && <Alert severity="warning">{error}</Alert>}
+    </>
+  )
+}
+
+export default TeamSubjectsSelector

--- a/packages/synapse-react-client/src/components/TeamSubjectsSelector/index.ts
+++ b/packages/synapse-react-client/src/components/TeamSubjectsSelector/index.ts
@@ -1,0 +1,4 @@
+import type { TeamSubjectsSelectorProps } from './TeamSubjectsSelector'
+import TeamSubjectsSelector from './TeamSubjectsSelector'
+export { TeamSubjectsSelector, TeamSubjectsSelectorProps }
+export default TeamSubjectsSelector

--- a/packages/synapse-react-client/src/mocks/mockAccessRequirements.ts
+++ b/packages/synapse-react-client/src/mocks/mockAccessRequirements.ts
@@ -153,18 +153,17 @@ export const mockACTAccessRequirementWithWikiPageKey: WikiPageKey = {
   ownerObjectType: ObjectType.ACCESS_REQUIREMENT,
 }
 
-export const mockTeamManagedACTAccessRequirement: ManagedACTAccessRequirement =
-  {
-    ...mockManagedACTAccessRequirement,
-    id: 8,
-    subjectIds: [
-      {
-        id: MOCK_TEAM_ID.toString(),
-        type: RestrictableObjectType.TEAM,
-      },
-    ],
-    accessType: ACCESS_TYPE.PARTICIPATE,
-  }
+export const mockTeamSelfSignAccessRequirement: SelfSignAccessRequirement = {
+  ...mockSelfSignAccessRequirement,
+  id: 8,
+  subjectIds: [
+    {
+      id: MOCK_TEAM_ID.toString(),
+      type: RestrictableObjectType.TEAM,
+    },
+  ],
+  accessType: ACCESS_TYPE.PARTICIPATE,
+}
 
 export const mockSearchResults: AccessRequirementSearchResponse = {
   results: [
@@ -219,7 +218,7 @@ export const mockAccessRequirements: AccessRequirement[] = [
   mockLockAccessRequirement,
   mockToUAccessRequirementWithWiki,
   mockACTAccessRequirementWithWiki,
-  mockTeamManagedACTAccessRequirement,
+  mockTeamSelfSignAccessRequirement,
 ]
 
 export const mockAccessRequirementWikiPageKeys: WikiPageKey[] = [

--- a/packages/synapse-react-client/src/mocks/mockAccessRequirements.ts
+++ b/packages/synapse-react-client/src/mocks/mockAccessRequirements.ts
@@ -25,8 +25,11 @@ import {
   mockToUAccessRequirementWikiPage,
 } from './mockWiki'
 import { mockDucTemplateFileHandle } from './mock_file_handle'
+import { MOCK_TEAM_ID } from './team/mockTeam'
 import { DAY_IN_MS } from '../utils/SynapseConstants'
 
+export const MOCK_NEWLY_CREATED_AR_ID = 1000
+export const MOCK_AR_ETAG = 'mock-ar-etag'
 const MOCK_PROJECT_ID = mockProjectData.id
 
 const defaultAccessRequirement = {
@@ -150,6 +153,19 @@ export const mockACTAccessRequirementWithWikiPageKey: WikiPageKey = {
   ownerObjectType: ObjectType.ACCESS_REQUIREMENT,
 }
 
+export const mockTeamManagedACTAccessRequirement: ManagedACTAccessRequirement =
+  {
+    ...mockManagedACTAccessRequirement,
+    id: 8,
+    subjectIds: [
+      {
+        id: MOCK_TEAM_ID.toString(),
+        type: RestrictableObjectType.TEAM,
+      },
+    ],
+    accessType: ACCESS_TYPE.PARTICIPATE,
+  }
+
 export const mockSearchResults: AccessRequirementSearchResponse = {
   results: [
     {
@@ -203,6 +219,7 @@ export const mockAccessRequirements: AccessRequirement[] = [
   mockLockAccessRequirement,
   mockToUAccessRequirementWithWiki,
   mockACTAccessRequirementWithWiki,
+  mockTeamManagedACTAccessRequirement,
 ]
 
 export const mockAccessRequirementWikiPageKeys: WikiPageKey[] = [

--- a/packages/synapse-react-client/src/mocks/msw/handlers/accessRequirementHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/accessRequirementHandlers.ts
@@ -1,5 +1,6 @@
 import { rest } from 'msw'
 import {
+  ACCESS_REQUIREMENT,
   ACCESS_REQUIREMENT_BY_ID,
   ACCESS_REQUIREMENT_STATUS,
   ACCESS_REQUIREMENT_WIKI_PAGE_KEY,
@@ -18,6 +19,8 @@ import {
 } from '@sage-bionetworks/synapse-types'
 import { SynapseApiResponse } from '../handlers'
 import {
+  MOCK_AR_ETAG,
+  MOCK_NEWLY_CREATED_AR_ID,
   mockAccessRequirements,
   mockAccessRequirementWikiPageKeys,
   mockSelfSignAccessRequirement,
@@ -71,6 +74,24 @@ export const getAccessRequirementHandlers = (backendOrigin: string) => [
     },
   ),
 ]
+
+export function createAccessRequirement(backendOrigin: string) {
+  return rest.post(
+    `${backendOrigin}${ACCESS_REQUIREMENT}`,
+    async (req, res, ctx) => {
+      const requestBody: AccessRequirement = await req.json()
+      return res(
+        ctx.status(201),
+        ctx.json({
+          ...requestBody,
+          id: MOCK_NEWLY_CREATED_AR_ID,
+          etag: MOCK_AR_ETAG,
+        }),
+      )
+    },
+  )
+}
+
 export function updateAccessRequirement(backendOrigin: string) {
   return rest.put(
     `${backendOrigin}${ACCESS_REQUIREMENT_BY_ID(':id')}`,
@@ -201,6 +222,7 @@ export function getCreateAccessApprovalHandler(backendOrigin: string) {
 export function getAllAccessRequirementHandlers(backendOrigin: string) {
   return [
     ...getAccessRequirementHandlers(backendOrigin),
+    createAccessRequirement(backendOrigin),
     updateAccessRequirement(backendOrigin),
     ...getAccessRequirementEntityBindingHandlers(backendOrigin),
     getAccessRequirementsBoundToTeamHandler(backendOrigin),

--- a/packages/synapse-react-client/src/mocks/msw/handlers/teamHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/teamHandlers.ts
@@ -61,12 +61,17 @@ export function getTeamListHandler(backendOrigin: string) {
     `${backendOrigin}/repo/v1/teamList`,
     async (req, res, ctx) => {
       const requestBody: { list: number[] } = await req.json()
-
-      const teams = requestBody.list
-        .map(teamId => {
-          return getMockTeamById(String(teamId))
-        })
-        .filter((team): team is Team => !!team)
+      const teams: Team[] = []
+      for (const teamId of requestBody.list) {
+        const team = getMockTeamById(teamId.toString())
+        if (!team) {
+          const errorResponse: SynapseApiResponse<ListWrapper<Team>> = {
+            reason: `Team with id ${teamId} not found`,
+          }
+          return res(ctx.status(404), ctx.json(errorResponse))
+        }
+        teams.push(team)
+      }
 
       const response: SynapseApiResponse<ListWrapper<Team>> = {
         concreteType: 'org.sagebionetworks.repo.model.Team',

--- a/packages/synapse-react-client/src/mocks/msw/handlers/teamHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/teamHandlers.ts
@@ -51,7 +51,14 @@ export function getTeamHandler(backendOrigin: string) {
     async (req, res, ctx) => {
       const team = getMockTeamById(req.params.teamId as string)
 
-      return res(ctx.status(200), ctx.json(team))
+      if (team) {
+        return res(ctx.status(200), ctx.json(team))
+      }
+
+      const errorResponse: SynapseApiResponse<ListWrapper<Team>> = {
+        reason: `Team id: '${req.params.teamId}' does not exist`,
+      }
+      return res(ctx.status(404), ctx.json(errorResponse))
     },
   )
 }

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -3094,6 +3094,28 @@ export const getAccessRequirementById = <T extends AccessRequirement>(
 }
 
 /**
+ * Add an Access Requirement to an Entity, or Team. This service may only be
+ * used by the Synapse Access and Compliance Team.
+ *
+ * See https://rest-docs.synapse.org/rest/POST/accessRequirement.html
+ *
+ * @param accessToken token of user
+ * @param accessRequirement access requirement to create
+ * @returns created access requirement
+ */
+export const createAccessRequirement = <T extends AccessRequirement>(
+  accessToken: string | undefined,
+  accessRequirement: Partial<T>,
+): Promise<T> => {
+  return doPost<T>(
+    ACCESS_REQUIREMENT,
+    accessRequirement,
+    accessToken,
+    BackendDestinationEnum.REPO_ENDPOINT,
+  )
+}
+
+/**
  * Modify an existing Access Requirement. This service may only be used by the
  * Synapse Access and Compliance Team.
  *

--- a/packages/synapse-react-client/src/synapse-queries/dataaccess/useAccessRequirements.ts
+++ b/packages/synapse-react-client/src/synapse-queries/dataaccess/useAccessRequirements.ts
@@ -11,6 +11,7 @@ import {
   UseQueryOptions,
 } from '@tanstack/react-query'
 import SynapseClient, {
+  createAccessRequirement,
   createAccessRequirementAcl,
   deleteAccessRequirementAcl,
   updateAccessRequirement,
@@ -95,6 +96,29 @@ export function useGetAccessRequirementWikiPageKey(
         accessToken,
         accessRequirementId,
       ),
+  })
+}
+
+export function useCreateAccessRequirement<T extends AccessRequirement>(
+  options?: UseMutationOptions<T, SynapseClientError, Partial<T>>,
+) {
+  const queryClient = useQueryClient()
+  const { accessToken, keyFactory } = useSynapseContext()
+
+  return useMutation<T, SynapseClientError, Partial<T>>({
+    ...options,
+    mutationFn: ar => createAccessRequirement<T>(accessToken, ar),
+    onSuccess: async (newAr, ar, ctx) => {
+      const accessRequirementQueryKey = keyFactory.getAccessRequirementQueryKey(
+        newAr.id.toString(),
+      )
+      queryClient.setQueryData(accessRequirementQueryKey, newAr)
+
+      if (options?.onSuccess) {
+        return await options.onSuccess(newAr, ar, ctx)
+      }
+      return
+    },
   })
 }
 

--- a/packages/synapse-react-client/src/testutils/MarkdownSynapseUtils.ts
+++ b/packages/synapse-react-client/src/testutils/MarkdownSynapseUtils.ts
@@ -22,6 +22,8 @@ export async function waitForMarkdownSynapseToGetWiki(times: number = 1) {
 // Note - matches text content rendered by MarkdownSynapse, but does not
 // confirm that formatting was applied or widgets embedded
 export async function confirmMarkdownSynapseTextContent(textContent: string) {
-  const markdownField = await screen.findByTestId('markdown')
-  expect(markdownField).toHaveTextContent(textContent)
+  await waitFor(() => {
+    const markdownField = screen.getByTestId('markdown')
+    expect(markdownField).toHaveTextContent(textContent)
+  })
 }


### PR DESCRIPTION
type | SWC | SRC
:---:|:---:|:---:
create entity AR | <img width="860" alt="SWC-6730_createEntityAR_SWC" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/5ce36223-18af-4bbb-96a9-216ae90f2fcc"> | <img width="711" alt="SWC-6730_createEntityAR_SRC" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/cd13d3f1-e69b-4df2-a103-807fc5bb5f0b">
create team AR | <img width="844" alt="SWC-6730_createTeamAR_SWC" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/f6b2143b-d729-4493-8a33-2b8ca658eb52"> | <img width="716" alt="SWC-6730_createTeamAR_SRC" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/565343ae-f1d3-420d-8f4e-b6b3ae2a1345">
edit entity AR | <img width="838" alt="SWC-6730_editEntityAR_SWC" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/3af4cf65-4a61-4d53-9dba-c0ad8339de81"> | <img width="713" alt="SWC-6730_editEntityAR_SRC" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/37a5ba62-0688-4217-b1c4-993921a64eff">
edit team AR | <img width="837" alt="SWC-6730_editTeamAR_SWC" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/e84eece0-423f-424c-a26c-40584532bbe2"> | <img width="735" alt="SWC-6730_editTeamAR_SRC" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/26949006/97748452-9c4b-41e7-b91b-2ead8f49bf1f">
