### PR TITLE
SWC-7242

### DIFF
--- a/packages/synapse-react-client/vite.config.ts
+++ b/packages/synapse-react-client/vite.config.ts
@@ -6,8 +6,13 @@ import { ConfigBuilder } from 'vite-config'
  */
 const config = new ConfigBuilder()
   .setIncludeReactConfig(true)
-  .setIncludeLibraryConfig(true)
-  .setBuildLibEntry(resolve(__dirname, 'src/index.ts'))
+  .setIncludeLibraryConfig(true, {
+    except: [
+      // Include @sage-bionetworks/synapse-types because the local version may drift from the version released on NPM
+      '@sage-bionetworks/synapse-types',
+    ],
+  })
+  .setBuildLibEntry(resolve(__dirname, 'src/umd.index.ts'))
   .setConfigOverrides({
     root: '.',
     build: {

--- a/packages/vite-config/src/ConfigBuilder.ts
+++ b/packages/vite-config/src/ConfigBuilder.ts
@@ -5,7 +5,6 @@ import viteLibraryConfig from './vite-library-config.js'
 import vitestConfig from './vitest-config.js'
 
 export class ConfigBuilder {
-  private includeReactConfig = false
   private includeLibraryConfig = false
   private buildLibEntry: string | string[] | undefined = undefined
   private includeVitestConfig = false
@@ -13,7 +12,7 @@ export class ConfigBuilder {
   private configOverrides: Record<string, any> | null = null
 
   setIncludeReactConfig(includeReactConfig: boolean): ConfigBuilder {
-    this.includeReactConfig = includeReactConfig
+    this.pluginConfigOptions.includeReactPlugins = includeReactConfig
     return this
   }
 
@@ -27,15 +26,14 @@ export class ConfigBuilder {
     return this
   }
 
-  setIncludeLibraryConfig(includeLibraryConfig: boolean): ConfigBuilder {
-    this.includeLibraryConfig = includeLibraryConfig
-    return this
-  }
-
-  setPluginConfigOptions(
-    pluginConfigOptions: PluginConfigOptions,
+  setIncludeLibraryConfig(
+    includeLibraryConfig: boolean,
+    externalizeDepsOptions?: Parameters<
+      typeof getPluginConfig
+    >[0]['externalizeDepsOptions'],
   ): ConfigBuilder {
-    this.pluginConfigOptions = pluginConfigOptions
+    this.includeLibraryConfig = includeLibraryConfig
+    this.pluginConfigOptions.externalizeDepsOptions = externalizeDepsOptions
     return this
   }
 
@@ -63,7 +61,7 @@ export class ConfigBuilder {
     if (this.pluginConfigOptions) {
       config = mergeConfig(config, {
         plugins: getPluginConfig({
-          includeReactPlugins: this.includeReactConfig,
+          ...this.pluginConfigOptions,
           includeLibraryPlugins: this.includeLibraryConfig,
         }),
       })

--- a/packages/vite-config/src/pluginConfig.ts
+++ b/packages/vite-config/src/pluginConfig.ts
@@ -8,6 +8,7 @@ import dts from 'vite-plugin-dts'
 export type PluginConfigOptions = {
   includeReactPlugins?: boolean
   includeLibraryPlugins?: boolean
+  externalizeDepsOptions?: Parameters<typeof externalizeDeps>[0]
 }
 
 /**
@@ -34,14 +35,18 @@ const REACT_PLUGINS: PluginOption[] = [
 /**
  * Plugins that libraries that should emit ESM and CJS bundles will use
  */
-const LIBRARY_PLUGINS: PluginOption[] = [
-  // Do not bundle any dependencies; the consumer's bundler will resolve and link them.
-  externalizeDeps(),
-  // Generate a single type definition file for distribution.
-  dts({
-    rollupTypes: true,
-  }),
-]
+function getLibraryPlugins(
+  externalizeDepsOptions?: Parameters<typeof externalizeDeps>[0],
+): PluginOption[] {
+  return [
+    // Do not bundle any dependencies; the consumer's bundler will resolve and link them.
+    externalizeDeps(externalizeDepsOptions),
+    // Generate a single type definition file for distribution.
+    dts({
+      rollupTypes: true,
+    }),
+  ]
+}
 
 /**
  * Get a shared configuration of Vite plugins to use based on the provided options. Note that Vite does not deeply merge
@@ -53,7 +58,7 @@ export function getPluginConfig(options: PluginConfigOptions): PluginOption[] {
     plugins.push(...REACT_PLUGINS)
   }
   if (options.includeLibraryPlugins) {
-    plugins.push(...LIBRARY_PLUGINS)
+    plugins.push(...getLibraryPlugins(options.externalizeDepsOptions))
   }
   return plugins
 }


### PR DESCRIPTION
Update our bundle config so that we build and distribute the modules used by SWC. In https://github.com/Sage-Bionetworks/SynapseWebClient/pull/5630 we are adding a bundler to SWC that can handle more modern ESM & CJS code, so we can update synapse-react-client to emit ESM/CJS versions of the same bundle here and later remove the UMD bundle.

- Update synapse-react-client ESM/CJS bundles to use 'UMD' entry file. SynapseWebClient will use this new bundle in a future change. In the future, we will also replace `src/index.ts` with the contents of `src/umd.index.ts` and delete the UMD-specific build processes.
- Include @sage-bionetworks/synapse-types in the synapse-react-client bundled output since it is prone to drift from the version on NPM, since we do not typically release every @sage-bionetworks/synapse-types change to NPM.

While this is a breaking change, no known applications currently use the synapse-react-client ESM/CJS bundles, so it should be safe.