### PR TITLE
fix cases where you may not be redirected on the root route

### DIFF
--- a/apps/SageAccountWeb/src/hooks/useMaybeRedirectToSignTermsOfService.ts
+++ b/apps/SageAccountWeb/src/hooks/useMaybeRedirectToSignTermsOfService.ts
@@ -1,5 +1,5 @@
 import { TermsOfServiceState } from '@sage-bionetworks/synapse-types'
-import { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
 import {
   storeLastPlace,
@@ -23,7 +23,7 @@ export default function useMaybeRedirectToSignTermsOfService(): UseMaybeRedirect
   const location = useLocation()
 
   // true until we confirm we will not redirect
-  const mayRedirect = useRef(true)
+  const [mayRedirect, setMayRedirect] = useState(true)
 
   useEffect(() => {
     if (termsOfServiceStatus) {
@@ -45,7 +45,7 @@ export default function useMaybeRedirectToSignTermsOfService(): UseMaybeRedirect
           history.push('/authenticated/signUpdatedTermsOfUse')
         }
       }
-      mayRedirect.current = false
+      setMayRedirect(false)
     }
   }, [
     termsOfServiceStatus,
@@ -54,5 +54,5 @@ export default function useMaybeRedirectToSignTermsOfService(): UseMaybeRedirect
     history,
   ])
 
-  return { mayRedirect: mayRedirect.current }
+  return { mayRedirect: mayRedirect }
 }


### PR DESCRIPTION
useMaybeRedirectToSignTermsOfService should return a `useState` variable to trigger a re-render, rather than the current value of a ref.

This fixes SWC e2e tests. 10/10 passed in chromium & ff, 9/10 passed in webkit with one timeout