### PR TITLE
SWC-6827

### DIFF
--- a/packages/synapse-react-client/src/components/AccessTokenPage/AccessTokenCard/AccessTokenCard.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessTokenPage/AccessTokenCard/AccessTokenCard.test.tsx
@@ -134,7 +134,7 @@ describe('AccessTokenCard', () => {
     })
   })
 
-  test('renders unknown scope definitions', () => {
+  test('SWC-6827: renders unknown scope definitions without crashing', () => {
     const tokenProps: AccessTokenCardProps = {
       accessToken: {
         ...activeTokenProps.accessToken,

--- a/packages/synapse-react-client/src/components/AccessTokenPage/AccessTokenCard/AccessTokenCard.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessTokenPage/AccessTokenCard/AccessTokenCard.test.tsx
@@ -133,4 +133,16 @@ describe('AccessTokenCard', () => {
       expect(mockOnDelete).toHaveBeenCalled()
     })
   })
+
+  test('renders unknown scope definitions', () => {
+    const tokenProps: AccessTokenCardProps = {
+      accessToken: {
+        ...activeTokenProps.accessToken,
+        scopes: ['unknownscope'],
+      },
+      onDelete: mockOnDelete,
+    }
+    renderComponent(tokenProps)
+    expect(screen.queryByText('Unknownscope')).toBeInTheDocument()
+  })
 })

--- a/packages/synapse-react-client/src/components/AccessTokenPage/AccessTokenCard/AccessTokenCard.tsx
+++ b/packages/synapse-react-client/src/components/AccessTokenPage/AccessTokenCard/AccessTokenCard.tsx
@@ -106,11 +106,11 @@ export function AccessTokenCard(props: AccessTokenCardProps) {
                 scope as keyof typeof scopeDescriptions
               let scopeDescription = scopeDescriptions[scopeDescriptionKey]
               if (scopeDescription === undefined) {
-                const upperCaseScope =
+                const titleCaseScope =
                   scope.charAt(0).toUpperCase() + scope.slice(1)
                 scopeDescription = {
-                  displayName: upperCaseScope,
-                  description: upperCaseScope,
+                  displayName: titleCaseScope,
+                  description: titleCaseScope,
                 }
               }
               return (

--- a/packages/synapse-react-client/src/components/AccessTokenPage/AccessTokenCard/AccessTokenCard.tsx
+++ b/packages/synapse-react-client/src/components/AccessTokenPage/AccessTokenCard/AccessTokenCard.tsx
@@ -77,7 +77,6 @@ export function AccessTokenCard(props: AccessTokenCardProps) {
       open={showModal}
     />
   )
-
   return (
     <Card
       sx={{
@@ -103,23 +102,25 @@ export function AccessTokenCard(props: AccessTokenCardProps) {
           <div>
             <span>Permissions: </span>
             {accessToken.scopes.map(scope => {
+              const scopeDescriptionKey =
+                scope as keyof typeof scopeDescriptions
+              let scopeDescription = scopeDescriptions[scopeDescriptionKey]
+              if (scopeDescription === undefined) {
+                const upperCaseScope =
+                  scope.charAt(0).toUpperCase() + scope.slice(1)
+                scopeDescription = {
+                  displayName: upperCaseScope,
+                  description: upperCaseScope,
+                }
+              }
               return (
-                <Tooltip
-                  key={scope}
-                  title={
-                    scopeDescriptions[scope as keyof typeof scopeDescriptions]
-                      .description
-                  }
-                >
+                <Tooltip key={scope} title={scopeDescription.description}>
                   <Typography
                     component={'span'}
                     variant={'smallText1'}
                     sx={{ mx: 0.25, cursor: 'default', color: 'primary.main' }}
                   >
-                    {
-                      scopeDescriptions[scope as keyof typeof scopeDescriptions]
-                        .displayName
-                    }
+                    {scopeDescription.displayName}
                   </Typography>
                 </Tooltip>
               )

--- a/packages/synapse-types/src/AccessToken/ScopeDescriptions.ts
+++ b/packages/synapse-types/src/AccessToken/ScopeDescriptions.ts
@@ -26,4 +26,13 @@ export const scopeDescriptions = {
     description:
       'Permission to access the resources authorized here when you are not logged in, until you explicitly revoke access',
   },
+  email: {
+    displayName: 'Email',
+    description:
+      'Permission to access the email address associated to your account',
+  },
+  profile: {
+    displayName: 'User Profile',
+    description: 'Permission to access your user profile information',
+  },
 }


### PR DESCRIPTION
With unsupported OAuth scope values:
<img width="834" alt="Screen Shot 2024-05-06 at 10 51 27 AM" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/1864447/a57ea419-d898-4504-8eb6-56fea9c6d4cd">

<img width="870" alt="Screen Shot 2024-05-06 at 10 51 34 AM" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/1864447/1e666f16-75a4-496c-a053-e1793a259033">

And added support for these two values (email and profile):

<img width="832" alt="Screen Shot 2024-05-06 at 10 58 54 AM" src="https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/1864447/9cca44db-4dfb-46fa-b215-443a034687b2">
