### PR TITLE
PORTALS-3291: bug fix. use the group label as the facet value rather than the …

### DIFF
--- a/packages/synapse-react-client/src/components/Plot/ThemesPlot.tsx
+++ b/packages/synapse-react-client/src/components/Plot/ThemesPlot.tsx
@@ -383,9 +383,10 @@ export function ThemesPlot({
                     >
                       <DotPlot
                         id={`${i}`}
-                        onClick={(e: any) =>
-                          onPointClick(getClickTargetData(e, false))
-                        }
+                        onClick={(e: any) => {
+                          const { type, event } = getClickTargetData(e, false)
+                          onPointClick({ facetValue: label, type, event })
+                        }}
                         plotData={dotPlotQueryData}
                         plotStyle={dotPlot.plotStyle}
                         markerSymbols={dotPlot.markerSymbols}


### PR DESCRIPTION
…y value (which is just an offset, such as 0 or 1 or 2) for the dot plots in the themes plot