### PR TITLE
Refactor vite-configs to simplify sharing code, expose a config builder

### DIFF
--- a/apps/SageAccountWeb/vite.config.ts
+++ b/apps/SageAccountWeb/vite.config.ts
@@ -1,10 +1,15 @@
-import { vitestConfig } from 'vite-config'
-import { mergeConfig } from 'vitest/config'
+import { ConfigBuilder } from 'vite-config'
 
-export default mergeConfig(vitestConfig, {
-  test: {
-    include: ['src/**/*.test.[jt]s?(x)'],
-    setupFiles: ['src/tests/setupTests.ts'],
-    environment: 'jsdom', // introduced due to random "ReferenceError: window is not defined" during tests
-  },
-})
+const config = new ConfigBuilder()
+  .setIncludeReactConfig(true)
+  .setIncludeVitestConfig(true)
+  .setConfigOverrides({
+    test: {
+      include: ['src/**/*.test.[jt]s?(x)'],
+      setupFiles: ['src/tests/setupTests.ts'],
+      environment: 'jsdom', // introduced due to random "ReferenceError: window is not defined" during tests
+    },
+  })
+  .build()
+
+export default config

--- a/apps/synapse-oauth-signin/vite.config.ts
+++ b/apps/synapse-oauth-signin/vite.config.ts
@@ -1,10 +1,15 @@
-import { vitestConfig } from 'vite-config'
-import { mergeConfig } from 'vitest/config'
+import { ConfigBuilder } from 'vite-config'
 
-export default mergeConfig(vitestConfig, {
-  test: {
-    include: ['src/test/**/*.test.[jt]s?(x)'],
-    setupFiles: ['src/test/setupTests.ts'],
-    environment: 'jsdom', // introduced due to random "ReferenceError: window is not defined" during tests
-  },
-})
+const config = new ConfigBuilder()
+  .setIncludeReactConfig(true)
+  .setIncludeVitestConfig(true)
+  .setConfigOverrides({
+    test: {
+      include: ['src/test/**/*.test.[jt]s?(x)'],
+      setupFiles: ['src/test/setupTests.ts'],
+      environment: 'jsdom', // introduced due to random "ReferenceError: window is not defined" during tests
+    },
+  })
+  .build()
+
+export default config

--- a/apps/synapse-portal-framework/vite.config.ts
+++ b/apps/synapse-portal-framework/vite.config.ts
@@ -1,32 +1,18 @@
-import { vitestConfig } from 'vite-config'
-import { mergeConfig } from 'vitest/config'
+import { ConfigBuilder } from 'vite-config'
 import { resolve } from 'path'
-export default mergeConfig(vitestConfig, {
-  build: {
-    outDir: 'dist',
-    lib: {
-      // Could also be a dictionary or array of multiple entry points
-      entry: resolve(__dirname, 'src/index.ts'),
-      name: 'SynapsePortalFramework',
-      // the proper extensions will be added
-      fileName: 'synapse-portal-framework',
+
+const config = new ConfigBuilder()
+  .setIncludeReactConfig(true)
+  .setIncludeLibraryConfig(true)
+  .setBuildLibEntry(resolve(__dirname, 'src/index.ts'))
+  .setIncludeVitestConfig(true)
+  .setConfigOverrides({
+    test: {
+      include: ['src/**/*.test.[jt]s?(x)'],
+      setupFiles: ['src/tests/setupTests.ts'],
+      environment: 'jsdom',
     },
-    rollupOptions: {
-      // make sure to externalize deps that shouldn't be bundled
-      // into your library
-      external: ['react'],
-      output: {
-        // Provide global variables to use in the UMD build
-        // for externalized deps
-        globals: {
-          react: 'React',
-        },
-      },
-    },
-  },
-  test: {
-    include: ['src/**/*.test.[jt]s?(x)'],
-    setupFiles: ['src/tests/setupTests.ts'],
-    environment: 'jsdom',
-  },
-})
+  })
+  .build()
+
+export default config

--- a/packages/markdown-it-synapse-table/vite.config.ts
+++ b/packages/markdown-it-synapse-table/vite.config.ts
@@ -1,31 +1,20 @@
-import { vitestConfig } from 'vite-config'
-import { mergeConfig } from 'vitest/config'
 import { resolve } from 'path'
-import { externalizeDeps } from 'vite-plugin-externalize-deps'
-import dts from 'vite-plugin-dts'
+import { ConfigBuilder } from 'vite-config'
 
-export default mergeConfig(vitestConfig, {
-  build: {
-    sourcemap: true,
-    emptyOutDir: true,
-    outDir: './dist',
-    lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
-      name: 'markdownitSynapseTable',
-      fileName: 'index',
-      formats: ['es', 'cjs', 'umd'],
+export default new ConfigBuilder()
+  .setIncludeLibraryConfig(true)
+  .setBuildLibEntry(resolve(__dirname, 'src/index.ts'))
+  .setIncludeVitestConfig(true)
+  .setConfigOverrides({
+    build: {
+      lib: {
+        name: 'markdownitSynapseTable',
+        formats: ['es', 'cjs', 'umd'],
+      },
     },
-  },
-  test: {
-    globals: true,
-    include: ['test/**/*.test.[jt]s?(x)'],
-  },
-  plugins: [
-    // Do not bundle any dependencies; the consumer's bundler will resolve and link them.
-    externalizeDeps(),
-    // Generate a single type definition file for distribution.
-    dts({
-      rollupTypes: true,
-    }),
-  ],
-})
+    test: {
+      globals: true,
+      include: ['test/**/*.test.[jt]s?(x)'],
+    },
+  })
+  .build()

--- a/packages/synapse-react-client/vite.config.ts
+++ b/packages/synapse-react-client/vite.config.ts
@@ -1,31 +1,20 @@
 import { resolve } from 'path'
-import { mergeConfig } from 'vite'
-import viteConfig from 'vite-config'
-import { externalizeDeps } from 'vite-plugin-externalize-deps'
-import dts from 'vite-plugin-dts'
+import { ConfigBuilder } from 'vite-config'
 
 /**
  * Vite config to generate the ESM & CJS bundles for Synapse React Client.
  */
-export default mergeConfig(viteConfig, {
-  root: '.',
-  build: {
-    sourcemap: true,
-    emptyOutDir: false,
-    outDir: './dist',
-    lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
-      name: 'SRC',
-      fileName: 'index',
-      formats: ['es', 'cjs'],
+const config = new ConfigBuilder()
+  .setIncludeReactConfig(true)
+  .setIncludeLibraryConfig(true)
+  .setBuildLibEntry(resolve(__dirname, 'src/index.ts'))
+  .setConfigOverrides({
+    root: '.',
+    build: {
+      // Do not clean the output directory before building, since we build ESM/CJS and UMD separately.
+      emptyOutDir: false,
     },
-  },
-  plugins: [
-    // Do not bundle any dependencies; the consumer's bundler will resolve and link them.
-    externalizeDeps(),
-    // Generate a single type definition file for distribution.
-    dts({
-      rollupTypes: true,
-    }),
-  ],
-})
+  })
+  .build()
+
+export default config

--- a/packages/synapse-react-client/vite.config.umd.ts
+++ b/packages/synapse-react-client/vite.config.umd.ts
@@ -1,6 +1,5 @@
 import { resolve } from 'path'
-import { mergeConfig } from 'vite'
-import viteConfig from 'vite-config'
+import { ConfigBuilder } from 'vite-config'
 import { version } from './package.json'
 
 // The set of dependencies that will NOT be included in our UMD bundle. The dependency will be loaded from the global object matching the dependency key's value in this object.
@@ -35,32 +34,36 @@ const globalExternals = {
  * A Vite configuration to create a UMD bundle for Synapse React Client. This bundle is primarily used to include Synapse
  * React Client code in the Synapse Web Client, which does not use a JavaScript bundler that could bundle the ES module.
  */
-const config = mergeConfig(viteConfig, {
-  root: '.',
-  build: {
-    sourcemap: true,
-    emptyOutDir: false,
-    outDir: './dist/umd',
-    minify: true,
-    lib: {
-      entry: resolve(__dirname, 'src/umd.index.ts'),
-      name: 'SRC',
-      fileName: () => 'synapse-react-client.production.min.js',
-      formats: ['umd'],
-    },
-    rollupOptions: {
-      external: Object.keys(globalExternals),
-      output: {
-        globals: globalExternals,
-        banner: `/*! SRC v${version} */`,
-        assetFileNames: assetInfo => {
-          if (assetInfo.name === 'style.css')
-            return 'synapse-react-client.production.min.css'
-          return assetInfo.name
+const config = new ConfigBuilder()
+  .setIncludeReactConfig(true)
+  // For our UMD bundle, we don't want to generate types or externalize all dependencies, so don't include the default library config.
+  .setConfigOverrides({
+    root: '.',
+    build: {
+      sourcemap: true,
+      emptyOutDir: false,
+      outDir: './dist/umd',
+      minify: true,
+      lib: {
+        entry: resolve(__dirname, 'src/umd.index.ts'),
+        name: 'SRC',
+        fileName: () => 'synapse-react-client.production.min.js',
+        formats: ['umd'],
+      },
+      rollupOptions: {
+        external: Object.keys(globalExternals),
+        output: {
+          globals: globalExternals,
+          banner: `/*! SRC v${version} */`,
+          assetFileNames: (assetInfo: { name: string }) => {
+            if (assetInfo.name === 'style.css')
+              return 'synapse-react-client.production.min.css'
+            return assetInfo.name
+          },
         },
       },
     },
-  },
-})
+  })
+  .build()
 
 export default config

--- a/packages/synapse-types/package.json
+++ b/packages/synapse-types/package.json
@@ -26,6 +26,7 @@
     "prepublishOnly": "pnpm install && pnpm nx run @sage-bionetworks/synapse-types:build"
   },
   "devDependencies": {
+    "@types/node": "^20.14.10",
     "rimraf": "^5.0.5",
     "tsup": "^8.0.2",
     "typescript": "5.5.2"

--- a/packages/vite-config/package.json
+++ b/packages/vite-config/package.json
@@ -41,6 +41,8 @@
     "svgo": "^3.2.0",
     "typescript": "5.5.2",
     "vite": "^5.4.3",
+    "vite-plugin-dts": "^4.2.1",
+    "vite-plugin-externalize-deps": "^0.8.0",
     "vite-plugin-html": "^3.2.2",
     "vite-plugin-node-polyfills": "0.17.0",
     "vite-plugin-svgr": "^4.2.0",

--- a/packages/vite-config/src/ConfigBuilder.ts
+++ b/packages/vite-config/src/ConfigBuilder.ts
@@ -1,0 +1,77 @@
+import { getPluginConfig, PluginConfigOptions } from './pluginConfig.js'
+import viteConfig from './vite-config.js'
+import { mergeConfig } from 'vitest/config'
+import viteLibraryConfig from './vite-library-config.js'
+import vitestConfig from './vitest-config.js'
+
+export class ConfigBuilder {
+  private includeReactConfig = false
+  private includeLibraryConfig = false
+  private buildLibEntry: string | string[] | undefined = undefined
+  private includeVitestConfig = false
+  private pluginConfigOptions: PluginConfigOptions = {}
+  private configOverrides: Record<string, any> | null = null
+
+  setIncludeReactConfig(includeReactConfig: boolean): ConfigBuilder {
+    this.includeReactConfig = includeReactConfig
+    return this
+  }
+
+  setIncludeVitestConfig(includeVitestConfig: boolean): ConfigBuilder {
+    this.includeVitestConfig = includeVitestConfig
+    return this
+  }
+
+  setBuildLibEntry(buildLibEntry: string | string[]): ConfigBuilder {
+    this.buildLibEntry = buildLibEntry
+    return this
+  }
+
+  setIncludeLibraryConfig(includeLibraryConfig: boolean): ConfigBuilder {
+    this.includeLibraryConfig = includeLibraryConfig
+    return this
+  }
+
+  setPluginConfigOptions(
+    pluginConfigOptions: PluginConfigOptions,
+  ): ConfigBuilder {
+    this.pluginConfigOptions = pluginConfigOptions
+    return this
+  }
+
+  setConfigOverrides(configOverrides: Record<string, any>): ConfigBuilder {
+    this.configOverrides = configOverrides
+    return this
+  }
+
+  build() {
+    let config = viteConfig
+    if (this.includeLibraryConfig) {
+      if (!this.buildLibEntry) {
+        throw new Error(
+          'buildLibEntry must be provided when includeLibraryConfig is true',
+        )
+      }
+      config = mergeConfig(config, viteLibraryConfig)
+      config = mergeConfig(config, {
+        build: { lib: { entry: this.buildLibEntry } },
+      })
+    }
+    if (this.includeVitestConfig) {
+      config = mergeConfig(config, vitestConfig)
+    }
+    if (this.pluginConfigOptions) {
+      config = mergeConfig(config, {
+        plugins: getPluginConfig({
+          includeReactPlugins: this.includeReactConfig,
+          includeLibraryPlugins: this.includeLibraryConfig,
+        }),
+      })
+    }
+    if (this.configOverrides) {
+      config = mergeConfig(config, this.configOverrides)
+    }
+
+    return config
+  }
+}

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -1,7 +1,15 @@
 import viteConfig from './vite-config.js'
 import vitestConfig from './vitest-config.js'
 import portalsViteConfig from './portals-vite-config.js'
+import viteLibraryConfig from './vite-library-config.js'
+import { ConfigBuilder } from './ConfigBuilder.js'
 
-export { viteConfig, vitestConfig, portalsViteConfig }
+export {
+  viteConfig,
+  vitestConfig,
+  portalsViteConfig,
+  viteLibraryConfig,
+  ConfigBuilder,
+}
 
 export default viteConfig

--- a/packages/vite-config/src/pluginConfig.ts
+++ b/packages/vite-config/src/pluginConfig.ts
@@ -1,0 +1,59 @@
+import { PluginOption } from 'vite'
+import react from '@vitejs/plugin-react'
+import svgr from 'vite-plugin-svgr'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
+import { externalizeDeps } from 'vite-plugin-externalize-deps'
+import dts from 'vite-plugin-dts'
+
+export type PluginConfigOptions = {
+  includeReactPlugins?: boolean
+  includeLibraryPlugins?: boolean
+}
+
+/**
+ * Plugins that all of our Vite configurations will use
+ */
+const COMMON_PLUGINS: PluginOption[] = [nodePolyfills()]
+
+/**
+ * Plugins that our React apps and libraries will use
+ */
+const REACT_PLUGINS: PluginOption[] = [
+  react(),
+  svgr({
+    svgrOptions: {
+      plugins: ['@svgr/plugin-jsx'],
+      ref: true,
+      exportType: 'named',
+    },
+    // Explicitly exclude SVG imports that end in a query (such as ?url) - Vite can already handle these
+    include: /^.*\.svg$/,
+  }),
+]
+
+/**
+ * Plugins that libraries that should emit ESM and CJS bundles will use
+ */
+const LIBRARY_PLUGINS: PluginOption[] = [
+  // Do not bundle any dependencies; the consumer's bundler will resolve and link them.
+  externalizeDeps(),
+  // Generate a single type definition file for distribution.
+  dts({
+    rollupTypes: true,
+  }),
+]
+
+/**
+ * Get a shared configuration of Vite plugins to use based on the provided options. Note that Vite does not deeply merge
+ * plugin configurations (see https://github.com/vitejs/vite/issues/16479)
+ */
+export function getPluginConfig(options: PluginConfigOptions): PluginOption[] {
+  const plugins: PluginOption[] = [...COMMON_PLUGINS]
+  if (options.includeReactPlugins) {
+    plugins.push(...REACT_PLUGINS)
+  }
+  if (options.includeLibraryPlugins) {
+    plugins.push(...LIBRARY_PLUGINS)
+  }
+  return plugins
+}

--- a/packages/vite-config/src/portals-vite-config.ts
+++ b/packages/vite-config/src/portals-vite-config.ts
@@ -1,13 +1,15 @@
-import vitestConfig from './vitest-config.js'
-import { mergeConfig } from 'vitest/config'
 import { createHtmlPlugin } from 'vite-plugin-html'
+import { ConfigBuilder } from './ConfigBuilder.js'
 
-export default mergeConfig(vitestConfig, {
-  plugins: [
-    createHtmlPlugin({
-      inject: {
-        data: {
-          headContent: `<meta charset="utf-8" />
+const portalsSharedViteConfig = new ConfigBuilder()
+  .setIncludeReactConfig(true)
+  .setIncludeVitestConfig(true)
+  .setConfigOverrides({
+    plugins: [
+      createHtmlPlugin({
+        inject: {
+          data: {
+            headContent: `<meta charset="utf-8" />
     <link rel="shortcut icon" href="/favicon.svg" />
 
 
@@ -71,13 +73,16 @@ export default mergeConfig(vitestConfig, {
 
         globalThis.global = globalThis
     </script>`,
-          gtmNoscript: `    <!-- Google Tag Manager (noscript) -->
+            gtmNoscript: `    <!-- Google Tag Manager (noscript) -->
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KPW4KS62"
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 `,
+          },
         },
-      },
-    }),
-  ],
-})
+      }),
+    ],
+  })
+  .build()
+
+export default portalsSharedViteConfig

--- a/packages/vite-config/src/vite-library-config.ts
+++ b/packages/vite-config/src/vite-library-config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite'
+
+/**
+ * Vite configuration snippet for generating an esm/cjs library bundle.
+ */
+const viteLibraryConfig = defineConfig({
+  build: {
+    sourcemap: true,
+    emptyOutDir: true,
+    outDir: './dist',
+    lib: {
+      // Note: entry MUST be overridden by an overridden config.
+      entry: '',
+      fileName: 'index',
+      formats: ['es', 'cjs'],
+    },
+  },
+})
+
+export default viteLibraryConfig

--- a/packages/vite-config/src/vitest-config.ts
+++ b/packages/vite-config/src/vitest-config.ts
@@ -1,7 +1,9 @@
-import { mergeConfig } from 'vitest/config'
-import { config } from './vite-config.js'
+import { defineConfig } from 'vitest/config'
 
-export default mergeConfig(config, {
+/**
+ * Partial config used to add a Vitest configuration to a Vite project.
+ */
+export default defineConfig({
   optimizeDeps: {
     exclude: ['vitest/utils'],
     include: ['@vitest/utils', 'vitest/browser'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1352,7 +1352,7 @@ importers:
         version: 2.6.3
       tsup:
         specifier: ^8.0.2
-        version: 8.0.2(@microsoft/api-extractor@7.43.0)(postcss@8.4.39)(typescript@5.5.2)
+        version: 8.0.2(@microsoft/api-extractor@7.47.7(@types/node@20.14.10))(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.2))(typescript@5.5.2)
       typescript:
         specifier: 5.5.2
         version: 5.5.2
@@ -1436,7 +1436,7 @@ importers:
         version: 6.19.6(@mui/material@5.15.13(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.15.13(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/x-date-pickers':
         specifier: ^6.19.6
-        version: 6.19.6(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@mui/material@5.15.13(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.15.13(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(dayjs@1.11.10)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 6.19.6(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@mui/material@5.15.13(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.15.13(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(date-fns@2.30.0)(dayjs@1.11.10)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@popperjs/core':
         specifier: ^2.11.8
         version: 2.11.8
@@ -1740,7 +1740,7 @@ importers:
         version: 8.2.4(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))
       '@storybook/addon-interactions':
         specifier: ^8.2.4
-        version: 8.2.4(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))
+        version: 8.2.4(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))
       '@storybook/addon-links':
         specifier: ^8.2.4
         version: 8.2.4(react@18.2.0)(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))
@@ -1758,7 +1758,7 @@ importers:
         version: 8.2.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.21.2)(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))(typescript@5.5.3)(vite@5.4.3(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2))
       '@storybook/test':
         specifier: ^8.2.4
-        version: 8.2.4(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))
+        version: 8.2.4(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))
       '@storybook/testing-library':
         specifier: ^0.2.2
         version: 0.2.2
@@ -1773,7 +1773,7 @@ importers:
         version: 10.3.0
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))
+        version: 6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.0.0(@testing-library/dom@10.3.0)(@types/react-dom@18.2.22)(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1908,7 +1908,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1917,13 +1917,13 @@ importers:
         version: 3.1.2
       jest-html-reporter:
         specifier: ^3.10.2
-        version: 3.10.2(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))(typescript@5.5.3)
+        version: 3.10.2(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))(typescript@5.5.3)
       jest-mock-promise:
         specifier: ^1.1.12
         version: 1.1.12
       jest-when:
         specifier: ^3.6.0
-        version: 3.6.0(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))
+        version: 3.6.0(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))
       jotai-devtools:
         specifier: ^0.6.3
         version: 0.6.3(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@5.0.1)
@@ -2008,12 +2008,15 @@ importers:
 
   packages/synapse-types:
     devDependencies:
+      '@types/node':
+        specifier: ^20.14.10
+        version: 20.14.10
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
       tsup:
         specifier: ^8.0.2
-        version: 8.0.2(@microsoft/api-extractor@7.43.0)(postcss@8.4.39)(typescript@5.5.2)
+        version: 8.0.2(@microsoft/api-extractor@7.47.7(@types/node@20.14.10))(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.2))(typescript@5.5.2)
       typescript:
         specifier: 5.5.2
         version: 5.5.2
@@ -2045,6 +2048,12 @@ importers:
       vite:
         specifier: ^5.4.3
         version: 5.4.3(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2)
+      vite-plugin-dts:
+        specifier: ^4.2.1
+        version: 4.2.1(@types/node@20.14.10)(rollup@4.21.2)(typescript@5.5.2)(vite@5.4.3(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2))
+      vite-plugin-externalize-deps:
+        specifier: ^0.8.0
+        version: 0.8.0(vite@5.4.3(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2))
       vite-plugin-html:
         specifier: ^3.2.2
         version: 3.2.2(vite@5.4.3(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2))
@@ -3232,6 +3241,10 @@ packages:
     resolution: {integrity: sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==}
     hasBin: true
 
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@csstools/normalize.css@12.1.1':
     resolution: {integrity: sha512-YAYeJ+Xqh7fUou1d1j9XHl44BmsuThiTr4iNrgCQ3J27IbhXsxXDGZ1cXv8Qvs99d4rBbLiSKy3+WZiet32PcQ==}
 
@@ -3775,8 +3788,14 @@ packages:
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
@@ -3866,15 +3885,28 @@ packages:
   '@microsoft/api-extractor-model@7.28.13':
     resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
 
+  '@microsoft/api-extractor-model@7.29.6':
+    resolution: {integrity: sha512-gC0KGtrZvxzf/Rt9oMYD2dHvtN/1KPEYsrQPyMKhLHnlVuO/f4AFN3E4toqZzD2pt4LhkKoYmL2H9tX3yCOyRw==}
+
   '@microsoft/api-extractor@7.43.0':
     resolution: {integrity: sha512-GFhTcJpB+MI6FhvXEI9b2K0snulNLWHqC/BbcJtyNYcKUiw7l3Lgis5ApsYncJ0leALX7/of4XfmXk+maT111w==}
+    hasBin: true
+
+  '@microsoft/api-extractor@7.47.7':
+    resolution: {integrity: sha512-fNiD3G55ZJGhPOBPMKD/enozj8yxJSYyVJWxRWdcUtw842rvthDHJgUWq9gXQTensFlMHv2wGuCjjivPv53j0A==}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.16.2':
     resolution: {integrity: sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==}
 
+  '@microsoft/tsdoc-config@0.17.0':
+    resolution: {integrity: sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==}
+
   '@microsoft/tsdoc@0.14.2':
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
+
+  '@microsoft/tsdoc@0.15.0':
+    resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
 
   '@mswjs/cookies@0.2.2':
     resolution: {integrity: sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==}
@@ -4562,8 +4594,19 @@ packages:
       '@types/node':
         optional: true
 
+  '@rushstack/node-core-library@5.7.0':
+    resolution: {integrity: sha512-Ff9Cz/YlWu9ce4dmqNBZpA45AEya04XaBFIjV7xTVeEf+y/kTjEasmozqFELXlNG4ROdevss75JrrZ5WgufDkQ==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@rushstack/rig-package@0.5.2':
     resolution: {integrity: sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==}
+
+  '@rushstack/rig-package@0.5.3':
+    resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
 
   '@rushstack/terminal@0.10.0':
     resolution: {integrity: sha512-UbELbXnUdc7EKwfH2sb8ChqNgapUOdqcCIdQP4NGxBpTZV2sQyeekuK3zmfQSa/MN+/7b4kBogl2wq0vpkpYGw==}
@@ -4573,8 +4616,19 @@ packages:
       '@types/node':
         optional: true
 
+  '@rushstack/terminal@0.14.0':
+    resolution: {integrity: sha512-juTKMAMpTIJKudeFkG5slD8Z/LHwNwGZLtU441l/u82XdTBfsP+LbGKJLCNwP5se+DMCT55GB8x9p6+C4UL7jw==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@rushstack/ts-command-line@4.19.1':
     resolution: {integrity: sha512-J7H768dgcpG60d7skZ5uSSwyCZs/S2HrWP1Ds8d1qYAyaaeJmpmmLr9BVw97RjFzmQPOYnoXcKA4GkqDCkduQg==}
+
+  '@rushstack/ts-command-line@4.22.6':
+    resolution: {integrity: sha512-QSRqHT/IfoC5nk9zn6+fgyqOPXHME0BfchII9EUPR19pocsNp/xSbeBCbD3PIR2Lg+Q5qk7OFqk1VhWPMdKHJg==}
 
   '@sage-bionetworks/react-base-table@1.13.4':
     resolution: {integrity: sha512-gbzTq6aso1iWr4n11omcq9PtClEWRaqYC01LR2JoTnsg8Y3/UyQZ5HAtZUn/QCinfZlbwMu/VjlMBjKGIcpyMw==}
@@ -4984,6 +5038,18 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
   '@turf/area@6.5.0':
     resolution: {integrity: sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==}
 
@@ -5244,6 +5310,9 @@ packages:
 
   '@types/lodash@4.17.0':
     resolution: {integrity: sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==}
+
+  '@types/lodash@4.17.7':
+    resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
 
   '@types/lz-string@1.5.0':
     resolution: {integrity: sha512-s84fKOrzqqNCAPljhVyC5TjAo6BH4jKHw9NRNFNiRUY5QSgZCmVm5XILlWbisiKl+0OcS7eWihmKGS5akc2iQw==}
@@ -5552,11 +5621,20 @@ packages:
   '@volar/language-core@1.11.1':
     resolution: {integrity: sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==}
 
+  '@volar/language-core@2.4.5':
+    resolution: {integrity: sha512-F4tA0DCO5Q1F5mScHmca0umsi2ufKULAnMOVBfMsZdT4myhVl4WdKRwCaKcfOkIEuyrAVvtq1ESBdZ+rSyLVww==}
+
   '@volar/source-map@1.11.1':
     resolution: {integrity: sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==}
 
+  '@volar/source-map@2.4.5':
+    resolution: {integrity: sha512-varwD7RaKE2J/Z+Zu6j3mNNJbNT394qIxXwdvz/4ao/vxOfyClZpSDtLKkwWmecinkOVos5+PWkWraelfMLfpw==}
+
   '@volar/typescript@1.11.1':
     resolution: {integrity: sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==}
+
+  '@volar/typescript@2.4.5':
+    resolution: {integrity: sha512-mcT1mHvLljAEtHviVcBuOyAwwMKz1ibXTi5uYtP/pf4XxoAzpdkQ+Br2IC0NPCvLCbjPZmbf3I0udndkfB1CDg==}
 
   '@vue/compiler-core@3.4.31':
     resolution: {integrity: sha512-skOiodXWTV3DxfDhB4rOf3OGalpITLlgCeOwb+Y9GJpfQ8ErigdBUHomBzvG78JoVE8MJoQsb+qhZiHfKeNeEg==}
@@ -5564,8 +5642,19 @@ packages:
   '@vue/compiler-dom@3.4.31':
     resolution: {integrity: sha512-wK424WMXsG1IGMyDGyLqB+TbmEBFM78hIsOJ9QwUVLGrcSk0ak6zYty7Pj8ftm7nEtdU/DGQxAXp0/lM/2cEpQ==}
 
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
   '@vue/language-core@1.8.27':
     resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/language-core@2.1.6':
+    resolution: {integrity: sha512-MW569cSky9R/ooKMh6xa2g1D0AtRKbL56k83dzus/bx//RDJk24RHWkMzbAlXjMdDNyxAaagKPRquBIxkxlCkg==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -5708,8 +5797,24 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -5731,6 +5836,9 @@ packages:
 
   ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+
+  ajv@8.13.0:
+    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
 
   almost-equal@1.1.0:
     resolution: {integrity: sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A==}
@@ -5788,6 +5896,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -6391,6 +6502,9 @@ packages:
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
   compute-gcd@1.2.1:
     resolution: {integrity: sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==}
 
@@ -6705,6 +6819,10 @@ packages:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
 
+  date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
+
   dateformat@3.0.2:
     resolution: {integrity: sha512-EelsCzH0gMC2YmXuMeaZ3c6md1sUJQxyb1XXc4xaisi/K6qKukqZhKPrEQyRkdNIncgYyLoDTReq0nNyuKerTg==}
 
@@ -6741,6 +6859,15 @@ packages:
 
   debug@4.3.5:
     resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -6845,6 +6972,10 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
 
   diff@5.0.0:
     resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
@@ -8652,6 +8783,9 @@ packages:
   magic-string@0.30.10:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
 
+  magic-string@0.30.11:
+    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+
   magicast@0.3.4:
     resolution: {integrity: sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==}
 
@@ -8666,6 +8800,9 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -8930,6 +9067,9 @@ packages:
 
   muggle-string@0.3.1:
     resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
+
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
   mui-one-time-password-input@2.0.2:
     resolution: {integrity: sha512-KALEh0fIxMOioGU5xUYBZ4bCoUE6/apERw0xo62JdHjnd6VM0Dux70LsMDUeQ4aHtvOMZV3o9tH21wIrPjucug==}
@@ -10675,6 +10815,20 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -10966,6 +11120,9 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
   v8-to-istanbul@9.2.0:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
@@ -11003,6 +11160,16 @@ packages:
 
   vite-plugin-dts@3.9.1:
     resolution: {integrity: sha512-rVp2KM9Ue22NGWB8dNtWEr+KekN3rIgz1tWD050QnRGlriUCmaDwa7qA5zDEjbXg5lAXhYMSBJtx3q3hQIJZSg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  vite-plugin-dts@4.2.1:
+    resolution: {integrity: sha512-/QlYvgUMiv8+ZTEerhNCYnYaZMM07cdlX6hQCR/w/g/nTh0tUXPoYwbT6SitizLJ9BybT1lnrcZgqheI6wromQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -11089,6 +11256,9 @@ packages:
 
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
+
+  vscode-uri@3.0.8:
+    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
 
   vt-pbf@3.1.3:
     resolution: {integrity: sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==}
@@ -11352,6 +11522,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -13134,6 +13308,11 @@ snapshots:
     dependencies:
       commander: 2.20.3
 
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    optional: true
+
   '@csstools/normalize.css@12.1.1': {}
 
   '@emotion/babel-plugin@11.11.0':
@@ -13541,7 +13720,7 @@ snapshots:
       - ts-node
     optional: true
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -13555,7 +13734,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -13721,10 +13900,18 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+    optional: true
 
   '@jsdevtools/ono@7.1.3(patch_hash=ftv5fxgpd6wo7ilbdz5gio2woe)': {}
 
@@ -13817,6 +14004,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@microsoft/api-extractor-model@7.29.6(@types/node@20.14.10)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc-config': 0.17.0
+      '@rushstack/node-core-library': 5.7.0(@types/node@20.14.10)
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@microsoft/api-extractor@7.43.0(@types/node@20.14.10)':
     dependencies:
       '@microsoft/api-extractor-model': 7.28.13(@types/node@20.14.10)
@@ -13835,6 +14030,24 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@microsoft/api-extractor@7.47.7(@types/node@20.14.10)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.29.6(@types/node@20.14.10)
+      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc-config': 0.17.0
+      '@rushstack/node-core-library': 5.7.0(@types/node@20.14.10)
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.14.0(@types/node@20.14.10)
+      '@rushstack/ts-command-line': 4.22.6(@types/node@20.14.10)
+      lodash: 4.17.21
+      minimatch: 3.0.8
+      resolve: 1.22.8
+      semver: 7.6.2
+      source-map: 0.6.1
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@microsoft/tsdoc-config@0.16.2':
     dependencies:
       '@microsoft/tsdoc': 0.14.2
@@ -13842,7 +14055,16 @@ snapshots:
       jju: 1.4.0
       resolve: 1.19.0
 
+  '@microsoft/tsdoc-config@0.17.0':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.0
+      ajv: 8.12.0
+      jju: 1.4.0
+      resolve: 1.22.8
+
   '@microsoft/tsdoc@0.14.2': {}
+
+  '@microsoft/tsdoc@0.15.0': {}
 
   '@mswjs/cookies@0.2.2':
     dependencies:
@@ -13982,7 +14204,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-date-pickers@6.19.6(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@mui/material@5.15.13(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.15.13(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(dayjs@1.11.10)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@mui/x-date-pickers@6.19.6(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@mui/material@5.15.13(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.15.13(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(date-fns@2.30.0)(dayjs@1.11.10)(moment@2.30.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.7
       '@mui/base': 5.0.0-beta.39(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -13998,6 +14220,7 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.11.4(@types/react@18.2.64)(react@18.2.0)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0)
+      date-fns: 2.30.0
       dayjs: 1.11.10
       moment: 2.30.1
     transitivePeerDependencies:
@@ -14541,7 +14764,25 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.14.10
 
+  '@rushstack/node-core-library@5.7.0(@types/node@20.14.10)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 7.0.1
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.8
+      semver: 7.6.2
+    optionalDependencies:
+      '@types/node': 20.14.10
+
   '@rushstack/rig-package@0.5.2':
+    dependencies:
+      resolve: 1.22.8
+      strip-json-comments: 3.1.1
+
+  '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
@@ -14553,9 +14794,25 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.14.10
 
+  '@rushstack/terminal@0.14.0(@types/node@20.14.10)':
+    dependencies:
+      '@rushstack/node-core-library': 5.7.0(@types/node@20.14.10)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 20.14.10
+
   '@rushstack/ts-command-line@4.19.1(@types/node@20.14.10)':
     dependencies:
       '@rushstack/terminal': 0.10.0(@types/node@20.14.10)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@rushstack/ts-command-line@4.22.6(@types/node@20.14.10)':
+    dependencies:
+      '@rushstack/terminal': 0.14.0(@types/node@20.14.10)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -14658,11 +14915,11 @@ snapshots:
       '@storybook/global': 5.0.0
       storybook: 8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7))
 
-  '@storybook/addon-interactions@8.2.4(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))':
+  '@storybook/addon-interactions@8.2.4(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/instrumenter': 8.2.4(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))
-      '@storybook/test': 8.2.4(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))
+      '@storybook/test': 8.2.4(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))
       polished: 4.3.1
       storybook: 8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7))
       ts-dedent: 2.2.0
@@ -14713,7 +14970,7 @@ snapshots:
       '@storybook/csf': 0.1.11
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.2.9(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@types/lodash': 4.17.0
+      '@types/lodash': 4.17.7
       color-convert: 2.0.1
       dequal: 2.0.3
       lodash: 4.17.21
@@ -14881,12 +15138,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.3
 
-  '@storybook/test@8.2.4(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))':
+  '@storybook/test@8.2.4(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))':
     dependencies:
       '@storybook/csf': 0.1.11
       '@storybook/instrumenter': 8.2.4(storybook@8.2.4(@babel/preset-env@7.24.0(@babel/core@7.24.7)))
       '@testing-library/dom': 10.1.0
-      '@testing-library/jest-dom': 6.4.5(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))
+      '@testing-library/jest-dom': 6.4.5(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.1.0)
       '@vitest/expect': 1.6.0
       '@vitest/spy': 1.6.0
@@ -15067,7 +15324,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.5(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))':
+  '@testing-library/jest-dom@6.4.5(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.24.8
@@ -15080,10 +15337,10 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.12
-      jest: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)
+      jest: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
       vitest: 1.6.0(@types/node@20.14.10)(@vitest/ui@1.6.0)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2)
 
-  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))':
+  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.24.7
@@ -15096,7 +15353,7 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.12
-      jest: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)
+      jest: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
       vitest: 1.6.0(@types/node@20.14.10)(@vitest/ui@1.6.0)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2)
 
   '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10))(vitest@1.6.0(@types/node@20.14.10)(@vitest/ui@1.6.0)(jsdom@21.1.2)(sass@1.77.6)(terser@5.31.2))':
@@ -15164,6 +15421,18 @@ snapshots:
   '@tootallnate/once@2.0.0': {}
 
   '@trysound/sax@0.2.0': {}
+
+  '@tsconfig/node10@1.0.11':
+    optional: true
+
+  '@tsconfig/node12@1.0.11':
+    optional: true
+
+  '@tsconfig/node14@1.0.3':
+    optional: true
+
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@turf/area@6.5.0':
     dependencies:
@@ -15468,9 +15737,11 @@ snapshots:
 
   '@types/lodash-es@4.17.7':
     dependencies:
-      '@types/lodash': 4.17.0
+      '@types/lodash': 4.17.7
 
   '@types/lodash@4.17.0': {}
+
+  '@types/lodash@4.17.7': {}
 
   '@types/lz-string@1.5.0':
     dependencies:
@@ -15869,14 +16140,26 @@ snapshots:
     dependencies:
       '@volar/source-map': 1.11.1
 
+  '@volar/language-core@2.4.5':
+    dependencies:
+      '@volar/source-map': 2.4.5
+
   '@volar/source-map@1.11.1':
     dependencies:
       muggle-string: 0.3.1
+
+  '@volar/source-map@2.4.5': {}
 
   '@volar/typescript@1.11.1':
     dependencies:
       '@volar/language-core': 1.11.1
       path-browserify: 1.0.1
+
+  '@volar/typescript@2.4.5':
+    dependencies:
+      '@volar/language-core': 2.4.5
+      path-browserify: 1.0.1
+      vscode-uri: 3.0.8
 
   '@vue/compiler-core@3.4.31':
     dependencies:
@@ -15890,6 +16173,11 @@ snapshots:
     dependencies:
       '@vue/compiler-core': 3.4.31
       '@vue/shared': 3.4.31
+
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
 
   '@vue/language-core@1.8.27(typescript@5.5.2)':
     dependencies:
@@ -15918,6 +16206,19 @@ snapshots:
       vue-template-compiler: 2.7.16
     optionalDependencies:
       typescript: 5.5.3
+
+  '@vue/language-core@2.1.6(typescript@5.5.2)':
+    dependencies:
+      '@volar/language-core': 2.4.5
+      '@vue/compiler-dom': 3.4.31
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.4.31
+      computeds: 0.0.1
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.5.2
 
   '@vue/shared@3.4.31': {}
 
@@ -16076,9 +16377,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ajv-draft-04@1.0.0(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
+
   ajv-formats@2.1.1(ajv@8.12.0):
     optionalDependencies:
       ajv: 8.12.0
+
+  ajv-formats@3.0.1(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
@@ -16097,6 +16406,13 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.12.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
+  ajv@8.13.0:
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -16143,6 +16459,9 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  arg@4.1.3:
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -16864,6 +17183,8 @@ snapshots:
 
   commondir@1.0.1: {}
 
+  compare-versions@6.1.1: {}
+
   compute-gcd@1.2.1:
     dependencies:
       validate.io-array: 1.0.6
@@ -17008,13 +17329,13 @@ snapshots:
       - ts-node
     optional: true
 
-  create-jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0):
+  create-jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -17253,6 +17574,11 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.1
 
+  date-fns@2.30.0:
+    dependencies:
+      '@babel/runtime': 7.24.8
+    optional: true
+
   dateformat@3.0.2: {}
 
   dayjs@1.11.10: {}
@@ -17276,6 +17602,10 @@ snapshots:
   debug@4.3.5:
     dependencies:
       ms: 2.1.2
+
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
 
   decamelize@1.2.0: {}
 
@@ -17366,6 +17696,9 @@ snapshots:
   diff-match-patch@1.0.5: {}
 
   diff-sequences@29.6.3: {}
+
+  diff@4.0.2:
+    optional: true
 
   diff@5.0.0: {}
 
@@ -17829,7 +18162,7 @@ snapshots:
       eslint: 9.5.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.14.1(@typescript-eslint/parser@7.14.1(eslint@9.5.0)(typescript@5.5.2))(eslint@9.5.0)(typescript@5.5.2)
-      jest: 29.7.0(@types/node@20.14.10)
+      jest: 29.7.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -19056,6 +19389,26 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0:
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.14.10)
+      exit: 0.1.2
+      import-local: 3.1.0
+      jest-config: 29.7.0(@types/node@20.14.10)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   jest-cli@29.7.0(@types/node@20.14.10):
     dependencies:
       '@jest/core': 29.7.0
@@ -19076,16 +19429,16 @@ snapshots:
       - ts-node
     optional: true
 
-  jest-cli@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0):
+  jest-cli@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)
+      create-jest: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)
+      jest-config: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -19126,7 +19479,7 @@ snapshots:
       - supports-color
     optional: true
 
-  jest-config@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0):
+  jest-config@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)):
     dependencies:
       '@babel/core': 7.24.7
       '@jest/test-sequencer': 29.7.0
@@ -19152,6 +19505,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
+      ts-node: 10.9.2(@types/node@20.14.10)(typescript@5.5.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -19219,12 +19573,12 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-html-reporter@3.10.2(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0))(typescript@5.5.3):
+  jest-html-reporter@3.10.2(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)))(typescript@5.5.3):
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       dateformat: 3.0.2
-      jest: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)
+      jest: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
       mkdirp: 1.0.4
       strip-ansi: 6.0.1
       typescript: 5.5.3
@@ -19394,9 +19748,9 @@ snapshots:
       jest-util: 29.7.0
       string-length: 4.0.2
 
-  jest-when@3.6.0(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)):
+  jest-when@3.6.0(jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))):
     dependencies:
-      jest: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)
+      jest: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
 
   jest-worker@27.5.1:
     dependencies:
@@ -19411,6 +19765,19 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
+  jest@29.7.0:
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.1.0
+      jest-cli: 29.7.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   jest@29.7.0(@types/node@20.14.10):
     dependencies:
       '@jest/core': 29.7.0
@@ -19424,12 +19791,12 @@ snapshots:
       - ts-node
     optional: true
 
-  jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0):
+  jest@29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)
+      jest-cli: 29.7.0(@types/node@20.14.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -19871,6 +20238,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  magic-string@0.30.11:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   magicast@0.3.4:
     dependencies:
       '@babel/parser': 7.24.7
@@ -19889,6 +20260,9 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.6.2
+
+  make-error@1.3.6:
+    optional: true
 
   makeerror@1.0.12:
     dependencies:
@@ -20226,6 +20600,8 @@ snapshots:
       typescript: 5.5.2
 
   muggle-string@0.3.1: {}
+
+  muggle-string@0.4.1: {}
 
   mui-one-time-password-input@2.0.2(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@mui/material@5.15.13(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react@18.2.0))(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -20861,12 +21237,13 @@ snapshots:
       browserslist: 4.23.2
       postcss: 8.4.39
 
-  postcss-load-config@4.0.2(postcss@8.4.39):
+  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.2)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.1
     optionalDependencies:
       postcss: 8.4.39
+      ts-node: 10.9.2(@types/node@20.14.10)(typescript@5.5.2)
 
   postcss-normalize@10.0.1(browserslist@4.23.2)(postcss@8.4.39):
     dependencies:
@@ -21025,7 +21402,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.24.7
       '@types/base16': 1.0.5
-      '@types/lodash': 4.17.0
+      '@types/lodash': 4.17.7
       base16: 1.0.0
       color: 3.2.1
       csstype: 3.1.3
@@ -21152,7 +21529,7 @@ snapshots:
   react-json-tree@0.18.0(@types/react@18.2.64)(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.7
-      '@types/lodash': 4.17.0
+      '@types/lodash': 4.17.7
       '@types/react': 18.2.64
       react: 18.2.0
       react-base16-styling: 0.9.1
@@ -22411,6 +22788,44 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.14.10
+      acorn: 8.12.1
+      acorn-walk: 8.3.3
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.5.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.14.10
+      acorn: 8.12.1
+      acorn-walk: 8.3.3
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.5.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -22421,7 +22836,7 @@ snapshots:
 
   tslib@2.6.3: {}
 
-  tsup@8.0.2(@microsoft/api-extractor@7.43.0)(postcss@8.4.39)(typescript@5.5.2):
+  tsup@8.0.2(@microsoft/api-extractor@7.47.7(@types/node@20.14.10))(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.2))(typescript@5.5.2):
     dependencies:
       bundle-require: 4.0.2(esbuild@0.19.12)
       cac: 6.7.14
@@ -22431,14 +22846,14 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.39)
+      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.2))
       resolve-from: 5.0.0
       rollup: 4.18.0
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.43.0(@types/node@20.14.10)
+      '@microsoft/api-extractor': 7.47.7(@types/node@20.14.10)
       postcss: 8.4.39
       typescript: 5.5.2
     transitivePeerDependencies:
@@ -22694,6 +23109,9 @@ snapshots:
 
   uuid@9.0.1: {}
 
+  v8-compile-cache-lib@3.0.1:
+    optional: true
+
   v8-to-istanbul@9.2.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -22766,6 +23184,25 @@ snapshots:
       magic-string: 0.30.10
       typescript: 5.5.3
       vue-tsc: 1.8.27(typescript@5.5.3)
+    optionalDependencies:
+      vite: 5.4.3(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
+
+  vite-plugin-dts@4.2.1(@types/node@20.14.10)(rollup@4.21.2)(typescript@5.5.2)(vite@5.4.3(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2)):
+    dependencies:
+      '@microsoft/api-extractor': 7.47.7(@types/node@20.14.10)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@volar/typescript': 2.4.5
+      '@vue/language-core': 2.1.6(typescript@5.5.2)
+      compare-versions: 6.1.1
+      debug: 4.3.7
+      kolorist: 1.8.0
+      local-pkg: 0.5.0
+      magic-string: 0.30.11
+      typescript: 5.5.2
     optionalDependencies:
       vite: 5.4.3(@types/node@20.14.10)(sass@1.77.6)(terser@5.31.2)
     transitivePeerDependencies:
@@ -22873,6 +23310,8 @@ snapshots:
       - terser
 
   vm-browserify@1.1.2: {}
+
+  vscode-uri@3.0.8: {}
 
   vt-pbf@3.1.3:
     dependencies:
@@ -23193,6 +23632,9 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
In SWC-6662 we are adding another library that needs to be bundled as a library. Instead of copying and matching the existing vite configs, I moved code into our shared `vite-config` package and exposed a ConfigBuilder to simplify writing and sharing these configs.