### PR TITLE
SWC-6954

### DIFF
--- a/packages/synapse-react-client/src/components/ImageFromSynapseTable.tsx
+++ b/packages/synapse-react-client/src/components/ImageFromSynapseTable.tsx
@@ -4,32 +4,25 @@ import {
   FileHandleAssociation,
 } from '@sage-bionetworks/synapse-types'
 import { useGetStablePresignedUrl } from '../synapse-queries'
-import { Fade } from '@mui/material'
-import { useFadeTransition } from '../utils/hooks/useFadeTransition'
 
 export type ImageFromSynapseTableProps = {
   tableId: string
   fileHandleId: string | null
   alt?: string
   style?: CSSProperties
-  fadeInTimeoutMs?: number
 }
 
 const ImageFromSynapseTable: React.FC<ImageFromSynapseTableProps> = (
   props: ImageFromSynapseTableProps,
 ) => {
-  const { tableId, fileHandleId, alt, style, fadeInTimeoutMs = 0 } = props
-  const { delayedState: fileHandleIdInState, visible } = useFadeTransition({
-    state: fileHandleId,
-    fadeInTimeoutMs,
-  })
+  const { tableId, fileHandleId, alt, style } = props
   const fha: FileHandleAssociation = {
     associateObjectId: tableId,
     associateObjectType: FileHandleAssociateType.TableEntity,
-    fileHandleId: (fileHandleIdInState as string) ?? '',
+    fileHandleId: fileHandleId ?? '',
   }
   const stablePresignedUrl = useGetStablePresignedUrl(fha, false, {
-    enabled: !!fileHandleIdInState,
+    enabled: !!fileHandleId,
   })
 
   const dataUrl = stablePresignedUrl?.dataUrl
@@ -39,13 +32,11 @@ const ImageFromSynapseTable: React.FC<ImageFromSynapseTableProps> = (
     return <></>
   }
   return (
-    <Fade in={visible} timeout={fadeInTimeoutMs}>
-      <img
-        style={style}
-        alt={alt ? `${alt}` : 'Image from table'}
-        src={dataUrl}
-      />
-    </Fade>
+    <img
+      style={style}
+      alt={alt ? `${alt}` : 'Image from table'}
+      src={dataUrl}
+    />
   )
 }
 

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseInAction.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseInAction.tsx
@@ -1,11 +1,9 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { useGetQueryResultBundleWithAsyncStatus } from '../../synapse-queries'
 import { BUNDLE_MASK_QUERY_RESULTS } from '../../utils/SynapseConstants'
 import { Box, useMediaQuery } from '@mui/material'
 import { SynapseInActionItem } from './SynapseInActionItem'
 import { useTheme } from '@mui/material'
-import ImageFromSynapseTable from '../ImageFromSynapseTable'
-import { useInView } from 'react-intersection-observer'
 
 export type SynapseInActionProps = {
   tableId: string
@@ -16,11 +14,7 @@ export const SynapseInAction: React.FunctionComponent<SynapseInActionProps> = ({
 }) => {
   const theme = useTheme()
   // Show the associated image (in desktop mode) if 10% of the div is visible
-  const [ref, inView] = useInView({ threshold: 0.1 })
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
-  const [imageFileHandleIdInView, setImageFileHandleIdInView] = useState<
-    string | undefined
-  >()
   const { data } = useGetQueryResultBundleWithAsyncStatus({
     entityId: tableId,
     query: {
@@ -69,97 +63,46 @@ export const SynapseInAction: React.FunctionComponent<SynapseInActionProps> = ({
     return <></>
   }
   return (
-    <Box sx={{ position: 'relative' }} ref={ref}>
-      <Box sx={{ width: { xs: '100%', sm: '45%' } }}>
-        <Box
-          sx={{
-            maxWidth: '450px',
-            m: 'auto',
-            zIndex: 100,
-            position: 'relative',
-            backgroundColor: 'rgba(245, 249, 249, .8)',
-            borderRadius: '12px',
-          }}
-        >
-          {rowSet.rows.map((row, index) => {
-            const title = row.values[titleColIndex]!
-            const description = row.values[descriptionColIndex]!
-            const tags: string[] = JSON.parse(row.values[tagsColIndex]!)
-            const imageFileHandleId = row.values[imageFileColIndex]!
-            const mobileImageFileHandleId = row.values[mobileImageFileColIndex]!
-            const logoFileHandleId = row.values[logoColIndex]!
-            const link = row.values[linkColIndex]!
-            const friendlyName = row.values[friendlyNameColIndex]!
-            const primaryColor = row.values[primaryColorColIndex]!
-            const secondaryColor = row.values[secondaryColorColIndex]!
-            const backgroundColor =
-              isMobileView && index % 2
-                ? '#E9F2F1' // SWC-6984: intentional break out of color palette
-                : undefined
-            return (
-              <Box
-                key={row.rowId}
-                sx={{
-                  py: { xs: '30px', sm: '120px' },
-                  backgroundColor: { backgroundColor },
-                }}
-              >
-                {/* Preload the desktop image file handle ID so it is ready when the user scrolls down to view it */}
-                <Box
-                  sx={{
-                    display: 'none',
-                  }}
-                >
-                  <ImageFromSynapseTable
-                    tableId={tableId}
-                    fileHandleId={imageFileHandleId}
-                  />
-                </Box>
-                {/* If mobile, show the mobile image file */}
-                <Box
-                  sx={{
-                    display: { xs: 'flex', sm: 'none' },
-                    justifyContent: 'center',
-                    width: '100%',
-                    img: { width: '320px' },
-                  }}
-                >
-                  <ImageFromSynapseTable
-                    tableId={tableId}
-                    fileHandleId={mobileImageFileHandleId}
-                  />
-                </Box>
-                <SynapseInActionItem
-                  tableId={tableId}
-                  friendlyName={friendlyName}
-                  title={title}
-                  description={description}
-                  logoFileHandleId={logoFileHandleId}
-                  tags={tags}
-                  link={link}
-                  primaryColor={primaryColor}
-                  secondaryColor={secondaryColor}
-                  onInView={() => setImageFileHandleIdInView(imageFileHandleId)}
-                />
-              </Box>
-            )
-          })}
-        </Box>
-      </Box>
-      {!isMobileView && inView && (
-        <Box sx={{ position: 'fixed', top: '10%', right: 0, zIndex: 1 }}>
-          {imageFileHandleIdInView && (
-            <ImageFromSynapseTable
+    <Box sx={{ position: 'relative' }}>
+      {rowSet.rows.map((row, index) => {
+        const title = row.values[titleColIndex]!
+        const description = row.values[descriptionColIndex]!
+        const tags: string[] = JSON.parse(row.values[tagsColIndex]!)
+        const imageFileHandleId = row.values[imageFileColIndex]!
+        const mobileImageFileHandleId = row.values[mobileImageFileColIndex]!
+        const logoFileHandleId = row.values[logoColIndex]!
+        const link = row.values[linkColIndex]!
+        const friendlyName = row.values[friendlyNameColIndex]!
+        const primaryColor = row.values[primaryColorColIndex]!
+        const secondaryColor = row.values[secondaryColorColIndex]!
+        const backgroundColor =
+          isMobileView && index % 2
+            ? '#E9F2F1' // SWC-6984: intentional break out of color palette
+            : undefined
+        return (
+          <Box
+            key={row.rowId}
+            sx={{
+              py: { xs: '30px', sm: '120px' },
+              backgroundColor: { backgroundColor },
+            }}
+          >
+            <SynapseInActionItem
               tableId={tableId}
-              fileHandleId={imageFileHandleIdInView}
-              fadeInTimeoutMs={600}
-              style={{
-                marginTop: '-100px',
-              }}
+              friendlyName={friendlyName}
+              title={title}
+              description={description}
+              logoFileHandleId={logoFileHandleId}
+              tags={tags}
+              link={link}
+              primaryColor={primaryColor}
+              secondaryColor={secondaryColor}
+              imageFileHandleId={imageFileHandleId}
+              mobileImageFileHandleId={mobileImageFileHandleId}
             />
-          )}
-        </Box>
-      )}
+          </Box>
+        )
+      })}
     </Box>
   )
 }

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseInActionItem.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseInActionItem.tsx
@@ -7,10 +7,9 @@ import {
   useMediaQuery,
   SxProps,
 } from '@mui/material'
-import React, { useEffect } from 'react'
+import React from 'react'
 import ImageFromSynapseTable from '../ImageFromSynapseTable'
 import { EastTwoTone } from '@mui/icons-material'
-import { useInView } from 'react-intersection-observer'
 import { darkTextColor, homepageBodyText } from './SynapseHomepageV2'
 
 export type SynapseInActionItemProps = {
@@ -23,7 +22,8 @@ export type SynapseInActionItemProps = {
   link: string
   primaryColor: string
   secondaryColor: string
-  onInView: () => void
+  imageFileHandleId: string
+  mobileImageFileHandleId: string
 }
 
 const mobileViewSxProps: SxProps = {
@@ -43,74 +43,110 @@ export const SynapseInActionItem: React.FunctionComponent<
   tags,
   logoFileHandleId,
   link,
-  onInView,
+  imageFileHandleId,
+  mobileImageFileHandleId,
 }) => {
-  const { ref, inView } = useInView({ threshold: 0.7 }) //do not report this is in view until the description is almost entirely shown (70%)
-  useEffect(() => {
-    if (inView) {
-      onInView()
-    }
-  }, [inView])
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
   return (
     <Box
       sx={{
         p: '15px',
+        display: 'grid',
+        gridTemplateColumns: {
+          xs: 'auto 0px',
+          md: '450px auto',
+        },
       }}
     >
-      <Box sx={isMobileView ? mobileViewSxProps : undefined}>
-        <Box>
-          {tags &&
-            tags.map(tag => {
-              return (
-                <Chip
-                  key={tag}
-                  sx={{
-                    mr: '5px',
-                    color: 'secondary.600',
-                    backgroundColor: 'secondary.100',
-                  }}
-                  label={tag}
-                />
-              )
-            })}
+      <Box
+        sx={{
+          ml: {
+            xs: '5px',
+            md: '20px',
+          },
+        }}
+      >
+        {/* mobile image */}
+        <Box
+          sx={{
+            display: { xs: 'flex', md: 'none' },
+            justifyContent: 'center',
+            width: '100%',
+            mb: '10px',
+            img: { width: '320px' },
+          }}
+        >
+          <ImageFromSynapseTable
+            tableId={tableId}
+            fileHandleId={mobileImageFileHandleId}
+          />
         </Box>
-        <Typography
-          variant="body1"
-          sx={{
-            fontWeight: 400,
-            fontSize: '36px',
-            lineHeight: '46px',
-            mt: '32px',
-            color: darkTextColor,
-          }}
-        >
-          {title}
-        </Typography>
-        <Typography
-          variant="body1"
-          sx={{
-            ...homepageBodyText,
-            mt: '32px',
-            mb: '32px',
-          }}
-          ref={ref}
-        >
-          {description}
-        </Typography>
+        <Box sx={isMobileView ? mobileViewSxProps : undefined}>
+          <Box>
+            {tags &&
+              tags.map(tag => {
+                return (
+                  <Chip
+                    key={tag}
+                    sx={{
+                      mr: '5px',
+                      color: 'secondary.600',
+                      backgroundColor: 'secondary.100',
+                    }}
+                    label={tag}
+                  />
+                )
+              })}
+          </Box>
+          <Typography
+            variant="body1"
+            sx={{
+              fontWeight: 400,
+              fontSize: '36px',
+              lineHeight: '46px',
+              mt: '32px',
+              color: darkTextColor,
+            }}
+          >
+            {title}
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{
+              ...homepageBodyText,
+              mt: '32px',
+              mb: '32px',
+            }}
+          >
+            {description}
+          </Typography>
+          <ImageFromSynapseTable
+            tableId={tableId}
+            fileHandleId={logoFileHandleId}
+            alt={`${friendlyName} logo`}
+            style={{ height: '40px' }}
+          />
+          <Box sx={{ mt: '32px' }}>
+            <Link href={link} target="_blank">
+              View {friendlyName.endsWith('Portal') ? 'the' : ''} {friendlyName}{' '}
+              <EastTwoTone sx={{ mb: '-8px', ml: '6px' }} />
+            </Link>
+          </Box>
+        </Box>
+      </Box>
+      {/* desktop image */}
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'block' },
+          justifySelf: 'end',
+          mt: '-100px',
+        }}
+      >
         <ImageFromSynapseTable
           tableId={tableId}
-          fileHandleId={logoFileHandleId}
-          alt={`${friendlyName} logo`}
-          style={{ height: '40px' }}
+          fileHandleId={imageFileHandleId}
         />
-        <Box sx={{ mt: '32px' }}>
-          <Link href={link} target="_blank">
-            View {friendlyName.endsWith('Portal') ? 'the' : ''} {friendlyName}{' '}
-            <EastTwoTone sx={{ mb: '-8px', ml: '6px' }} />
-          </Link>
-        </Box>
       </Box>
     </Box>
   )

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseInActionItem.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseInActionItem.tsx
@@ -7,10 +7,11 @@ import {
   useMediaQuery,
   SxProps,
 } from '@mui/material'
-import React, { useEffect, useRef, useState } from 'react'
+import React from 'react'
 import ImageFromSynapseTable from '../ImageFromSynapseTable'
 import { EastTwoTone } from '@mui/icons-material'
 import { darkTextColor, homepageBodyText } from './SynapseHomepageV2'
+import { useScrollFadeTransition } from 'src/utils/hooks/useScrollFadeTransition'
 
 export type SynapseInActionItemProps = {
   tableId: string
@@ -34,26 +35,6 @@ const mobileViewSxProps: SxProps = {
   textAlign: 'center',
 }
 
-const calculateOpacity = (rect: DOMRect): number => {
-  const viewportHeight = window.innerHeight
-  const elementCenterY = rect.top + rect.height / 2
-  const middleRangeStart = viewportHeight * 0.3
-  const middleRangeEnd = viewportHeight * 0.7
-
-  if (elementCenterY >= middleRangeStart && elementCenterY <= middleRangeEnd) {
-    // center of element is within the viewport bounds that I want to show full opacity
-    return 1
-  } else {
-    //otherwise, subtract the % (of the center of the element to one of the boundaries)
-    const distanceToMiddle = Math.min(
-      Math.abs(elementCenterY - middleRangeStart),
-      Math.abs(elementCenterY - middleRangeEnd),
-    )
-    const maxDistance = viewportHeight / 4
-    return Math.max(0, 1 - distanceToMiddle / maxDistance)
-  }
-}
-
 export const SynapseInActionItem: React.FunctionComponent<
   SynapseInActionItemProps
 > = ({
@@ -70,23 +51,8 @@ export const SynapseInActionItem: React.FunctionComponent<
   const theme = useTheme()
   const isMobileView = useMediaQuery(theme.breakpoints.down('sm'))
 
-  const ref = useRef(null)
   // opacity of the desktop image
-  const [opacity, setOpacity] = useState(1)
-
-  // listen to the scroll event, and calculate the opacity based on where the ref element is in the current viewport
-  useEffect(() => {
-    const handleScroll = () => {
-      const rect = (ref.current as any).getBoundingClientRect()
-      setOpacity(calculateOpacity(rect))
-    }
-
-    if (ref) {
-      window.addEventListener('scroll', handleScroll)
-      handleScroll()
-    }
-    return () => window.removeEventListener('scroll', handleScroll)
-  }, [ref])
+  const { ref, opacity } = useScrollFadeTransition()
 
   return (
     <Box

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseInActionItem.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseInActionItem.tsx
@@ -11,7 +11,7 @@ import React from 'react'
 import ImageFromSynapseTable from '../ImageFromSynapseTable'
 import { EastTwoTone } from '@mui/icons-material'
 import { darkTextColor, homepageBodyText } from './SynapseHomepageV2'
-import { useScrollFadeTransition } from 'src/utils/hooks/useScrollFadeTransition'
+import { useScrollFadeTransition } from '../../utils/hooks/useScrollFadeTransition'
 
 export type SynapseInActionItemProps = {
   tableId: string

--- a/packages/synapse-react-client/src/utils/hooks/useScrollFadeTransition.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useScrollFadeTransition.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect, useRef } from 'react'
+
+const calculateOpacity = (rect: DOMRect): number => {
+  const viewportHeight = window.innerHeight
+  const elementCenterY = rect.top + rect.height / 2
+  const middleRangeStart = viewportHeight * 0.3
+  const middleRangeEnd = viewportHeight * 0.7
+
+  if (elementCenterY >= middleRangeStart && elementCenterY <= middleRangeEnd) {
+    // center of element is within the viewport bounds that I want to show full opacity
+    return 1
+  } else {
+    //otherwise, subtract the % (of the center of the element to one of the boundaries)
+    const distanceToMiddle = Math.min(
+      Math.abs(elementCenterY - middleRangeStart),
+      Math.abs(elementCenterY - middleRangeEnd),
+    )
+    const maxDistance = viewportHeight / 4
+    return Math.max(0, 1 - distanceToMiddle / maxDistance)
+  }
+}
+/**
+ * Use this hook if you want to change the opacity of an element dynamically based on where an element is in the current viewport.
+ * Opacity will be 1 when the element is in the middle of the viewport, and 0 when it is outside of the viewport.
+ * @returns
+ */
+export function useScrollFadeTransition() {
+  const ref = useRef(null)
+  // opacity of the desktop image
+  const [opacity, setOpacity] = useState(1)
+
+  // listen to the scroll event, and calculate the opacity based on
+  useEffect(() => {
+    const handleScroll = () => {
+      const rect = (ref.current as any).getBoundingClientRect()
+      setOpacity(calculateOpacity(rect))
+    }
+
+    if (ref) {
+      window.addEventListener('scroll', handleScroll)
+      handleScroll()
+    }
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [ref])
+  return { ref, opacity }
+}


### PR DESCRIPTION
Move the SynapseInAction images into the SynapseInActionItem, and change the layout (to a flex grid).  
And instead of fading in when the element is in view, set the desktop image opacity based on the element position in the viewport! 