### PR TITLE
SWC-7064 - Optimize creating many dirs by using cache for entity lookup

### DIFF
--- a/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
+++ b/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
@@ -1,3 +1,4 @@
+import { EntityLookupRequest } from '@sage-bionetworks/synapse-client'
 import {
   AccessApprovalSearchRequest,
   AccessRequirementSearchRequest,
@@ -257,6 +258,14 @@ export class KeyFactory {
 
   public getEntityVersionQueryKey(id: string, versionNumber?: string | number) {
     return this.getKey(entityQueryKeyObjects.entity(id, versionNumber))
+  }
+
+  public getEntityLookupQueryKey(entityLookupRequest: EntityLookupRequest) {
+    return this.getKey(
+      entityQueryKeyObjects.all,
+      'entityLookup',
+      entityLookupRequest,
+    )
   }
 
   public getPaginatedEntityVersionsQueryKey(

--- a/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useCreateFolderPath.test.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useUploadFileEntity/useCreateFolderPath.test.ts
@@ -7,20 +7,35 @@ import {
 import mockFileEntity, {
   MOCK_FILE_ENTITY_ID,
 } from '../../../mocks/entity/mockFileEntity'
-import { MOCK_CONTEXT_VALUE } from '../../../mocks/MockSynapseContext'
-import SynapseClient from '../../../synapse-client/index'
+import {
+  useCreateEntity,
+  useGetEntityLookupQueryOptions,
+  useGetEntityQueryOptions,
+} from '../../../synapse-queries/index'
+import { getUseMutationMock } from '../../../testutils/ReactQueryMockUtils'
 import { createWrapper } from '../../../testutils/TestingLibraryUtils'
 import { useCreateFolderPath } from './useCreateFolderPath'
 
-const lookupEntitySpy = jest.spyOn(
-  MOCK_CONTEXT_VALUE.synapseClient.entityServicesClient,
-  'postRepoV1EntityChild',
-)
-const getEntitySpy = jest.spyOn(
-  MOCK_CONTEXT_VALUE.synapseClient.entityServicesClient,
-  'getRepoV1EntityId',
-)
-const createEntitySpy = jest.spyOn(SynapseClient, 'createEntity')
+jest.mock('../../../synapse-queries/entity/useEntity', () => ({
+  useCreateEntity: jest.fn(),
+  useGetEntityLookupQueryOptions: jest.fn(),
+  useGetEntityQueryOptions: jest.fn(),
+}))
+
+const mockGetEntity = jest.fn()
+jest.mocked(useGetEntityQueryOptions).mockReturnValue(args => ({
+  queryFn: () => mockGetEntity(args),
+  queryKey: ['mockGetEntityQueryKey', args],
+}))
+
+const mockLookupEntity = jest.fn()
+jest.mocked(useGetEntityLookupQueryOptions).mockReturnValue(args => ({
+  queryFn: () => mockLookupEntity(args),
+  queryKey: ['mockLookupEntityQueryKey', args],
+}))
+
+const useCreateEntityMockReturnValue = getUseMutationMock()
+jest.mocked(useCreateEntity).mockReturnValue(useCreateEntityMockReturnValue)
 
 describe('useCreateFolderPath', () => {
   function renderHook() {
@@ -32,8 +47,8 @@ describe('useCreateFolderPath', () => {
     jest.clearAllMocks()
   })
   test('existing folder', async () => {
-    lookupEntitySpy.mockResolvedValue({ id: MOCK_FOLDER_ID })
-    getEntitySpy.mockResolvedValue(mockFolderEntity)
+    mockLookupEntity.mockResolvedValue(MOCK_FOLDER_ID)
+    mockGetEntity.mockResolvedValue(mockFolderEntity)
 
     const { result: hook } = renderHook()
 
@@ -44,20 +59,16 @@ describe('useCreateFolderPath', () => {
 
     expect(result).toEqual(MOCK_FOLDER_ID)
 
-    expect(lookupEntitySpy).toHaveBeenCalledTimes(1)
-    expect(getEntitySpy).toHaveBeenCalledTimes(1)
-    expect(createEntitySpy).not.toHaveBeenCalled()
+    expect(mockLookupEntity).toHaveBeenCalledTimes(1)
+    expect(mockGetEntity).toHaveBeenCalledTimes(1)
+    expect(useCreateEntityMockReturnValue.mutateAsync).not.toHaveBeenCalled()
   })
 
   test('create a new folder', async () => {
-    lookupEntitySpy.mockRejectedValue(
-      new SynapseClientError(
-        404,
-        'Not found',
-        expect.getState().currentTestName!,
-      ),
+    mockLookupEntity.mockResolvedValue(null)
+    useCreateEntityMockReturnValue.mutateAsync.mockResolvedValue(
+      mockFolderEntity,
     )
-    createEntitySpy.mockResolvedValue(mockFolderEntity)
 
     const { result: hook } = renderHook()
 
@@ -68,17 +79,14 @@ describe('useCreateFolderPath', () => {
 
     expect(result).toEqual(MOCK_FOLDER_ID)
 
-    expect(lookupEntitySpy).toHaveBeenCalledTimes(1)
-    expect(getEntitySpy).not.toHaveBeenCalled()
-    expect(createEntitySpy).toHaveBeenCalledTimes(1)
-    expect(createEntitySpy).toHaveBeenCalledWith(
-      {
-        concreteType: 'org.sagebionetworks.repo.model.Folder',
-        name: 'folder',
-        parentId: 'syn123',
-      },
-      MOCK_CONTEXT_VALUE.accessToken,
-    )
+    expect(mockLookupEntity).toHaveBeenCalledTimes(1)
+    expect(mockGetEntity).not.toHaveBeenCalled()
+    expect(useCreateEntityMockReturnValue.mutateAsync).toHaveBeenCalledTimes(1)
+    expect(useCreateEntityMockReturnValue.mutateAsync).toHaveBeenCalledWith({
+      concreteType: 'org.sagebionetworks.repo.model.Folder',
+      name: 'folder',
+      parentId: 'syn123',
+    })
   })
 
   test('empty path', async () => {
@@ -96,17 +104,13 @@ describe('useCreateFolderPath', () => {
     const existingFolderId = 'syn456'
     const createdFolderId = 'syn789'
 
-    lookupEntitySpy.mockImplementation(args => {
-      if (args.entityLookupRequest.entityName == 'parentFolder') {
-        return Promise.resolve({ id: existingFolderId })
+    mockLookupEntity.mockImplementation(args => {
+      if (args.entityName == 'parentFolder') {
+        return Promise.resolve(existingFolderId)
       }
-      throw new SynapseClientError(
-        404,
-        'Not found',
-        expect.getState().currentTestName!,
-      )
+      return Promise.resolve(null)
     })
-    createEntitySpy.mockResolvedValue({
+    useCreateEntityMockReturnValue.mutateAsync.mockResolvedValue({
       ...mockFolderEntity,
       name: 'childFolder',
       id: createdFolderId,
@@ -121,22 +125,19 @@ describe('useCreateFolderPath', () => {
 
     expect(result).toEqual(createdFolderId)
 
-    expect(lookupEntitySpy).toHaveBeenCalledTimes(2)
-    expect(getEntitySpy).toHaveBeenCalledTimes(1)
-    expect(createEntitySpy).toHaveBeenCalledTimes(1)
-    expect(createEntitySpy).toHaveBeenCalledWith(
-      {
-        concreteType: 'org.sagebionetworks.repo.model.Folder',
-        name: 'childFolder',
-        parentId: existingFolderId,
-      },
-      MOCK_CONTEXT_VALUE.accessToken,
-    )
+    expect(mockLookupEntity).toHaveBeenCalledTimes(2)
+    expect(mockGetEntity).toHaveBeenCalledTimes(1)
+    expect(useCreateEntityMockReturnValue.mutateAsync).toHaveBeenCalledTimes(1)
+    expect(useCreateEntityMockReturnValue.mutateAsync).toHaveBeenCalledWith({
+      concreteType: 'org.sagebionetworks.repo.model.Folder',
+      name: 'childFolder',
+      parentId: existingFolderId,
+    })
   })
 
   test('existing entity is not a folder', async () => {
-    lookupEntitySpy.mockResolvedValue({ id: MOCK_FILE_ENTITY_ID })
-    getEntitySpy.mockResolvedValue(mockFileEntity.entity)
+    mockLookupEntity.mockResolvedValue(MOCK_FILE_ENTITY_ID)
+    mockGetEntity.mockResolvedValue(mockFileEntity.entity)
 
     const { result: hook } = renderHook()
 
@@ -149,20 +150,14 @@ describe('useCreateFolderPath', () => {
       `A(n) File named "some_name" already exists in this location (syn123). A folder could not be created.`,
     )
 
-    expect(lookupEntitySpy).toHaveBeenCalledTimes(1)
-    expect(getEntitySpy).toHaveBeenCalledTimes(1)
-    expect(createEntitySpy).not.toHaveBeenCalled()
+    expect(mockLookupEntity).toHaveBeenCalledTimes(1)
+    expect(mockGetEntity).toHaveBeenCalledTimes(1)
+    expect(useCreateEntityMockReturnValue.mutateAsync).not.toHaveBeenCalled()
   })
 
   test('createEntity fails', async () => {
-    lookupEntitySpy.mockRejectedValue(
-      new SynapseClientError(
-        404,
-        'Not found',
-        expect.getState().currentTestName!,
-      ),
-    )
-    createEntitySpy.mockRejectedValue(
+    mockLookupEntity.mockResolvedValue(null)
+    useCreateEntityMockReturnValue.mutateAsync.mockRejectedValue(
       new SynapseClientError(
         403,
         'Forbidden',
@@ -178,16 +173,13 @@ describe('useCreateFolderPath', () => {
       }),
     ).rejects.toThrow(`Forbidden`)
 
-    expect(lookupEntitySpy).toHaveBeenCalledTimes(1)
-    expect(getEntitySpy).not.toHaveBeenCalled()
-    expect(createEntitySpy).toHaveBeenCalledTimes(1)
-    expect(createEntitySpy).toHaveBeenCalledWith(
-      {
-        concreteType: 'org.sagebionetworks.repo.model.Folder',
-        name: 'folder',
-        parentId: 'syn123',
-      },
-      MOCK_CONTEXT_VALUE.accessToken,
-    )
+    expect(mockLookupEntity).toHaveBeenCalledTimes(1)
+    expect(mockGetEntity).not.toHaveBeenCalled()
+    expect(useCreateEntityMockReturnValue.mutateAsync).toHaveBeenCalledTimes(1)
+    expect(useCreateEntityMockReturnValue.mutateAsync).toHaveBeenCalledWith({
+      concreteType: 'org.sagebionetworks.repo.model.Folder',
+      name: 'folder',
+      parentId: 'syn123',
+    })
   })
 })


### PR DESCRIPTION
Improves the performance of the case where a folder with many items is uploaded by using the react-query cache when looking up whether an entity exists, and fetching it to check if it's a folder.

For example, if you upload these files:

```
folder_1/folder_2/.../folder_m/file_1.txt
folder_1/folder_2/.../folder_m/file_2.txt
...
folder_1/folder_2/.../folder_m/file_n.txt
```

without a cache, we would call `POST entity/child` and `GET /entity/id` $m * n$ times.

With the cache, these will only be called $m$ times.