### PR TITLE
SWC-7064 - Handle case where a FileEntity is directly updated

### DIFF
--- a/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useCreateFolderPath.test.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useCreateFolderPath.test.ts
@@ -38,7 +38,7 @@ describe('useCreateFolderPath', () => {
     const { result: hook } = renderHook()
 
     const result = await hook.current.mutateAsync({
-      parentId: 'syn123',
+      rootContainerId: 'syn123',
       path: ['folder'],
     })
 
@@ -62,7 +62,7 @@ describe('useCreateFolderPath', () => {
     const { result: hook } = renderHook()
 
     const result = await hook.current.mutateAsync({
-      parentId: 'syn123',
+      rootContainerId: 'syn123',
       path: ['folder'],
     })
 
@@ -85,7 +85,7 @@ describe('useCreateFolderPath', () => {
     const { result: hook } = renderHook()
 
     const result = await hook.current.mutateAsync({
-      parentId: 'syn123',
+      rootContainerId: 'syn123',
       path: [],
     })
 
@@ -115,7 +115,7 @@ describe('useCreateFolderPath', () => {
     const { result: hook } = renderHook()
 
     const result = await hook.current.mutateAsync({
-      parentId: 'syn123',
+      rootContainerId: 'syn123',
       path: ['parentFolder', 'childFolder'],
     })
 
@@ -142,7 +142,7 @@ describe('useCreateFolderPath', () => {
 
     await expect(
       hook.current.mutateAsync({
-        parentId: 'syn123',
+        rootContainerId: 'syn123',
         path: ['some_name'],
       }),
     ).rejects.toThrow(
@@ -173,7 +173,7 @@ describe('useCreateFolderPath', () => {
     const { result: hook } = renderHook()
     await expect(
       hook.current.mutateAsync({
-        parentId: 'syn123',
+        rootContainerId: 'syn123',
         path: ['folder'],
       }),
     ).rejects.toThrow(`Forbidden`)

--- a/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useCreateFolderPath.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useCreateFolderPath.ts
@@ -17,9 +17,9 @@ export function useCreateFolderPath() {
   const { mutateAsync: createEntity } = useCreateEntity()
 
   return useMutation({
-    mutationFn: async (args: { parentId: string; path: string[] }) => {
-      const { parentId: initialParentId, path } = args
-      let parentId = initialParentId
+    mutationFn: async (args: { rootContainerId: string; path: string[] }) => {
+      const { rootContainerId: rootContainerId, path } = args
+      let parentId = rootContainerId
       for (const pathElement of path) {
         const foundEntityIdResult = await allowNotFoundError(() =>
           synapseClient.entityServicesClient.postRepoV1EntityChild({

--- a/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useCreatePathsAndGetParentId.test.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useCreatePathsAndGetParentId.test.ts
@@ -38,7 +38,7 @@ describe('useCreatePathsAndGetParentId', () => {
 
     const result = await hook.current.mutateAsync({
       file,
-      parentId: 'syn123',
+      rootContainerId: 'syn123',
     })
 
     expect(result).toEqual({ file, parentId: 'syn123' })
@@ -51,7 +51,7 @@ describe('useCreatePathsAndGetParentId', () => {
       webkitRelativePath: 'folder1/file.txt',
     }
 
-    const parentId = 'syn123'
+    const rootContainerId = 'syn123'
     const folderId = 'syn456'
     const mockUseCreateFolderPathResult = getUseMutationMock<
       string,
@@ -64,12 +64,12 @@ describe('useCreatePathsAndGetParentId', () => {
 
     const result = await hook.current.mutateAsync({
       file,
-      parentId: 'syn123',
+      rootContainerId: rootContainerId,
     })
 
     expect(result).toEqual({ file, parentId: folderId })
     expect(mockUseCreateFolderPathResult.mutateAsync).toHaveBeenCalledWith({
-      parentId,
+      rootContainerId,
       path: ['folder1'],
     })
   })
@@ -80,7 +80,7 @@ describe('useCreatePathsAndGetParentId', () => {
       webkitRelativePath: 'folder1/folder2/file.txt',
     }
 
-    const parentId = 'syn123'
+    const rootContainerId = 'syn123'
     const finalFolderId = 'syn456'
     const mockUseCreateFolderPathResult = getUseMutationMock<
       string,
@@ -93,12 +93,12 @@ describe('useCreatePathsAndGetParentId', () => {
 
     const result = await hook.current.mutateAsync({
       file,
-      parentId: 'syn123',
+      rootContainerId,
     })
 
     expect(result).toEqual({ file, parentId: finalFolderId })
     expect(mockUseCreateFolderPathResult.mutateAsync).toHaveBeenCalledWith({
-      parentId,
+      rootContainerId,
       path: ['folder1', 'folder2'],
     })
   })

--- a/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useCreatePathsAndGetParentId.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useCreatePathsAndGetParentId.ts
@@ -9,8 +9,8 @@ export function useCreatePathsAndGetParentId() {
   const { mutateAsync: createFolderPath } = useCreateFolderPath()
 
   return useMutation({
-    mutationFn: (args: { file: File; parentId: string }) => {
-      const { file, parentId } = args
+    mutationFn: (args: { file: File; rootContainerId: string }) => {
+      const { file, rootContainerId } = args
       const relativePath = file.webkitRelativePath
       // Create folders as necessary based on the path
       if (relativePath) {
@@ -18,15 +18,15 @@ export function useCreatePathsAndGetParentId() {
           .split('/')
           // remove the file name
           .slice(0, -1)
-        return createFolderPath({ parentId, path }).then(parentId => ({
+        return createFolderPath({ rootContainerId, path }).then(parentId => ({
           file,
           parentId,
         }))
       } else {
-        // There is no relative path, so just use the passed parentId
+        // There is no relative path, so just use the passed rootContainerId
         return Promise.resolve({
           file,
-          parentId,
+          parentId: rootContainerId,
         })
       }
     },

--- a/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/usePrepareFileEntityUpload.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/usePrepareFileEntityUpload.ts
@@ -4,16 +4,23 @@ import { useSynapseContext } from '../../context/index'
 import { getFileEntityIdWithSameName } from './getFileEntityIdWithSameName'
 import { useCreatePathsAndGetParentId } from './useCreatePathsAndGetParentId'
 
-export type FilePreparedForUpload = {
-  file: File
-  parentId: string
-  existingEntityId: string | null
-}
+export type NewEntityFileUploadArgs = { file: File; rootContainerId: string }
+export type NewEntityFileUploadReturn = { file: File; parentId: string }
+export type UpdateEntityFileUpload = { file: File; existingEntityId: string }
+
+export type FilePreparedForUpload =
+  | NewEntityFileUploadReturn
+  | UpdateEntityFileUpload
 
 export type PrepareDirsForUploadReturn = {
-  newFileEntities: FilePreparedForUpload[]
-  updatedFileEntities: FilePreparedForUpload[]
+  filesReadyForUpload: FilePreparedForUpload[]
+  filesToPromptForNewVersion: FilePreparedForUpload[]
 }
+
+export type PrepareFileEntityUploadArgs = (
+  | NewEntityFileUploadArgs
+  | UpdateEntityFileUpload
+)[]
 
 /**
  * Mutation used to check and prepare the entity tree just before uploading a list of files.
@@ -24,8 +31,9 @@ export type PrepareDirsForUploadReturn = {
  * 2. Check if any of the files to be uploaded already exist in the target parent folder
  *
  * The mutation will return two lists of files and their destination parentIds:
- *    - newFileEntities: New files that do not have corresponding file entities in the target parent folder
- *    - updatedFileEntities: Files that have corresponding file entities in the target parent folder. The user
+ *    - filesReadyForUpload: New files that do not have corresponding file entities in the target parent folder, or a file
+ *        that should be updated without a prompt.
+ *    - filesToPromptForNewVersion: Files that have corresponding file entities in the target parent folder. The user
  *        should be prompted to accept or reject the creation of a new version of the file.
  *
  * In the future, this sequence could be amended to check if the storage location has enough space to accommodate all the
@@ -38,7 +46,7 @@ export function usePrepareFileEntityUpload(
     UseMutationOptions<
       PrepareDirsForUploadReturn,
       SynapseClientError,
-      { files: File[]; parentId: string }
+      PrepareFileEntityUploadArgs
     >
   >,
 ) {
@@ -47,21 +55,30 @@ export function usePrepareFileEntityUpload(
 
   return useMutation({
     ...options,
-    mutationFn: async (args: { files: File[]; parentId: string }) => {
-      const { files, parentId } = args
+    mutationFn: async (args: PrepareFileEntityUploadArgs) => {
+      // If `existingEntityId` is defined, the file will be used to update a chosen FileEntity
+      // we don't need to create dirs or prompt the user to confirm an update.
+      const updatedFileEntitiesNoPrompt: FilePreparedForUpload[] = args.filter(
+        arg => 'existingEntityId' in arg,
+      )
 
-      // 1. Create directories for the files as needed
+      // 1. Create directories for the files uploaded to a container as needed
       const fileAndParentIds: { file: File; parentId: string }[] = []
-      for (const file of files) {
+      for (const arg of args) {
         try {
-          // Create the directories serially; if multiple files are uploaded, they may share new directories
-          // Creating folders in parallel could cause race conditions
-          fileAndParentIds.push(await createDirsForFileList({ file, parentId }))
+          if ('rootContainerId' in arg) {
+            const { file, rootContainerId } = arg
+            // Create the directories serially; if multiple files are uploaded, they may share new directories
+            // Creating folders in parallel could cause race conditions
+            fileAndParentIds.push(
+              await createDirsForFileList({ file, parentId: rootContainerId }),
+            )
+          }
         } catch (e) {
           throw new Error(
-            `Unable to create target folder structure for file ${file.name}${
-              Object.hasOwn(e, 'message') ? `: ${e.message}` : null
-            }`,
+            `Unable to create target folder structure for file ${
+              arg.file.name
+            }${Object.hasOwn(e, 'message') ? `: ${e.message}` : null}`,
             { cause: e },
           )
         }
@@ -103,11 +120,19 @@ export function usePrepareFileEntityUpload(
         f => f.existingEntityId == null,
       )
 
-      const updatedFileEntities = filesPreparedForUpload.filter(
+      const filesReadyForUpload = [
+        ...newFileEntities,
+        ...updatedFileEntitiesNoPrompt,
+      ]
+
+      const filesToPromptForNewVersion = filesPreparedForUpload.filter(
         f => f.existingEntityId != null,
       )
 
-      return { newFileEntities, updatedFileEntities }
+      return {
+        filesReadyForUpload,
+        filesToPromptForNewVersion,
+      }
     },
   })
 }

--- a/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/usePrepareFileEntityUpload.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/usePrepareFileEntityUpload.ts
@@ -71,7 +71,10 @@ export function usePrepareFileEntityUpload(
             // Create the directories serially; if multiple files are uploaded, they may share new directories
             // Creating folders in parallel could cause race conditions
             fileAndParentIds.push(
-              await createDirsForFileList({ file, parentId: rootContainerId }),
+              await createDirsForFileList({
+                file,
+                rootContainerId: rootContainerId,
+              }),
             )
           }
         } catch (e) {

--- a/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useTrackFileUploads.test.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useTrackFileUploads.test.ts
@@ -17,13 +17,12 @@ describe('useTrackFileUploads', () => {
       hook.current.trackNewFiles({
         file: file,
         parentId: 'syn123',
-        existingEntityId: null,
       })
     })
 
     expect(hook.current.trackedUploadProgress.size).toBe(1)
     expect(hook.current.trackedUploadProgress.get(file)).toMatchObject({
-      parentId: 'syn123',
+      filePreparedForUpload: { file: expect.any(File), parentId: 'syn123' },
       abortController: expect.any(AbortController),
       progress: { value: 0, total: 1 },
       status: 'PREPARING',
@@ -43,7 +42,6 @@ describe('useTrackFileUploads', () => {
       hook.current.trackNewFiles({
         file: file,
         parentId: 'syn123',
-        existingEntityId: null,
       })
     })
 
@@ -54,13 +52,12 @@ describe('useTrackFileUploads', () => {
       hook.current.trackNewFiles({
         file: file,
         parentId: 'syn456',
-        existingEntityId: null,
       })
     })
 
     expect(hook.current.trackedUploadProgress.size).toBe(1)
     expect(hook.current.trackedUploadProgress.get(file)).toMatchObject({
-      parentId: 'syn456',
+      filePreparedForUpload: { file: expect.any(File), parentId: 'syn456' },
       abortController: expect.any(AbortController),
       progress: { value: 0, total: 1 },
       status: 'PREPARING',
@@ -77,7 +74,6 @@ describe('useTrackFileUploads', () => {
       hook.current.trackNewFiles({
         file: file,
         parentId: 'syn123',
-        existingEntityId: null,
       })
 
       hook.current.setProgress(file, { value: 10, total: 20 })
@@ -85,7 +81,7 @@ describe('useTrackFileUploads', () => {
 
     expect(hook.current.trackedUploadProgress.size).toBe(1)
     expect(hook.current.trackedUploadProgress.get(file)).toMatchObject({
-      parentId: 'syn123',
+      filePreparedForUpload: { file: expect.any(File), parentId: 'syn123' },
       abortController: expect.any(AbortController),
       progress: { value: 10, total: 20 },
       status: 'PREPARING',
@@ -101,7 +97,6 @@ describe('useTrackFileUploads', () => {
       hook.current.trackNewFiles({
         file: file,
         parentId: 'syn123',
-        existingEntityId: null,
       })
 
       hook.current.setIsUploading(file)
@@ -109,7 +104,7 @@ describe('useTrackFileUploads', () => {
 
     expect(hook.current.trackedUploadProgress.size).toBe(1)
     expect(hook.current.trackedUploadProgress.get(file)).toMatchObject({
-      parentId: 'syn123',
+      filePreparedForUpload: { file: expect.any(File), parentId: 'syn123' },
       abortController: expect.any(AbortController),
       progress: { value: 0, total: 1 },
       status: 'UPLOADING',
@@ -124,7 +119,6 @@ describe('useTrackFileUploads', () => {
       hook.current.trackNewFiles({
         file: file,
         parentId: 'syn123',
-        existingEntityId: null,
       })
 
       hook.current.setComplete(file)
@@ -132,7 +126,7 @@ describe('useTrackFileUploads', () => {
 
     expect(hook.current.trackedUploadProgress.size).toBe(1)
     expect(hook.current.trackedUploadProgress.get(file)).toMatchObject({
-      parentId: 'syn123',
+      filePreparedForUpload: { file: expect.any(File), parentId: 'syn123' },
       abortController: expect.any(AbortController),
       progress: { value: 0, total: 1 },
       status: 'COMPLETE',
@@ -147,7 +141,6 @@ describe('useTrackFileUploads', () => {
       hook.current.trackNewFiles({
         file: file,
         parentId: 'syn123',
-        existingEntityId: null,
       })
 
       hook.current.setFailed(file, 'some reason')
@@ -155,7 +148,7 @@ describe('useTrackFileUploads', () => {
 
     expect(hook.current.trackedUploadProgress.size).toBe(1)
     expect(hook.current.trackedUploadProgress.get(file)).toMatchObject({
-      parentId: 'syn123',
+      filePreparedForUpload: { file: expect.any(File), parentId: 'syn123' },
       abortController: expect.any(AbortController),
       progress: { value: 0, total: 1 },
       status: 'FAILED',
@@ -172,7 +165,6 @@ describe('useTrackFileUploads', () => {
       hook.current.trackNewFiles({
         file: file,
         parentId: 'syn123',
-        existingEntityId: null,
       })
     })
 
@@ -182,7 +174,7 @@ describe('useTrackFileUploads', () => {
 
     expect(hook.current.trackedUploadProgress.size).toBe(1)
     expect(hook.current.trackedUploadProgress.get(file)).toMatchObject({
-      parentId: 'syn123',
+      filePreparedForUpload: { file: expect.any(File), parentId: 'syn123' },
       abortController: expect.any(AbortController),
       progress: { value: 0, total: 1 },
       status: 'CANCELED_BY_USER',
@@ -202,7 +194,6 @@ describe('useTrackFileUploads', () => {
       hook.current.trackNewFiles({
         file: file,
         parentId: 'syn123',
-        existingEntityId: null,
       })
     })
 
@@ -212,7 +203,7 @@ describe('useTrackFileUploads', () => {
 
     expect(hook.current.trackedUploadProgress.size).toBe(1)
     expect(hook.current.trackedUploadProgress.get(file)).toMatchObject({
-      parentId: 'syn123',
+      filePreparedForUpload: { file: expect.any(File), parentId: 'syn123' },
       abortController: expect.any(AbortController),
       progress: { value: 0, total: 1 },
       status: 'PAUSED',
@@ -238,17 +229,14 @@ describe('useTrackFileUploads', () => {
         {
           file: file1,
           parentId: 'syn123',
-          existingEntityId: null,
         },
         {
           file: file2,
           parentId: 'syn123',
-          existingEntityId: null,
         },
         {
           file: file3,
           parentId: 'syn123',
-          existingEntityId: null,
         },
       )
 
@@ -264,7 +252,7 @@ describe('useTrackFileUploads', () => {
     // File 3 remains uncancelled
     expect(hook.current.trackedUploadProgress.size).toBe(1)
     expect(hook.current.trackedUploadProgress.get(file3)).toMatchObject({
-      parentId: 'syn123',
+      filePreparedForUpload: { file: expect.any(File), parentId: 'syn123' },
       abortController: expect.any(AbortController),
       progress: { value: 0, total: 1 },
       status: 'PREPARING',
@@ -277,7 +265,7 @@ describe('useTrackFileUploads', () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       `Attempted to remove tracked upload progress before it was canceled.`,
       {
-        parentId: 'syn123',
+        filePreparedForUpload: { file: expect.any(File), parentId: 'syn123' },
         abortController: expect.any(AbortController),
         progress: { value: 0, total: 1 },
         status: 'PREPARING',
@@ -300,32 +288,26 @@ describe('useTrackFileUploads', () => {
         {
           file: preparingFile,
           parentId: 'syn123',
-          existingEntityId: null,
         },
         {
           file: uploadingFile,
           parentId: 'syn123',
-          existingEntityId: null,
         },
         {
           file: pausedFile,
           parentId: 'syn123',
-          existingEntityId: null,
         },
         {
           file: canceledFile,
           parentId: 'syn123',
-          existingEntityId: null,
         },
         {
           file: failedFile,
           parentId: 'syn123',
-          existingEntityId: null,
         },
         {
           file: completedFile,
           parentId: 'syn123',
-          existingEntityId: null,
         },
       )
 
@@ -364,7 +346,6 @@ describe('useTrackFileUploads', () => {
       hook.current.trackNewFiles({
         file: file1,
         parentId: 'syn123',
-        existingEntityId: null,
       })
     })
 
@@ -400,7 +381,6 @@ describe('useTrackFileUploads', () => {
       hook.current.trackNewFiles({
         file: file2,
         parentId: 'syn123',
-        existingEntityId: null,
       })
     })
     expect(hook.current.isUploadComplete).toBe(false)

--- a/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useTrackFileUploads.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useTrackFileUploads.ts
@@ -3,7 +3,7 @@ import { ProgressCallback } from '../../../synapse-client/index'
 import { FilePreparedForUpload } from './usePrepareFileEntityUpload'
 
 export type TrackedUploadProgress = {
-  parentId: string
+  filePreparedForUpload: FilePreparedForUpload
   progress: ProgressCallback
   abortController: AbortController
   status:
@@ -54,7 +54,7 @@ export function useTrackFileUploads() {
 
     preparedFiles.forEach(preparedFile => {
       newTrackedUploadProgress.set(preparedFile.file, {
-        parentId: preparedFile.parentId,
+        filePreparedForUpload: preparedFile,
         abortController: new AbortController(),
         // Note that this is number of parts uploaded, not file size or %
         progress: { value: 0, total: 1 },


### PR DESCRIPTION
- Handle case where a FileEntity is directly updated (e.g. from the entity page) and the user should not be prompted.
- Minor refactoring