### PR TITLE
PORTALS-3195 - add canonical URL tags to Explore pages 

### DIFF
--- a/apps/portals/nf/src/pages/DatasetDetailsPage.tsx
+++ b/apps/portals/nf/src/pages/DatasetDetailsPage.tsx
@@ -40,6 +40,7 @@ export default function DatasetDetailsPage() {
         ContainerProps={{
           maxWidth: 'xl',
         }}
+        resourcePrimaryKey={['id']}
       >
         <DetailsPageContent
           content={[

--- a/apps/portals/nf/src/pages/InitiativeDetailsPage.tsx
+++ b/apps/portals/nf/src/pages/InitiativeDetailsPage.tsx
@@ -35,6 +35,7 @@ export default function InitiativeDetailsPage() {
         ContainerProps={{
           maxWidth: 'xl',
         }}
+        resourcePrimaryKey={['initiative']}
       >
         <DetailsPageContent
           content={[

--- a/apps/portals/nf/src/pages/OrganizationDetailsPage/OrganizationDetailsPage.tsx
+++ b/apps/portals/nf/src/pages/OrganizationDetailsPage/OrganizationDetailsPage.tsx
@@ -42,7 +42,11 @@ function OrganizationDetailsPage() {
         isHeader={true}
         searchParams={searchParams}
       />
-      <DetailsPage sql={fundersSql} ContainerProps={{ maxWidth: 'xl' }}>
+      <DetailsPage
+        sql={fundersSql}
+        ContainerProps={{ maxWidth: 'xl' }}
+        resourcePrimaryKey={['abbreviation']}
+      >
         <DetailsPageTabs tabConfig={tabConfig} />
         <Outlet />
       </DetailsPage>

--- a/apps/synapse-portal-framework/src/components/DetailsPage/DetailsPage.tsx
+++ b/apps/synapse-portal-framework/src/components/DetailsPage/DetailsPage.tsx
@@ -19,6 +19,7 @@ import {
 import { DetailsPageProps } from '../../types/portal-util-types'
 import { useGetPortalComponentSearchParams } from '../../utils/UseGetPortalComponentSearchParams'
 import { DetailsPageContextProvider } from './DetailsPageContext'
+import { DetailsPageDocumentMetadata } from './DetailsPageDocumentMetadata'
 import { useScrollOnMount } from './utils'
 
 const goToExplorePage = () => {
@@ -51,6 +52,7 @@ export default function DetailsPage(props: DetailsPageProps) {
     additionalFiltersSessionStorageKey,
     ContainerProps,
     children = <Outlet />,
+    resourcePrimaryKey,
   } = props
 
   const searchParams = useGetPortalComponentSearchParams()
@@ -117,6 +119,7 @@ export default function DetailsPage(props: DetailsPageProps) {
         rowData: row,
       }}
     >
+      <DetailsPageDocumentMetadata resourcePrimaryKey={resourcePrimaryKey} />
       <Container
         maxWidth={'lg'}
         className="DetailsPage tab-layout"

--- a/apps/synapse-portal-framework/src/components/DetailsPage/DetailsPageDocumentMetadata.tsx
+++ b/apps/synapse-portal-framework/src/components/DetailsPage/DetailsPageDocumentMetadata.tsx
@@ -1,0 +1,60 @@
+import { Row, RowSet } from '@sage-bionetworks/synapse-types'
+import React from 'react'
+import { useLocation } from 'react-router-dom'
+import { getColumnIndex } from 'synapse-react-client'
+import { useSetCanonicalUrl } from '../../utils/useSetCanonicalUrl'
+import { useDetailsPageContext } from './DetailsPageContext'
+
+type DetailsPageDocumentMetadataProps = {
+  /** The set of column name(s) which define the main unique key of the column (used to define the canonical URL for SEO) */
+  resourcePrimaryKey?: string[]
+}
+
+function getCanonicalUrl(
+  pathname: string,
+  resourcePrimaryKey: string[],
+  rowSet: RowSet,
+  rowData: Row,
+) {
+  try {
+    const canonicalUrl = new URL(pathname, window.location.origin)
+    resourcePrimaryKey.forEach(columnName => {
+      const columnIndex = getColumnIndex(resourcePrimaryKey[0], rowSet?.headers)
+      if (columnIndex == null) {
+        throw new Error(
+          'No column name in rowSet.headers matching: ' + columnName,
+        )
+      }
+      const value = rowData.values[columnIndex]
+      if (value == null) {
+        throw new Error(`Retrieved null value for column ${columnName}`)
+      }
+      canonicalUrl.searchParams.append(columnName, value)
+    })
+
+    return canonicalUrl.toString()
+  } catch (e) {
+    console.error('Error generating canonical URL', e)
+    return undefined
+  }
+}
+
+export function DetailsPageDocumentMetadata(
+  props: DetailsPageDocumentMetadataProps,
+) {
+  const { resourcePrimaryKey } = props
+
+  const { pathname } = useLocation()
+  const {
+    context: { rowSet, rowData },
+  } = useDetailsPageContext()
+
+  const canonicalUrl =
+    resourcePrimaryKey != null && rowSet != null && rowData != null
+      ? getCanonicalUrl(pathname, resourcePrimaryKey, rowSet, rowData)
+      : undefined
+
+  useSetCanonicalUrl(canonicalUrl)
+
+  return <></>
+}

--- a/apps/synapse-portal-framework/src/components/Explore/ExploreWrapper.tsx
+++ b/apps/synapse-portal-framework/src/components/Explore/ExploreWrapper.tsx
@@ -1,12 +1,13 @@
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material'
 import { Box, Typography, useMediaQuery, useTheme } from '@mui/material'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Outlet, useLocation, useMatch } from 'react-router-dom'
 import { OrientationBanner } from 'synapse-react-client'
 import {
   NEGATIVE_RESPONSIVE_SIDE_MARGIN,
   RESPONSIVE_SIDE_PADDING,
 } from '../../utils'
+import { useSetCanonicalUrl } from '../../utils/useSetCanonicalUrl'
 import { ExplorePageRoute, ExploreWrapperProps } from './ExploreWrapperProps'
 import { ExploreWrapperTabs } from './ExploreWrapperTabs'
 
@@ -21,8 +22,7 @@ function RouteMatchedOrientationBanner(props: { route: ExplorePageRoute }) {
 }
 
 /**
- * RouteControl is the set of controls used on the /Explore page to navigate the
- * different keys.
+ * The set of controls shared between Explore page to navigate the different Explore routes
  */
 export default function ExploreWrapper(props: ExploreWrapperProps) {
   const { explorePaths } = props
@@ -36,15 +36,22 @@ export default function ExploreWrapper(props: ExploreWrapperProps) {
   const currentRoute = explorePaths.find(
     route => encodeURI(route.path!) === currentExploreRoute,
   )
-  if (currentRoute) {
-    const pageName =
-      currentRoute.displayName ?? currentRoute.path?.replaceAll('/', '')
-    const documentTitle = `${import.meta.env.VITE_PORTAL_NAME} - ${pageName}`
-    const newTitle: string = documentTitle
-    if (document.title !== newTitle) {
-      document.title = newTitle
+  const pageName =
+    currentRoute?.displayName ?? currentRoute?.path?.replaceAll('/', '')
+
+  useEffect(() => {
+    if (pageName) {
+      const newTitle: string = `${
+        import.meta.env.VITE_PORTAL_NAME
+      } - ${pageName}`
+      if (document.title !== newTitle) {
+        document.title = newTitle
+      }
     }
-  }
+  }, [pathname, pageName])
+
+  // The canonical URL is the explore route with no searchParams
+  useSetCanonicalUrl(new URL(pathname, window.location.origin).toString())
 
   return (
     <>
@@ -76,7 +83,7 @@ export default function ExploreWrapper(props: ExploreWrapperProps) {
           }}
           onClick={() => setShowSubNav(showSubNav => !showSubNav)}
         >
-          <Typography variant={'headline3'}>{currentExploreRoute}</Typography>
+          <Typography variant={'headline3'}>{pageName}</Typography>
           {showSubNav ? (
             <ArrowDropDown fontSize={'large'} />
           ) : (

--- a/apps/synapse-portal-framework/src/components/Explore/ExploreWrapperTabs.tsx
+++ b/apps/synapse-portal-framework/src/components/Explore/ExploreWrapperTabs.tsx
@@ -60,7 +60,6 @@ export function ExploreWrapperTabs(props: ExploreWrapperProps) {
     >
       {explorePaths.map(({ path, displayName = path }) => {
         path = `/Explore/${path}`
-        console.log('path', path, pathname)
         return (
           <Tab
             key={path}

--- a/apps/synapse-portal-framework/src/types/portal-util-types.ts
+++ b/apps/synapse-portal-framework/src/types/portal-util-types.ts
@@ -13,4 +13,6 @@ export type DetailsPageProps = React.PropsWithChildren<{
   sqlOperator?: ColumnSingleValueFilterOperator | ColumnMultiValueFunction
   additionalFiltersSessionStorageKey?: string
   ContainerProps?: ContainerProps
+  /** The set of column name(s) which define the main unique key of the column (used to define the canonical URL for SEO) */
+  resourcePrimaryKey?: string[]
 }>

--- a/apps/synapse-portal-framework/src/utils/useSetCanonicalUrl.ts
+++ b/apps/synapse-portal-framework/src/utils/useSetCanonicalUrl.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+
+/**
+ * Hook to set the canonical URL of the page.
+ *
+ * The canonical URL helps search crawlers understand which URL(s) to index when there are multiple URLs that point to
+ * the same content.
+ * @param canonicalUrl
+ */
+export function useSetCanonicalUrl(canonicalUrl?: string) {
+  useEffect(() => {
+    const previousCanonicalUrlTag = document.querySelector(
+      'link[rel="canonical"]',
+    )
+    if (canonicalUrl) {
+      if (previousCanonicalUrlTag) {
+        document.head.removeChild(previousCanonicalUrlTag)
+      }
+      const newCanonicalUrlTag = document.createElement('link')
+      newCanonicalUrlTag.setAttribute('rel', 'canonical')
+      newCanonicalUrlTag.setAttribute('href', canonicalUrl)
+      document.head.appendChild(newCanonicalUrlTag)
+    }
+
+    return () => {
+      document.querySelector('link[rel="canonical"]')?.remove()
+      if (previousCanonicalUrlTag) {
+        document.head.appendChild(previousCanonicalUrlTag)
+      }
+    }
+  }, [canonicalUrl])
+}


### PR DESCRIPTION
...and a few details pages

One hypothesis is that Google is not indexing pages in our portals because they do not identify them as unique. Adding the canonical URL to the document head could help Google dedifferentiate duplicate pages, and also identify unique pages.
