### PR TITLE
PORTALS-3206: hypothesis that hasInitializedSession is not set to true in failure c…

### DIFF
--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -2008,7 +2008,12 @@ export async function deleteAllSessionAccessTokens(accessToken: string) {
 }
 
 export const signOut = async () => {
-  const accessToken = await getAccessTokenFromCookie()
+  let accessToken = undefined
+  try {
+    accessToken = await getAccessTokenFromCookie()
+  } catch (e) {
+    console.warn('Could not get the access token from the cookie', e)
+  }
   if (accessToken) {
     try {
       // This call may fail if the token was already revoked, so just log any encountered errors


### PR DESCRIPTION
…ase, perhaps because initAnonymousUserState() call to signOut() causes an error since it is unable to get the current access token from the cookie. 