### PR TITLE
PORTALS-3293: Fix access token issue, as well as discrepancy in API d…

### DIFF
--- a/apps/SageAccountWeb/src/AppInitializer.tsx
+++ b/apps/SageAccountWeb/src/AppInitializer.tsx
@@ -77,7 +77,7 @@ function AppInitializer(props: { children?: React.ReactNode }) {
   let redirectRoute = undefined
   if (termsOfServiceStatus) {
     if (
-      termsOfServiceStatus.usersCurrentTermsOfServiceState !=
+      termsOfServiceStatus.userCurrentTermsOfServiceState !=
         TermsOfServiceState.UP_TO_DATE &&
       skippedSigningUpdatedToS === false
     ) {

--- a/apps/SageAccountWeb/src/components/SignUpdatedTermsOfUsePage.tsx
+++ b/apps/SageAccountWeb/src/components/SignUpdatedTermsOfUsePage.tsx
@@ -28,10 +28,15 @@ export const SignUpdatedTermsOfUsePage = (
   const { mutate: signTermsOfService } = SynapseQueries.useSignTermsOfService()
 
   const { data: tosInfo } = SynapseQueries.useTermsOfServiceInfo()
-  const { data: tosStatus } = SynapseQueries.useTermsOfServiceStatus()
+  const { data: tosStatus } = SynapseQueries.useTermsOfServiceStatus(
+    accessToken,
+    {
+      enabled: !!accessToken,
+    },
+  )
 
   const isSkipAvailable =
-    tosStatus?.usersCurrentTermsOfServiceState ==
+    tosStatus?.userCurrentTermsOfServiceState ==
     TermsOfServiceState.MUST_AGREE_SOON
   const onSignTermsOfUse = async (event: React.SyntheticEvent) => {
     event.preventDefault()

--- a/packages/synapse-react-client/src/mocks/termsOfService/mockTermsOfService.ts
+++ b/packages/synapse-react-client/src/mocks/termsOfService/mockTermsOfService.ts
@@ -17,26 +17,26 @@ export const termsOfServiceNewUserStatus: TermsOfServiceStatus = {
   userId: '12345',
   lastAgreementDate: null,
   lastAgreementVersion: null,
-  usersCurrentTermsOfServiceState: TermsOfServiceState.MUST_AGREE_NOW,
+  userCurrentTermsOfServiceState: TermsOfServiceState.MUST_AGREE_NOW,
 }
 
 export const termsOfServiceUpdatedMustAgreeNowStatus: TermsOfServiceStatus = {
   userId: '12345',
   lastAgreementDate: '2024-09-15T12:34:56Z',
   lastAgreementVersion: '2.0.0',
-  usersCurrentTermsOfServiceState: TermsOfServiceState.MUST_AGREE_NOW,
+  userCurrentTermsOfServiceState: TermsOfServiceState.MUST_AGREE_NOW,
 }
 
 export const termsOfServiceUpdatedMustAgreeSoonStatus: TermsOfServiceStatus = {
   userId: '12345',
   lastAgreementDate: '2024-09-15T12:34:56Z',
   lastAgreementVersion: '2.0.0',
-  usersCurrentTermsOfServiceState: TermsOfServiceState.MUST_AGREE_SOON,
+  userCurrentTermsOfServiceState: TermsOfServiceState.MUST_AGREE_SOON,
 }
 
 export const termsOfServiceUpToDateStatus: TermsOfServiceStatus = {
   userId: '12345',
   lastAgreementDate: '2024-09-15T12:34:56Z',
   lastAgreementVersion: '2.0.0',
-  usersCurrentTermsOfServiceState: TermsOfServiceState.UP_TO_DATE,
+  userCurrentTermsOfServiceState: TermsOfServiceState.UP_TO_DATE,
 }

--- a/packages/synapse-react-client/src/synapse-queries/termsOfService/useTermsOfService.ts
+++ b/packages/synapse-react-client/src/synapse-queries/termsOfService/useTermsOfService.ts
@@ -29,9 +29,10 @@ export function useTermsOfServiceInfo(
 }
 
 export function useTermsOfServiceStatus(
+  accessToken?: string, //usually we can fetch the access token from the context, but this hook is used by ApplicationSessionManager which sets the access token in the context (ApplicationSessionContextProvider)!
   options?: Partial<UseQueryOptions<TermsOfServiceStatus, SynapseClientError>>,
 ) {
-  const { accessToken, keyFactory } = useSynapseContext()
+  const { keyFactory } = useSynapseContext()
   return useQuery({
     ...options,
     queryKey: keyFactory.getTermsOfServiceStatus(),

--- a/packages/synapse-react-client/src/utils/AppUtils/session/ApplicationSession.test.tsx
+++ b/packages/synapse-react-client/src/utils/AppUtils/session/ApplicationSession.test.tsx
@@ -67,7 +67,7 @@ const EXPECTED_ANONYMOUS_STATE: Partial<ApplicationSessionContextType> = {
 }
 const TERMS_OF_SERVICE_STATUS_UP_TO_DATE: TermsOfServiceStatus = {
   userId: `${MOCK_USER_ID}`,
-  usersCurrentTermsOfServiceState: TermsOfServiceState.UP_TO_DATE,
+  userCurrentTermsOfServiceState: TermsOfServiceState.UP_TO_DATE,
   lastAgreementDate: '',
   lastAgreementVersion: '0.0.0',
 }
@@ -81,7 +81,7 @@ const EXPECTED_AUTH_STATE: Partial<ApplicationSessionContextType> = {
 
 const TERMS_OF_SERVICE_STATUS_MUST_AGREE_NOW: TermsOfServiceStatus = {
   userId: `${MOCK_USER_ID}`,
-  usersCurrentTermsOfServiceState: TermsOfServiceState.MUST_AGREE_NOW,
+  userCurrentTermsOfServiceState: TermsOfServiceState.MUST_AGREE_NOW,
   lastAgreementDate: '',
   lastAgreementVersion: '0.0.0',
 }

--- a/packages/synapse-react-client/src/utils/AppUtils/session/ApplicationSessionManager.tsx
+++ b/packages/synapse-react-client/src/utils/AppUtils/session/ApplicationSessionManager.tsx
@@ -74,10 +74,9 @@ export function ApplicationSessionManager(
       setHasInitializedSession(true)
     })
   }, [onNoAccessTokenFound])
-  const { data: tosStatus } = useTermsOfServiceStatus({
+  const { data: tosStatus } = useTermsOfServiceStatus(token, {
     enabled: !!token,
   })
-
   const refreshSession = useCallback(async () => {
     setTwoFactorAuthSSOError(undefined)
     let token

--- a/packages/synapse-types/src/TermsOfService.ts
+++ b/packages/synapse-types/src/TermsOfService.ts
@@ -15,7 +15,7 @@ export type TermsOfServiceStatus = {
   userId: string // The ID of the user
   lastAgreementDate?: string | null // The date/time when the user last agreed to the ToS, or null if never agreed
   lastAgreementVersion?: string | null // The version of ToS the user last agreed to, or null if never agreed
-  usersCurrentTermsOfServiceState: TermsOfServiceState // Defines the user's current ToS state. Used to guide the UI in what the user needs to do with their ToS agreements.  This will always be provided.
+  userCurrentTermsOfServiceState: TermsOfServiceState // Defines the user's current ToS state. Used to guide the UI in what the user needs to do with their ToS agreements.  This will always be provided.
 }
 
 export enum TermsOfServiceState {


### PR DESCRIPTION
…esign doc (field renamed during backend implementation).

During this set of testing, I was able to log in with an up-to-date ToU agreement.
Then (as an admin), I set the ToU requirement (PUT /termsOfUse2/requirements) on staging to a few days in the future.
{
     "requirementDate": "2024-10-25T22:03:55.000Z",
     "minimumTermsOfServiceVersion": "1.0.1"
}
On OneSage login I was then sent to the ToU page, where I could skip.  So I did!  I verified that I was not prompted to agree to the new terms in this browser session.  I then verified that in a new browser session, I was again prompted to agree to the updated terms.  I agreed to the terms, and verified the ToU status response was updated appropriately.
This seems to work! 