### PR TITLE
SWC-6737

### DIFF
--- a/apps/SageAccountWeb/src/App.tsx
+++ b/apps/SageAccountWeb/src/App.tsx
@@ -12,7 +12,7 @@ import { RegisterAccount2 } from './components/RegisterAccount2'
 import { ResetPassword } from './components/ResetPassword'
 import { TermsOfUsePage } from './components/TermsOfUsePage'
 import React from 'react'
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
+import { Route, Switch, useHistory } from 'react-router-dom'
 import {
   ApplicationSessionManager,
   CookiesNotification,
@@ -31,6 +31,8 @@ import TwoFactorAuthBackupCodesPage from './components/TwoFactorAuth/TwoFactorAu
 import { PersonalAccessTokensPage } from './components/PersonalAccessTokensPage'
 import { OAuthClientManagementPage } from './components/OAuthClientManagementPage'
 import { SourceAppProvider } from './components/useSourceApp'
+import { ResetTwoFactorAuth } from './components/ResetTwoFactorAuth'
+import { RESET_2FA_ROUTE, RESET_2FA_SIGNED_TOKEN_PARAM } from './Constants'
 
 const isCodeSearchParam = getSearchParam('code') !== undefined
 const isProviderSearchParam = getSearchParam('provider') !== undefined
@@ -46,154 +48,154 @@ const queryClient = new QueryClient({
 })
 
 function App() {
+  const history = useHistory()
   return (
     <div className="App">
-      <Router>
-        <StyledEngineProvider injectFirst>
-          <QueryClientProvider client={queryClient}>
-            <ApplicationSessionManager>
-              <SourceAppProvider>
-                <SynapseToastContainer />
-                <AppInitializer>
-                  <CookiesNotification />
-                  <Switch>
-                    <Route exact path="/">
-                      <SynapseContextConsumer>
-                        {(ctx?: SynapseContextType) => {
-                          if (!ctx?.accessToken) {
-                            return <LoginPage returnToUrl={'/'} />
-                          } else {
-                            return (
-                              <AppContextConsumer>
-                                {appContext => (
-                                  <>
-                                    {appContext?.redirectURL &&
-                                      !isInSSOFlow &&
-                                      window.location.replace(
-                                        appContext?.redirectURL,
-                                      )}
-                                  </>
-                                )}
-                              </AppContextConsumer>
-                            )
-                          }
-                        }}
-                      </SynapseContextConsumer>
-                    </Route>
-                    <Route
-                      exact
-                      path="/logout"
-                      render={props => {
-                        SynapseClient.signOut().then(() => {
-                          window.history.replaceState(
-                            null,
-                            '',
-                            '/authenticated/myaccount',
-                          )
-                        })
-                        return <></>
-                      }}
-                    />
-                    <Route
-                      exact
-                      path="/register1"
-                      component={RegisterAccount1}
-                    />
-                    <Route
-                      exact
-                      path="/register2"
-                      component={RegisterAccount2}
-                    />
-                    <Route exact path="/jointeam" component={JoinTeamPage} />
-                    <Route
-                      exact
-                      path="/sageresources"
-                      component={SageResourcesPage}
-                    />
-                    <Route exact path="/resetPassword">
-                      <ResetPassword returnToUrl="/authenticated/myaccount" />
-                    </Route>
+      <StyledEngineProvider injectFirst>
+        <QueryClientProvider client={queryClient}>
+          <ApplicationSessionManager
+            onTwoFactorAuthResetThroughSSO={(twoFaError, twoFaResetCode) => {
+              // The user completed SSO with a twoFaResetCode
+              // Send them to the reset 2FA page with the token
+              history.push(
+                `${RESET_2FA_ROUTE}?${RESET_2FA_SIGNED_TOKEN_PARAM}=${twoFaResetCode}`,
+              )
+            }}
+          >
+            <SourceAppProvider>
+              <SynapseToastContainer />
+              <AppInitializer>
+                <CookiesNotification />
+                <Switch>
+                  <Route exact path="/">
                     <SynapseContextConsumer>
                       {(ctx?: SynapseContextType) => {
-                        const isAuthenticated = !!ctx?.accessToken
-                        return (
-                          <>
-                            {/* If not signed in and in the "/authenticated" path, show the login page */}
-                            {!isAuthenticated && (
-                              <Route path="/authenticated" exact={false}>
-                                <LoginPage />
-                              </Route>
-                            )}
-                            {isAuthenticated && (
-                              <>
-                                <Route path={'/authenticated/validate'} exact>
-                                  <ProfileValidation />
-                                </Route>
-                                <Route
-                                  path={'/authenticated/signTermsOfUse'}
-                                  exact
-                                >
-                                  <TermsOfUsePage />
-                                </Route>
-                                <Route path={'/authenticated/myaccount'} exact>
-                                  <AccountSettings />
-                                </Route>
-                                <Route
-                                  path={'/authenticated/currentaffiliation'}
-                                  exact
-                                >
-                                  <CurrentAffiliationPage />
-                                </Route>
-                                <Route
-                                  path={'/authenticated/accountcreated'}
-                                  exact
-                                >
-                                  <AccountCreatedPage />
-                                </Route>
-                                <Route
-                                  path={'/authenticated/certificationquiz'}
-                                  exact
-                                >
-                                  <CertificationQuiz />
-                                </Route>
-                                <Route
-                                  path={'/authenticated/2fa/enroll'}
-                                  exact
-                                  render={() => <TwoFactorAuthEnrollmentPage />}
-                                />
-                                <Route
-                                  path={'/authenticated/2fa/generatecodes'}
-                                  exact
-                                  render={() => (
-                                    <TwoFactorAuthBackupCodesPage />
-                                  )}
-                                />
-                                <Route
-                                  path={'/authenticated/personalaccesstokens'}
-                                  exact
-                                  render={() => <PersonalAccessTokensPage />}
-                                />
-                                <Route
-                                  path={'/authenticated/oauthclientmanagement'}
-                                  exact
-                                  render={() => <OAuthClientManagementPage />}
-                                />
-                              </>
-                            )}
-                          </>
-                        )
+                        if (!ctx?.accessToken) {
+                          return <LoginPage returnToUrl={'/'} />
+                        } else {
+                          return (
+                            <AppContextConsumer>
+                              {appContext => (
+                                <>
+                                  {appContext?.redirectURL &&
+                                    !isInSSOFlow &&
+                                    window.location.replace(
+                                      appContext?.redirectURL,
+                                    )}
+                                </>
+                              )}
+                            </AppContextConsumer>
+                          )
+                        }
                       }}
                     </SynapseContextConsumer>
-                    <Route exact={true} path="/login">
-                      <LoginPage returnToUrl={'/'} />
-                    </Route>
-                  </Switch>
-                </AppInitializer>
-              </SourceAppProvider>
-            </ApplicationSessionManager>
-          </QueryClientProvider>
-        </StyledEngineProvider>
-      </Router>
+                  </Route>
+                  <Route
+                    exact
+                    path="/logout"
+                    render={props => {
+                      SynapseClient.signOut().then(() => {
+                        window.history.replaceState(
+                          null,
+                          '',
+                          '/authenticated/myaccount',
+                        )
+                      })
+                      return <></>
+                    }}
+                  />
+                  <Route exact path="/register1" component={RegisterAccount1} />
+                  <Route exact path="/register2" component={RegisterAccount2} />
+                  <Route exact path="/jointeam" component={JoinTeamPage} />
+                  <Route
+                    exact
+                    path="/sageresources"
+                    component={SageResourcesPage}
+                  />
+                  <Route exact path="/resetPassword">
+                    <ResetPassword returnToUrl="/authenticated/myaccount" />
+                  </Route>
+                  <Route exact path={RESET_2FA_ROUTE}>
+                    <ResetTwoFactorAuth />
+                  </Route>
+                  <SynapseContextConsumer>
+                    {(ctx?: SynapseContextType) => {
+                      const isAuthenticated = !!ctx?.accessToken
+                      return (
+                        <>
+                          {/* If not signed in and in the "/authenticated" path, show the login page */}
+                          {!isAuthenticated && (
+                            <Route path="/authenticated" exact={false}>
+                              <LoginPage />
+                            </Route>
+                          )}
+                          {isAuthenticated && (
+                            <>
+                              <Route path={'/authenticated/validate'} exact>
+                                <ProfileValidation />
+                              </Route>
+                              <Route
+                                path={'/authenticated/signTermsOfUse'}
+                                exact
+                              >
+                                <TermsOfUsePage />
+                              </Route>
+                              <Route path={'/authenticated/myaccount'} exact>
+                                <AccountSettings />
+                              </Route>
+                              <Route
+                                path={'/authenticated/currentaffiliation'}
+                                exact
+                              >
+                                <CurrentAffiliationPage />
+                              </Route>
+                              <Route
+                                path={'/authenticated/accountcreated'}
+                                exact
+                              >
+                                <AccountCreatedPage />
+                              </Route>
+                              <Route
+                                path={'/authenticated/certificationquiz'}
+                                exact
+                              >
+                                <CertificationQuiz />
+                              </Route>
+                              <Route
+                                path={'/authenticated/2fa/enroll'}
+                                exact
+                                render={() => <TwoFactorAuthEnrollmentPage />}
+                              />
+                              <Route
+                                path={'/authenticated/2fa/generatecodes'}
+                                exact
+                                render={() => <TwoFactorAuthBackupCodesPage />}
+                              />
+                              <Route
+                                path={'/authenticated/personalaccesstokens'}
+                                exact
+                                render={() => <PersonalAccessTokensPage />}
+                              />
+                              <Route
+                                path={'/authenticated/oauthclientmanagement'}
+                                exact
+                                render={() => <OAuthClientManagementPage />}
+                              />
+                            </>
+                          )}
+                        </>
+                      )
+                    }}
+                  </SynapseContextConsumer>
+                  <Route exact={true} path="/login">
+                    <LoginPage returnToUrl={'/'} />
+                  </Route>
+                </Switch>
+              </AppInitializer>
+            </SourceAppProvider>
+          </ApplicationSessionManager>
+        </QueryClientProvider>
+      </StyledEngineProvider>
     </div>
   )
 }

--- a/apps/SageAccountWeb/src/Constants.ts
+++ b/apps/SageAccountWeb/src/Constants.ts
@@ -1,0 +1,2 @@
+export const RESET_2FA_ROUTE = '/reset2FA'
+export const RESET_2FA_SIGNED_TOKEN_PARAM = 'twoFAResetToken'

--- a/apps/SageAccountWeb/src/LoginPage.tsx
+++ b/apps/SageAccountWeb/src/LoginPage.tsx
@@ -18,6 +18,7 @@ import {
   StyledOuterContainer,
 } from './components/StyledComponents.js'
 import { useSourceApp } from './components/useSourceApp'
+import { RESET_2FA_ROUTE, RESET_2FA_SIGNED_TOKEN_PARAM } from './Constants'
 
 export type LoginPageProps = {
   returnToUrl?: string
@@ -93,6 +94,7 @@ function LoginPage(props: LoginPageProps) {
                   preparePostSSORedirect()
                 }}
                 twoFactorAuthenticationRequired={twoFactorAuthSSOErrorResponse}
+                twoFactorAuthResetUri={`${window.location.origin}${RESET_2FA_ROUTE}?${RESET_2FA_SIGNED_TOKEN_PARAM}=`}
               />
             </Box>
           </Box>

--- a/apps/SageAccountWeb/src/components/ResetTwoFactorAuth.tsx
+++ b/apps/SageAccountWeb/src/components/ResetTwoFactorAuth.tsx
@@ -1,0 +1,164 @@
+import { Alert, Box, Button, Typography } from '@mui/material'
+import React, { useMemo, useState } from 'react'
+import { useHistory } from 'react-router-dom'
+import {
+  displayToast,
+  StandaloneLoginForm,
+  SynapseQueries,
+  useApplicationSessionContext,
+} from 'synapse-react-client'
+import {
+  TwoFactorAuthErrorResponse,
+  TwoFactorAuthResetToken,
+} from '@sage-bionetworks/synapse-types'
+import { getSearchParam, hexDecodeAndDeserialize } from '../URLUtils'
+import { BackButton } from './BackButton'
+import { LeftRightPanel } from './LeftRightPanel'
+import { SourceAppLogo } from './SourceApp'
+import { RESET_2FA_SIGNED_TOKEN_PARAM } from '../Constants'
+
+export function ResetTwoFactorAuth() {
+  const history = useHistory()
+  const { refreshSession, twoFactorAuthSSOErrorResponse } =
+    useApplicationSessionContext()
+
+  const twoFactorAuthResetTokenParam = getSearchParam(
+    RESET_2FA_SIGNED_TOKEN_PARAM,
+  )
+
+  const token = useMemo(() => {
+    if (twoFactorAuthResetTokenParam) {
+      return hexDecodeAndDeserialize(
+        twoFactorAuthResetTokenParam,
+      ) as TwoFactorAuthResetToken
+    }
+    return undefined
+  }, [twoFactorAuthResetTokenParam])
+
+  // To disable 2FA, we must send both the token in the search param and a fresh twoFaToken from a login attempt
+  const [twoFaRequiredToken, setTwoFaRequiredToken] = useState<
+    Pick<TwoFactorAuthErrorResponse, 'twoFaToken' | 'userId'> | undefined
+  >()
+
+  const promptForSignIn = token && !twoFaRequiredToken
+  const promptConfirmDisable2FA = token && twoFaRequiredToken
+
+  const {
+    mutate: disableTwoFactorAuth,
+    isSuccess,
+    isPending,
+    error,
+  } = SynapseQueries.useDisableTwoFactorAuthWithResetToken({
+    onSuccess: () => {
+      displayToast('2FA has been successfully disabled on your account.')
+      history.push('/authenticated/myaccount')
+      // We must refresh the session to clear previous 2FA error responses and allow the user to log in.
+      refreshSession()
+    },
+  })
+
+  return (
+    <>
+      <LeftRightPanel
+        className={'ResetPasswords'}
+        leftContent={
+          <>
+            <div className={'panel-logo'}>
+              <SourceAppLogo />
+            </div>
+            <Box sx={{ my: 4 }}>
+              {promptForSignIn && (
+                <>
+                  <StandaloneLoginForm
+                    hideRegisterButton
+                    hideForgotPasswordButton
+                    sessionCallback={() => {
+                      // noop
+                      // Since the user will not complete the 2FA login on this page, sessionCallback is never invoked
+                    }}
+                    twoFactorAuthenticationRequired={
+                      twoFactorAuthSSOErrorResponse
+                    }
+                    onTwoFactorAuthRequired={setTwoFaRequiredToken}
+                    ssoState={{
+                      twoFaResetToken: twoFactorAuthResetTokenParam,
+                    }}
+                  />
+                </>
+              )}
+              {promptConfirmDisable2FA && (
+                <>
+                  <Typography variant={'body1'} my={2}>
+                    If you disable two-factor authentication, your account will
+                    be less secure. Additionally, you may be unable to download
+                    certain data that requires you to have two-factor
+                    authentication enabled on your account.
+                  </Typography>
+                  <Typography variant={'body1'} my={2}>
+                    You can re-activate two-factor authentication at any time in
+                    your account settings.
+                  </Typography>
+                  <Button
+                    fullWidth
+                    variant={'contained'}
+                    onClick={() => {
+                      disableTwoFactorAuth({
+                        ...twoFaRequiredToken,
+                        twoFaResetToken: token,
+                      })
+                    }}
+                    disabled={isSuccess || isPending}
+                  >
+                    Disable Two-Factor Authentication
+                  </Button>
+                </>
+              )}
+              {!token && (
+                <Box>
+                  <BackButton
+                    onClick={() => {
+                      history.goBack()
+                    }}
+                  />
+                  <SourceAppLogo />
+                  <Alert severity={'error'}>
+                    No token was found in the URL.
+                  </Alert>
+                </Box>
+              )}
+              {error && (
+                <Alert severity={'error'} sx={{ my: 2 }}>
+                  {error.reason}
+                </Alert>
+              )}
+            </Box>
+          </>
+        }
+        rightContent={
+          promptForSignIn ? (
+            <div>
+              <Typography variant="headline2">
+                Sign in to your account
+              </Typography>
+              <Typography variant="smallText1">
+                Before you can reset two-factor authentication, you must sign in
+                to your account with an identity provider, or enter your
+                password.
+              </Typography>
+            </div>
+          ) : (
+            <div>
+              <Typography variant="headline2">
+                Disable Two-Factor Authentication?
+              </Typography>
+              <Typography variant="smallText1">
+                Follow the instructions to confirm disabling two-factor
+                authentication on your account.
+              </Typography>
+            </div>
+          )
+        }
+      ></LeftRightPanel>
+    </>
+  )
+}

--- a/apps/SageAccountWeb/src/index.tsx
+++ b/apps/SageAccountWeb/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import { BrowserRouter } from 'react-router-dom'
 import * as serviceWorker from './serviceWorker'
 
 // KaTeX CSS is not included in the SRC style bundle since it includes many large font files.
@@ -12,7 +13,9 @@ const root = createRoot(container!)
 
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 )
 

--- a/apps/SageAccountWeb/src/tests/App.test.tsx
+++ b/apps/SageAccountWeb/src/tests/App.test.tsx
@@ -2,7 +2,13 @@ import React from 'react'
 import App from '../App'
 import { render } from '@testing-library/react'
 import { it } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+
 it('renders without crashing', () => {
   window.history.pushState({}, 'Sage account', '/route')
-  render(<App />)
+  render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>,
+  )
 })

--- a/packages/synapse-react-client/src/components/Authentication/LoginFlowBackButton.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/LoginFlowBackButton.tsx
@@ -22,6 +22,8 @@ function getPreviousStep(currentStep: UseLoginReturn['step']) {
       return 'CHOOSE_AUTH_METHOD'
     case 'RECOVERY_CODE':
       return 'VERIFICATION_CODE'
+    case 'DISABLE_2FA_PROMPT':
+      return 'VERIFICATION_CODE'
     case 'LOGGED_IN':
       // Should never happen
       return 'LOGGED_IN'

--- a/packages/synapse-react-client/src/components/Authentication/LoginPage.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/LoginPage.tsx
@@ -30,6 +30,8 @@ export type LoginPageProps = {
   ssoRedirectUrl?: string
   sessionCallback: () => void // Callback is invoked after login
   ssoState?: OAuth2State
+  /* The URI where the user should be directed in an email when attempting to reset 2FA */
+  twoFactorAuthResetUri?: string
 }
 
 const Tagline: StyledComponent<TypographyProps> = styled(Typography, {
@@ -64,7 +66,8 @@ function BackupCodeInstructions(props: TypographyProps) {
 }
 
 export default function LoginPage(props: LoginPageProps) {
-  const { ssoRedirectUrl, sessionCallback, ssoState } = props
+  const { ssoRedirectUrl, sessionCallback, ssoState, twoFactorAuthResetUri } =
+    props
   const showDesktop = useShowDesktop(910)
   const theme = useTheme()
 
@@ -74,8 +77,11 @@ export default function LoginPage(props: LoginPageProps) {
     submitUsernameAndPassword,
     submitOneTimePassword,
     errorMessage,
-    isLoading,
-  } = useLogin(sessionCallback)
+    loginIsPending,
+    beginTwoFactorAuthReset,
+    twoFactorAuthResetIsPending,
+    twoFactorAuthResetIsSuccess,
+  } = useLogin({ sessionCallback })
 
   const loginForm = (
     <Stack
@@ -126,8 +132,12 @@ export default function LoginPage(props: LoginPageProps) {
         submitUsernameAndPassword={submitUsernameAndPassword}
         submitOneTimePassword={submitOneTimePassword}
         errorMessage={errorMessage}
-        isLoading={isLoading}
+        loginIsPending={loginIsPending}
+        beginTwoFactorAuthReset={beginTwoFactorAuthReset}
+        twoFactorAuthResetIsPending={twoFactorAuthResetIsPending}
+        twoFactorAuthResetIsSuccess={twoFactorAuthResetIsSuccess}
         ssoState={ssoState}
+        twoFactorAuthResetUri={twoFactorAuthResetUri}
       />
     </Stack>
   )

--- a/packages/synapse-react-client/src/components/Authentication/OneTimePasswordForm.test.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/OneTimePasswordForm.test.tsx
@@ -1,0 +1,179 @@
+import React from 'react'
+import { SynapseContextType } from '../../utils'
+import { render, screen } from '@testing-library/react'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import userEvent from '@testing-library/user-event'
+import OneTimePasswordForm, {
+  BEGIN_RESET_2FA_BUTTON_TEXT,
+  OneTimePasswordFormProps,
+  SEND_RESET_2FA_EMAIL_BUTTON_TEXT,
+  SHOW_RECOVERY_CODE_FORM_BUTTON_TEXT,
+  SHOW_TOTP_FORM_BUTTON_TEXT,
+} from './OneTimePasswordForm'
+import { MOCK_CONTEXT_VALUE } from '../../mocks/MockSynapseContext'
+
+const defaultProps = {
+  step: 'VERIFICATION_CODE',
+  hideReset2FA: false,
+  loginIsPending: false,
+  onClickPromptReset2FA: jest.fn(),
+  onClickReset2FA: jest.fn(),
+  onClickUseBackupCode: jest.fn(),
+  onClickUseTOTP: jest.fn(),
+  onSubmit: jest.fn(),
+  twoFactorAuthResetIsPending: false,
+  twoFactorAuthResetIsSuccess: false,
+} satisfies OneTimePasswordFormProps
+
+function renderComponent(
+  props: OneTimePasswordFormProps,
+  wrapperPropOverrides?: Partial<SynapseContextType>,
+) {
+  return render(<OneTimePasswordForm {...props} />, {
+    wrapper: createWrapper({ ...MOCK_CONTEXT_VALUE, ...wrapperPropOverrides }),
+  })
+}
+
+function setUp(
+  props: OneTimePasswordFormProps = defaultProps,
+  wrapperPropOverrides?: Partial<SynapseContextType>,
+) {
+  const user = userEvent.setup()
+  const component = renderComponent(props, wrapperPropOverrides)
+  return { component, user }
+}
+describe('OneTimePasswordForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows the TOTP form when the step is VERIFICATION_CODE', async () => {
+    const props = {
+      ...defaultProps,
+      step: 'VERIFICATION_CODE',
+    } satisfies OneTimePasswordFormProps
+    setUp(props)
+
+    // TOTP, so there will be 6 input fields
+    const inputs = await screen.findAllByRole('textbox')
+    expect(inputs.length).toBe(6)
+
+    // A button exists to switch to entering a recovery code
+    const switchToRecoveryCodeFormButton = await screen.findByText(
+      SHOW_RECOVERY_CODE_FORM_BUTTON_TEXT,
+    )
+    await userEvent.click(switchToRecoveryCodeFormButton)
+    expect(props.onClickUseBackupCode).toHaveBeenCalled()
+
+    // No button is shown to reset 2FA (experimental mode only)
+    const reset2FAButton = screen.queryByText(BEGIN_RESET_2FA_BUTTON_TEXT)
+    expect(reset2FAButton).not.toBeInTheDocument()
+  })
+
+  it('shows the RecoveryCodeForm when the step is RECOVERY_CODE', async () => {
+    const props = {
+      ...defaultProps,
+      step: 'RECOVERY_CODE',
+    } satisfies OneTimePasswordFormProps
+    setUp(props)
+
+    // recovery code, so there will be 1 input field
+    const inputs = await screen.findAllByRole('textbox')
+    expect(inputs.length).toBe(1)
+
+    // A button exists to switch to entering a TOTP
+    const switchToTotpFormButton = await screen.findByText(
+      SHOW_TOTP_FORM_BUTTON_TEXT,
+    )
+    await userEvent.click(switchToTotpFormButton)
+    expect(props.onClickUseTOTP).toHaveBeenCalled()
+
+    // No button is shown to reset 2FA (experimental mode only)
+    const reset2FAButton = screen.queryByText(BEGIN_RESET_2FA_BUTTON_TEXT)
+    expect(reset2FAButton).not.toBeInTheDocument()
+  })
+
+  it('shows a button to prompt to reset 2FA when the step is VERIFICATION_CODE (experimental mode only)', async () => {
+    const props = {
+      ...defaultProps,
+      step: 'VERIFICATION_CODE',
+    } satisfies OneTimePasswordFormProps
+    setUp(props, { isInExperimentalMode: true })
+
+    // A button is shown to reset 2FA
+    const reset2FAButton = await screen.findByText(BEGIN_RESET_2FA_BUTTON_TEXT)
+    await userEvent.click(reset2FAButton)
+    expect(props.onClickPromptReset2FA).toHaveBeenCalled()
+  })
+
+  it('shows a button to prompt to reset 2FA when the step is RECOVERY_CODE (experimental mode only)', async () => {
+    const props = {
+      ...defaultProps,
+      step: 'RECOVERY_CODE',
+    } satisfies OneTimePasswordFormProps
+    setUp(props, { isInExperimentalMode: true })
+
+    // A button is shown to reset 2FA
+    const reset2FAButton = await screen.findByText(BEGIN_RESET_2FA_BUTTON_TEXT)
+    await userEvent.click(reset2FAButton)
+    expect(props.onClickPromptReset2FA).toHaveBeenCalled()
+  })
+
+  it('shows a prompt to send the reset 2FA email when the step is DISABLE_2FA_PROMPT', async () => {
+    const props = {
+      ...defaultProps,
+      step: 'DISABLE_2FA_PROMPT',
+    } satisfies OneTimePasswordFormProps
+    setUp(props, { isInExperimentalMode: true })
+
+    // A button is shown to reset 2FA
+    const reset2FAButton = await screen.findByText(
+      SEND_RESET_2FA_EMAIL_BUTTON_TEXT,
+    )
+    await userEvent.click(reset2FAButton)
+    expect(props.onClickReset2FA).toHaveBeenCalled()
+  })
+
+  it('disables the reset 2FA button when the request to reset is pending', async () => {
+    const props = {
+      ...defaultProps,
+      step: 'DISABLE_2FA_PROMPT',
+      twoFactorAuthResetIsPending: true,
+    } satisfies OneTimePasswordFormProps
+    setUp(props, { isInExperimentalMode: true })
+
+    const reset2FAButton = await screen.findByText(
+      SEND_RESET_2FA_EMAIL_BUTTON_TEXT,
+    )
+    // Prevent sending multiple requests to reset when waiting for one to go through
+    expect(reset2FAButton).toBeDisabled()
+  })
+
+  it('disables the reset 2FA button when the request to reset is successful', async () => {
+    const props = {
+      ...defaultProps,
+      step: 'DISABLE_2FA_PROMPT',
+      twoFactorAuthResetIsSuccess: true,
+    } satisfies OneTimePasswordFormProps
+    setUp(props, { isInExperimentalMode: true })
+
+    const reset2FAButton = await screen.findByText(
+      SEND_RESET_2FA_EMAIL_BUTTON_TEXT,
+    )
+    // Prevent sending multiple requests to reset when one has already succeeded
+    expect(reset2FAButton).toBeDisabled()
+  })
+
+  it('shows a button to re-prompt for a 2FA code when the step is DISABLE_2FA_PROMPT', async () => {
+    const props = {
+      ...defaultProps,
+      step: 'DISABLE_2FA_PROMPT',
+      twoFactorAuthResetIsSuccess: true,
+    } satisfies OneTimePasswordFormProps
+    setUp(props, { isInExperimentalMode: true })
+
+    const useTwoFaButton = await screen.findByText('Go back')
+    await userEvent.click(useTwoFaButton)
+    expect(props.onClickUseTOTP).toHaveBeenCalled()
+  })
+})

--- a/packages/synapse-react-client/src/components/Authentication/RecoveryCodeForm.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/RecoveryCodeForm.tsx
@@ -8,11 +8,11 @@ const RECOVERY_CODE_LENGTH = 19
 
 type RecoveryCodeFormProps = {
   onSubmit: (value: string) => void
-  isLoading: UseLoginReturn['isLoading']
+  loginIsPending: UseLoginReturn['loginIsPending']
 }
 
 export default function RecoveryCodeForm(props: RecoveryCodeFormProps) {
-  const { onSubmit, isLoading } = props
+  const { onSubmit, loginIsPending } = props
   const [recoveryCode, setRecoveryCode] = React.useState('')
   return (
     <Box>
@@ -38,13 +38,15 @@ export default function RecoveryCodeForm(props: RecoveryCodeFormProps) {
           mt: 4,
           mb: 2,
         }}
-        disabled={recoveryCode.length !== RECOVERY_CODE_LENGTH || isLoading}
+        disabled={
+          recoveryCode.length !== RECOVERY_CODE_LENGTH || loginIsPending
+        }
         onClick={e => {
           e.preventDefault()
           onSubmit(recoveryCode)
         }}
       >
-        {isLoading ? 'Verifying...' : 'Submit'}
+        {loginIsPending ? 'Verifying...' : 'Submit'}
       </Button>
     </Box>
   )

--- a/packages/synapse-react-client/src/components/Authentication/StandaloneLoginForm.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/StandaloneLoginForm.tsx
@@ -20,7 +20,15 @@ export type StandaloneLoginFormProps = {
   showUsernameOrPassword?: boolean | undefined
   /* optionally pass the 2FA error response to directly start the 2FA challenge */
   twoFactorAuthenticationRequired?: TwoFactorAuthErrorResponse
+  /* If a twoFactorAuthError is encountered (including passed in the twoFactorAuthenticationRequired prop), this callback will be invoked */
+  onTwoFactorAuthRequired?: (
+    twoFaToken: Pick<TwoFactorAuthErrorResponse, 'twoFaToken' | 'userId'>,
+  ) => void
+  hideRegisterButton?: boolean
+  hideForgotPasswordButton?: boolean
   ssoState?: OAuth2State
+  /* The URI where the user should be directed in an email when attempting to reset 2FA */
+  twoFactorAuthResetUri?: string
 }
 
 export default function StandaloneLoginForm(props: StandaloneLoginFormProps) {
@@ -30,7 +38,11 @@ export default function StandaloneLoginForm(props: StandaloneLoginFormProps) {
     registerAccountUrl,
     resetPasswordUrl,
     onBeginOAuthSignIn,
+    onTwoFactorAuthRequired,
+    hideRegisterButton,
+    hideForgotPasswordButton,
     ssoState,
+    twoFactorAuthResetUri,
   } = props
 
   const {
@@ -39,8 +51,15 @@ export default function StandaloneLoginForm(props: StandaloneLoginFormProps) {
     submitUsernameAndPassword,
     submitOneTimePassword,
     errorMessage,
-    isLoading,
-  } = useLogin(sessionCallback, props.twoFactorAuthenticationRequired)
+    loginIsPending,
+    beginTwoFactorAuthReset,
+    twoFactorAuthResetIsPending,
+    twoFactorAuthResetIsSuccess,
+  } = useLogin({
+    sessionCallback,
+    twoFaErrorResponse: props.twoFactorAuthenticationRequired,
+    onTwoFactorAuthRequired,
+  })
 
   return (
     <Box
@@ -76,8 +95,14 @@ export default function StandaloneLoginForm(props: StandaloneLoginFormProps) {
         registerAccountUrl={registerAccountUrl}
         resetPasswordUrl={resetPasswordUrl}
         onBeginOAuthSignIn={onBeginOAuthSignIn}
-        isLoading={isLoading}
+        loginIsPending={loginIsPending}
+        beginTwoFactorAuthReset={beginTwoFactorAuthReset}
+        hideRegisterButton={hideRegisterButton}
+        hideForgotPasswordButton={hideForgotPasswordButton}
+        twoFactorAuthResetIsPending={twoFactorAuthResetIsPending}
+        twoFactorAuthResetIsSuccess={twoFactorAuthResetIsSuccess}
         ssoState={ssoState}
+        twoFactorAuthResetUri={twoFactorAuthResetUri}
       />
     </Box>
   )

--- a/packages/synapse-react-client/src/components/Authentication/TOTPForm.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/TOTPForm.tsx
@@ -8,11 +8,11 @@ const DIGIT_CHARACTERS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 
 type TOTPFormProps = {
   onSubmit: (value: string) => void
-  isLoading: UseLoginReturn['isLoading']
+  loginIsPending: UseLoginReturn['loginIsPending']
 }
 
 export default function TOTPForm(props: TOTPFormProps) {
-  const { onSubmit, isLoading } = props
+  const { onSubmit, loginIsPending } = props
   const [verificationCode, setVerificationCode] = React.useState('')
   return (
     <Box>
@@ -57,13 +57,13 @@ export default function TOTPForm(props: TOTPFormProps) {
           mt: 4,
           mb: 2,
         }}
-        disabled={verificationCode.length !== TOTP_LENGTH || isLoading}
+        disabled={verificationCode.length !== TOTP_LENGTH || loginIsPending}
         onClick={e => {
           e.preventDefault()
           onSubmit(verificationCode)
         }}
       >
-        {isLoading ? 'Verifying...' : 'Submit'}
+        {loginIsPending ? 'Verifying...' : 'Submit'}
       </Button>
     </Box>
   )

--- a/packages/synapse-react-client/src/components/Authentication/UsernamePasswordForm.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/UsernamePasswordForm.tsx
@@ -1,16 +1,14 @@
 import { Button, Link } from '@mui/material'
 import React, { useState } from 'react'
-import {
-  BackendDestinationEnum,
-  getEndpoint,
-} from '../../utils/functions/getEndpoint'
+import { BackendDestinationEnum, getEndpoint } from '../../utils/functions'
 import TextField from '../TextField/TextField'
 import { UseLoginReturn } from '../../utils/hooks'
 
 type UsernamePasswordFormProps = {
   onSubmit: (username: string, password: string) => void
   resetPasswordUrl?: string
-  isLoading: UseLoginReturn['isLoading']
+  loginIsPending: UseLoginReturn['loginIsPending']
+  hideForgotPasswordButton?: boolean
 }
 
 export default function UsernamePasswordForm(props: UsernamePasswordFormProps) {
@@ -19,7 +17,8 @@ export default function UsernamePasswordForm(props: UsernamePasswordFormProps) {
       BackendDestinationEnum.PORTAL_ENDPOINT,
     )}#!PasswordReset:0`,
     onSubmit,
-    isLoading,
+    loginIsPending,
+    hideForgotPasswordButton,
   } = props
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
@@ -55,20 +54,22 @@ export default function UsernamePasswordForm(props: UsernamePasswordFormProps) {
         value={password}
         onChange={e => setPassword(e.target.value)}
       />
-      <Link href={resetPasswordUrl}>Forgot password?</Link>
+      {!hideForgotPasswordButton && (
+        <Link href={resetPasswordUrl}>Forgot password?</Link>
+      )}
       <Button
         fullWidth
         type="submit"
         color="primary"
         variant="contained"
-        disabled={isLoading}
+        disabled={loginIsPending}
         sx={{
           height: '50px',
           mt: 4,
           mb: 2,
         }}
       >
-        {isLoading ? 'Logging you in...' : 'Sign in'}
+        {loginIsPending ? 'Logging you in...' : 'Sign in'}
       </Button>
     </form>
   )

--- a/packages/synapse-react-client/src/components/ChangePassword/useChangePasswordFormState.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/useChangePasswordFormState.tsx
@@ -124,7 +124,7 @@ export default function useChangePasswordFormState(
           onClickUseBackupCode={() => {
             setOtpStep('RECOVERY_CODE')
           }}
-          isLoading={isPending}
+          loginIsPending={isPending}
           onSubmit={(code, otpType) =>
             handleChangePasswordWithOtp(newPassword, code, otpType)
           }

--- a/packages/synapse-react-client/src/components/ChangePassword/useChangePasswordFormState.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/useChangePasswordFormState.tsx
@@ -52,54 +52,52 @@ export default function useChangePasswordFormState(
     },
   })
 
-  function handleChangePasswordWithCurrentPassword(
-    username: string,
-    currentPassword: string,
-    newPassword: string,
-  ) {
-    setNewPassword(newPassword)
-    const changeRequest: ChangePasswordWithCurrentPassword = {
-      username,
-      currentPassword,
-      newPassword,
-      concreteType:
-        'org.sagebionetworks.repo.model.auth.ChangePasswordWithCurrentPassword',
-    }
-    changePassword(changeRequest)
-  }
-
-  function handleChangePasswordWithResetToken(
-    newPassword: string,
-    passwordChangeToken: PasswordResetSignedToken,
-  ) {
-    setNewPassword(newPassword)
-    const changeRequest: ChangePasswordWithTokenObject = {
-      newPassword,
-      concreteType:
-        'org.sagebionetworks.repo.model.auth.ChangePasswordWithToken',
-      passwordChangeToken: passwordChangeToken,
-    }
-    changePassword(changeRequest)
-  }
-
-  function handleChangePasswordWithOtp(
-    newPassword: string,
-    code: string,
-    otpType: TwoFactorAuthOtpType,
-  ) {
-    if (twoFactorAuthErrorResponse) {
-      const changeRequest: ChangePasswordWithTwoFactorAuthToken = {
+  const handleChangePasswordWithCurrentPassword = useCallback(
+    (username: string, currentPassword: string, newPassword: string) => {
+      setNewPassword(newPassword)
+      const changeRequest: ChangePasswordWithCurrentPassword = {
+        username,
+        currentPassword,
         newPassword,
         concreteType:
-          'org.sagebionetworks.repo.model.auth.ChangePasswordWithTwoFactorAuthToken',
-        userId: twoFactorAuthErrorResponse.userId,
-        twoFaToken: twoFactorAuthErrorResponse.twoFaToken,
-        otpType: otpType,
-        otpCode: code,
+          'org.sagebionetworks.repo.model.auth.ChangePasswordWithCurrentPassword',
       }
       changePassword(changeRequest)
-    }
-  }
+    },
+    [changePassword],
+  )
+
+  const handleChangePasswordWithResetToken = useCallback(
+    (newPassword: string, passwordChangeToken: PasswordResetSignedToken) => {
+      setNewPassword(newPassword)
+      const changeRequest: ChangePasswordWithTokenObject = {
+        newPassword,
+        concreteType:
+          'org.sagebionetworks.repo.model.auth.ChangePasswordWithToken',
+        passwordChangeToken: passwordChangeToken,
+      }
+      changePassword(changeRequest)
+    },
+    [changePassword],
+  )
+
+  const handleChangePasswordWithOtp = useCallback(
+    (newPassword: string, code: string, otpType: TwoFactorAuthOtpType) => {
+      if (twoFactorAuthErrorResponse) {
+        const changeRequest: ChangePasswordWithTwoFactorAuthToken = {
+          newPassword,
+          concreteType:
+            'org.sagebionetworks.repo.model.auth.ChangePasswordWithTwoFactorAuthToken',
+          userId: twoFactorAuthErrorResponse.userId,
+          twoFaToken: twoFactorAuthErrorResponse.twoFaToken,
+          otpType: otpType,
+          otpCode: code,
+        }
+        changePassword(changeRequest)
+      }
+    },
+    [changePassword, twoFactorAuthErrorResponse],
+  )
   const promptForTwoFactorAuth = Boolean(twoFactorAuthErrorResponse)
 
   const TwoFactorAuthPrompt = useCallback(() => {
@@ -130,6 +128,9 @@ export default function useChangePasswordFormState(
           onSubmit={(code, otpType) =>
             handleChangePasswordWithOtp(newPassword, code, otpType)
           }
+          hideReset2FA={true}
+          twoFactorAuthResetIsPending={false}
+          twoFactorAuthResetIsSuccess={false}
         />
         <Alert severity={'info'} sx={{ my: 2 }}>
           Two-factor authentication is required to change your password.

--- a/packages/synapse-react-client/src/utils/AppUtils/session/ApplicationSessionManager.tsx
+++ b/packages/synapse-react-client/src/utils/AppUtils/session/ApplicationSessionManager.tsx
@@ -17,6 +17,15 @@ export type ApplicationSessionManagerProps = React.PropsWithChildren<{
   onNoAccessTokenFound?: () => void
   /* If defined, the session will be cleared and the user will have to re-authenticate (if logged in) */
   forceRelogin?: boolean
+  /*
+   * Callback invoked after the user has successfully signed in through SSO when the purpose of signing in is to disable 2FA on the account.
+   * The twoFactorAuthSSOError and twoFaResetToken are passed in the callback and can be used to complete the 2FA reset process.
+   * This only needs to be implemented if the app implements the workflow to disable 2FA (i.e. only if the app supports account management).
+   */
+  onTwoFactorAuthResetThroughSSO?: (
+    twoFactorAuthSSOError: TwoFactorAuthErrorResponse,
+    twoFaResetToken: string,
+  ) => void
 }>
 
 /**
@@ -43,6 +52,7 @@ export function ApplicationSessionManager(
     maxAge,
     onNoAccessTokenFound,
     forceRelogin,
+    onTwoFactorAuthResetThroughSSO,
   } = props
   const history = useHistory()
 
@@ -144,6 +154,12 @@ export function ApplicationSessionManager(
     },
     onTwoFactorAuthRequired: twoFactorAuthError => {
       setTwoFactorAuthSSOError(twoFactorAuthError)
+    },
+    onTwoFactorAuthResetTokenPresent: (twoFactorAuthError, twoFaResetToken) => {
+      setTwoFactorAuthSSOError(twoFactorAuthError)
+      if (onTwoFactorAuthResetThroughSSO) {
+        onTwoFactorAuthResetThroughSSO(twoFactorAuthError, twoFaResetToken)
+      }
     },
   })
 


### PR DESCRIPTION
- Update Login components, SageAccountWeb to support 2FA reset flow

### Requesting email to disable 2FA

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/0a9f83af-923a-4d08-a830-fc80841f0802

### 2FA reset email

![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/f347a0b0-fe87-4d44-b9f2-3e72ed235917)

### Disabling 2FA

https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/8f339eae-1d67-4df6-b6ae-3e7359a6d43e

### Confirmation that 2FA was disabled (cropped in previous clip)

![image](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/17580037/d920e457-9f5c-48c6-a9bc-5fa2fac5c746)

