### PR TITLE
SWC-6777 - Specify UTF-8 encoding in Content-Type on POST/PUT

### DIFF
--- a/packages/synapse-react-client/src/synapse-client/HttpClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/HttpClient.ts
@@ -104,7 +104,7 @@ export const doPost = <T>(
     headers: {
       Accept: '*/*',
       'Access-Control-Request-Headers': 'authorization',
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json; charset=utf8',
       ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
     },
     method: 'POST',
@@ -164,7 +164,7 @@ export const doPut = <T>(
     headers: {
       Accept: '*/*',
       'Access-Control-Request-Headers': 'authorization',
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json; charset=utf8',
       ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
     },
     method: 'PUT',


### PR DESCRIPTION
Fixes SWC-6777

The encoding issue occurred on data submission, so this will not fix historical data.