### PR TITLE
PORTALS-3253 - Remove imports against `src/index.ts`

### DIFF
--- a/packages/synapse-react-client/README.md
+++ b/packages/synapse-react-client/README.md
@@ -97,7 +97,7 @@ In this example, make sure that your `node_modules` folder is in your Dart Sass 
 
 ## Adding a new component and Publishing a new version of SRC
 
-To expose a component from the library you must export it from [index.ts](src/index.ts). Ideally, your component will get its own subfolder within `src/components/`, which will contain an `index.ts` file that exports the public API of the component (typically the component and its props type). In `src/components/index.ts`, you can then export the contents of the new subfolder.
+JavaScript packages and applications inside the monorepo can directly import modules within the `src` folder, so modules created within the `src` directory are accessible from other TypeScript packages and applications within the monorepo--they have been configured to reference the synapse-react-client source files.
 
 To expose a component for use in synapse.org, you must export it from [umd.index.ts](src/umd.index.ts). Note that certain dependencies are not included in the UMD bundle. See the config used to build the bundle, `vite.config.umd.ts`, for more details.
 
@@ -112,6 +112,10 @@ In the project directory, you can run:
 ### `pnpm start`
 
 Runs Storybook, which allows you to inspect and interact with components.
+
+### `pnpm type-check`
+
+Runs the TypeScript compiler to type-check the project.
 
 ### `pnpm test`
 

--- a/packages/synapse-react-client/README.md
+++ b/packages/synapse-react-client/README.md
@@ -97,7 +97,7 @@ In this example, make sure that your `node_modules` folder is in your Dart Sass 
 
 ## Adding a new component and Publishing a new version of SRC
 
-JavaScript packages and applications inside the monorepo can directly import modules within the `src` folder, so modules created within the `src` directory are accessible from other TypeScript packages and applications within the monorepo--they have been configured to reference the synapse-react-client source files.
+JavaScript packages and applications inside the monorepo that have been configured to reference the synapse-react-client source files can directly import modules within the `src` folder without exporting them from any additional file.
 
 To expose a component for use in synapse.org, you must export it from [umd.index.ts](src/umd.index.ts). Note that certain dependencies are not included in the UMD bundle. See the config used to build the bundle, `vite.config.umd.ts`, for more details.
 

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManagedACTAccessRequirementItem.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManagedACTAccessRequirementItem.test.tsx
@@ -1,21 +1,22 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
-import ManagedACTAccessRequirementItem, {
-  ManagedACTAccessRequirementItemProps,
-} from './ManagedACTAccessRequirementItem'
-import { createWrapper } from '../../../testutils/TestingLibraryUtils'
 import {
   AccessRequirementStatus,
   SubmissionState,
 } from '@sage-bionetworks/synapse-types'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {
   mockManagedACTAccessRequirement,
   mockManagedACTAccessRequirementWikiPageKey,
 } from '../../../mocks/accessRequirement/mockAccessRequirements'
-import { SynapseClient, SynapseContextType } from '../../../index'
-import { MOCK_USER_ID } from '../../../mocks/user/mock_user_profile'
-import userEvent from '@testing-library/user-event'
-import MarkdownSynapse from '../../Markdown/MarkdownSynapse'
 import { MOCK_ACCESS_TOKEN } from '../../../mocks/MockSynapseContext'
+import { MOCK_USER_ID } from '../../../mocks/user/mock_user_profile'
+import SynapseClient from '../../../synapse-client'
+import { createWrapper } from '../../../testutils/TestingLibraryUtils'
+import { SynapseContextType } from '../../../utils/index'
+import MarkdownSynapse from '../../Markdown/MarkdownSynapse'
+import ManagedACTAccessRequirementItem, {
+  ManagedACTAccessRequirementItemProps,
+} from './ManagedACTAccessRequirementItem'
 
 async function renderComponent(
   props: ManagedACTAccessRequirementItemProps,

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.test.tsx
@@ -15,7 +15,7 @@ import {
   mockManagedACTAccessRequirement,
   mockManagedACTAccessRequirementWikiPageKey,
 } from '../../../../mocks/accessRequirement/mockAccessRequirements'
-import { SynapseClient } from '../../../../index'
+import * as SynapseClient from '../../../../synapse-client/SynapseClient'
 import {
   MOCK_EMPTY_RESEARCH_PROJECT,
   MOCK_RESEARCH_PROJECT,

--- a/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/SelfSignAccessRequirementItem.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/SelfSignAccessRequirementItem.test.tsx
@@ -1,28 +1,30 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
-import { createWrapper } from '../../../testutils/TestingLibraryUtils'
-import { SynapseClient, SynapseContextType } from '../../../index'
 import {
   AccessApproval,
   AccessRequirementStatus,
   ApprovalState,
 } from '@sage-bionetworks/synapse-types'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {
   mockAccessRequirementWikiPageKeys,
   mockSelfSignAccessRequirement,
   mockSelfSignAccessRequirementWikiPageKey,
   mockToUAccessRequirement,
 } from '../../../mocks/accessRequirement/mockAccessRequirements'
-import userEvent from '@testing-library/user-event'
-import { MarkdownSynapseProps } from '../../Markdown/MarkdownSynapse'
-import SelfSignAccessRequirementItem, {
-  SelfSignAccessRequirementItemProps,
-} from './SelfSignAccessRequirementItem'
 import {
   MOCK_USER_ID,
   mockUserBundle,
   mockUserProfileData,
 } from '../../../mocks/user/mock_user_profile'
-import MarkdownSynapse from '../../Markdown/MarkdownSynapse'
+import SynapseClient from '../../../synapse-client'
+import { createWrapper } from '../../../testutils/TestingLibraryUtils'
+import { SynapseContextType } from '../../../utils/index'
+import MarkdownSynapse, {
+  MarkdownSynapseProps,
+} from '../../Markdown/MarkdownSynapse'
+import SelfSignAccessRequirementItem, {
+  SelfSignAccessRequirementItemProps,
+} from './SelfSignAccessRequirementItem'
 
 jest.mock('../../Markdown/MarkdownSynapse', () => ({
   __esModule: true,

--- a/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/UnmanagedACTAccessRequirementItem.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/UnmanagedACTAccessRequirementItem.test.tsx
@@ -1,19 +1,20 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
-import { createWrapper } from '../../../testutils/TestingLibraryUtils'
-import UnmanagedACTAccessRequirementItem, {
-  UnmanagedACTAccessRequirementItemProps,
-} from './UnmanagedACTAccessRequirementItem'
-import { SynapseClient, SynapseContextType } from '../../../index'
 import {
   AccessRequirementStatus,
   RestrictableObjectType,
 } from '@sage-bionetworks/synapse-types'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {
   mockACTAccessRequirement,
   mockManagedACTAccessRequirement,
 } from '../../../mocks/accessRequirement/mockAccessRequirements'
 import { MOCK_FILE_ENTITY_ID } from '../../../mocks/entity/mockFileEntity'
-import userEvent from '@testing-library/user-event'
+import SynapseClient from '../../../synapse-client'
+import { createWrapper } from '../../../testutils/TestingLibraryUtils'
+import { SynapseContextType } from '../../../utils/index'
+import UnmanagedACTAccessRequirementItem, {
+  UnmanagedACTAccessRequirementItemProps,
+} from './UnmanagedACTAccessRequirementItem'
 
 function renderComponent(
   props: UnmanagedACTAccessRequirementItemProps,

--- a/packages/synapse-react-client/src/components/AccessTokenPage/AccessTokenCard/AccessTokenCard.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessTokenPage/AccessTokenCard/AccessTokenCard.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { SynapseClient } from '../../../index'
+import SynapseClient from '../../../synapse-client'
 import {
   AccessTokenCard,
   AccessTokenCardProps,

--- a/packages/synapse-react-client/src/components/FeaturedResearch/FeaturedResearch.test.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedResearch/FeaturedResearch.test.tsx
@@ -8,7 +8,7 @@ import {
   QueryResultBundle,
 } from '@sage-bionetworks/synapse-types'
 import { getUseQuerySuccessMock } from '../../testutils/ReactQueryMockUtils'
-import { SynapseClient } from '../../index'
+import SynapseClient from '../../synapse-client'
 
 jest.mock('../../synapse-queries/entity/useGetQueryResultBundle')
 const mockUseGetQueryResultBundle = jest.mocked(useGetQueryResultBundle)

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.test.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.test.tsx
@@ -7,7 +7,7 @@ import {
   QueryResultBundle,
   BatchFileResult,
 } from '@sage-bionetworks/synapse-types'
-import { SynapseClient } from '../../index'
+import SynapseClient from '../../synapse-client'
 
 const tableQueryResult: QueryResultBundle = {
   concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',

--- a/packages/synapse-react-client/src/components/ImageCardGridWithLinks/ImageCardGridWithLinks.test.tsx
+++ b/packages/synapse-react-client/src/components/ImageCardGridWithLinks/ImageCardGridWithLinks.test.tsx
@@ -5,7 +5,7 @@ import {
 } from '@sage-bionetworks/synapse-types'
 import { render, screen, waitFor } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router'
-import { SynapseClient } from '../../index'
+import SynapseClient from '../../synapse-client'
 import useGetQueryResultBundle from '../../synapse-queries/entity/useGetQueryResultBundle'
 import { getUseQuerySuccessMock } from '../../testutils/ReactQueryMockUtils'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'

--- a/packages/synapse-react-client/src/components/Plot/SynapsePlot.test.tsx
+++ b/packages/synapse-react-client/src/components/Plot/SynapsePlot.test.tsx
@@ -1,5 +1,5 @@
 import SynapsePlot, { SynapsePlotProps } from './SynapsePlot'
-import { SynapseClient } from '../../index'
+import SynapseClient from '../../synapse-client'
 import { QueryResultBundle } from '@sage-bionetworks/synapse-types'
 import mockSyn26438037Counts from '../../mocks/query/syn26438037Counts.json'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'

--- a/packages/synapse-react-client/src/components/PortalFeaturedPartners/PortalFeaturedPartners.test.tsx
+++ b/packages/synapse-react-client/src/components/PortalFeaturedPartners/PortalFeaturedPartners.test.tsx
@@ -10,7 +10,7 @@ import {
   QueryResultBundle,
 } from '@sage-bionetworks/synapse-types'
 import { getUseQuerySuccessMock } from '../../testutils/ReactQueryMockUtils'
-import { SynapseClient } from '../../index'
+import SynapseClient from '../../synapse-client'
 
 jest.mock('../../synapse-queries/entity/useGetQueryResultBundle')
 const mockUseGetQueryResultBundle = jest.mocked(useGetQueryResultBundle)

--- a/packages/synapse-react-client/src/components/ProgrammaticTableDownload/ProgrammaticTableDownload.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/ProgrammaticTableDownload/ProgrammaticTableDownload.integration.test.tsx
@@ -13,7 +13,7 @@ import { MOCK_CONTEXT_VALUE } from '../../mocks/MockSynapseContext'
 import ProgrammaticTableDownload, {
   ProgrammaticTableDownloadProps,
 } from './ProgrammaticTableDownload'
-import { SynapseConstants } from '../../index'
+import * as SynapseConstants from '../../utils/SynapseConstants'
 import { DEFAULT_PAGE_SIZE } from '../../utils/SynapseConstants'
 import { registerTableQueryResult } from '../../mocks/msw/handlers/tableQueryService'
 

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.stories.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.stories.tsx
@@ -1,10 +1,3 @@
-import { Meta, StoryObj } from '@storybook/react'
-import {
-  DATASET,
-  EXPERIMENTAL_TOOL,
-  GENERIC_CARD,
-  MEDIUM_USER_CARD,
-} from '../../utils/SynapseConstants'
 import {
   ColumnMultiValueFunction,
   ColumnSingleValueFilterOperator,
@@ -12,15 +5,22 @@ import {
   Direction,
   Query,
 } from '@sage-bionetworks/synapse-types'
+import { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import SynapseClient from '../../synapse-client'
+import { QUERY_FILTERS_SESSION_STORAGE_KEY } from '../../utils/functions'
+import {
+  DATASET,
+  EXPERIMENTAL_TOOL,
+  GENERIC_CARD,
+  MEDIUM_USER_CARD,
+} from '../../utils/SynapseConstants'
+import { CustomControlCallbackData } from '../SynapseTable'
+import { displayToast } from '../ToastMessage'
 import QueryWrapperPlotNav, {
   QueryWrapperPlotNavProps,
 } from './QueryWrapperPlotNav'
-import { displayToast } from '../ToastMessage'
-import { CustomControlCallbackData } from '../SynapseTable'
-import { QUERY_FILTERS_SESSION_STORAGE_KEY } from '../../utils/functions'
-import { SynapseClient } from '../../index'
 import { QueryWrapperSynapsePlotRowClickEvent } from './QueryWrapperSynapsePlot'
-import { fn } from '@storybook/test'
 
 const meta: Meta<QueryWrapperPlotNavProps> = {
   title: 'Explore/QueryWrapperPlotNav',

--- a/packages/synapse-react-client/src/components/SubscriptionPage/SubscriptionPage.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/SubscriptionPage/SubscriptionPage.integration.test.tsx
@@ -1,9 +1,10 @@
-import userEvent from '@testing-library/user-event'
-import { act, render, screen, waitFor, within } from '@testing-library/react'
-import { SubscriptionPage, SynapseClient } from '../../index'
-import { createWrapper } from '../../testutils/TestingLibraryUtils'
-import { server } from '../../mocks/msw/server'
 import { SubscriptionObjectType } from '@sage-bionetworks/synapse-types'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { server } from '../../mocks/msw/server'
+import SynapseClient from '../../synapse-client'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import SubscriptionPage from './SubscriptionPage'
 
 function setUp() {
   const user = userEvent.setup()

--- a/packages/synapse-react-client/src/components/SynapseNavDrawer/SynapseNavDrawer.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseNavDrawer/SynapseNavDrawer.test.tsx
@@ -7,7 +7,7 @@ import {
   MOCK_USER_ID_2,
   mockUserBundle,
 } from '../../mocks/user/mock_user_profile'
-import { SynapseClient } from '../../index'
+import SynapseClient from '../../synapse-client'
 import { SubmissionState } from '@sage-bionetworks/synapse-types'
 import { SubmissionSearchResult } from '@sage-bionetworks/synapse-types'
 import { mockManagedACTAccessRequirement } from '../../mocks/accessRequirement/mockAccessRequirements'

--- a/packages/synapse-react-client/src/components/SynapseTable/RowSelection/RowSelection.stories.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/RowSelection/RowSelection.stories.tsx
@@ -1,9 +1,9 @@
-import { Meta, StoryObj } from '@storybook/react'
-import { displayToast } from '../../../index'
 import { GetApp } from '@mui/icons-material'
-import { RowSelectionUI, RowSelectionUIProps } from './RowSelectionUI'
 import { Button } from '@mui/material'
+import { Meta, StoryObj } from '@storybook/react'
 import { times } from 'lodash-es'
+import { displayToast } from '../../../components/ToastMessage/ToastMessage'
+import { RowSelectionUI, RowSelectionUIProps } from './RowSelectionUI'
 
 const meta = {
   title: 'Explore/RowSelection',

--- a/packages/synapse-react-client/src/components/SynapseTable/SendToCavaticaConfirmationDialog.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SendToCavaticaConfirmationDialog.integration.test.tsx
@@ -1,32 +1,32 @@
-import { PropsWithChildren } from 'react'
-import SendToCavaticaConfirmationDialog from './SendToCavaticaConfirmationDialog'
-import { QueryWrapper } from '../../index'
+import { ColumnSingleValueFilterOperator } from '@sage-bionetworks/synapse-types'
 import { act, render, screen, waitFor } from '@testing-library/react'
-import { createWrapper } from '../../testutils/TestingLibraryUtils'
 import userEvent from '@testing-library/user-event'
+import { useSetAtom } from 'jotai'
+import { PropsWithChildren } from 'react'
+import { mockManagedACTAccessRequirement } from '../../mocks/accessRequirement/mockAccessRequirements'
 import {
   mockQueryBundleRequest,
   mockQueryResultBundle,
 } from '../../mocks/mockFileViewQuery'
+import { getEntityHandlers } from '../../mocks/msw/handlers/entityHandlers'
+import { registerTableQueryResult } from '../../mocks/msw/handlers/tableQueryService'
+import { server } from '../../mocks/msw/server'
+import * as UseActionsRequiredForTableQueryModule from '../../synapse-queries/entity/useActionsRequiredForTableQuery'
+import * as UseExportToCavaticaModule from '../../synapse-queries/entity/useExportToCavatica'
+import {
+  getUseQueryLoadingMock,
+  getUseQuerySuccessMock,
+} from '../../testutils/ReactQueryMockUtils'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import { MOCK_REPO_ORIGIN } from '../../utils/functions/getEndpoint'
 import {
   QueryVisualizationContextType,
   QueryVisualizationWrapper,
   useQueryVisualizationContext,
 } from '../QueryVisualizationWrapper'
-import { ColumnSingleValueFilterOperator } from '@sage-bionetworks/synapse-types'
-import { mockManagedACTAccessRequirement } from '../../mocks/accessRequirement/mockAccessRequirements'
-import * as UseExportToCavaticaModule from '../../synapse-queries/entity/useExportToCavatica'
-import * as UseActionsRequiredForTableQueryModule from '../../synapse-queries/entity/useActionsRequiredForTableQuery'
-import { server } from '../../mocks/msw/server'
-import { useSetAtom } from 'jotai'
+import { QueryWrapper } from '../QueryWrapper'
 import { selectedRowsAtom } from '../QueryWrapper/TableRowSelectionState'
-import {
-  getUseQueryLoadingMock,
-  getUseQuerySuccessMock,
-} from '../../testutils/ReactQueryMockUtils'
-import { getEntityHandlers } from '../../mocks/msw/handlers/entityHandlers'
-import { MOCK_REPO_ORIGIN } from '../../utils/functions/getEndpoint'
-import { registerTableQueryResult } from '../../mocks/msw/handlers/tableQueryService'
+import SendToCavaticaConfirmationDialog from './SendToCavaticaConfirmationDialog'
 
 const onExportToCavatica = jest.fn().mockImplementation(() => Promise.resolve())
 

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.integration.test.tsx
@@ -1,21 +1,4 @@
 /* eslint jest/no-conditional-expect: 0 */
-import { render, screen, waitFor, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { cloneDeep } from 'lodash-es'
-import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
-import { SynapseConstants } from '../../utils'
-import {
-  QueryVisualizationWrapper,
-  QueryVisualizationWrapperProps,
-} from '../QueryVisualizationWrapper'
-import { SynapseTable, SynapseTableProps } from './SynapseTable'
-import { createWrapper } from '../../testutils/TestingLibraryUtils'
-import { ENTITY_HEADERS, ENTITY_ID_VERSION } from '../../utils/APIConstants'
-import {
-  BackendDestinationEnum,
-  getEndpoint,
-} from '../../utils/functions/getEndpoint'
-import { DEFAULT_PAGE_SIZE } from '../../utils/SynapseConstants'
 import {
   EntityHeader,
   FileEntity,
@@ -29,32 +12,48 @@ import {
   RestrictionLevel,
   Table,
 } from '@sage-bionetworks/synapse-types'
-import { rest, server } from '../../mocks/msw/server'
-import queryResultBundle from '../../mocks/query/syn16787123'
-import { MOCK_USER_ID } from '../../mocks/user/mock_user_profile'
-import * as HasAccessModule from '../HasAccess/HasAccessV2'
-import * as UserCardModule from '../UserCard/UserCard'
-import * as AddToDownloadListV2Module from '../AddToDownloadListV2'
-import {
-  QueryContextConsumer,
-  QueryContextType,
-  QueryWrapper,
-  QueryWrapperProps,
-} from '../../index'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { cloneDeep } from 'lodash-es'
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
+import { mockDatasetEntity } from '../../mocks/entity/mockDataset'
+import { mockFileViewEntity } from '../../mocks/entity/mockFileView'
+import { mockProjectIds } from '../../mocks/entity/mockProject'
+import { mockProjectViewEntity } from '../../mocks/entity/mockProjectView'
 import {
   MOCK_TABLE_ENTITY_ID,
   mockTableEntity,
 } from '../../mocks/entity/mockTableEntity'
-import { mockProjectIds } from '../../mocks/entity/mockProject'
 import { mockFileHandle } from '../../mocks/mock_file_handle'
-import { mockFileViewEntity } from '../../mocks/entity/mockFileView'
-import { mockProjectViewEntity } from '../../mocks/entity/mockProjectView'
-import { mockDatasetEntity } from '../../mocks/entity/mockDataset'
-import { mockQueryResult } from '../../mocks/query/mockProjectViewQueryResults'
-import * as NoContentPlaceholderModule from '../QueryVisualizationWrapper/NoContentPlaceholder'
-import { normalizeNumericId } from '../../utils/functions/StringUtils'
-import { registerTableQueryResult } from '../../mocks/msw/handlers/tableQueryService'
 import mockQueryResponseData from '../../mocks/mockQueryResponseData'
+import { registerTableQueryResult } from '../../mocks/msw/handlers/tableQueryService'
+import { rest, server } from '../../mocks/msw/server'
+import { mockQueryResult } from '../../mocks/query/mockProjectViewQueryResults'
+import queryResultBundle from '../../mocks/query/syn16787123'
+import { MOCK_USER_ID } from '../../mocks/user/mock_user_profile'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import { SynapseConstants } from '../../utils'
+import { ENTITY_HEADERS, ENTITY_ID_VERSION } from '../../utils/APIConstants'
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from '../../utils/functions/getEndpoint'
+import { normalizeNumericId } from '../../utils/functions/StringUtils'
+import { DEFAULT_PAGE_SIZE } from '../../utils/SynapseConstants'
+import * as AddToDownloadListV2Module from '../AddToDownloadListV2'
+import * as HasAccessModule from '../HasAccess/HasAccessV2'
+import {
+  QueryContextConsumer,
+  QueryContextType,
+} from '../QueryContext/QueryContext'
+import {
+  QueryVisualizationWrapper,
+  QueryVisualizationWrapperProps,
+} from '../QueryVisualizationWrapper'
+import * as NoContentPlaceholderModule from '../QueryVisualizationWrapper/NoContentPlaceholder'
+import { QueryWrapper, QueryWrapperProps } from '../QueryWrapper'
+import * as UserCardModule from '../UserCard/UserCard'
+import { SynapseTable, SynapseTableProps } from './SynapseTable'
 
 const synapseTableEntityId = 'syn16787123'
 

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/SynapseTableCell.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/SynapseTableCell.test.tsx
@@ -1,17 +1,3 @@
-import { render, screen } from '@testing-library/react'
-import { SynapseConstants } from '../../../utils'
-import SynapseTableCell, { SynapseTableCellProps } from './SynapseTableCell'
-import { NOT_SET_DISPLAY_VALUE } from '../SynapseTableConstants'
-import { createWrapper } from '../../../testutils/TestingLibraryUtils'
-import { ENTITY_HEADERS, ENTITY_ID_VERSION } from '../../../utils/APIConstants'
-import {
-  BackendDestinationEnum,
-  getEndpoint,
-} from '../../../utils/functions/getEndpoint'
-import {
-  AUTHENTICATED_PRINCIPAL_ID,
-  DEFAULT_PAGE_SIZE,
-} from '../../../utils/SynapseConstants'
 import {
   ColumnTypeEnum,
   EntityHeader,
@@ -22,23 +8,37 @@ import {
   ReferenceList,
   VersionableEntity,
 } from '@sage-bionetworks/synapse-types'
+import { render, screen } from '@testing-library/react'
+import dayjs from 'dayjs'
+import { uniqueId } from 'lodash-es'
+import { mockFileViewEntity } from '../../../mocks/entity/mockFileView'
+import { mockTableEntity } from '../../../mocks/entity/mockTableEntity'
+import { registerTableQueryResult } from '../../../mocks/msw/handlers/tableQueryService'
 import { rest, server } from '../../../mocks/msw/server'
 import queryResultBundleJson from '../../../mocks/query/syn16787123'
-import dayjs from 'dayjs'
-import { formatDate } from '../../../utils/functions/DateFormatter'
-import { MOCK_USER_ID } from '../../../mocks/user/mock_user_profile'
-import * as HasAccessModule from '../../HasAccess/HasAccessV2'
-import * as EntityLinkModule from '../../EntityLink'
-import * as UserBadgeModule from '../../UserCard/UserBadge'
-import * as AddToDownloadListV2Module from '../../AddToDownloadListV2'
-import * as EntityIdListModule from './EntityIdList'
-import { QueryWrapper } from '../../../index'
-import { mockTableEntity } from '../../../mocks/entity/mockTableEntity'
-import { mockFileViewEntity } from '../../../mocks/entity/mockFileView'
 import { MOCK_TEAM_ID, mockTeamData } from '../../../mocks/team/mockTeam'
-import { uniqueId } from 'lodash-es'
+import { MOCK_USER_ID } from '../../../mocks/user/mock_user_profile'
+import { createWrapper } from '../../../testutils/TestingLibraryUtils'
+import { SynapseConstants } from '../../../utils'
+import { ENTITY_HEADERS, ENTITY_ID_VERSION } from '../../../utils/APIConstants'
+import { formatDate } from '../../../utils/functions/DateFormatter'
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from '../../../utils/functions/getEndpoint'
+import {
+  AUTHENTICATED_PRINCIPAL_ID,
+  DEFAULT_PAGE_SIZE,
+} from '../../../utils/SynapseConstants'
+import * as AddToDownloadListV2Module from '../../AddToDownloadListV2'
+import * as EntityLinkModule from '../../EntityLink'
+import * as HasAccessModule from '../../HasAccess/HasAccessV2'
+import { QueryWrapper } from '../../QueryWrapper'
 import { AUTHENTICATED_GROUP_DISPLAY_TEXT } from '../../TeamBadge'
-import { registerTableQueryResult } from '../../../mocks/msw/handlers/tableQueryService'
+import * as UserBadgeModule from '../../UserCard/UserBadge'
+import { NOT_SET_DISPLAY_VALUE } from '../SynapseTableConstants'
+import * as EntityIdListModule from './EntityIdList'
+import SynapseTableCell, { SynapseTableCellProps } from './SynapseTableCell'
 
 const queryResultBundle: QueryResultBundle =
   queryResultBundleJson as QueryResultBundle

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaEditor.integration.test.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../mocks/msw/handlers/tableQueryHandlers'
 import { syn17328596 as mockTableQueryData } from '../../mocks/query/syn17328596'
 import userEvent from '@testing-library/user-event'
-import { SynapseClient } from '../../index'
+import SynapseClient from '../../synapse-client'
 import { ColumnModel, ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
 import { mockFileViewEntity } from '../../mocks/entity/mockFileView'
 import { ImportTableColumnsButtonProps } from './ImportTableColumnsButton'

--- a/packages/synapse-react-client/src/components/TermsAndConditions/TermsAndConditions.test.tsx
+++ b/packages/synapse-react-client/src/components/TermsAndConditions/TermsAndConditions.test.tsx
@@ -1,9 +1,10 @@
-import TermsAndConditions from './TermsAndConditions'
-import { SynapseClient, SynapseContextType } from '../../index'
 import { QueryResultBundle } from '@sage-bionetworks/synapse-types'
-import mockSyn51718002 from '../../mocks/query/syn51718002.json'
-import { createWrapper } from '../../testutils/TestingLibraryUtils'
 import { render, screen, waitFor } from '@testing-library/react'
+import mockSyn51718002 from '../../mocks/query/syn51718002.json'
+import SynapseClient from '../../synapse-client'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import { SynapseContextType } from '../../utils/index'
+import TermsAndConditions from './TermsAndConditions'
 
 const defaultProps = {
   onFormChange: jest.fn(),

--- a/packages/synapse-react-client/src/components/TermsAndConditions/TermsAndConditionsItem.test.tsx
+++ b/packages/synapse-react-client/src/components/TermsAndConditions/TermsAndConditionsItem.test.tsx
@@ -1,13 +1,14 @@
+import { BatchFileResult, FileResult } from '@sage-bionetworks/synapse-types'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import TermsAndConditionsItem, {
-  TermsAndConditionsItemProps,
-  tcItem,
-} from './TermsAndConditionsItem'
-import { SynapseClient, SynapseContextType } from '../../index'
-import { BatchFileResult, FileResult } from '@sage-bionetworks/synapse-types'
 import { mockFileHandle } from '../../mocks/mock_file_handle'
+import SynapseClient from '../../synapse-client'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import { SynapseContextType } from '../../utils/index'
+import TermsAndConditionsItem, {
+  tcItem,
+  TermsAndConditionsItemProps,
+} from './TermsAndConditionsItem'
 
 function renderComponent(
   itemProps: TermsAndConditionsItemProps,

--- a/packages/synapse-react-client/src/components/TimelinePlot/TimelinePlot.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/TimelinePlot/TimelinePlot.integration.test.tsx
@@ -1,8 +1,7 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
 import TimelinePlot, { TimelinePlotProps } from './TimelinePlot'
 import { createWrapper } from '../../testutils/TestingLibraryUtils'
-
-import { SynapseClient } from '../../index'
+import SynapseClient from '../../synapse-client'
 import queryResultBundleJson from '../../mocks/query/syn51735464'
 import { ColumnSingleValueFilterOperator } from '@sage-bionetworks/synapse-types'
 

--- a/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter/EnumFacetFilter.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter/EnumFacetFilter.integration.test.tsx
@@ -1,4 +1,3 @@
-import { EnumFacetFilter, EnumFacetFilterProps } from './EnumFacetFilter'
 import {
   ColumnModel,
   ColumnTypeEnum,
@@ -8,24 +7,25 @@ import {
   QueryBundleRequest,
 } from '@sage-bionetworks/synapse-types'
 import { render, screen, waitFor } from '@testing-library/react'
-import { SynapseConstants } from '../../../../utils'
-import { QueryVisualizationWrapper } from '../../../QueryVisualizationWrapper'
-import { QueryContextType, useQueryContext } from '../../../../index'
 import userEvent from '@testing-library/user-event'
-import { server } from '../../../../mocks/msw/server'
-import mockQueryResponseData from '../../../../mocks/mockQueryResponseData'
-import { createWrapper } from '../../../../testutils/TestingLibraryUtils'
-import QueryWrapper from '../../../QueryWrapper'
-import { mockTableEntity } from '../../../../mocks/entity/mockTableEntity'
-import { DEBOUNCE_DELAY_MS } from '../../../../utils/hooks/useImmutableTableQuery/useImmutableTableQuery'
 import mockFileEntityData from '../../../../mocks/entity/mockFileEntity'
+import { mockTableEntity } from '../../../../mocks/entity/mockTableEntity'
+import mockQueryResponseData from '../../../../mocks/mockQueryResponseData'
+import { registerTableQueryResult } from '../../../../mocks/msw/handlers/tableQueryService'
+import { server } from '../../../../mocks/msw/server'
 import {
   MOCK_USER_ID,
   MOCK_USER_ID_2,
   mockUserProfileData,
   mockUserProfileData2,
 } from '../../../../mocks/user/mock_user_profile'
-import { registerTableQueryResult } from '../../../../mocks/msw/handlers/tableQueryService'
+import { createWrapper } from '../../../../testutils/TestingLibraryUtils'
+import { SynapseConstants } from '../../../../utils'
+import { DEBOUNCE_DELAY_MS } from '../../../../utils/hooks/useImmutableTableQuery/useImmutableTableQuery'
+import { QueryContextType, useQueryContext } from '../../../QueryContext/index'
+import { QueryVisualizationWrapper } from '../../../QueryVisualizationWrapper'
+import QueryWrapper from '../../../QueryWrapper'
+import { EnumFacetFilter, EnumFacetFilterProps } from './EnumFacetFilter'
 
 const stringFacetValues: FacetColumnResultValueCount[] = [
   { value: 'Honda', count: 2, isSelected: false },

--- a/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilter.integration.test.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilter.integration.test.tsx
@@ -1,14 +1,4 @@
 import { Collapse as MockCollapse } from '@mui/material'
-import { act, render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { Suspense } from 'react'
-import { RangeFacetFilter, RangeFacetFilterProps } from './RangeFacetFilter'
-import { RangeValues } from '../Range'
-import RangeSlider from '../RangeSlider/RangeSlider'
-import {
-  DEFAULT_PAGE_SIZE,
-  VALUE_NOT_SET,
-} from '../../../utils/SynapseConstants'
 import {
   ColumnModel,
   ColumnTypeEnum,
@@ -16,14 +6,25 @@ import {
   QueryBundleRequest,
   QueryResultBundle,
 } from '@sage-bionetworks/synapse-types'
-import { server } from '../../../mocks/msw/server'
-import { QueryContextType, QueryWrapper, useQueryContext } from '../../../index'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { cloneDeep } from 'lodash-es'
+import { Suspense } from 'react'
 import { MOCK_TABLE_ENTITY_ID } from '../../../mocks/entity/mockTableEntity'
 import mockQueryResponseData from '../../../mocks/mockQueryResponseData'
-import { QueryVisualizationWrapper } from '../../QueryVisualizationWrapper'
-import { cloneDeep } from 'lodash-es'
-import { createWrapper } from '../../../testutils/TestingLibraryUtils'
 import { registerTableQueryResult } from '../../../mocks/msw/handlers/tableQueryService'
+import { server } from '../../../mocks/msw/server'
+import { createWrapper } from '../../../testutils/TestingLibraryUtils'
+import {
+  DEFAULT_PAGE_SIZE,
+  VALUE_NOT_SET,
+} from '../../../utils/SynapseConstants'
+import { QueryContextType, useQueryContext } from '../../QueryContext'
+import { QueryVisualizationWrapper } from '../../QueryVisualizationWrapper'
+import { QueryWrapper } from '../../QueryWrapper'
+import { RangeValues } from '../Range'
+import RangeSlider from '../RangeSlider/RangeSlider'
+import { RangeFacetFilter, RangeFacetFilterProps } from './RangeFacetFilter'
 
 let capturedOnApplyClicked: ((values: RangeValues) => void) | undefined
 

--- a/packages/synapse-react-client/src/utils/AppUtils/session/ApplicationSession.test.tsx
+++ b/packages/synapse-react-client/src/utils/AppUtils/session/ApplicationSession.test.tsx
@@ -10,15 +10,15 @@ import { renderHook, waitFor } from '@testing-library/react'
 import dayjs from 'dayjs'
 import { MemoryRouter } from 'react-router'
 import {
-  defaultQueryClientConfig,
-  FullContextProvider,
-  SynapseClient,
-} from '../../../index'
-import {
   MOCK_ACCESS_TOKEN,
   MOCK_CONTEXT_VALUE,
 } from '../../../mocks/MockSynapseContext'
 import { MOCK_USER_ID } from '../../../mocks/user/mock_user_profile'
+import SynapseClient from '../../../synapse-client'
+import {
+  defaultQueryClientConfig,
+  FullContextProvider,
+} from '../../context/index'
 import * as UseDetectSSOCodeModule from '../../hooks/useDetectSSOCode'
 import { UseDetectSSOCodeOptions } from '../../hooks/useDetectSSOCode'
 import {

--- a/packages/synapse-react-client/src/utils/AppUtils/session/ApplicationSessionManager.tsx
+++ b/packages/synapse-react-client/src/utils/AppUtils/session/ApplicationSessionManager.tsx
@@ -1,5 +1,6 @@
 import { TwoFactorAuthErrorResponse } from '@sage-bionetworks/synapse-client/generated/models/TwoFactorAuthErrorResponse'
 import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
 import { PropsWithChildren, useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import SynapseClient from '../../../synapse-client'
@@ -8,6 +9,8 @@ import { SynapseContextProvider, SynapseContextType } from '../../context'
 import useDetectSSOCode from '../../hooks/useDetectSSOCode'
 import { restoreLastPlace } from '../AppUtils'
 import { ApplicationSessionContextProvider } from './ApplicationSessionContext'
+
+dayjs.extend(utc)
 
 export type ApplicationSessionManagerProps = PropsWithChildren<{
   downloadCartPageUrl?: string

--- a/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.test.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.test.ts
@@ -1,18 +1,19 @@
-import { renderHook as _renderHook, waitFor } from '@testing-library/react'
-import useDetectSSOCode, { UseDetectSSOCodeOptions } from './useDetectSSOCode'
-import { OAuth2State, SynapseClient } from '../../index'
+import { SynapseClientError } from '@sage-bionetworks/synapse-client/util/SynapseClientError'
 import {
   ErrorResponseCode,
   LoginResponse,
   TwoFactorAuthErrorResponse,
 } from '@sage-bionetworks/synapse-types'
+import { renderHook as _renderHook, waitFor } from '@testing-library/react'
+import { MOCK_ACCESS_TOKEN } from '../../mocks/MockSynapseContext'
+import SynapseClient from '../../synapse-client'
 import { BackendDestinationEnum } from '../functions'
-import { SynapseClientError } from '@sage-bionetworks/synapse-client/util/SynapseClientError'
 import {
   LOGIN_METHOD_OAUTH2_GOOGLE,
   OAUTH2_PROVIDERS,
 } from '../SynapseConstants'
-import { MOCK_ACCESS_TOKEN } from '../../mocks/MockSynapseContext'
+import { OAuth2State } from '../types/index'
+import useDetectSSOCode, { UseDetectSSOCodeOptions } from './useDetectSSOCode'
 
 const authorizationCode = '12345'
 

--- a/packages/synapse-react-client/src/utils/hooks/useGetGoalData.test.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useGetGoalData.test.ts
@@ -6,7 +6,7 @@ import {
   QueryResultBundle,
   BatchFileResult,
 } from '@sage-bionetworks/synapse-types'
-import { SynapseClient } from '../../index'
+import SynapseClient from '../../synapse-client'
 
 const tableQueryResult: QueryResultBundle = {
   concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',

--- a/packages/synapse-react-client/stories/SynapseTableCell.stories.tsx
+++ b/packages/synapse-react-client/stories/SynapseTableCell.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta, StoryObj } from '@storybook/react'
-import SynapseTableCell from '../src/components/SynapseTable/SynapseTableCell/SynapseTableCell'
 import { ColumnTypeEnum } from '@sage-bionetworks/synapse-types'
-import { QueryContextProvider } from '../src'
+import { Meta, StoryObj } from '@storybook/react'
+import { QueryContextProvider } from '../src/components/QueryContext'
+import SynapseTableCell from '../src/components/SynapseTable/SynapseTableCell/SynapseTableCell'
 import { mockTableEntity } from '../src/mocks/entity/mockTableEntity'
 
 const meta = {

--- a/packages/synapse-react-client/test/containers/table/EntityIDColumnCopyIcon.test.tsx
+++ b/packages/synapse-react-client/test/containers/table/EntityIDColumnCopyIcon.test.tsx
@@ -1,21 +1,22 @@
 import '@testing-library/jest-dom'
-import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
-import EntityIDColumnCopyIcon from '../../../src/components/SynapseTable/EntityIDColumnCopyIcon'
-import { createWrapper } from '../../../src/testutils/TestingLibraryUtils'
-import { SynapseContextType } from '../../../src/utils/context/SynapseContext'
 import {
   QueryBundleRequest,
   QueryResultBundle,
+  TextMatchesQueryFilter,
 } from '@sage-bionetworks/synapse-types'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
 import {
   QueryContextProvider,
   QueryContextType,
 } from '../../../src/components/QueryContext/QueryContext'
+import EntityIDColumnCopyIcon from '../../../src/components/SynapseTable/EntityIDColumnCopyIcon'
 import idsQueryResponse from '../../../src/mocks/mockIDListQueryResponseData.json'
-import { SynapseClient, SynapseConstants } from '../../../src'
-import { TextMatchesQueryFilter } from '@sage-bionetworks/synapse-types'
+import SynapseClient from '../../../src/synapse-client'
+import { createWrapper } from '../../../src/testutils/TestingLibraryUtils'
+import { SynapseContextType } from '../../../src/utils/context/SynapseContext'
+import * as SynapseConstants from '../../../src/utils/SynapseConstants'
 
 const synID = 'syn55555'
 const version = '7'


### PR DESCRIPTION
synapse-react-client: Remove local imports against `src/index.ts`

We will remove index.ts in a future change (or replace it with umd.index.ts). These imports are unnecessarily broad and may slow down building the project, since they trigger importing basically the entirety of synapse-react-client.