### PR TITLE
SWC-4693

### DIFF
--- a/packages/synapse-react-client/src/components/EntityUpload/EntityUpload.tsx
+++ b/packages/synapse-react-client/src/components/EntityUpload/EntityUpload.tsx
@@ -12,13 +12,13 @@ import {
 import { noop } from 'lodash-es'
 import pluralize from 'pluralize'
 import {
+  ForwardedRef,
+  forwardRef,
+  MouseEvent,
   useEffect,
   useImperativeHandle,
   useRef,
   useState,
-  MouseEvent,
-  forwardRef,
-  ForwardedRef,
 } from 'react'
 import { FixedSizeList } from 'react-window'
 import { SYNAPSE_STORAGE_LOCATION_ID } from '../../synapse-client/index'
@@ -48,6 +48,8 @@ export type EntityUploadProps = {
   entityId: string
   /** Callback that is invoked when the state of the uploader changes */
   onStateChange?: (state: UploaderState) => void
+  /** Callback that is invoked when component is ready to upload */
+  onUploadReady?: () => void
 }
 
 // This padding value will be used to manipulate the appearance of a virtualized list of FileUploadProgress components
@@ -67,7 +69,7 @@ export const EntityUpload = forwardRef(function EntityUpload(
   props: EntityUploadProps,
   ref: ForwardedRef<EntityUploadHandle>,
 ) {
-  const { entityId, onStateChange = noop } = props
+  const { entityId, onStateChange = noop, onUploadReady = noop } = props
 
   const { data: entity, isLoading: isLoadingEntity } = useGetEntity(entityId)
 
@@ -91,6 +93,7 @@ export const EntityUpload = forwardRef(function EntityUpload(
     activePrompts,
     activeUploadCount,
     isPrecheckingUpload,
+    isUploadReady,
   } = useUploadFileEntities(entityId, accessKey, secretKey, () =>
     setDidUploadsExceedStorageLimit(true),
   )
@@ -98,6 +101,12 @@ export const EntityUpload = forwardRef(function EntityUpload(
   useEffect(() => {
     onStateChange(state)
   }, [state, onStateChange])
+
+  useEffect(() => {
+    if (isUploadReady) {
+      onUploadReady()
+    }
+  }, [isUploadReady, onUploadReady])
 
   const fileInputRef = useRef<HTMLInputElement>(null)
   const folderInputRef = useRef<HTMLInputElement>(null)

--- a/packages/synapse-react-client/src/components/EntityUpload/EntityUploadModal.tsx
+++ b/packages/synapse-react-client/src/components/EntityUpload/EntityUploadModal.tsx
@@ -3,20 +3,25 @@ import {
   ForwardedRef,
   forwardRef,
   KeyboardEvent,
+  useImperativeHandle,
   useRef,
   useState,
 } from 'react'
 import { UploaderState } from '../../utils/hooks/useUploadFileEntity/useUploadFileEntities'
 import { DialogBase } from '../DialogBase'
 import { displayToast } from '../ToastMessage/ToastMessage'
-import { EntityUpload, EntityUploadHandle } from './EntityUpload'
+import {
+  EntityUpload,
+  EntityUploadHandle,
+  EntityUploadProps,
+} from './EntityUpload'
 import { LinkToURL, LinkToURLHandle } from './LinkToURL'
 
 export type EntityUploadModalProps = {
   entityId: string
   open: boolean
   onClose: () => void
-}
+} & Pick<EntityUploadProps, 'onUploadReady'>
 
 enum UploadTab {
   UploadFile,
@@ -27,13 +32,15 @@ export const EntityUploadModal = forwardRef(function EntityUploadModal(
   props: EntityUploadModalProps,
   ref: ForwardedRef<EntityUploadHandle>,
 ) {
-  const { entityId, open, onClose } = props
+  const { entityId, open, onClose, onUploadReady } = props
   const [tabValue, setTabValue] = useState<UploadTab>(UploadTab.UploadFile)
 
   const [uploadState, setUploadState] = useState<UploaderState>('LOADING')
 
   const [isLinkFormValid, setIsLinkFormValid] = useState(false)
   const linkToUrlFormRef = useRef<LinkToURLHandle>(null)
+
+  const entityUploadRef = useRef<EntityUploadHandle>(null)
 
   const disableClose =
     uploadState === 'PROMPT_USER' || uploadState === 'UPLOADING'
@@ -54,6 +61,14 @@ export const EntityUploadModal = forwardRef(function EntityUploadModal(
     }
   }
 
+  useImperativeHandle(ref, () => ({
+    handleUploads: (fileList: ArrayLike<File>) => {
+      // When an upload starts via imperative handle (e.g. via drag-and-drop), switch to the upload tab
+      setTabValue(UploadTab.UploadFile)
+      entityUploadRef.current?.handleUploads(fileList)
+    },
+  }))
+
   return (
     <DialogBase
       DialogProps={{
@@ -62,6 +77,8 @@ export const EntityUploadModal = forwardRef(function EntityUploadModal(
             onFinish()
           }
         },
+        // SWC-4693 - For drag-and-drop upload to be ready before the modal opens, the modal contents must be mounted
+        keepMounted: true,
       }}
       title={'Upload or Link to File'}
       open={open}
@@ -81,9 +98,10 @@ export const EntityUploadModal = forwardRef(function EntityUploadModal(
           </Tabs>
           <Box display={tabValue === UploadTab.UploadFile ? 'block' : 'none'}>
             <EntityUpload
-              ref={ref}
+              ref={entityUploadRef}
               entityId={entityId}
               onStateChange={setUploadState}
+              onUploadReady={onUploadReady}
             />
           </Box>
           <Box display={tabValue === UploadTab.LinkToURL ? 'block' : 'none'}>


### PR DESCRIPTION
Support drag-and-drop upload before opening modal

- Update useUploadFileEntities to indicate when required data has been fetched, so the caller knows when imperative upload can begin
- Add callback prop to EntityUpload/EntityUploadModal to indicate to SWC widget when imperative upload can begin
- EntityUploadModal changes to ensure upload tab is shown after imperative upload starts
- Use keepMounted dialog prop to ensure EntityUpload component is mounted to be ready for drag-and-drop