### PR TITLE
FeaturedResearch Component Update: Removing Tags and Affiliation

### DIFF
--- a/packages/synapse-react-client/src/components/FeaturedResearch/FeaturedResearch.test.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedResearch/FeaturedResearch.test.tsx
@@ -43,22 +43,12 @@ describe('FeaturedResearch Tests', () => {
             id: '3',
           },
           {
-            name: 'tags',
-            columnType: ColumnTypeEnum.STRING_LIST,
-            id: '4',
-          },
-          {
-            name: 'affiliation',
-            columnType: ColumnTypeEnum.STRING,
-            id: '5',
-          },
-          {
             name: 'image',
             columnType: ColumnTypeEnum.FILEHANDLEID,
-            id: '6',
+            id: '4',
           },
-          { name: 'link', columnType: ColumnTypeEnum.LINK, id: '7' },
-          { name: 'order', columnType: ColumnTypeEnum.INTEGER, id: '8' },
+          { name: 'link', columnType: ColumnTypeEnum.LINK, id: '5' },
+          { name: 'order', columnType: ColumnTypeEnum.INTEGER, id: '6' },
         ],
         rows: [
           {
@@ -67,8 +57,6 @@ describe('FeaturedResearch Tests', () => {
               'Title 1',
               'Description 1',
               '1726164997000',
-              '["tag1_1", "tag1_2"]',
-              'affiliation 1',
               '151525812',
               'https://mockurl.com/data-release-1',
               '2',
@@ -80,8 +68,6 @@ describe('FeaturedResearch Tests', () => {
               'Title 2',
               'Description 2',
               '1726164997000',
-              '["tag2_1"]',
-              'affiliation 2',
               '151468828',
               'https://mockurl.com/data-release-2',
               '2',
@@ -107,22 +93,12 @@ describe('FeaturedResearch Tests', () => {
         id: '3',
       },
       {
-        name: 'tags',
-        columnType: ColumnTypeEnum.STRING_LIST,
-        id: '4',
-      },
-      {
-        name: 'affiliation',
-        columnType: ColumnTypeEnum.STRING,
-        id: '5',
-      },
-      {
         name: 'image',
         columnType: ColumnTypeEnum.FILEHANDLEID,
-        id: '6',
+        id: '4',
       },
-      { name: 'link', columnType: ColumnTypeEnum.LINK, id: '7' },
-      { name: 'order', columnType: ColumnTypeEnum.INTEGER, id: '8' },
+      { name: 'link', columnType: ColumnTypeEnum.LINK, id: '5' },
+      { name: 'order', columnType: ColumnTypeEnum.INTEGER, id: '6' },
     ],
   }
 
@@ -169,12 +145,8 @@ describe('FeaturedResearch Tests', () => {
     expect(screen.getByText('Read more')).toBeInTheDocument()
     expect(screen.getByText('Title 1')).toBeInTheDocument()
     expect(screen.getByText('Description 1')).toBeInTheDocument()
-    expect(screen.getByText('tag1_1')).toBeInTheDocument()
-    expect(screen.getByText('affiliation 1')).toBeInTheDocument()
 
     expect(screen.getByText('Title 2')).toBeInTheDocument()
-    expect(screen.getByText('tag2_1')).toBeInTheDocument()
-    expect(screen.getByText('affiliation 2')).toBeInTheDocument()
     expect(screen.getByText('September, 2024')).toBeInTheDocument()
 
     await waitFor(() => {

--- a/packages/synapse-react-client/src/components/FeaturedResearch/FeaturedResearch.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedResearch/FeaturedResearch.tsx
@@ -28,11 +28,9 @@ export type FeaturedResearchCardProps = {
   research: Row
   entityId: string
   isLoading: boolean
-  affiliationColIndex: number
   publicationDateColIndex: number
   titleColIndex: number
   descriptionColIndex: number
-  tagsColIndex: number
   linkColIndex: number
   imageColIndex: number
 }
@@ -51,30 +49,11 @@ const useImageUrl = (fileId: string, entityId: string) => {
   return dataUrl
 }
 
-const parseTags = (
-  tagsColIndex: number,
-  research: { values: (string | null)[] },
-): string[] => {
-  try {
-    const tags = (
-      research.values[tagsColIndex]
-        ? JSON.parse(research.values[tagsColIndex] || '')
-        : []
-    ) as string[]
-    return tags
-  } catch (e) {
-    console.error(e)
-    return []
-  }
-}
-
 const FeaturedResearchCard = ({
   research,
   entityId,
-  affiliationColIndex,
   publicationDateColIndex,
   titleColIndex,
-  tagsColIndex,
   linkColIndex,
   imageColIndex,
   isLoading,
@@ -99,14 +78,6 @@ const FeaturedResearchCard = ({
       }}
     >
       <Stack useFlexGap gap={'10px'}>
-        <Typography
-          fontSize={'14px'}
-          lineHeight={'normal'}
-          fontWeight={500}
-          color={'grey.600'}
-        >
-          {research.values[affiliationColIndex]}
-        </Typography>
         <Typography variant="headline2" color="gray.1000" fontSize={'21px'}>
           <Link
             href={research.values[linkColIndex] ?? ''}
@@ -122,29 +93,13 @@ const FeaturedResearchCard = ({
             {research.values[titleColIndex]}
           </Link>
         </Typography>
-        <Stack direction={'row'} useFlexGap gap={'16px'} alignItems={'center'}>
-          {parseTags(tagsColIndex, research)[0] && (
-            <Typography
-              variant="overline"
-              fontSize={'14px'}
-              sx={{
-                backgroundColor: 'grey.300',
-                borderRadius: '3px',
-                padding: '4px 8px',
-                lineHeight: 'initial',
-              }}
-            >
-              {parseTags(tagsColIndex, research)[0] || ''}
-            </Typography>
-          )}
-          <Typography lineHeight={'normal'} color={'grey.600'}>
-            {research.values[publicationDateColIndex] &&
-              formatDate(
-                dayjs(Number(research.values[publicationDateColIndex])),
-                'MMMM, YYYY',
-              )}
-          </Typography>
-        </Stack>
+        <Typography lineHeight={'normal'} color={'grey.600'}>
+          {research.values[publicationDateColIndex] &&
+            formatDate(
+              dayjs(Number(research.values[publicationDateColIndex])),
+              'MMMM, YYYY',
+            )}
+        </Typography>
       </Stack>
       <CardMedia
         component="img"
@@ -166,10 +121,8 @@ const FeaturedResearchCard = ({
 const FeaturedResearchTopCard = ({
   research,
   entityId,
-  affiliationColIndex,
   titleColIndex,
   descriptionColIndex,
-  tagsColIndex,
   linkColIndex,
   imageColIndex,
   isLoading,
@@ -199,32 +152,6 @@ const FeaturedResearchTopCard = ({
           marginBottom: '30px',
         }}
       />
-      <Stack
-        direction="row"
-        useFlexGap
-        gap={'10px'}
-        paddingBottom={'20px'}
-        alignItems={'start'}
-      >
-        {parseTags(tagsColIndex, research)[0] && (
-          <Typography
-            fontSize={'14px'}
-            lineHeight={'normal'}
-            sx={{
-              fontWeight: 700,
-              backgroundColor: 'primary.main',
-              color: '#FFFF',
-              padding: '3px 8px',
-              borderRadius: '3px',
-            }}
-          >
-            {parseTags(tagsColIndex, research)[0] || ''}
-          </Typography>
-        )}
-        <Typography lineHeight={'normal'} color={'grey.600'}>
-          {research.values[affiliationColIndex] ?? ''}
-        </Typography>
-      </Stack>
       <Stack useFlexGap gap={'16px'}>
         <Typography variant="headline2" fontSize={'36px'} color={'grey.1000'}>
           <Link
@@ -276,8 +203,6 @@ function FeaturedResearch(props: FeaturedResearchProps) {
     TITLE = 'title',
     DESCRIPTION = 'description',
     PUBLICATION_DATE = 'publicationDate',
-    TAGS = 'tags',
-    AFFILIATION = 'affiliation',
     IMAGE = 'image',
     LINK = 'link',
   }
@@ -289,11 +214,6 @@ function FeaturedResearch(props: FeaturedResearchProps) {
   )
   const publicationDateColIndex = getFieldIndex(
     ExpectedColumns.PUBLICATION_DATE,
-    queryResultBundle,
-  )
-  const tagsColIndex = getFieldIndex(ExpectedColumns.TAGS, queryResultBundle)
-  const affiliationColIndex = getFieldIndex(
-    ExpectedColumns.AFFILIATION,
     queryResultBundle,
   )
   const imageColIndex = getFieldIndex(ExpectedColumns.IMAGE, queryResultBundle)
@@ -323,8 +243,6 @@ function FeaturedResearch(props: FeaturedResearchProps) {
             isLoading={isLoading}
             descriptionColIndex={descriptionColIndex}
             publicationDateColIndex={publicationDateColIndex}
-            tagsColIndex={tagsColIndex}
-            affiliationColIndex={affiliationColIndex}
             imageColIndex={imageColIndex}
             linkColIndex={linkColIndex}
           />
@@ -350,8 +268,6 @@ function FeaturedResearch(props: FeaturedResearchProps) {
             titleColIndex={titleColIndex}
             descriptionColIndex={descriptionColIndex}
             publicationDateColIndex={publicationDateColIndex}
-            tagsColIndex={tagsColIndex}
-            affiliationColIndex={affiliationColIndex}
             imageColIndex={imageColIndex}
             linkColIndex={linkColIndex}
           />


### PR DESCRIPTION
In a thread with Milan and Adam, we have discussed removing tags and affiliation like so:

<img width="850" alt="Screenshot 2025-01-13 at 3 21 55 PM" src="https://github.com/user-attachments/assets/1e73b31a-d5d1-4442-92be-96d43ab0d577" />

<img width="850" alt="Screenshot 2025-01-13 at 3 32 03 PM" src="https://github.com/user-attachments/assets/559de1b2-4328-4d3f-9769-c717700fc36a" />
