### PR TITLE
Use ubuntu-latest for test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ jobs:
       - run: pnpm nx affected --target=build --base=remotes/origin/main
   test:
     runs-on:
-      labels: ubuntu-22.04-4core-16GBRAM-150GBSSD
+      labels: ubuntu-latest
     # Job should not last longer than 60 minutes--and the larger runner is billed per-minute ;)
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Back in February, GitHub increased the `ubuntu-latest` runner from 2 cores to 4 cores. The only difference between the public runner and the current one is the SSD volume size, which we don't need.