### PR TITLE
SWC-6985 - Fix bug where Safari users + 2FA cannot log in / reset 2FA

### DIFF
--- a/packages/synapse-react-client/src/utils/hooks/useLogin.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useLogin.ts
@@ -101,7 +101,6 @@ export default function useLogin(opts: UseLoginOptions): UseLoginReturn {
     if (searchParams) {
       const userId = searchParams.get('userId')
       const twoFaToken = searchParams.get('twoFaToken')
-      console.log('twoFaToken search param:', twoFaToken)
       if (userId && twoFaToken) {
         setTwoFaErrorResponse({
           errorCode: ErrorResponseCode.TWO_FA_REQUIRED,

--- a/packages/synapse-react-client/src/utils/hooks/useLogin.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useLogin.ts
@@ -95,13 +95,13 @@ export default function useLogin(opts: UseLoginOptions): UseLoginReturn {
    * This effect will check if the search params are present, and change the step to 'VERIFICATION_CODE' if they are.
    */
   useEffect(() => {
-    // Replace the hash with a slash to handle SWC, which uses a hash in the URL. Otherwise, the searchParams aren't found
-    const fullUrl: URL = new URL(window.location.href.replaceAll('#', '/'))
+    const fullUrl: URL = new URL(window.location.href)
 
     const { searchParams } = fullUrl
     if (searchParams) {
       const userId = searchParams.get('userId')
       const twoFaToken = searchParams.get('twoFaToken')
+      console.log('twoFaToken search param:', twoFaToken)
       if (userId && twoFaToken) {
         setTwoFaErrorResponse({
           errorCode: ErrorResponseCode.TWO_FA_REQUIRED,


### PR DESCRIPTION
 Fix case where trailing hash was transformed and then added to the twoFaToken