### PR TITLE
PORTALS-2970 - allow resetting debounce timer without recreating query

### DIFF
--- a/packages/synapse-react-client/src/components/QueryContext/QueryContext.tsx
+++ b/packages/synapse-react-client/src/components/QueryContext/QueryContext.tsx
@@ -35,6 +35,7 @@ export type QueryContextType<
   executeQueryRequest: ImmutableTableQueryResult['setQuery']
   /** Resets the query to its initial state, clearing all filters added by the user */
   resetQuery: ImmutableTableQueryResult['resetQuery']
+  resetDebounceTimer: ImmutableTableQueryResult['resetDebounceTimer']
   addValueToSelectedFacet: ImmutableTableQueryResult['addValueToSelectedFacet']
   setRangeFacetValue: ImmutableTableQueryResult['setRangeFacetValue']
   removeSelectedFacet: ImmutableTableQueryResult['removeSelectedFacet']

--- a/packages/synapse-react-client/src/components/QueryWrapper/QueryWrapper.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapper/QueryWrapper.tsx
@@ -137,6 +137,7 @@ function _QueryWrapper(props: QueryWrapperProps) {
     currentQueryRequest,
     addValueToSelectedFacet,
     setRangeFacetValue,
+    resetDebounceTimer,
   } = immutableTableQueryResult
 
   const lastQueryRequest = useMemo(() => {
@@ -270,6 +271,7 @@ function _QueryWrapper(props: QueryWrapperProps) {
       addValueToSelectedFacet,
       combineRangeFacetConfig,
       setRangeFacetValue,
+      resetDebounceTimer,
       ...paginationControls,
     })
 

--- a/packages/synapse-react-client/src/components/QueryWrapper/useQueryWrapperPaginationControls.test.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapper/useQueryWrapperPaginationControls.test.tsx
@@ -32,6 +32,7 @@ describe('useQueryWrapperPaginationControls tests', () => {
     resetQuery: jest.fn(),
     setPageSize: jest.fn(),
     setQuery: jest.fn(),
+    resetDebounceTimer: jest.fn(),
   }
 
   beforeEach(() => {

--- a/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter/EnumFacetFilter.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter/EnumFacetFilter.tsx
@@ -44,6 +44,7 @@ export function EnumFacetFilter(props: EnumFacetFilterProps) {
     removeSelectedFacet,
     removeValueFromSelectedFacet,
     executeQueryRequest,
+    resetDebounceTimer,
   } = useQueryContext()
 
   const data = useAtomValue(tableQueryDataAtom)
@@ -162,12 +163,7 @@ export function EnumFacetFilter(props: EnumFacetFilterProps) {
       hideCollapsible={hideCollapsible}
       onHoverOverValue={() => {
         // SWC-6698: delay the query execution (via the debounce) when an item is hovered over
-        executeQueryRequest(
-          request => {
-            return cloneDeep(request)
-          },
-          { debounce: true },
-        )
+        resetDebounceTimer()
       }}
       onAddValueToSelection={value => {
         addValueToSelectedFacet(

--- a/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter/EnumFacetFilter.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter/EnumFacetFilter.tsx
@@ -43,7 +43,6 @@ export function EnumFacetFilter(props: EnumFacetFilterProps) {
     addValueToSelectedFacet,
     removeSelectedFacet,
     removeValueFromSelectedFacet,
-    executeQueryRequest,
     resetDebounceTimer,
   } = useQueryContext()
 

--- a/packages/synapse-react-client/src/utils/hooks/useImmutableTableQuery/useImmutableTableQuery.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useImmutableTableQuery/useImmutableTableQuery.ts
@@ -25,6 +25,8 @@ export type ImmutableTableQueryResult = {
   currentQueryRequest: ReadonlyDeep<QueryBundleRequest>
   /** The next (uncommitted) query request. This will become the current query request when commitChanges is called, or the configured debounced timer elapses. */
   nextQueryRequest: ReadonlyDeep<QueryBundleRequest>
+  /** Resets the debounce timer to delay committing changes in `nextQueryRequest` */
+  resetDebounceTimer: () => void
   /** Update the currentQueryRequest to be the nextQueryRequest */
   commitChanges: () => void
   getInitQueryRequest: () => QueryBundleRequest
@@ -345,9 +347,14 @@ export default function useImmutableTableQuery(
     dispatch({ type: 'commitChanges' })
   }, [dispatch])
 
+  const resetDebounceTimer = useCallback(() => {
+    dispatch({ type: 'resetDebounce' })
+  }, [dispatch])
+
   return {
     entityId,
     commitChanges,
+    resetDebounceTimer,
     currentQueryRequest,
     nextQueryRequest,
     versionNumber,


### PR DESCRIPTION
Tracking component rerenders demo:

Before:


https://github.com/user-attachments/assets/e48d0458-bb1f-44e7-ad91-c3a90a68fe73



After:


https://github.com/user-attachments/assets/7a0699b0-644d-47ff-8b13-84100723167d

