### PR TITLE
PORTALS-3199: external recommendation to fix sitemap.xml to fix SEO

### DIFF
--- a/apps/synapse-portal-framework/sitemap/generate-sitemap.cjs
+++ b/apps/synapse-portal-framework/sitemap/generate-sitemap.cjs
@@ -53,7 +53,6 @@ fs.readFile(`src/config/${fileName}`, (err, data) => {
       previousNestingSpaceCount = spaceCount
       currentNestedPath[spaceCount] = newPath
       const currentPath = currentNestedPath.filter(value => value !== undefined).join('/')
-      console.log(`newPath: '${newPath}'`)
       if (!newPath.match('^[:]slug.*')) {
         fileContent += `\t<url>\n\t\t<loc>${baseUrl}/${currentPath}</loc>\n\t\t<lastmod>${now}</lastmod>\n\t</url>\n`
       }

--- a/apps/synapse-portal-framework/sitemap/generate-sitemap.cjs
+++ b/apps/synapse-portal-framework/sitemap/generate-sitemap.cjs
@@ -23,19 +23,40 @@ fs.readFile(`src/config/${fileName}`, (err, data) => {
     )
   }
 
-  const baseUrl = `https://${args[0]}.synapse.org`
+  // strip surrounding double quotes (if exist)
+  const portalName = args[0].replace(/^"|"$/g, '')
+  const baseUrl = `https://${portalName}.synapse.org`
   const now = new Date().toISOString()
   let fileContent =
     '<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
-  var regex = /path[:]\s*\'(.*)\'/g
+  var regex = /^(\s*)path:\s*'(.*)'/gm
   var m
-
+  // Discover the paths by relying on the linter to set up the spaces correctly, then we find all of the "path" entries in the routesConfig file
+  var currentNestedPath = new Array(100)
+  var previousNestingSpaceCount = -1
   do {
     m = regex.exec(routesConfigContent)
+    // m[1] contains the leading spaces
+    // m[2] contains the target path
     if (m) {
-      // assuming hash router
-      let path = `${m[1]}`
-      fileContent += `\t<url>\n\t\t<loc>${baseUrl}/${path}</loc>\n\t\t<lastmod>${now}</lastmod>\n\t</url>\n`
+      const spaceCount = m[1].length
+      let newPath = `${m[2]}`.replaceAll(' ', '%20')
+      if (spaceCount <= previousNestingSpaceCount) {
+        //reset from space count
+        currentNestedPath.forEach((_value, index) => {
+          if (index >= spaceCount) {
+            currentNestedPath[index] = undefined;
+          }
+      })
+        currentNestingSpaceCount = 0
+      }
+      previousNestingSpaceCount = spaceCount
+      currentNestedPath[spaceCount] = newPath
+      const currentPath = currentNestedPath.filter(value => value !== undefined).join('/')
+      console.log(`newPath: '${newPath}'`)
+      if (!newPath.match('^[:]slug.*')) {
+        fileContent += `\t<url>\n\t\t<loc>${baseUrl}/${currentPath}</loc>\n\t\t<lastmod>${now}</lastmod>\n\t</url>\n`
+      }
     }
   } while (m)
   fileContent += '</urlset>'


### PR DESCRIPTION
sitemap.xml is currently broken.  Here's an example entry from the NF sitemap.xml, which is an invalid route and invalid URL:
```
<url>
<loc>https://"nf".synapse.org/DetailsPage?abbreviation=GFF</loc>
<lastmod>2024-07-03T16:12:31.279Z</lastmod>
</url>
```