### PR TITLE
SageAccountWeb: add a min height to the logo container

### DIFF
--- a/apps/SageAccountWeb/src/App.scss
+++ b/apps/SageAccountWeb/src/App.scss
@@ -96,6 +96,7 @@ $wrapper-width: 955px;
     padding: 60px 72px;
   }
   .panel-logo {
+    min-height: 70px;
     display: flex;
     align-items: stretch;
     justify-content: center;


### PR DESCRIPTION
add a min height to the logo container to prevent the layout from shifting when the logo loads