### PR TITLE
Remove openapi-generator version configuration step

### DIFF
--- a/packages/synapse-client/README.md
+++ b/packages/synapse-client/README.md
@@ -19,7 +19,7 @@ Once you have new models built, tests and type-checking on the full project shou
 
 ## Upgrading the openapi-generator version and overriding templates
 
-The current version of openapi-generator can be set by changing the version number set in the `pnpm configure` script.
+The current version of openapi-generator can be set by running `openapi-generator-cli version-manager set <version-number>`.
 When the version is changed, our template overrides should be updated.
 
 To copy all the base template files into the `./out` directory, run the following command:

--- a/packages/synapse-client/package.json
+++ b/packages/synapse-client/package.json
@@ -37,8 +37,7 @@
     "get-spec:staging": "npx tsx src/codegen/downloadSpec.ts --stack staging && pnpm format-spec",
     "get-spec:production": "npx tsx src/codegen/downloadSpec.ts --stack production && pnpm format-spec",
     "get-spec": "pnpm get-spec:production",
-    "configure": "openapi-generator-cli version-manager set 7.8.0",
-    "generate": "MODEL_NAME_MAPPINGS=$(npx tsx src/codegen/generateModelNameMappings.ts); pnpm configure && rimraf src/generated && openapi-generator-cli generate -i src/spec/openapispecification.json -c config.json -o src/generated -t out/ --model-name-mappings $MODEL_NAME_MAPPINGS",
+    "generate": "MODEL_NAME_MAPPINGS=$(npx tsx src/codegen/generateModelNameMappings.ts); rimraf src/generated && openapi-generator-cli generate -i src/spec/openapispecification.json -c config.json -o src/generated -t out/ --model-name-mappings $MODEL_NAME_MAPPINGS",
     "build": "pnpm tsc --build",
     "test": "vitest",
     "lint": "eslint src"


### PR DESCRIPTION
Fetching the list of versions queries search.maven.org, which can experience downtime. This request is unnecessary to run unless changing the version of the generator tool.