### PR TITLE
PORTALS-3344 - fix reference issue causing mismatched artifact usage

### DIFF
--- a/apps/portals/arkportal/tsconfig.json
+++ b/apps/portals/arkportal/tsconfig.json
@@ -22,5 +22,10 @@
     }
   },
   "include": ["src/**/*.tsx", "src/**/*.ts"],
-  "files": ["src/types.d.ts"]
+  "files": ["src/types.d.ts"],
+  "references": [
+    { "path": "../../synapse-portal-framework" },
+    { "path": "../../../packages/synapse-react-client" },
+    { "path": "../../../packages/vite-config" }
+  ]
 }

--- a/apps/portals/bsmn/tsconfig.json
+++ b/apps/portals/bsmn/tsconfig.json
@@ -22,5 +22,10 @@
     }
   },
   "include": ["src/**/*.tsx", "src/**/*.ts"],
-  "files": ["src/types.d.ts"]
+  "files": ["src/types.d.ts"],
+  "references": [
+    { "path": "../../synapse-portal-framework" },
+    { "path": "../../../packages/synapse-react-client" },
+    { "path": "../../../packages/vite-config" }
+  ]
 }

--- a/apps/portals/cancercomplexity/tsconfig.json
+++ b/apps/portals/cancercomplexity/tsconfig.json
@@ -22,5 +22,10 @@
     }
   },
   "include": ["src/**/*.tsx", "src/**/*.ts"],
-  "files": ["src/types.d.ts"]
+  "files": ["src/types.d.ts"],
+  "references": [
+    { "path": "../../synapse-portal-framework" },
+    { "path": "../../../packages/synapse-react-client" },
+    { "path": "../../../packages/vite-config" }
+  ]
 }

--- a/apps/portals/challengeportal/tsconfig.json
+++ b/apps/portals/challengeportal/tsconfig.json
@@ -22,5 +22,10 @@
     }
   },
   "include": ["src/**/*.tsx", "src/**/*.ts"],
-  "files": ["src/types.d.ts"]
+  "files": ["src/types.d.ts"],
+  "references": [
+    { "path": "../../synapse-portal-framework" },
+    { "path": "../../../packages/synapse-react-client" },
+    { "path": "../../../packages/vite-config" }
+  ]
 }

--- a/apps/portals/digitalhealth/tsconfig.json
+++ b/apps/portals/digitalhealth/tsconfig.json
@@ -22,5 +22,10 @@
     }
   },
   "include": ["src/**/*.tsx", "src/**/*.ts"],
-  "files": ["src/types.d.ts"]
+  "files": ["src/types.d.ts"],
+  "references": [
+    { "path": "../../synapse-portal-framework" },
+    { "path": "../../../packages/synapse-react-client" },
+    { "path": "../../../packages/vite-config" }
+  ]
 }

--- a/apps/portals/elportal/tsconfig.json
+++ b/apps/portals/elportal/tsconfig.json
@@ -22,5 +22,10 @@
     }
   },
   "include": ["src/**/*.tsx", "src/**/*.ts"],
-  "files": ["src/types.d.ts"]
+  "files": ["src/types.d.ts"],
+  "references": [
+    { "path": "../../synapse-portal-framework" },
+    { "path": "../../../packages/synapse-react-client" },
+    { "path": "../../../packages/vite-config" }
+  ]
 }

--- a/apps/portals/genie/tsconfig.json
+++ b/apps/portals/genie/tsconfig.json
@@ -22,5 +22,10 @@
     }
   },
   "include": ["src/**/*.tsx", "src/**/*.ts"],
-  "files": ["src/types.d.ts"]
+  "files": ["src/types.d.ts"],
+  "references": [
+    { "path": "../../synapse-portal-framework" },
+    { "path": "../../../packages/synapse-react-client" },
+    { "path": "../../../packages/vite-config" }
+  ]
 }

--- a/apps/portals/nf/tsconfig.json
+++ b/apps/portals/nf/tsconfig.json
@@ -22,5 +22,10 @@
     }
   },
   "include": ["src/**/*.tsx", "src/**/*.ts"],
-  "files": ["src/types.d.ts"]
+  "files": ["src/types.d.ts"],
+  "references": [
+    { "path": "../../synapse-portal-framework" },
+    { "path": "../../../packages/synapse-react-client" },
+    { "path": "../../../packages/vite-config" }
+  ]
 }

--- a/apps/portals/stopadportal/tsconfig.json
+++ b/apps/portals/stopadportal/tsconfig.json
@@ -22,5 +22,10 @@
     }
   },
   "include": ["src/**/*.tsx", "src/**/*.ts"],
-  "files": ["src/types.d.ts"]
+  "files": ["src/types.d.ts"],
+  "references": [
+    { "path": "../../synapse-portal-framework" },
+    { "path": "../../../packages/synapse-react-client" },
+    { "path": "../../../packages/vite-config" }
+  ]
 }

--- a/apps/synapse-portal-framework/tsconfig.json
+++ b/apps/synapse-portal-framework/tsconfig.json
@@ -15,18 +15,14 @@
     "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
-      "@sage-bionetworks/synapse-types": [
-        "../../../packages/synapse-types/src"
-      ],
+      "@sage-bionetworks/synapse-types": ["../../packages/synapse-types/src"],
       "@sage-bionetworks/synapse-types/*": [
-        "../../../packages/synapse-types/src/*"
+        "../../packages/synapse-types/src/*"
       ],
-      "synapse-react-client": ["../../../packages/synapse-react-client/src"],
-      "synapse-react-client/*": [
-        "../../../packages/synapse-react-client/src/*"
-      ],
-      "vite-config": ["../../../packages/vite-config/src"],
-      "vite-config/*": ["../../../packages/vite-config/src/*"]
+      "synapse-react-client": ["../../packages/synapse-react-client/src"],
+      "synapse-react-client/*": ["../../packages/synapse-react-client/src/*"],
+      "vite-config": ["../../packages/vite-config/src"],
+      "vite-config/*": ["../../packages/vite-config/src/*"]
     }
   },
   "include": ["src/**/*.tsx", "src/**/*.ts"],


### PR DESCRIPTION
- Fix erroneous tsconfig paths that caused one package to use the build artifacts and another to use source code, leading to the app using 2 different copies of the same React context
- Fill in missing tsconfig references in portals projects