### PR TITLE
CPO-fix: configure `doi` column as a link

### DIFF
--- a/apps/portals/cancercomplexity/src/config/synapseConfigs/publications.ts
+++ b/apps/portals/cancercomplexity/src/config/synapseConfigs/publications.ts
@@ -41,6 +41,10 @@ export const publicationsCardConfiguration: CardConfiguration = {
       matchColumnName: 'pubMedLink',
     },
     {
+      isMarkdown: true,
+      matchColumnName: 'doi',
+    },
+    {
       isMarkdown: false,
       baseURL: 'Explore/Grants/DetailsPage',
       matchColumnName: 'grantName',


### PR DESCRIPTION
## Changelog
* configure the `doi` column to render as a link on the portal (otherwise, "https" is seen)

## Preview

**Before**
![Screenshot 2024-07-23 at 2 49 00 PM](https://github.com/user-attachments/assets/7893a3bc-5dbd-4dd2-aa16-4477186e7696)

**After**
![Screenshot 2024-07-23 at 2 49 18 PM](https://github.com/user-attachments/assets/81f9785c-7ca3-4a84-9806-cd9cc689a798)
