### PR TITLE
CPO-943: Update Grant card + details page

### DIFF
--- a/apps/portals/src/configurations/cancercomplexity/routesConfig.ts
+++ b/apps/portals/src/configurations/cancercomplexity/routesConfig.ts
@@ -284,6 +284,18 @@ const routes: GenericRoute[] = [
                         columnAliases,
                       },
                     },
+                    {
+                      name: 'CardContainerLogic',
+                      columnName: 'grantNumber',
+                      title: 'Related Educational Resources',
+                      tableSqlKeys: ['grantNumber'],
+                      props: {
+                        sqlOperator: ColumnMultiValueFunction.HAS,
+                        sql: educationSql,
+                        ...educationDetailsCardConfiguration,
+                        columnAliases,
+                      },
+                    },
                   ],
                 },
               },

--- a/apps/portals/src/configurations/cancercomplexity/synapseConfigs/grants.ts
+++ b/apps/portals/src/configurations/cancercomplexity/synapseConfigs/grants.ts
@@ -20,6 +20,8 @@ export const grantsSchema: GenericCardSchema = {
     'grantNumber',
     'consortium',
     'grantType',
+    'nihReporterLink',
+    'grantStartDate',
     'theme',
   ],
 }
@@ -37,6 +39,12 @@ export const grantsCardConfiguration: CardConfiguration = {
     matchColumnName: 'grantId',
     baseURL: 'Explore/Grants/DetailsPage',
   },
+  labelLinkConfig: [
+    {
+      isMarkdown: true,
+      matchColumnName: 'nihReporterLink',
+    },
+  ],
   type: SynapseConstants.GENERIC_CARD,
   secondaryLabelLimit: 4,
   iconOptions,


### PR DESCRIPTION
More information about the proposed feature in the parent ticket [here](https://sagebionetworks.jira.com/browse/CPO-943)

CC: @aclayton555 

## Changelog

* Add two secondary labels to the grant card: NIH Reporter Link, Grant Start Date
* Add new "Related Educational Resources" section

## Preview

Educational resource with no associating grant number:
![Screenshot 2024-06-10 at 5 28 18 PM](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/9377970/5044de10-7681-4447-ae14-d310723b83cf)

Educational resource with associating grant number + updated grant Details Page:
![preview](https://github.com/Sage-Bionetworks/synapse-web-monorepo/assets/9377970/4df8f2f9-e10d-45a2-9821-39dd24e1209e)

