### PR TITLE
PORTALS-3195

### DIFF
--- a/apps/portals/nf/src/pages/OrganizationDetailsPage/OrganizationDetailsPage.tsx
+++ b/apps/portals/nf/src/pages/OrganizationDetailsPage/OrganizationDetailsPage.tsx
@@ -29,7 +29,7 @@ const tabConfig: DetailsPageTabConfig[] = [
 ]
 
 function OrganizationDetailsPage() {
-  const { abbreviation } = useGetPortalComponentSearchParams()
+  const searchParams = useGetPortalComponentSearchParams()
   return (
     <>
       <CardContainerLogic
@@ -40,7 +40,7 @@ function OrganizationDetailsPage() {
           imageFileHandleColumnName: 'headerLogo',
         }}
         isHeader={true}
-        searchParams={{ abbreviation }}
+        searchParams={searchParams}
       />
       <DetailsPage sql={fundersSql} ContainerProps={{ maxWidth: 'xl' }}>
         <DetailsPageTabs tabConfig={tabConfig} />

--- a/apps/synapse-portal-framework/src/App.tsx
+++ b/apps/synapse-portal-framework/src/App.tsx
@@ -7,8 +7,11 @@ import {
 import AppInitializer from './components/AppInitializer'
 import Footer from './components/Footer'
 import Navbar from './components/navbar/Navbar'
+import { useDocumentTitleFromRoutes } from './utils/useDocumentTitleFromRoutes'
 
 export default function App(props: PropsWithChildren) {
+  useDocumentTitleFromRoutes()
+
   return (
     <AppInitializer>
       <SynapseToastContainer />

--- a/apps/synapse-portal-framework/src/utils/useDocumentTitleFromRoutes.ts
+++ b/apps/synapse-portal-framework/src/utils/useDocumentTitleFromRoutes.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+import { useMatches } from 'react-router-dom'
+
+/**
+ * Uses the current routes to set the document title. The title will only be set when routes change, so if placed high
+ * in the React tree, descendant components (e.g. Details pages) can implement their own logic to override the behavior
+ * as long as they rerun when the routes change.
+ */
+export function useDocumentTitleFromRoutes() {
+  const matches = useMatches()
+
+  useEffect(() => {
+    // As a heuristic, we get the last path string of the most specific current route.
+
+    // To improve this, we could put custom data in the route handle returned by useMatches:
+    // https://reactrouter.com/en/main/hooks/use-matches#usematches
+
+    const portalTitle = import.meta.env.VITE_PORTAL_NAME
+    const routeTitle = matches.at(-1)?.pathname.split('/').at(-1)
+    if (routeTitle) {
+      document.title = `${portalTitle} - ${routeTitle}`
+    } else {
+      // Set a default title
+      document.title = portalTitle
+    }
+  }, [matches])
+}

--- a/packages/markdown-it-synapse-table/package.json
+++ b/packages/markdown-it-synapse-table/package.json
@@ -14,6 +14,7 @@
     "table"
   ],
   "scripts": {
+    "clean": "rimraf ./dist && rimraf *.tsbuildinfo",
     "build": "vite build",
     "lint": "eslint src/*",
     "test": "vitest",

--- a/packages/synapse-client/package.json
+++ b/packages/synapse-client/package.json
@@ -32,6 +32,7 @@
     "vitest": "^1.6.0"
   },
   "scripts": {
+    "clean": "rimraf ./dist && rimraf *.tsbuildinfo",
     "format-spec": "prettier --write src/spec/openapispecification.json",
     "get-spec:staging": "npx tsx src/codegen/downloadSpec.ts --stack staging && pnpm format-spec",
     "get-spec:production": "npx tsx src/codegen/downloadSpec.ts --stack production && pnpm format-spec",

--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -238,7 +238,7 @@
     "whatwg-fetch": "^3.6.20"
   },
   "scripts": {
-    "clean": "rimraf dist storybook-static coverage",
+    "clean": "rimraf dist storybook-static coverage *.tsbuildinfo",
     "prepublishOnly": "pnpm install && pnpm nx run synapse-react-client:build",
     "start": "storybook dev -p 6060",
     "test": "jest",

--- a/packages/synapse-types/package.json
+++ b/packages/synapse-types/package.json
@@ -20,6 +20,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
+    "clean": "rimraf ./dist && rimraf *.tsbuildinfo",
     "build": "tsc --build",
     "prepublishOnly": "pnpm install && pnpm nx run @sage-bionetworks/synapse-types:build"
   },

--- a/packages/vite-config/package.json
+++ b/packages/vite-config/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "types": "dist/index.ts",
   "scripts": {
+    "clean": "rimraf ./dist && rimraf *.tsbuildinfo",
     "build": "tsc --build"
   },
   "exports": [


### PR DESCRIPTION
- fix NF portal OrganizationDetailsPage to pass searchParams along since there are multiple lookup keys
- add hook to dynamically set document.title
- add clean jobs that remove tsbuildinfo