### PR TITLE
SWC-7221: SRC UserCards don't stretch for 2-column grid layout on some devices

### DIFF
--- a/packages/synapse-react-client/src/style/base/_core.scss
+++ b/packages/synapse-react-client/src/style/base/_core.scss
@@ -346,7 +346,7 @@ a.SRC-whiteText {
   width: 100%;
   width: -webkit-fill-available; // for chrome
   width: -moz-available; // for firefox
-  padding-left: 25px;
+  padding: 0 25px;
   min-width: 350px;
 }
 

--- a/packages/synapse-react-client/src/style/base/_core.scss
+++ b/packages/synapse-react-client/src/style/base/_core.scss
@@ -377,7 +377,7 @@ a.SRC-whiteText {
 .SRC-card-grid-row {
   display: flex;
   flex-flow: row wrap;
-  justify-content: space-between;
+  column-gap: 18px;
 }
 
 .SRC-split {
@@ -389,7 +389,7 @@ a.SRC-whiteText {
 
 .SRC-grid-item {
   height: 120px;
-  flex-grow: 0;
+  flex-grow: 1;
   flex-shrink: 1;
   margin: 10px 10px;
   width: 350px;


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/SWC-7221

<img width="420" alt="Screenshot 2025-01-13 at 9 57 10 AM" src="https://github.com/user-attachments/assets/69242dc1-4394-4029-a320-d36deb2e36e1" />
