### PR TITLE
PORTALS-3405: Consistent styling and mobile responsiveness review

### DIFF
--- a/apps/portals/elportal/src/pages/HomePageV2.tsx
+++ b/apps/portals/elportal/src/pages/HomePageV2.tsx
@@ -164,8 +164,7 @@ export default function HomePage() {
             title="Explore the Data"
             buttonText="View All Studies"
             link="/Explore/Studies"
-            summaryText="fsfds"
-            sx={{ margin: 'auto' }}
+            centered
           />
           <UpsetPlot
             sql={upsetPlotSql}

--- a/apps/portals/elportal/src/pages/HomePageV2.tsx
+++ b/apps/portals/elportal/src/pages/HomePageV2.tsx
@@ -8,6 +8,7 @@ import {
   PortalHomePageHeader,
   GoalsV2,
   PortalFeaturedPartners,
+  PortalSectionHeader,
 } from 'synapse-react-client'
 import ELContributeYourData from '@sage-bionetworks/synapse-portal-framework/components/elportal/ELContributeYourData'
 import ELGettingStarted from '@sage-bionetworks/synapse-portal-framework/components/elportal/ELGettingStarted'
@@ -158,24 +159,22 @@ export default function HomePage() {
       >
         <ELGettingStarted />
         <GoalsV2 entityId={goalsV2Table} dataLink="/Explore/Data" />
-        <div className={'home-bg-dark'}>
-          <SectionLayout
-            title="Exploring the Data"
-            centerTitle
-            ContainerProps={{ className: 'home-spacer' }}
-          >
-            <UpsetPlot
-              sql={upsetPlotSql}
-              rgbIndex={0}
-              maxBarCount={20}
-              setName="Set size"
-              combinationName="Intersection size"
-              onClick={handleUpsetPlotClick}
-              // summaryLinkText='Explore All Data'
-              // summaryLink='/Explore/Data'
-            />
-          </SectionLayout>
-        </div>
+        <SectionLayout
+          title="Exploring the Data"
+          centerTitle
+          ContainerProps={{ className: 'home-spacer' }}
+        >
+          <UpsetPlot
+            sql={upsetPlotSql}
+            rgbIndex={0}
+            maxBarCount={20}
+            setName="Set size"
+            combinationName="Intersection size"
+            onClick={handleUpsetPlotClick}
+            // summaryLinkText='Explore All Data'
+            // summaryLink='/Explore/Data'
+          />
+        </SectionLayout>
         <div className={'home-bg-dark'}>
           <FeaturedDataTabs
             sql={dataSql}

--- a/apps/portals/elportal/src/pages/HomePageV2.tsx
+++ b/apps/portals/elportal/src/pages/HomePageV2.tsx
@@ -8,7 +8,6 @@ import {
   PortalHomePageHeader,
   GoalsV2,
   PortalFeaturedPartners,
-  PortalSectionHeader,
 } from 'synapse-react-client'
 import ELContributeYourData from '@sage-bionetworks/synapse-portal-framework/components/elportal/ELContributeYourData'
 import ELGettingStarted from '@sage-bionetworks/synapse-portal-framework/components/elportal/ELGettingStarted'
@@ -160,16 +159,10 @@ export default function HomePage() {
         <ELGettingStarted />
         <GoalsV2 entityId={goalsV2Table} dataLink="/Explore/Data" />
         <SectionLayout ContainerProps={{ className: 'home-spacer' }}>
-          <PortalSectionHeader
-            title="Explore the Data"
-            buttonText="View All Studies"
-            link="/Explore/Studies"
-            centered
-          />
           <UpsetPlot
             sql={upsetPlotSql}
             rgbIndex={0}
-            maxBarCount={20}
+            maxBarCount={10}
             setName="Set size"
             combinationName="Intersection size"
             onClick={handleUpsetPlotClick}
@@ -178,80 +171,82 @@ export default function HomePage() {
           />
         </SectionLayout>
         <div className={'home-bg-dark'}>
-          <FeaturedDataTabs
-            sql={dataSql}
-            rgbIndex={3}
-            configs={[
-              {
-                title: 'Human Studies',
-                icon: 'PERSON',
-                explorePagePath: '/Explore/Studies',
-                exploreObjectType: 'Studies',
-                plotsConfig: {
-                  configs: [
-                    {
-                      title: 'The Long Life Family Study',
-                      description:
-                        'The Long Life Family Study (LLFS) investigates genetic and familial factors in exceptional longevity. Families were recruited based on a Family Longevity Selection Score (FLOSS) of ≥7. Over 4,953 individuals from 539 families were phenotyped through in-home visits in the U.S. and Denmark with centralized assays and standardized protocols.',
-                      facetsToPlot: ['dataTypes'],
-                      selectFacetColumnName: 'Study',
-                      selectFacetColumnValue: 'LLFS',
-                      detailsPagePath:
-                        '/Explore/Studies/DetailsPage?studyKey=LLFS',
-                      unitDescription: 'Files',
-                      plotType: 'STACKED_HORIZONTAL_BAR',
-                    },
-                    {
-                      title: 'ADAMTS7 Study',
-                      description:
-                        'The Characterization of gene associations with aging-related traits with a genetically-predicted transcriptome-wide association study (ADAMTS7) provides analyses of candidate genes and the association of Longevity-Associated Variants (LAVs) with aging-related traits and diseases.',
-                      facetsToPlot: ['dataTypes'],
-                      selectFacetColumnName: 'Study',
-                      selectFacetColumnValue: 'ADAMTS7',
-                      detailsPagePath:
-                        '/Explore/Studies/DetailsPage?studyKey=ADAMTS7',
-                      unitDescription: 'Files',
-                      plotType: 'STACKED_HORIZONTAL_BAR',
-                    },
-                  ],
+          <SectionLayout ContainerProps={{ className: 'home-spacer' }}>
+            <FeaturedDataTabs
+              sql={dataSql}
+              rgbIndex={3}
+              configs={[
+                {
+                  title: 'Human Studies',
+                  icon: 'PERSON',
+                  explorePagePath: '/Explore/Studies',
+                  exploreObjectType: 'Studies',
+                  plotsConfig: {
+                    configs: [
+                      {
+                        title: 'The Long Life Family Study',
+                        description:
+                          'The Long Life Family Study (LLFS) investigates genetic and familial factors in exceptional longevity. Families were recruited based on a Family Longevity Selection Score (FLOSS) of ≥7. Over 4,953 individuals from 539 families were phenotyped through in-home visits in the U.S. and Denmark with centralized assays and standardized protocols.',
+                        facetsToPlot: ['dataTypes'],
+                        selectFacetColumnName: 'Study',
+                        selectFacetColumnValue: 'LLFS',
+                        detailsPagePath:
+                          '/Explore/Studies/DetailsPage?studyKey=LLFS',
+                        unitDescription: 'Files',
+                        plotType: 'STACKED_HORIZONTAL_BAR',
+                      },
+                      {
+                        title: 'ADAMTS7 Study',
+                        description:
+                          'The Characterization of gene associations with aging-related traits with a genetically-predicted transcriptome-wide association study (ADAMTS7) provides analyses of candidate genes and the association of Longevity-Associated Variants (LAVs) with aging-related traits and diseases.',
+                        facetsToPlot: ['dataTypes'],
+                        selectFacetColumnName: 'Study',
+                        selectFacetColumnValue: 'ADAMTS7',
+                        detailsPagePath:
+                          '/Explore/Studies/DetailsPage?studyKey=ADAMTS7',
+                        unitDescription: 'Files',
+                        plotType: 'STACKED_HORIZONTAL_BAR',
+                      },
+                    ],
+                  },
                 },
-              },
-              {
-                title: 'Translational Studies',
-                icon: 'TRANSLATIONAL',
-                explorePagePath: '/Explore/Studies',
-                exploreObjectType: 'Studies',
-                plotsConfig: {
-                  configs: [
-                    {
-                      title: 'MRGWAS',
-                      description:
-                        'The Mendelian randomization of human longevity using genetically-predicted exposures from the GWAS catalog (MRGWAS) study provides analysis results of a two Sample Mendelian Randomization used to analyze the relationship between significantly associated GWAS  traits and five distinct definitions of longevity.',
-                      facetsToPlot: ['dataTypes'],
-                      selectFacetColumnName: 'Study',
-                      selectFacetColumnValue: 'MRGWAS',
-                      detailsPagePath:
-                        '/Explore/Studies/DetailsPage?studyKey=MRGWAS',
-                      unitDescription: 'Files',
-                      plotType: 'STACKED_HORIZONTAL_BAR',
-                    },
-                    {
-                      title: 'Aging-PheWAS',
-                      description:
-                        'This study is a collection of genetically-predicted tissue-specific gene expression associations with a collection of aging-related traits and outcomes.',
-                      facetsToPlot: ['dataTypes'],
-                      selectFacetColumnName: 'Study',
-                      selectFacetColumnValue: 'Aging-PheWAS',
-                      detailsPagePath:
-                        '/Explore/Studies/DetailsPage?studyKey=Aging-PheWAS',
-                      unitDescription: 'Files',
-                      plotType: 'STACKED_HORIZONTAL_BAR',
-                    },
-                  ],
+                {
+                  title: 'Translational Studies',
+                  icon: 'TRANSLATIONAL',
+                  explorePagePath: '/Explore/Studies',
+                  exploreObjectType: 'Studies',
+                  plotsConfig: {
+                    configs: [
+                      {
+                        title: 'MRGWAS',
+                        description:
+                          'The Mendelian randomization of human longevity using genetically-predicted exposures from the GWAS catalog (MRGWAS) study provides analysis results of a two Sample Mendelian Randomization used to analyze the relationship between significantly associated GWAS  traits and five distinct definitions of longevity.',
+                        facetsToPlot: ['dataTypes'],
+                        selectFacetColumnName: 'Study',
+                        selectFacetColumnValue: 'MRGWAS',
+                        detailsPagePath:
+                          '/Explore/Studies/DetailsPage?studyKey=MRGWAS',
+                        unitDescription: 'Files',
+                        plotType: 'STACKED_HORIZONTAL_BAR',
+                      },
+                      {
+                        title: 'Aging-PheWAS',
+                        description:
+                          'This study is a collection of genetically-predicted tissue-specific gene expression associations with a collection of aging-related traits and outcomes.',
+                        facetsToPlot: ['dataTypes'],
+                        selectFacetColumnName: 'Study',
+                        selectFacetColumnValue: 'Aging-PheWAS',
+                        detailsPagePath:
+                          '/Explore/Studies/DetailsPage?studyKey=Aging-PheWAS',
+                        unitDescription: 'Files',
+                        plotType: 'STACKED_HORIZONTAL_BAR',
+                      },
+                    ],
+                  },
                 },
-              },
-            ]}
-          />
+              ]}
+            />
+          </SectionLayout>
         </div>
         <ELContributeYourData />
         <PortalFeatureHighlights

--- a/apps/portals/elportal/src/pages/HomePageV2.tsx
+++ b/apps/portals/elportal/src/pages/HomePageV2.tsx
@@ -8,6 +8,7 @@ import {
   PortalHomePageHeader,
   GoalsV2,
   PortalFeaturedPartners,
+  PortalSectionHeader,
 } from 'synapse-react-client'
 import ELContributeYourData from '@sage-bionetworks/synapse-portal-framework/components/elportal/ELContributeYourData'
 import ELGettingStarted from '@sage-bionetworks/synapse-portal-framework/components/elportal/ELGettingStarted'
@@ -74,9 +75,12 @@ export default function HomePage() {
       <Box
         component={'span'}
         sx={theme => ({
+          [theme.breakpoints.down('md')]: {
+            display: 'block',
+            minHeight: '100px',
+          },
           [theme.breakpoints.down('sm')]: {
             minHeight: '150px',
-            display: 'block',
           },
         })}
       >
@@ -159,6 +163,13 @@ export default function HomePage() {
         <ELGettingStarted />
         <GoalsV2 entityId={goalsV2Table} dataLink="/Explore/Data" />
         <SectionLayout ContainerProps={{ className: 'home-spacer' }}>
+          <PortalSectionHeader
+            title="Explore the Data"
+            buttonText="View All Studies"
+            link="/Explore/Studies"
+            centered
+            sx={{ marginBottom: '90px' }}
+          />
           <UpsetPlot
             sql={upsetPlotSql}
             rgbIndex={0}

--- a/apps/portals/elportal/src/pages/HomePageV2.tsx
+++ b/apps/portals/elportal/src/pages/HomePageV2.tsx
@@ -177,82 +177,80 @@ export default function HomePage() {
           </SectionLayout>
         </div>
         <div className={'home-bg-dark'}>
-          <SectionLayout ContainerProps={{ className: 'home-spacer' }}>
-            <FeaturedDataTabs
-              sql={dataSql}
-              rgbIndex={3}
-              configs={[
-                {
-                  title: 'Human Studies',
-                  icon: 'PERSON',
-                  explorePagePath: '/Explore/Studies',
-                  exploreObjectType: 'Studies',
-                  plotsConfig: {
-                    configs: [
-                      {
-                        title: 'The Long Life Family Study',
-                        description:
-                          'The Long Life Family Study (LLFS) investigates genetic and familial factors in exceptional longevity. Families were recruited based on a Family Longevity Selection Score (FLOSS) of ≥7. Over 4,953 individuals from 539 families were phenotyped through in-home visits in the U.S. and Denmark with centralized assays and standardized protocols.',
-                        facetsToPlot: ['dataTypes'],
-                        selectFacetColumnName: 'Study',
-                        selectFacetColumnValue: 'LLFS',
-                        detailsPagePath:
-                          '/Explore/Studies/DetailsPage?studyKey=LLFS',
-                        unitDescription: 'Files',
-                        plotType: 'STACKED_HORIZONTAL_BAR',
-                      },
-                      {
-                        title: 'ADAMTS7 Study',
-                        description:
-                          'The Characterization of gene associations with aging-related traits with a genetically-predicted transcriptome-wide association study (ADAMTS7) provides analyses of candidate genes and the association of Longevity-Associated Variants (LAVs) with aging-related traits and diseases.',
-                        facetsToPlot: ['dataTypes'],
-                        selectFacetColumnName: 'Study',
-                        selectFacetColumnValue: 'ADAMTS7',
-                        detailsPagePath:
-                          '/Explore/Studies/DetailsPage?studyKey=ADAMTS7',
-                        unitDescription: 'Files',
-                        plotType: 'STACKED_HORIZONTAL_BAR',
-                      },
-                    ],
-                  },
+          <FeaturedDataTabs
+            sql={dataSql}
+            rgbIndex={3}
+            configs={[
+              {
+                title: 'Human Studies',
+                icon: 'PERSON',
+                explorePagePath: '/Explore/Studies',
+                exploreObjectType: 'Studies',
+                plotsConfig: {
+                  configs: [
+                    {
+                      title: 'The Long Life Family Study',
+                      description:
+                        'The Long Life Family Study (LLFS) investigates genetic and familial factors in exceptional longevity. Families were recruited based on a Family Longevity Selection Score (FLOSS) of ≥7. Over 4,953 individuals from 539 families were phenotyped through in-home visits in the U.S. and Denmark with centralized assays and standardized protocols.',
+                      facetsToPlot: ['dataTypes'],
+                      selectFacetColumnName: 'Study',
+                      selectFacetColumnValue: 'LLFS',
+                      detailsPagePath:
+                        '/Explore/Studies/DetailsPage?studyKey=LLFS',
+                      unitDescription: 'Files',
+                      plotType: 'STACKED_HORIZONTAL_BAR',
+                    },
+                    {
+                      title: 'ADAMTS7 Study',
+                      description:
+                        'The Characterization of gene associations with aging-related traits with a genetically-predicted transcriptome-wide association study (ADAMTS7) provides analyses of candidate genes and the association of Longevity-Associated Variants (LAVs) with aging-related traits and diseases.',
+                      facetsToPlot: ['dataTypes'],
+                      selectFacetColumnName: 'Study',
+                      selectFacetColumnValue: 'ADAMTS7',
+                      detailsPagePath:
+                        '/Explore/Studies/DetailsPage?studyKey=ADAMTS7',
+                      unitDescription: 'Files',
+                      plotType: 'STACKED_HORIZONTAL_BAR',
+                    },
+                  ],
                 },
-                {
-                  title: 'Translational Studies',
-                  icon: 'TRANSLATIONAL',
-                  explorePagePath: '/Explore/Studies',
-                  exploreObjectType: 'Studies',
-                  plotsConfig: {
-                    configs: [
-                      {
-                        title: 'MRGWAS',
-                        description:
-                          'The Mendelian randomization of human longevity using genetically-predicted exposures from the GWAS catalog (MRGWAS) study provides analysis results of a two Sample Mendelian Randomization used to analyze the relationship between significantly associated GWAS  traits and five distinct definitions of longevity.',
-                        facetsToPlot: ['dataTypes'],
-                        selectFacetColumnName: 'Study',
-                        selectFacetColumnValue: 'MRGWAS',
-                        detailsPagePath:
-                          '/Explore/Studies/DetailsPage?studyKey=MRGWAS',
-                        unitDescription: 'Files',
-                        plotType: 'STACKED_HORIZONTAL_BAR',
-                      },
-                      {
-                        title: 'Aging-PheWAS',
-                        description:
-                          'This study is a collection of genetically-predicted tissue-specific gene expression associations with a collection of aging-related traits and outcomes.',
-                        facetsToPlot: ['dataTypes'],
-                        selectFacetColumnName: 'Study',
-                        selectFacetColumnValue: 'Aging-PheWAS',
-                        detailsPagePath:
-                          '/Explore/Studies/DetailsPage?studyKey=Aging-PheWAS',
-                        unitDescription: 'Files',
-                        plotType: 'STACKED_HORIZONTAL_BAR',
-                      },
-                    ],
-                  },
+              },
+              {
+                title: 'Translational Studies',
+                icon: 'TRANSLATIONAL',
+                explorePagePath: '/Explore/Studies',
+                exploreObjectType: 'Studies',
+                plotsConfig: {
+                  configs: [
+                    {
+                      title: 'MRGWAS',
+                      description:
+                        'The Mendelian randomization of human longevity using genetically-predicted exposures from the GWAS catalog (MRGWAS) study provides analysis results of a two Sample Mendelian Randomization used to analyze the relationship between significantly associated GWAS  traits and five distinct definitions of longevity.',
+                      facetsToPlot: ['dataTypes'],
+                      selectFacetColumnName: 'Study',
+                      selectFacetColumnValue: 'MRGWAS',
+                      detailsPagePath:
+                        '/Explore/Studies/DetailsPage?studyKey=MRGWAS',
+                      unitDescription: 'Files',
+                      plotType: 'STACKED_HORIZONTAL_BAR',
+                    },
+                    {
+                      title: 'Aging-PheWAS',
+                      description:
+                        'This study is a collection of genetically-predicted tissue-specific gene expression associations with a collection of aging-related traits and outcomes.',
+                      facetsToPlot: ['dataTypes'],
+                      selectFacetColumnName: 'Study',
+                      selectFacetColumnValue: 'Aging-PheWAS',
+                      detailsPagePath:
+                        '/Explore/Studies/DetailsPage?studyKey=Aging-PheWAS',
+                      unitDescription: 'Files',
+                      plotType: 'STACKED_HORIZONTAL_BAR',
+                    },
+                  ],
                 },
-              ]}
-            />
-          </SectionLayout>
+              },
+            ]}
+          />
         </div>
         <ELContributeYourData />
         <PortalFeatureHighlights

--- a/apps/portals/elportal/src/pages/HomePageV2.tsx
+++ b/apps/portals/elportal/src/pages/HomePageV2.tsx
@@ -162,7 +162,7 @@ export default function HomePage() {
           <UpsetPlot
             sql={upsetPlotSql}
             rgbIndex={0}
-            maxBarCount={10}
+            maxBarCount={20}
             setName="Set size"
             combinationName="Intersection size"
             onClick={handleUpsetPlotClick}

--- a/apps/portals/elportal/src/pages/HomePageV2.tsx
+++ b/apps/portals/elportal/src/pages/HomePageV2.tsx
@@ -159,11 +159,14 @@ export default function HomePage() {
       >
         <ELGettingStarted />
         <GoalsV2 entityId={goalsV2Table} dataLink="/Explore/Data" />
-        <SectionLayout
-          title="Exploring the Data"
-          centerTitle
-          ContainerProps={{ className: 'home-spacer' }}
-        >
+        <SectionLayout ContainerProps={{ className: 'home-spacer' }}>
+          <PortalSectionHeader
+            title="Explore the Data"
+            buttonText="View All Studies"
+            link="/Explore/Studies"
+            summaryText="fsfds"
+            sx={{ margin: 'auto' }}
+          />
           <UpsetPlot
             sql={upsetPlotSql}
             rgbIndex={0}

--- a/apps/synapse-portal-framework/src/components/elportal/ELContributeYourData.tsx
+++ b/apps/synapse-portal-framework/src/components/elportal/ELContributeYourData.tsx
@@ -31,7 +31,6 @@ function ELContributeYourData() {
         sx={{
           flex: '1 1 auto',
           zIndex: 1,
-          textAlign: 'center',
           padding: { xs: '100px 40px', md: '100px 0' },
         }}
       >
@@ -45,13 +44,17 @@ function ELContributeYourData() {
           buttonText="Start Contributing"
           link="https://sagebionetworks.jira.com/servicedesk/customer/portal/12"
           sx={{
-            '*': { color: '#FFF', borderTop: 'none' },
             h2: {
+              color: 'primary.contrastText',
               fontSize: '24px',
-              borderTop: '4px solid rgba(255, 255, 255, 0.40)',
+              borderColor: 'rgba(255, 255, 255, 0.40)',
             },
-            a: { border: '1px solid white' },
-            '& p': { fontSize: '16px', paddingBottom: '10px' },
+            '.MuiButton-root': { border: '1px solid white' },
+            '& p': {
+              fontSize: '16px',
+              paddingBottom: '10px',
+              color: 'primary.contrastText',
+            },
           }}
         />
       </Box>

--- a/apps/synapse-portal-framework/src/components/elportal/ELContributeYourData.tsx
+++ b/apps/synapse-portal-framework/src/components/elportal/ELContributeYourData.tsx
@@ -1,6 +1,7 @@
-import { Box, Link, Button, Typography } from '@mui/material'
+import { Box } from '@mui/material'
 import backgroundSpotsLeft from './assets/dot_blob_top_left.png'
 import backgroundSpotsRight from './assets/dot_blob_bottom_right.png'
+import { PortalSectionHeader } from 'synapse-react-client'
 
 function ELContributeYourData() {
   return (
@@ -34,47 +35,25 @@ function ELContributeYourData() {
           padding: { xs: '100px 40px', md: '100px 0' },
         }}
       >
-        <Typography
-          variant="headline1"
-          style={{ color: 'white' }}
+        <PortalSectionHeader
+          centered
+          reverseButtonAndText
+          title="Contribute Your Data"
+          summaryText="If you are a funded portal contributor and ready to upload data to the
+        ELITE Portal, you can begin the data submission process by contacting
+        our data curation team through our service desk."
+          buttonText="Start Contributing"
+          link="https://sagebionetworks.jira.com/servicedesk/customer/portal/12"
           sx={{
-            pt: 4,
-            mb: 2,
-            mx: 'auto',
-            width: 'max-content',
-            borderTop: '6px solid #ffffff88',
+            '*': { color: '#FFF', borderTop: 'none' },
+            h2: {
+              fontSize: '24px',
+              borderTop: '4px solid rgba(255, 255, 255, 0.40)',
+            },
+            a: { border: '1px solid white' },
+            '& p': { fontSize: '16px', paddingBottom: '10px' },
           }}
-        >
-          Contribute Your Data
-        </Typography>
-        <Typography
-          variant="body1"
-          sx={{ color: 'white', fontStyle: 'italic', mb: 3 }}
-        >
-          If you are a funded portal contributor and ready to upload data to the
-          ELITE Portal, you can begin the data submission process by contacting
-          our data curation team through our service desk.
-        </Typography>
-        <Link
-          href="https://sagebionetworks.jira.com/servicedesk/customer/portal/12"
-          target="_blank"
-          rel="noopener noreferrer"
-          fontFamily="Lato"
-          fontSize="18"
-          fontStyle="semi-bold"
-        >
-          <Button
-            variant="contained"
-            sx={theme => ({
-              border: '1px solid white',
-              [theme.breakpoints.down('sm')]: {
-                width: '100%',
-              },
-            })}
-          >
-            Start Contributing
-          </Button>
-        </Link>
+        />
       </Box>
       <Box
         sx={{

--- a/apps/synapse-portal-framework/src/components/elportal/ELGettingStarted.tsx
+++ b/apps/synapse-portal-framework/src/components/elportal/ELGettingStarted.tsx
@@ -1,7 +1,8 @@
-import { Box, Button, Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import exploreIcon from './assets/explore_icon.png'
 import uncoverIcon from './assets/uncover_icon.png'
 import accessIcon from './assets/access_icon.png'
+import { PortalSectionHeader } from 'synapse-react-client'
 
 export function IconSquare({ iconUrl, headline, description }) {
   return (
@@ -54,53 +55,20 @@ const ELGettingStarted = () => {
         gap: { xs: '50px', md: '80px' },
       }}
     >
-      <Box
+      <PortalSectionHeader
+        reverseButtonAndText
+        title="Getting Started"
+        summaryText="We provide all the help you need for navigating the portal and
+        accelerating your research."
+        buttonText="Visit Our Help Section"
+        link="https://help.eliteportal.org/help/"
         sx={{
-          borderTop: '3px solid #ffffff88',
-          py: '20px',
+          '*': { color: '#FFF', borderColor: 'rgba(255, 255, 255, 0.40)' },
+          '& p': { fontSize: '16px' },
+          h2: { fontSize: '24px' },
+          a: { border: '1px solid white' },
         }}
-      >
-        <Typography
-          variant="headline2"
-          sx={{
-            width: '100%',
-            color: 'white',
-            fontSize: '24px',
-          }}
-        >
-          Getting Started
-        </Typography>
-        <Typography
-          variant="body1"
-          sx={{
-            maxWidth: '100%',
-            my: '16px',
-            color: 'white',
-            fontStyle: 'italic',
-            fontSize: '13px',
-            lineHeight: '20px',
-          }}
-        >
-          We provide all the help you need for navigating the portal and
-          accelerating your research.
-        </Typography>
-        <Button
-          variant="contained"
-          href="https://help.eliteportal.org/help/"
-          rel="noopener noreferrer"
-          target="_blank"
-          sx={theme => ({
-            border: '1px solid white',
-            padding: '6px 24px',
-            fontSize: '14px',
-            [theme.breakpoints.down('sm')]: {
-              width: '100%',
-            },
-          })}
-        >
-          Visit Our Help Section
-        </Button>
-      </Box>
+      />
       <Box
         sx={{
           display: 'grid',

--- a/apps/synapse-portal-framework/src/components/elportal/ELGettingStarted.tsx
+++ b/apps/synapse-portal-framework/src/components/elportal/ELGettingStarted.tsx
@@ -24,7 +24,6 @@ export function IconSquare({ iconUrl, headline, description }) {
         sx={{
           mb: '10px',
           maxWidth: '100%',
-          color: 'white',
           fontWeight: 400,
         }}
       >
@@ -34,7 +33,6 @@ export function IconSquare({ iconUrl, headline, description }) {
         variant="body1"
         sx={{
           maxWidth: '100%',
-          color: 'white',
           fontSize: '13px',
         }}
       >
@@ -49,6 +47,7 @@ const ELGettingStarted = () => {
     <Box
       sx={{
         backgroundColor: 'primary.main',
+        color: 'primary.contrastText',
         display: 'grid',
         padding: { xs: '40px', md: '80px' },
         gridTemplateColumns: { xs: '1fr', md: '1fr 3fr' },
@@ -63,10 +62,14 @@ const ELGettingStarted = () => {
         buttonText="Visit Our Help Section"
         link="https://help.eliteportal.org/help/"
         sx={{
-          '*': { color: '#FFF', borderColor: 'rgba(255, 255, 255, 0.40)' },
-          '& p': { fontSize: '16px' },
-          h2: { fontSize: '24px' },
-          a: { border: '1px solid white' },
+          h2: {
+            fontSize: '24px',
+            width: '100%',
+            borderColor: 'rgba(255, 255, 255, 0.40)',
+            color: 'primary.contrastText',
+          },
+          '& p': { fontSize: '16px', color: 'primary.contrastText' },
+          '.MuiButton-root': { border: '1px solid white' },
         }}
       />
       <Box

--- a/apps/synapse-portal-framework/src/components/elportal/ELSupportedByNIH.tsx
+++ b/apps/synapse-portal-framework/src/components/elportal/ELSupportedByNIH.tsx
@@ -20,7 +20,10 @@ const ELSupportedByNIH: React.FC = () => {
         buttonText="Visit the NIA Website"
         link="https://www.nia.nih.gov/research/dgcg"
         sx={{
-          '& > *': { borderColor: alpha(theme.palette.primary.main, 0.2) },
+          h2: {
+            borderColor: alpha(theme.palette.primary.main, 0.2),
+            width: '100%',
+          },
         }}
       />
       <Box
@@ -51,8 +54,14 @@ const ELSupportedByNIH: React.FC = () => {
           of Health (NIH), NIA supports cutting-edge research on aging and
           age-related diseases, including Alzheimer's disease and other forms of
           dementia.
-          <br />
-          <br />
+        </Typography>
+        <Typography
+          variant="body1"
+          sx={{
+            pt: '10px',
+            fontSize: '18px',
+          }}
+        >
           With a mission to improve the health and well-being of older
           populations, NIA funds innovative scientific studies, promotes
           training for the next generation of researchers, and provides trusted

--- a/apps/synapse-portal-framework/src/components/elportal/ELSupportedByNIH.tsx
+++ b/apps/synapse-portal-framework/src/components/elportal/ELSupportedByNIH.tsx
@@ -7,13 +7,9 @@ const ELSupportedByNIH: React.FC = () => {
     <Box
       sx={{
         display: 'grid',
-        gridTemplateColumns: {
-          xs: '100%',
-          sm: '50% 50%',
-          md: '25% 75%',
-        },
-        position: 'relative',
-        p: '80px',
+        gridTemplateColumns: { xs: '1fr', md: '1fr 3fr' },
+        gap: { xs: '38px', md: '80px' },
+        padding: { xs: '40px', lg: '80px' },
       }}
     >
       <Box
@@ -54,7 +50,6 @@ const ELSupportedByNIH: React.FC = () => {
         sx={{
           width: '100%',
           height: '100%',
-          pl: { xs: 'none', md: '80px' },
         }}
       >
         <Box
@@ -65,7 +60,7 @@ const ELSupportedByNIH: React.FC = () => {
             backgroundRepeat: 'no-repeat',
             backgroundSize: 'contain',
           }}
-        ></Box>
+        />
         <Typography
           variant="body1"
           sx={{

--- a/apps/synapse-portal-framework/src/components/elportal/ELSupportedByNIH.tsx
+++ b/apps/synapse-portal-framework/src/components/elportal/ELSupportedByNIH.tsx
@@ -20,9 +20,7 @@ const ELSupportedByNIH: React.FC = () => {
         buttonText="Visit the NIA Website"
         link="https://www.nia.nih.gov/research/dgcg"
         sx={{
-          '*': {
-            borderColor: alpha(theme.palette.primary.main, 0.2),
-          },
+          '& > *': { borderColor: alpha(theme.palette.primary.main, 0.2) },
         }}
       />
       <Box

--- a/apps/synapse-portal-framework/src/components/elportal/ELSupportedByNIH.tsx
+++ b/apps/synapse-portal-framework/src/components/elportal/ELSupportedByNIH.tsx
@@ -1,8 +1,11 @@
-import { Box, Button, Typography } from '@mui/material'
+import { Box, alpha, Typography, useTheme } from '@mui/material'
 import React from 'react'
 import NIHLogo from './assets/nia_logo.png'
+import { PortalSectionHeader } from 'synapse-react-client'
 
 const ELSupportedByNIH: React.FC = () => {
+  const theme = useTheme()
+
   return (
     <Box
       sx={{
@@ -12,40 +15,16 @@ const ELSupportedByNIH: React.FC = () => {
         padding: { xs: '40px', lg: '80px' },
       }}
     >
-      <Box
+      <PortalSectionHeader
+        title="Supported by the National Institute on Aging"
+        buttonText="Visit the NIA Website"
+        link="https://www.nia.nih.gov/research/dgcg"
         sx={{
-          width: '100%',
-          height: '100%',
-          borderTop: '3px solid #B5D3CE',
-          py: '30px',
+          '*': {
+            borderColor: alpha(theme.palette.primary.main, 0.2),
+          },
         }}
-      >
-        <Typography
-          variant="headline2"
-          sx={{
-            fontSize: '28px',
-            mb: '20px',
-          }}
-        >
-          Supported by the NIA’s Division of Geriatrics and Clinical Gerontology
-          (DGCG)
-        </Typography>
-        <Button
-          variant="contained"
-          href="https://www.nia.nih.gov/research/dgcg"
-          rel="noopener noreferrer"
-          target="_blank"
-          sx={theme => ({
-            padding: '6px 24px',
-            fontWeight: '600',
-            [theme.breakpoints.down('sm')]: {
-              width: '100%',
-            },
-          })}
-        >
-          Visit the DCGC Website
-        </Button>
-      </Box>
+      />
       <Box
         sx={{
           width: '100%',
@@ -65,6 +44,7 @@ const ELSupportedByNIH: React.FC = () => {
           variant="body1"
           sx={{
             pt: '32px',
+            fontSize: '18px',
           }}
         >
           The National Institute on Aging (NIA) is a leading research
@@ -72,7 +52,10 @@ const ELSupportedByNIH: React.FC = () => {
           the healthy, active years of life. As part of the National Institutes
           of Health (NIH), NIA supports cutting-edge research on aging and
           age-related diseases, including Alzheimer's disease and other forms of
-          dementia. With a mission to improve the health and well-being of older
+          dementia.
+          <br />
+          <br />
+          With a mission to improve the health and well-being of older
           populations, NIA funds innovative scientific studies, promotes
           training for the next generation of researchers, and provides trusted
           health information to the public. By fostering collaboration across

--- a/packages/synapse-react-client/src/components/FeaturedDataTabs/FacetPlotsCard.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedDataTabs/FacetPlotsCard.tsx
@@ -204,6 +204,9 @@ function FacetPlotsCard(props: FacetPlotsCardProps) {
               variant={'contained'}
               href={detailsPagePath}
               color={'secondary'}
+              sx={theme => ({
+                [theme.breakpoints.down('sm')]: { width: '100%' },
+              })}
             >
               Explore {selectedFacetValue}
             </Button>

--- a/packages/synapse-react-client/src/components/FeaturedDataTabs/FeaturedDataTabs.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedDataTabs/FeaturedDataTabs.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import FeaturedDataPlots, { FeaturedDataPlotsProps } from './FeaturedDataPlots'
 import { Icon } from '../row_renderers/utils'
 import NoContentAvailable from '../SynapseTable/NoContentAvailable'
-import { Button } from '@mui/material'
+import { Box, Button } from '@mui/material'
 import { Paper } from '@mui/material'
 
 export type FeatureDataTabProps = {
@@ -25,7 +25,10 @@ function FeaturedDataTabs(props: FeaturedDataTabsProps) {
   // explore all data button
   const selectedTabProps: FeatureDataTabProps = configs[selectedTabIndex]
   return (
-    <div className="FeaturedDataTabs">
+    <Box
+      className="FeaturedDataTabs"
+      sx={{ padding: { xs: '40px', lg: '80px' } }}
+    >
       {/* tabs */}
       <div className="FeaturedDataTabs__tabs">
         {configs.map((config, index) => {
@@ -68,6 +71,11 @@ function FeaturedDataTabs(props: FeaturedDataTabsProps) {
                     variant="contained"
                     color="secondary"
                     href={selectedTabProps.explorePagePath}
+                    sx={theme => ({
+                      [theme.breakpoints.down('sm')]: {
+                        width: '100%',
+                      },
+                    })}
                   >
                     View All {selectedTabProps.exploreObjectType}
                   </Button>
@@ -81,7 +89,7 @@ function FeaturedDataTabs(props: FeaturedDataTabsProps) {
           )}
         </>
       )}
-    </div>
+    </Box>
   )
 }
 

--- a/packages/synapse-react-client/src/components/FeaturedResearch/FeaturedResearch.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedResearch/FeaturedResearch.tsx
@@ -244,7 +244,7 @@ function FeaturedResearch(props: FeaturedResearchProps) {
       <Stack>
         <PortalSectionHeader
           title="Featured Research"
-          sx={{ h2: { fontSize: '24px', paddingBottom: 0 } }}
+          sx={{ h2: { fontSize: '24px', paddingBottom: 0, width: '100%' } }}
         />
         <Stack gap="16px">
           {remainingCards.map((research, index) => (

--- a/packages/synapse-react-client/src/components/FeaturedResearch/FeaturedResearch.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedResearch/FeaturedResearch.tsx
@@ -16,6 +16,7 @@ import { formatDate } from '../../utils/functions/DateFormatter'
 import { useImageUrl } from '../../utils/hooks/useImageUrlUtils'
 import dayjs from 'dayjs'
 import { useInView } from 'react-intersection-observer'
+import PortalSectionHeader from '../PortalSectionHeader'
 
 const transitionTimeoutMs = 400
 
@@ -240,30 +241,26 @@ function FeaturedResearch(props: FeaturedResearchProps) {
           />
         )}
       </Box>
-      <Stack
-        gap="16px"
-        sx={{
-          borderTop: '3px solid',
-          borderColor: 'grey.400',
-          padding: '30px 0 0 0',
-        }}
-      >
-        <Typography variant="headline2" color="grey.1000" fontSize={'24px'}>
-          Featured Research
-        </Typography>
-        {remainingCards.map((research, index) => (
-          <FeaturedResearchCard
-            entityId={entityId}
-            research={research}
-            key={index}
-            isLoading={isLoading}
-            titleColIndex={titleColIndex}
-            descriptionColIndex={descriptionColIndex}
-            publicationDateColIndex={publicationDateColIndex}
-            imageColIndex={imageColIndex}
-            linkColIndex={linkColIndex}
-          />
-        ))}
+      <Stack>
+        <PortalSectionHeader
+          title="Featured Research"
+          sx={{ h2: { fontSize: '24px', paddingBottom: 0 } }}
+        />
+        <Stack gap="16px">
+          {remainingCards.map((research, index) => (
+            <FeaturedResearchCard
+              entityId={entityId}
+              research={research}
+              key={index}
+              isLoading={isLoading}
+              titleColIndex={titleColIndex}
+              descriptionColIndex={descriptionColIndex}
+              publicationDateColIndex={publicationDateColIndex}
+              imageColIndex={imageColIndex}
+              linkColIndex={linkColIndex}
+            />
+          ))}
+        </Stack>
       </Stack>
     </Box>
   )

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.Desktop.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.Desktop.tsx
@@ -35,7 +35,10 @@ export default function GoalsV2Desktop({
             justifyContent: 'center',
           }}
         >
-          <Typography variant="h6" component="strong" sx={{ marginRight: 1 }}>
+          <Typography
+            variant="h6"
+            sx={{ marginRight: 1, fontSize: '16px', fontWeight: 900 }}
+          >
             {countSql && (
               <QueryCount parens={false} query={{ sql: countSql }} />
             )}

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
@@ -6,7 +6,7 @@ import useShowDesktop from '../../utils/hooks/useShowDesktop'
 import GoalsV2Mobile from './GoalsV2.Mobile'
 import GoalsV2Desktop from './GoalsV2.Desktop'
 import { getFieldIndex } from '../../utils/functions/queryUtils'
-import { Box, alpha, useTheme } from '@mui/material'
+import { Box, alpha } from '@mui/material'
 import useGetGoalData from '../../utils/hooks/useGetGoalData'
 import PortalSectionHeader from '../PortalSectionHeader'
 
@@ -38,7 +38,6 @@ const GOALSV2_DESKTOP_MIN_BREAKPOINT = 1200
 export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
   const { entityId, dataLink } = props
   const showDesktop = useShowDesktop(GOALSV2_DESKTOP_MIN_BREAKPOINT)
-  const theme = useTheme()
   const queryBundleRequest: QueryBundleRequest = {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
     entityId,

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
@@ -115,7 +115,7 @@ export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
         buttonText="Start Exploring Data"
         link={dataLink}
         sx={{
-          '*': { borderColor: alpha(theme.palette.primary.main, 0.2) },
+          '& > *': { borderColor: alpha(theme.palette.primary.main, 0.2) },
           a: { marginTop: '24px', marginBottom: '30px' },
         }}
       />

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
@@ -114,10 +114,10 @@ export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
         title="What's in the Portal?"
         buttonText="Start Exploring Data"
         link={dataLink}
-        sx={{
-          '& > *': { borderColor: alpha(theme.palette.primary.main, 0.2) },
+        sx={theme => ({
+          h2: { borderColor: alpha(theme.palette.primary.main, 0.2) },
           a: { marginTop: '24px', marginBottom: '30px' },
-        }}
+        })}
       />
       {goalError && <ErrorBanner error={goalError} />}
       <div className={`Goals${showDesktop ? '__Desktop' : ''}`}>

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
@@ -6,8 +6,9 @@ import useShowDesktop from '../../utils/hooks/useShowDesktop'
 import GoalsV2Mobile from './GoalsV2.Mobile'
 import GoalsV2Desktop from './GoalsV2.Desktop'
 import { getFieldIndex } from '../../utils/functions/queryUtils'
-import { Box, Typography, Button } from '@mui/material'
+import { Box, alpha, useTheme } from '@mui/material'
 import useGetGoalData from '../../utils/hooks/useGetGoalData'
+import PortalSectionHeader from '../PortalSectionHeader'
 
 export type GoalsV2Props = {
   entityId: string
@@ -37,6 +38,7 @@ const GOALSV2_DESKTOP_MIN_BREAKPOINT = 1200
 export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
   const { entityId, dataLink } = props
   const showDesktop = useShowDesktop(GOALSV2_DESKTOP_MIN_BREAKPOINT)
+  const theme = useTheme()
   const queryBundleRequest: QueryBundleRequest = {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
     entityId,
@@ -107,40 +109,16 @@ export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
         padding: { xs: '40px', lg: '80px' },
       }}
     >
-      <Box
+      <PortalSectionHeader
+        centered
+        title="What's in the Portal?"
+        buttonText="Start Exploring Data"
+        link={dataLink}
         sx={{
-          textAlign: 'center',
-          paddingBottom: '30px',
+          '*': { borderColor: alpha(theme.palette.primary.main, 0.2) },
+          a: { marginTop: '24px', marginBottom: '30px' },
         }}
-      >
-        <Typography
-          variant="headline2"
-          sx={{
-            pt: '30px',
-            mb: '40px',
-            mx: 'auto',
-            width: 'max-content',
-            borderTop: '3px solid rgba(128, 128, 128, 0.25)',
-            color: 'grey.1000',
-            fontSize: { xs: '24px', md: '32px' },
-          }}
-        >
-          What's in the Portal?
-        </Typography>
-        <Button
-          href={dataLink}
-          target="_blank"
-          rel="noopener noreferrer"
-          variant="contained"
-          sx={theme => ({
-            [theme.breakpoints.down('sm')]: {
-              width: '100%',
-            },
-          })}
-        >
-          Start Exploring Data
-        </Button>
-      </Box>
+      />
       {goalError && <ErrorBanner error={goalError} />}
       <div className={`Goals${showDesktop ? '__Desktop' : ''}`}>
         {goalsDataArray.map((row, index) => {

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
@@ -104,7 +104,7 @@ export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
     <Box
       sx={{
         height: '560px',
-        padding: '80px',
+        padding: { xs: '40px', lg: '80px' },
       }}
     >
       <Box
@@ -114,7 +114,7 @@ export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
         }}
       >
         <Typography
-          variant="headline1"
+          variant="headline2"
           sx={{
             pt: '30px',
             mb: '40px',
@@ -122,7 +122,7 @@ export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
             width: 'max-content',
             borderTop: '3px solid rgba(128, 128, 128, 0.25)',
             color: 'grey.1000',
-            fontSize: '32px',
+            fontSize: { xs: '24px', md: '32px' },
           }}
         >
           What's in the Portal?
@@ -132,6 +132,11 @@ export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
           target="_blank"
           rel="noopener noreferrer"
           variant="contained"
+          sx={theme => ({
+            [theme.breakpoints.down('sm')]: {
+              width: '100%',
+            },
+          })}
         >
           Start Exploring Data
         </Button>
@@ -140,9 +145,9 @@ export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
       <div className={`Goals${showDesktop ? '__Desktop' : ''}`}>
         {goalsDataArray.map((row, index) => {
           return showDesktop ? (
-            <Box sx={{ display: 'grid' }}>
+            <div>
               <GoalsV2Desktop key={index} {...row} />
-            </Box>
+            </div>
           ) : (
             <Box sx={{ display: 'grid' }}>
               <GoalsV2Mobile key={index} {...row} />

--- a/packages/synapse-react-client/src/components/ImageCardGridWithLinks/ImageCardGridWithLinks.tsx
+++ b/packages/synapse-react-client/src/components/ImageCardGridWithLinks/ImageCardGridWithLinks.tsx
@@ -183,7 +183,7 @@ function ImageCardGridWithLinks(props: ImageCardGridWithLinksProps) {
         title={title}
         summaryText={summaryText}
         sx={{
-          h2: { fontSize: '24px', paddingTop: '26px' },
+          h2: { fontSize: '24px', paddingTop: '26px', width: '100%' },
           '& p': { fontSize: '16px', lineHeight: '24px' },
         }}
       />

--- a/packages/synapse-react-client/src/components/ImageCardGridWithLinks/ImageCardGridWithLinks.tsx
+++ b/packages/synapse-react-client/src/components/ImageCardGridWithLinks/ImageCardGridWithLinks.tsx
@@ -20,6 +20,7 @@ import useGetQueryResultBundle from '../../synapse-queries/entity/useGetQueryRes
 import { SynapseConstants } from '../../utils'
 import { getFieldIndex } from '../../utils/functions/queryUtils'
 import { parseEntityIdFromSqlStatement } from '../../utils/functions/SqlFunctions'
+import PortalSectionHeader from '../PortalSectionHeader'
 
 const BORDER_RADIUS = '6px'
 
@@ -178,30 +179,14 @@ function ImageCardGridWithLinks(props: ImageCardGridWithLinksProps) {
         padding: { xs: '40px', lg: '80px' },
       }}
     >
-      <div>
-        <Box
-          display="flex"
-          flexDirection="column"
-          gap="16px"
-          sx={{ borderTop: '3px solid', borderColor: 'grey.400' }}
-        >
-          <Typography
-            color="grey.1000"
-            variant="headline2"
-            paddingTop="26px"
-            fontSize="24px"
-          >
-            {title}
-          </Typography>
-          <Typography
-            variant="body1"
-            color="grey.800"
-            sx={{ fontStyle: 'italic' }}
-          >
-            {summaryText}
-          </Typography>
-        </Box>
-      </div>
+      <PortalSectionHeader
+        title={title}
+        summaryText={summaryText}
+        sx={{
+          h2: { fontSize: '24px', paddingTop: '26px' },
+          '& p': { fontSize: '16px', lineHeight: '24px' },
+        }}
+      />
       <Grid
         container
         spacing={2.5}

--- a/packages/synapse-react-client/src/components/Plot/UpsetPlot.tsx
+++ b/packages/synapse-react-client/src/components/Plot/UpsetPlot.tsx
@@ -23,6 +23,8 @@ import { ErrorBanner } from '../error/ErrorBanner'
 import loadingScreen from '../LoadingScreen/LoadingScreen'
 import LargeButton from '../../components/styled/LargeButton'
 import { useSynapseContext } from '../../utils/context/SynapseContext'
+import PortalSectionHeader from '../PortalSectionHeader'
+import { Box } from '@mui/material'
 
 export type UpsetPlotProps = {
   sql: string // first column should contain values, second column should contain a single set value.  ie. SELECT distinct individualID, assay FROM syn20821313
@@ -162,38 +164,51 @@ export function UpsetPlot({
       {!isLoading && data && (
         <SizeMe>
           {({ size }) => (
-            <div className="UpsetPlot">
-              <UpSetJS
-                sets={data.sets}
-                combinations={data.combinations}
-                width={size.width!}
-                height={height}
-                onHover={setSelection}
-                onClick={onClick}
-                selection={selection}
-                color={colorPalette[0]}
-                selectionColor={colorPalette[0]}
-                hasSelectionOpacity={0.3}
-                // alternatingBackgroundColor={false}
-                setName={setName?.toUpperCase()}
-                combinationName={combinationName?.toUpperCase()}
-                fontFamily="'DM Sans', sans-serif"
-                fontSizes={updateFontSizes}
-                exportButtons={false}
-                notMemberColor="transparent"
+            <Box
+              sx={{
+                height: '560px',
+                padding: { xs: '40px', lg: '80px' },
+              }}
+            >
+              <PortalSectionHeader
+                title="Explore the Data"
+                buttonText="View All Studies"
+                link="/Explore/Studies"
+                centered
               />
-              {summaryLink && summaryLinkText && (
-                <div className="UpsetPlot__summary">
-                  <LargeButton
-                    color="secondary"
-                    variant="contained"
-                    href={summaryLink}
-                  >
-                    {summaryLinkText}
-                  </LargeButton>
-                </div>
-              )}
-            </div>
+              <div className="UpsetPlot">
+                <UpSetJS
+                  sets={data.sets}
+                  combinations={data.combinations}
+                  width={size.width!}
+                  height={height}
+                  onHover={setSelection}
+                  onClick={onClick}
+                  selection={selection}
+                  color={colorPalette[0]}
+                  selectionColor={colorPalette[0]}
+                  hasSelectionOpacity={0.3}
+                  // alternatingBackgroundColor={false}
+                  setName={setName?.toUpperCase()}
+                  combinationName={combinationName?.toUpperCase()}
+                  fontFamily="'DM Sans', sans-serif"
+                  fontSizes={updateFontSizes}
+                  exportButtons={false}
+                  notMemberColor="transparent"
+                />
+                {summaryLink && summaryLinkText && (
+                  <div className="UpsetPlot__summary">
+                    <LargeButton
+                      color="secondary"
+                      variant="contained"
+                      href={summaryLink}
+                    >
+                      {summaryLinkText}
+                    </LargeButton>
+                  </div>
+                )}
+              </div>
+            </Box>
           )}
         </SizeMe>
       )}

--- a/packages/synapse-react-client/src/components/Plot/UpsetPlot.tsx
+++ b/packages/synapse-react-client/src/components/Plot/UpsetPlot.tsx
@@ -23,8 +23,6 @@ import { ErrorBanner } from '../error/ErrorBanner'
 import loadingScreen from '../LoadingScreen/LoadingScreen'
 import LargeButton from '../../components/styled/LargeButton'
 import { useSynapseContext } from '../../utils/context/SynapseContext'
-import PortalSectionHeader from '../PortalSectionHeader'
-import { Box } from '@mui/material'
 
 export type UpsetPlotProps = {
   sql: string // first column should contain values, second column should contain a single set value.  ie. SELECT distinct individualID, assay FROM syn20821313
@@ -164,51 +162,38 @@ export function UpsetPlot({
       {!isLoading && data && (
         <SizeMe>
           {({ size }) => (
-            <Box
-              sx={{
-                height: '560px',
-              }}
-            >
-              {/* <PortalSectionHeader
-                title="Explore the Data"
-                buttonText="View All Studies"
-                link="/Explore/Studies"
-                centered
-                sx={{ marginBottom: '90px' }}
-              /> */}
-              <div className="UpsetPlot">
-                <UpSetJS
-                  sets={data.sets}
-                  combinations={data.combinations}
-                  width={size.width!}
-                  height={height}
-                  onHover={setSelection}
-                  onClick={onClick}
-                  selection={selection}
-                  color={colorPalette[0]}
-                  selectionColor={colorPalette[0]}
-                  hasSelectionOpacity={0.3}
-                  // alternatingBackgroundColor={false}
-                  setName={setName?.toUpperCase()}
-                  combinationName={combinationName?.toUpperCase()}
-                  fontFamily="'DM Sans', sans-serif"
-                  fontSizes={updateFontSizes}
-                  exportButtons={false}
-                  notMemberColor="transparent"
-                />
-                {summaryLink && summaryLinkText && (
-                  <div className="UpsetPlot__summary">
-                    <LargeButton
-                      color="secondary"
-                      variant="contained"
-                      href={summaryLink}
-                    >
-                      {summaryLinkText}
-                    </LargeButton>
-                  </div>
-                )}
-              </div>
-            </Box>
+            <div className="UpsetPlot">
+              <UpSetJS
+                sets={data.sets}
+                combinations={data.combinations}
+                width={size.width!}
+                height={height}
+                onHover={setSelection}
+                onClick={onClick}
+                selection={selection}
+                color={colorPalette[0]}
+                selectionColor={colorPalette[0]}
+                hasSelectionOpacity={0.3}
+                // alternatingBackgroundColor={false}
+                setName={setName?.toUpperCase()}
+                combinationName={combinationName?.toUpperCase()}
+                fontFamily="'DM Sans', sans-serif"
+                fontSizes={updateFontSizes}
+                exportButtons={false}
+                notMemberColor="transparent"
+              />
+              {summaryLink && summaryLinkText && (
+                <div className="UpsetPlot__summary">
+                  <LargeButton
+                    color="secondary"
+                    variant="contained"
+                    href={summaryLink}
+                  >
+                    {summaryLinkText}
+                  </LargeButton>
+                </div>
+              )}
+            </div>
           )}
         </SizeMe>
       )}

--- a/packages/synapse-react-client/src/components/Plot/UpsetPlot.tsx
+++ b/packages/synapse-react-client/src/components/Plot/UpsetPlot.tsx
@@ -167,15 +167,15 @@ export function UpsetPlot({
             <Box
               sx={{
                 height: '560px',
-                padding: { xs: '40px', lg: '80px' },
               }}
             >
-              <PortalSectionHeader
+              {/* <PortalSectionHeader
                 title="Explore the Data"
                 buttonText="View All Studies"
                 link="/Explore/Studies"
                 centered
-              />
+                sx={{ marginBottom: '90px' }}
+              /> */}
               <div className="UpsetPlot">
                 <UpSetJS
                   sets={data.sets}

--- a/packages/synapse-react-client/src/components/PortalFeatureHighlights/PortalFeatureHighlights.tsx
+++ b/packages/synapse-react-client/src/components/PortalFeatureHighlights/PortalFeatureHighlights.tsx
@@ -1,19 +1,11 @@
-import {
-  Box,
-  Button,
-  CardMedia,
-  Fade,
-  Slide,
-  Stack,
-  Typography,
-} from '@mui/material'
+import { Box, CardMedia, Fade, Slide } from '@mui/material'
 import React from 'react'
 import { useInView } from 'react-intersection-observer'
-import { Link } from 'react-router'
+import PortalSectionHeader from '../PortalSectionHeader'
 
 export type PortalFeatureHighlightsProps = {
   reverseOrder?: boolean
-  title?: string
+  title: string
   image?: string
   buttonText?: string
   summaryText?: React.ReactNode
@@ -67,51 +59,13 @@ const PortalFeatureHighlights = (props: PortalFeatureHighlightsProps) => {
           </Slide>
         </div>
       </Fade>
-      <Stack
-        sx={{
-          gridArea: 'content',
-          gap: '16px',
-          borderTop: '3px solid',
-          borderColor: 'grey.400',
-        }}
-      >
-        <Typography
-          variant="headline2"
-          paddingTop="30px"
-          paddingBottom="10px"
-          color="grey.1000"
-          fontSize={'31px'}
-        >
-          {title}
-        </Typography>
-        <Button
-          variant="contained"
-          component={Link}
-          to={link || ''}
-          sx={theme => ({
-            [theme.breakpoints.up('sm')]: {
-              width: 'fit-content',
-            },
-            whiteSpace: 'nowrap',
-            padding: '6px 24px',
-            fontWeight: '600',
-            fontSize: '16px',
-          })}
-        >
-          {buttonText}
-        </Button>
-        <Typography
-          variant="body1"
-          sx={{
-            fontStyle: 'italic',
-            color: 'grey.800',
-            fontSize: '18px',
-            lineHeight: '27px',
-          }}
-        >
-          {summaryText}
-        </Typography>
-      </Stack>
+      <PortalSectionHeader
+        title={title}
+        buttonText={buttonText}
+        link={link}
+        summaryText={summaryText}
+        sx={{ gridArea: 'content' }}
+      />
     </Box>
   )
 }

--- a/packages/synapse-react-client/src/components/PortalFeatureHighlights/PortalFeatureHighlights.tsx
+++ b/packages/synapse-react-client/src/components/PortalFeatureHighlights/PortalFeatureHighlights.tsx
@@ -64,7 +64,7 @@ const PortalFeatureHighlights = (props: PortalFeatureHighlightsProps) => {
         buttonText={buttonText}
         link={link}
         summaryText={summaryText}
-        sx={{ gridArea: 'content' }}
+        sx={{ gridArea: 'content', h2: { width: '100%' } }}
       />
     </Box>
   )

--- a/packages/synapse-react-client/src/components/PortalFeaturedPartners/PortalFeaturedPartners.tsx
+++ b/packages/synapse-react-client/src/components/PortalFeaturedPartners/PortalFeaturedPartners.tsx
@@ -156,7 +156,7 @@ const PortalFeaturedPartners = ({ sql }: PortalFeaturedPartnersProps) => {
     >
       <PortalSectionHeader
         title="Our Partners"
-        sx={{ h2: { fontSize: '24px', paddingTop: '26px' } }}
+        sx={{ h2: { fontSize: '24px', paddingTop: '26px', width: '100%' } }}
       />
       <Box
         sx={theme => ({

--- a/packages/synapse-react-client/src/components/PortalFeaturedPartners/PortalFeaturedPartners.tsx
+++ b/packages/synapse-react-client/src/components/PortalFeaturedPartners/PortalFeaturedPartners.tsx
@@ -5,6 +5,7 @@ import { SynapseConstants } from '../../utils'
 import useGetQueryResultBundle from '../../synapse-queries/entity/useGetQueryResultBundle'
 import { getFieldIndex } from '../../utils/functions/queryUtils'
 import { useImageUrl } from '../../utils/hooks/useImageUrlUtils'
+import PortalSectionHeader from '../PortalSectionHeader'
 
 export type PortalFeaturedPartnersProps = {
   sql: string
@@ -147,28 +148,16 @@ const PortalFeaturedPartners = ({ sql }: PortalFeaturedPartnersProps) => {
     <Box
       sx={{
         display: 'grid',
-        padding: { xs: '40px', md: '20px 80px' },
+        padding: { xs: '40px', lg: '20px 80px' },
         backgroundColor: 'grey.100',
         gridTemplateColumns: { xs: '1fr', md: '1fr 3fr' },
         gap: '50px',
       }}
     >
-      <Box
-        sx={{
-          borderTop: '3px solid',
-          borderColor: 'grey.400',
-          gap: '16px',
-        }}
-      >
-        <Typography
-          color="grey.1000"
-          variant="headline2"
-          paddingTop="26px"
-          fontSize="24px"
-        >
-          Our Partners
-        </Typography>
-      </Box>
+      <PortalSectionHeader
+        title="Our Partners"
+        sx={{ h2: { fontSize: '24px', paddingTop: '26px' } }}
+      />
       <Box
         sx={theme => ({
           display: 'flex',

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.stories.tsx
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.stories.tsx
@@ -1,0 +1,28 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { MemoryRouter } from 'react-router'
+import PortalSectionHeader from './PortalSectionHeader'
+
+const meta = {
+  title: 'Home Page/PortalSectionHeader',
+  component: PortalSectionHeader,
+  parameters: {
+    chromatic: { viewports: [600, 1200] },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  render: args => (
+    <MemoryRouter>
+      <PortalSectionHeader {...args} />
+    </MemoryRouter>
+  ),
+  args: {
+    title: 'Section Title',
+    summaryText: 'Section summary text.',
+    buttonText: 'Section button',
+    link: 'https://example.com',
+  },
+}

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.test.tsx
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.test.tsx
@@ -72,7 +72,6 @@ describe('PortalSectionHeader tests', () => {
       centered: true,
     })
 
-    expect(container.firstChild).toHaveStyle('display: flex')
-    expect(container.firstChild).toHaveStyle('justify-content: center')
+    expect(container.firstChild).toHaveStyle('width: 100%')
   })
 })

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.test.tsx
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import { RouterProvider, createMemoryRouter } from 'react-router'
+import PortalSectionHeader, {
+  PortalSectionHeaderProps,
+} from './PortalSectionHeader'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+
+describe('PortalSectionHeader tests', () => {
+  const mockProps: PortalSectionHeaderProps = {
+    title: 'Some Title',
+    buttonText: 'Some button text',
+    summaryText: 'Some summary text',
+    link: '/some-link',
+  }
+
+  const renderWithRouter = (mockProps: PortalSectionHeaderProps) => {
+    const router = createMemoryRouter([
+      {
+        path: '/',
+        element: <PortalSectionHeader {...mockProps} />,
+      },
+    ])
+    return render(<RouterProvider router={router} />, {
+      wrapper: createWrapper(),
+    })
+  }
+
+  it('renders title', () => {
+    renderWithRouter(mockProps)
+    expect(screen.getByText('Some Title')).toBeInTheDocument()
+  })
+
+  it('renders button when buttonText is provided', () => {
+    renderWithRouter(mockProps)
+    expect(screen.getByText('Some button text')).toBeInTheDocument()
+  })
+
+  it('renders summary text when provided', () => {
+    renderWithRouter(mockProps)
+    expect(screen.getByText('Some summary text')).toBeInTheDocument()
+  })
+
+  it('button links to the correct URL', () => {
+    renderWithRouter(mockProps)
+
+    const button = screen.getByRole('link', { name: 'Some button text' })
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveAttribute('href', mockProps.link)
+  })
+
+  test('reverses the order of button and summary text when reverseButtonAndText is true', () => {
+    const { container } = renderWithRouter({
+      ...mockProps,
+      reverseButtonAndText: true,
+    })
+
+    const nestedStack = container.querySelectorAll('div')[2]
+    expect(nestedStack).toHaveStyle('flex-direction: column-reverse')
+    const button = nestedStack?.querySelector('a')
+    const summary = nestedStack?.querySelector('p')
+
+    expect(button).toBeInTheDocument()
+    expect(summary).toBeInTheDocument()
+
+    expect(button?.textContent).toBe('Some button text')
+    expect(summary?.textContent).toBe('Some summary text')
+  })
+
+  it('applies centered styles when centered prop is true', () => {
+    const { container } = renderWithRouter({
+      ...mockProps,
+      centered: true,
+    })
+
+    expect(container.firstChild).toHaveStyle('display: flex')
+    expect(container.firstChild).toHaveStyle('justify-content: center')
+  })
+})

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
@@ -1,25 +1,36 @@
-import { Stack, Typography, Button } from '@mui/material'
+import { Stack, Typography, Button, SxProps, Theme } from '@mui/material'
 import { Link } from 'react-router'
+import { spreadSx } from '../../theme/spreadSx'
 
 export type PortalSectionHeaderProps = {
   title: string
   buttonText?: string
   summaryText?: string
+  link?: string
+  sx?: SxProps<Theme>
 }
 
 const PortalSectionHeader = ({
   title,
   buttonText,
   summaryText,
+  link,
+  sx,
 }: PortalSectionHeaderProps) => {
   return (
     <Stack
-      sx={{
+      // sx={{
+      //   gridArea: 'content',
+      //   gap: '16px',
+      //   borderTop: '3px solid',
+      //   borderColor: 'grey.400',
+      // }}
+      sx={spreadSx(sx, {
         gridArea: 'content',
         gap: '16px',
         borderTop: '3px solid',
         borderColor: 'grey.400',
-      }}
+      })}
     >
       <Typography
         variant="headline2"
@@ -33,7 +44,7 @@ const PortalSectionHeader = ({
       <Button
         variant="contained"
         component={Link}
-        to={''}
+        to={link || ''}
         sx={theme => ({
           [theme.breakpoints.up('sm')]: {
             width: 'fit-content',

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
@@ -5,7 +5,7 @@ import { spreadSx } from '../../theme/spreadSx'
 export type PortalSectionHeaderProps = {
   title: string
   buttonText?: string
-  summaryText?: string
+  summaryText?: React.ReactNode
   link?: string
   sx?: SxProps<Theme>
   centered?: boolean
@@ -18,8 +18,8 @@ const PortalSectionHeader = ({
   summaryText,
   link,
   sx,
-  centered,
-  reverseButtonAndText,
+  centered = false,
+  reverseButtonAndText = false,
 }: PortalSectionHeaderProps) => {
   return (
     <Box
@@ -31,7 +31,7 @@ const PortalSectionHeader = ({
       <Stack
         sx={{
           gap: '16px',
-          borderTop: '3px solid',
+          borderTop: '4px solid',
           borderColor: 'grey.400',
           alignItems: centered ? 'center' : 'flex-start',
         }}
@@ -39,53 +39,57 @@ const PortalSectionHeader = ({
         <Typography
           variant="headline2"
           paddingTop="30px"
-          paddingBottom="10px"
           color="grey.1000"
-          fontSize={'32px'}
+          fontSize={{ xs: '24px', md: '32px' }}
         >
           {title}
         </Typography>
-        <Box
-          sx={{
-            ...(reverseButtonAndText && {
-              display: 'flex',
+        {(buttonText || summaryText) && (
+          <Stack
+            sx={{
               gap: '16px',
-              flexDirection: 'column-reverse',
-            }),
-          }}
-        >
-          {buttonText && (
-            <Button
-              variant="contained"
-              component={Link}
-              to={link || ''}
-              sx={theme => ({
-                [theme.breakpoints.up('sm')]: {
-                  width: 'fit-content',
-                },
-                whiteSpace: 'nowrap',
-                padding: '6px 24px',
-                fontWeight: '600',
-                fontSize: '16px',
-              })}
-            >
-              {buttonText}
-            </Button>
-          )}
-          {summaryText && (
-            <Typography
-              variant="body1"
-              sx={{
-                fontStyle: 'italic',
-                color: 'grey.800',
-                fontSize: '18px',
-                lineHeight: '27px',
-              }}
-            >
-              {summaryText}
-            </Typography>
-          )}
-        </Box>
+              width: '100%',
+              alignItems: centered ? 'center' : 'flex-start',
+              ...(reverseButtonAndText && {
+                flexDirection: 'column-reverse',
+              }),
+            }}
+          >
+            {buttonText && (
+              <Button
+                variant="contained"
+                component={Link}
+                to={link || ''}
+                sx={theme => ({
+                  [theme.breakpoints.down('sm')]: {
+                    width: '100%',
+                  },
+                  maxWidth: '100%',
+                  whiteSpace: 'nowrap',
+                  padding: { xs: '6px', md: '6px 24px' },
+                  fontWeight: '600',
+                  fontSize: { xs: '16px', md: '18px' },
+                  lineHeight: '144%',
+                })}
+              >
+                {buttonText}
+              </Button>
+            )}
+            {summaryText && (
+              <Typography
+                variant="body1"
+                sx={{
+                  fontStyle: 'italic',
+                  color: 'grey.800',
+                  fontSize: '18px',
+                  lineHeight: '27px',
+                }}
+              >
+                {summaryText}
+              </Typography>
+            )}
+          </Stack>
+        )}
       </Stack>
     </Box>
   )

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
@@ -1,5 +1,13 @@
-import { Stack, Typography, Button, SxProps, Theme, Box } from '@mui/material'
-import { Link } from 'react-router'
+import {
+  Stack,
+  Typography,
+  Button,
+  SxProps,
+  Theme,
+  Box,
+  Link as MuiLink,
+} from '@mui/material'
+import { Link as RouterLink } from 'react-router'
 import { spreadSx } from '../../theme/spreadSx'
 
 export type PortalSectionHeaderProps = {
@@ -21,6 +29,8 @@ const PortalSectionHeader = ({
   centered = false,
   reverseButtonAndText = false,
 }: PortalSectionHeaderProps) => {
+  const iisExternalLink =
+    link?.startsWith('http://') || link?.startsWith('https://')
   return (
     <Box
       sx={spreadSx(sx, {
@@ -64,8 +74,14 @@ const PortalSectionHeader = ({
             {buttonText && (
               <Button
                 variant="contained"
-                component={Link}
-                to={link || ''}
+                component={iisExternalLink ? MuiLink : RouterLink}
+                {...(iisExternalLink
+                  ? {
+                      href: link,
+                      target: '_blank',
+                      rel: 'noopener noreferrer',
+                    }
+                  : { to: link })}
                 sx={theme => ({
                   [theme.breakpoints.down('sm')]: {
                     width: '100%',

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
@@ -42,9 +42,9 @@ const PortalSectionHeader = ({
       <Stack
         sx={{
           gap: '16px',
-          alignItems: centered ? 'center' : 'flex-start',
           ...(centered && {
             textAlign: 'center',
+            alignItems: 'center',
           }),
         }}
       >

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
@@ -1,0 +1,64 @@
+import { Stack, Typography, Button } from '@mui/material'
+import { Link } from 'react-router'
+
+export type PortalSectionHeaderProps = {
+  title: string
+  buttonText?: string
+  summaryText?: string
+}
+
+const PortalSectionHeader = ({
+  title,
+  buttonText,
+  summaryText,
+}: PortalSectionHeaderProps) => {
+  return (
+    <Stack
+      sx={{
+        gridArea: 'content',
+        gap: '16px',
+        borderTop: '3px solid',
+        borderColor: 'grey.400',
+      }}
+    >
+      <Typography
+        variant="headline2"
+        paddingTop="30px"
+        paddingBottom="10px"
+        color="grey.1000"
+        fontSize={'31px'}
+      >
+        {title}
+      </Typography>
+      <Button
+        variant="contained"
+        component={Link}
+        to={''}
+        sx={theme => ({
+          [theme.breakpoints.up('sm')]: {
+            width: 'fit-content',
+          },
+          whiteSpace: 'nowrap',
+          padding: '6px 24px',
+          fontWeight: '600',
+          fontSize: '16px',
+        })}
+      >
+        {buttonText}
+      </Button>
+      <Typography
+        variant="body1"
+        sx={{
+          fontStyle: 'italic',
+          color: 'grey.800',
+          fontSize: '18px',
+          lineHeight: '27px',
+        }}
+      >
+        {summaryText}
+      </Typography>
+    </Stack>
+  )
+}
+
+export default PortalSectionHeader

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
@@ -1,4 +1,4 @@
-import { Stack, Typography, Button, SxProps, Theme } from '@mui/material'
+import { Stack, Typography, Button, SxProps, Theme, Box } from '@mui/material'
 import { Link } from 'react-router'
 import { spreadSx } from '../../theme/spreadSx'
 
@@ -8,6 +8,8 @@ export type PortalSectionHeaderProps = {
   summaryText?: string
   link?: string
   sx?: SxProps<Theme>
+  centered?: boolean
+  reverseButtonAndText?: boolean
 }
 
 const PortalSectionHeader = ({
@@ -16,59 +18,76 @@ const PortalSectionHeader = ({
   summaryText,
   link,
   sx,
+  centered,
+  reverseButtonAndText,
 }: PortalSectionHeaderProps) => {
   return (
-    <Stack
-      // sx={{
-      //   gridArea: 'content',
-      //   gap: '16px',
-      //   borderTop: '3px solid',
-      //   borderColor: 'grey.400',
-      // }}
+    <Box
       sx={spreadSx(sx, {
-        gridArea: 'content',
-        gap: '16px',
-        borderTop: '3px solid',
-        borderColor: 'grey.400',
+        display: centered ? 'flex' : 'block',
+        justifyContent: centered ? 'center' : 'flex-start',
       })}
     >
-      <Typography
-        variant="headline2"
-        paddingTop="30px"
-        paddingBottom="10px"
-        color="grey.1000"
-        fontSize={'31px'}
-      >
-        {title}
-      </Typography>
-      <Button
-        variant="contained"
-        component={Link}
-        to={link || ''}
-        sx={theme => ({
-          [theme.breakpoints.up('sm')]: {
-            width: 'fit-content',
-          },
-          whiteSpace: 'nowrap',
-          padding: '6px 24px',
-          fontWeight: '600',
-          fontSize: '16px',
-        })}
-      >
-        {buttonText}
-      </Button>
-      <Typography
-        variant="body1"
+      <Stack
         sx={{
-          fontStyle: 'italic',
-          color: 'grey.800',
-          fontSize: '18px',
-          lineHeight: '27px',
+          gap: '16px',
+          borderTop: '3px solid',
+          borderColor: 'grey.400',
+          alignItems: centered ? 'center' : 'flex-start',
         }}
       >
-        {summaryText}
-      </Typography>
-    </Stack>
+        <Typography
+          variant="headline2"
+          paddingTop="30px"
+          paddingBottom="10px"
+          color="grey.1000"
+          fontSize={'32px'}
+        >
+          {title}
+        </Typography>
+        <Box
+          sx={{
+            ...(reverseButtonAndText && {
+              display: 'flex',
+              gap: '16px',
+              flexDirection: 'column-reverse',
+            }),
+          }}
+        >
+          {buttonText && (
+            <Button
+              variant="contained"
+              component={Link}
+              to={link || ''}
+              sx={theme => ({
+                [theme.breakpoints.up('sm')]: {
+                  width: 'fit-content',
+                },
+                whiteSpace: 'nowrap',
+                padding: '6px 24px',
+                fontWeight: '600',
+                fontSize: '16px',
+              })}
+            >
+              {buttonText}
+            </Button>
+          )}
+          {summaryText && (
+            <Typography
+              variant="body1"
+              sx={{
+                fontStyle: 'italic',
+                color: 'grey.800',
+                fontSize: '18px',
+                lineHeight: '27px',
+              }}
+            >
+              {summaryText}
+            </Typography>
+          )}
+        </Box>
+      </Stack>
+    </Box>
   )
 }
 

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
@@ -24,8 +24,11 @@ const PortalSectionHeader = ({
   return (
     <Box
       sx={spreadSx(sx, {
-        display: centered ? 'flex' : 'block',
-        justifyContent: centered ? 'center' : 'flex-start',
+        ...(centered && {
+          width: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+        }),
       })}
     >
       <Stack
@@ -49,7 +52,10 @@ const PortalSectionHeader = ({
             sx={{
               gap: '16px',
               width: '100%',
-              alignItems: centered ? 'center' : 'flex-start',
+              ...(centered && {
+                alignItems: 'center',
+                width: '100%',
+              }),
               ...(reverseButtonAndText && {
                 flexDirection: 'column-reverse',
               }),
@@ -65,10 +71,11 @@ const PortalSectionHeader = ({
                     width: '100%',
                   },
                   maxWidth: '100%',
+                  width: 'fit-content',
                   whiteSpace: 'nowrap',
-                  padding: { xs: '6px', md: '6px 24px' },
+                  padding: { xs: '6px', sm: '6px 24px' },
                   fontWeight: '600',
-                  fontSize: { xs: '16px', md: '18px' },
+                  fontSize: { xs: '16px', sm: '18px' },
                   lineHeight: '144%',
                 })}
               >

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/PortalSectionHeader.tsx
@@ -36,24 +36,30 @@ const PortalSectionHeader = ({
       sx={spreadSx(sx, {
         ...(centered && {
           width: '100%',
-          display: 'flex',
-          justifyContent: 'center',
         }),
       })}
     >
       <Stack
         sx={{
           gap: '16px',
-          borderTop: '4px solid',
-          borderColor: 'grey.400',
           alignItems: centered ? 'center' : 'flex-start',
+          ...(centered && {
+            textAlign: 'center',
+          }),
         }}
       >
         <Typography
           variant="headline2"
           paddingTop="30px"
           color="grey.1000"
-          fontSize={{ xs: '24px', md: '32px' }}
+          sx={theme => ({
+            fontSize: { xs: '24px', md: '32px' },
+            borderTop: '4px solid',
+            borderColor: 'grey.400',
+            [theme.breakpoints.down('md')]: {
+              width: '100%',
+            },
+          })}
         >
           {title}
         </Typography>

--- a/packages/synapse-react-client/src/components/PortalSectionHeader/index.ts
+++ b/packages/synapse-react-client/src/components/PortalSectionHeader/index.ts
@@ -1,0 +1,4 @@
+import PortalSectionHeader from './PortalSectionHeader'
+import type { PortalSectionHeaderProps } from './PortalSectionHeader'
+export { PortalSectionHeader, PortalSectionHeaderProps }
+export default PortalSectionHeader

--- a/packages/synapse-react-client/src/components/RecentPublicationsGrid/RecentPublicationsGrid.tsx
+++ b/packages/synapse-react-client/src/components/RecentPublicationsGrid/RecentPublicationsGrid.tsx
@@ -8,12 +8,12 @@ import {
 import Grid from '@mui/material/Unstable_Grid2'
 import { QueryBundleRequest, Row } from '@sage-bionetworks/synapse-types'
 import dayjs from 'dayjs'
-import { Link } from 'react-router'
 import useGetQueryResultBundle from '../../synapse-queries/entity/useGetQueryResultBundle'
 import { SynapseConstants, SynapseUtilityFunctions } from '../../utils'
 import { formatDate } from '../../utils/functions/DateFormatter'
 import { getFieldIndex } from '../../utils/functions/queryUtils'
 import { convertDoiToLink } from '../../utils/functions/RegularExpressions'
+import PortalSectionHeader from '../PortalSectionHeader'
 
 export type RecentPublicationsGridProps = {
   sql: string
@@ -209,45 +209,18 @@ function RecentPublicationsGrid(props: RecentPublicationsGridProps) {
           ))}
         </Box>
       </Box>
-      <Box>
-        <Box
-          display="flex"
-          flexDirection="column"
-          gap="16px"
+      <Box sx={{ paddingBottom: '30px' }}>
+        <PortalSectionHeader
+          title="Recently Published"
+          summaryText={summaryText}
+          buttonText={buttonLinkText}
+          link={buttonLink}
+          reverseButtonAndText
           sx={{
-            borderTop: '3px solid',
-            borderColor: 'grey.400',
-            padding: '30px 0',
+            h2: { fontSize: '24px', paddingTop: '30px' },
+            '& p': { fontSize: '16px', lineHeight: '24px' },
           }}
-        >
-          <Typography variant="headline2" color="grey.1000" fontSize={'24px'}>
-            Recently Published
-          </Typography>
-          <Typography
-            variant="body1"
-            sx={{ fontStyle: 'italic', color: 'grey.800' }}
-          >
-            {summaryText && summaryText}
-          </Typography>
-          {buttonLink && buttonLinkText && (
-            <Button
-              variant="contained"
-              to={buttonLink}
-              component={Link}
-              sx={theme => ({
-                whiteSpace: 'nowrap',
-                alignSelf: 'flex-start',
-                padding: '6px 24px',
-                fontWeight: 600,
-                [theme.breakpoints.down('sm')]: {
-                  width: '100%',
-                },
-              })}
-            >
-              {buttonLinkText}
-            </Button>
-          )}
-        </Box>
+        />
       </Box>
     </Box>
   )

--- a/packages/synapse-react-client/src/components/RecentPublicationsGrid/RecentPublicationsGrid.tsx
+++ b/packages/synapse-react-client/src/components/RecentPublicationsGrid/RecentPublicationsGrid.tsx
@@ -211,7 +211,7 @@ function RecentPublicationsGrid(props: RecentPublicationsGridProps) {
           link={buttonLink}
           reverseButtonAndText
           sx={{
-            h2: { fontSize: '24px', paddingTop: '30px' },
+            h2: { fontSize: '24px', paddingTop: '30px', width: '100%' },
             '& p': { fontSize: '16px', lineHeight: '24px' },
           }}
         />

--- a/packages/synapse-react-client/src/components/RecentPublicationsGrid/RecentPublicationsGrid.tsx
+++ b/packages/synapse-react-client/src/components/RecentPublicationsGrid/RecentPublicationsGrid.tsx
@@ -1,10 +1,4 @@
-import {
-  Box,
-  Button,
-  Link as MuiLink,
-  Skeleton,
-  Typography,
-} from '@mui/material'
+import { Box, Link as MuiLink, Skeleton, Typography } from '@mui/material'
 import Grid from '@mui/material/Unstable_Grid2'
 import { QueryBundleRequest, Row } from '@sage-bionetworks/synapse-types'
 import dayjs from 'dayjs'

--- a/packages/synapse-react-client/src/components/index.ts
+++ b/packages/synapse-react-client/src/components/index.ts
@@ -90,6 +90,7 @@ export * from './PortalFeatureHighlights'
 export * from './FeaturedResearch'
 export * from './PortalHomePageHeader'
 export * from './PortalFeaturedPartners'
+export * from './PortalSectionHeader'
 
 // TODO: Find a better way to expose Icon components
 export { Project as ProjectIcon } from '../assets/themed_icons/Project'


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/PORTALS-3405

The majority of the new components used a similar section header so I created a reusable component out of it.

<img width="300" alt="Screenshot 2025-02-11 at 8 59 19 PM" src="https://github.com/user-attachments/assets/0890ffed-f79a-463c-8144-eea6bdc332b7" />
<img width="300" alt="Screenshot 2025-02-11 at 8 28 44 PM" src="https://github.com/user-attachments/assets/db7b4e41-f52e-465a-999d-ccdc452a1611" />
