### PR TITLE
fix cookie on dev domain

### DIFF
--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -3,6 +3,7 @@ import SparkMD5 from 'spark-md5'
 import UniversalCookies from 'universal-cookie'
 import {
   ACCESS_TOKEN_COOKIE_KEY,
+  getCookieDomain,
   OAuth2State,
   SynapseConstants,
 } from '../utils'
@@ -1974,6 +1975,7 @@ export const setAccessTokenCookie = async (
         // expires in 10 days (see SWC-6190)
         maxAge: 60 * 60 * 24 * 10,
         path: '/',
+        domain: getCookieDomain(),
       })
     }
   } else {

--- a/packages/synapse-react-client/src/utils/AppUtils/AppUtils.ts
+++ b/packages/synapse-react-client/src/utils/AppUtils/AppUtils.ts
@@ -15,9 +15,13 @@ export const ONE_SAGE_REDIRECT_COOKIE_KEY =
   'org.sagebionetworks.cookies.redirect-after-login'
 
 export const getCookieDomain = () => {
-  return window.location.hostname.toLowerCase().endsWith('.synapse.org')
-    ? '.synapse.org'
-    : undefined
+  if (window.location.hostname.toLowerCase().endsWith('.synapse.org')) {
+    return '.synapse.org'
+  }
+  if (window.location.hostname.toLowerCase().endsWith('dev.sagebase.org')) {
+    return '.dev.sagebase.org'
+  }
+  return undefined
 }
 
 export function storeRedirectURLForOneSageLoginAndGotoURL(href: string) {

--- a/packages/synapse-react-client/src/utils/AppUtils/AppUtils.ts
+++ b/packages/synapse-react-client/src/utils/AppUtils/AppUtils.ts
@@ -18,7 +18,7 @@ export const getCookieDomain = () => {
   if (window.location.hostname.toLowerCase().endsWith('.synapse.org')) {
     return '.synapse.org'
   }
-  if (window.location.hostname.toLowerCase().endsWith('dev.sagebase.org')) {
+  if (window.location.hostname.toLowerCase().endsWith('.dev.sagebase.org')) {
     return '.dev.sagebase.org'
   }
   return undefined


### PR DESCRIPTION
When the accounts site will be created, the cookie will be set on a domain like `accounts.dev.sagebase.org`. Manually set the domain to `.dev.sagebase.org` so it will work on `portal-dev.dev.sagebase.org`.