### PR TITLE
PORTALS-3410 - Make plotType customizable

### DIFF
--- a/apps/portals/standards/src/config/synapseConfigs/data.ts
+++ b/apps/portals/standards/src/config/synapseConfigs/data.ts
@@ -58,7 +58,7 @@ export const dataQueryWrapperPlotNavProps: QueryWrapperPlotNavProps = {
       'digitalAssessmentDetails',
     ],
   },
-  plotType: 'BAR',
+  initialPlotType: 'BAR',
 }
 
 export const dataDetailPageProps: StandaloneQueryWrapperProps = {

--- a/apps/portals/standards/src/config/synapseConfigs/data.ts
+++ b/apps/portals/standards/src/config/synapseConfigs/data.ts
@@ -6,6 +6,7 @@ import {
 } from 'synapse-react-client'
 import columnAliases from '../columnAliases'
 import { dataSql } from '../resources'
+import { data } from 'react-router'
 
 const dataRgbIndex = 0
 export const dataColumnLinks: LabelLinkConfig = [
@@ -58,6 +59,7 @@ export const dataQueryWrapperPlotNavProps: QueryWrapperPlotNavProps = {
       'digitalAssessmentDetails',
     ],
   },
+  plotType: 'BAR',
 }
 
 export const dataDetailPageProps: StandaloneQueryWrapperProps = {

--- a/apps/portals/standards/src/config/synapseConfigs/data.ts
+++ b/apps/portals/standards/src/config/synapseConfigs/data.ts
@@ -6,7 +6,6 @@ import {
 } from 'synapse-react-client'
 import columnAliases from '../columnAliases'
 import { dataSql } from '../resources'
-import { data } from 'react-router'
 
 const dataRgbIndex = 0
 export const dataColumnLinks: LabelLinkConfig = [

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
@@ -143,6 +143,7 @@ type QueryWrapperPlotNavContentsProps = Pick<
   | 'fileNameColumnName'
   | 'fileVersionColumnName'
   | 'initialLimit'
+  | 'plotType'
 > & {
   isFullTextSearchEnabled: boolean
   remount: () => void
@@ -168,6 +169,7 @@ function QueryWrapperPlotNavContents(props: QueryWrapperPlotNavContentsProps) {
     isFullTextSearchEnabled,
     customPlots,
     initialLimit,
+    plotType,
   } = props
   const queryContext = useQueryContext()
   const [showExportMetadata, setShowExportMetadata] = useState(false)
@@ -257,6 +259,7 @@ function QueryWrapperPlotNavContents(props: QueryWrapperPlotNavContentsProps) {
               <PlotsContainer
                 facetsToPlot={facetsToPlot}
                 customPlots={customPlots}
+                plotType={plotType}
               />
               <RowSetView
                 tableConfiguration={tableConfiguration}

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
@@ -143,7 +143,7 @@ type QueryWrapperPlotNavContentsProps = Pick<
   | 'fileNameColumnName'
   | 'fileVersionColumnName'
   | 'initialLimit'
-  | 'plotType'
+  | 'initialPlotType'
 > & {
   isFullTextSearchEnabled: boolean
   remount: () => void
@@ -169,7 +169,7 @@ function QueryWrapperPlotNavContents(props: QueryWrapperPlotNavContentsProps) {
     isFullTextSearchEnabled,
     customPlots,
     initialLimit,
-    plotType,
+    initialPlotType,
   } = props
   const queryContext = useQueryContext()
   const [showExportMetadata, setShowExportMetadata] = useState(false)
@@ -259,7 +259,7 @@ function QueryWrapperPlotNavContents(props: QueryWrapperPlotNavContentsProps) {
               <PlotsContainer
                 facetsToPlot={facetsToPlot}
                 customPlots={customPlots}
-                plotType={plotType}
+                initialPlotType={initialPlotType}
               />
               <RowSetView
                 tableConfiguration={tableConfiguration}

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/PlotsContainer.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/PlotsContainer.tsx
@@ -21,6 +21,7 @@ type ShowMoreState = 'MORE' | 'LESS' | 'NONE'
 export type PlotsContainerProps = {
   facetsToPlot?: string[]
   customPlots?: QueryWrapperSynapsePlotProps[]
+  plotType?: PlotType
 }
 type CustomPlotIdentifier = {
   title: string
@@ -89,6 +90,7 @@ const getCombinedNewPlots = (
     FacetNavPanelProps,
     'applyChangesToFacetFilter' | 'applyChangesToGraphSlice' | 'facetToPlot'
   >[] = [],
+  plotType: PlotType,
 ): UiPlotState[] => [
   ...customPlots.map((plotProps, index) => ({
     plotId: getCustomPlotIdentifier(plotProps),
@@ -98,7 +100,7 @@ const getCombinedNewPlots = (
   ...facetNavPanelPropsArray.map((facetPlotProps, index) => ({
     plotId: facetPlotProps.facetToPlot,
     isHidden: index + customPlots.length >= DEFAULT_VISIBLE_PLOTS,
-    plotType: DEFAULT_PLOT_TYPE,
+    plotType: plotType ?? 'PIE', // default to pie
   })),
 ]
 
@@ -133,6 +135,7 @@ function PlotsContainer(props: PlotsContainerProps) {
   const {
     facetsToPlot = DEFAULT_FACETS_TO_PLOT,
     customPlots = DEFAULT_CUSTOM_PLOTS,
+    plotType = DEFAULT_PLOT_TYPE,
   } = props
   const { queryMetadataQueryOptions } = useQueryContext()
   const { data: queryMetadata } = useSuspenseQuery(queryMetadataQueryOptions)
@@ -144,13 +147,14 @@ function PlotsContainer(props: PlotsContainerProps) {
     const plotType = plotUiStateArray.find(item =>
       plotMatchesDefinition(plotId, item.plotId),
     )?.plotType
-    return plotType ?? 'PIE'
+    return plotType ?? 'PIE' // default to PIE
   }
 
   useEffect(() => {
     const combinedNewPlots = getCombinedNewPlots(
       customPlots,
       facetNavPanelPropsArray,
+      plotType,
     )
 
     // Update the state with new plots

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/PlotsContainer.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/PlotsContainer.tsx
@@ -21,7 +21,7 @@ type ShowMoreState = 'MORE' | 'LESS' | 'NONE'
 export type PlotsContainerProps = {
   facetsToPlot?: string[]
   customPlots?: QueryWrapperSynapsePlotProps[]
-  plotType?: PlotType
+  initialPlotType?: PlotType
 }
 type CustomPlotIdentifier = {
   title: string
@@ -90,7 +90,7 @@ const getCombinedNewPlots = (
     FacetNavPanelProps,
     'applyChangesToFacetFilter' | 'applyChangesToGraphSlice' | 'facetToPlot'
   >[] = [],
-  plotType: PlotType,
+  initialPlotType: PlotType = DEFAULT_PLOT_TYPE,
 ): UiPlotState[] => [
   ...customPlots.map((plotProps, index) => ({
     plotId: getCustomPlotIdentifier(plotProps),
@@ -100,7 +100,7 @@ const getCombinedNewPlots = (
   ...facetNavPanelPropsArray.map((facetPlotProps, index) => ({
     plotId: facetPlotProps.facetToPlot,
     isHidden: index + customPlots.length >= DEFAULT_VISIBLE_PLOTS,
-    plotType: plotType ?? 'PIE', // default to pie
+    plotType: initialPlotType,
   })),
 ]
 
@@ -135,7 +135,7 @@ function PlotsContainer(props: PlotsContainerProps) {
   const {
     facetsToPlot = DEFAULT_FACETS_TO_PLOT,
     customPlots = DEFAULT_CUSTOM_PLOTS,
-    plotType = DEFAULT_PLOT_TYPE,
+    initialPlotType = DEFAULT_PLOT_TYPE,
   } = props
   const { queryMetadataQueryOptions } = useQueryContext()
   const { data: queryMetadata } = useSuspenseQuery(queryMetadataQueryOptions)
@@ -147,14 +147,14 @@ function PlotsContainer(props: PlotsContainerProps) {
     const plotType = plotUiStateArray.find(item =>
       plotMatchesDefinition(plotId, item.plotId),
     )?.plotType
-    return plotType ?? 'PIE' // default to PIE
+    return plotType ?? DEFAULT_PLOT_TYPE
   }
 
   useEffect(() => {
     const combinedNewPlots = getCombinedNewPlots(
       customPlots,
       facetNavPanelPropsArray,
-      plotType,
+      initialPlotType,
     )
 
     // Update the state with new plots


### PR DESCRIPTION
PORTALS-3410 - Allows portals to create bar charts in addition to pie charts by exposing plotType as a prop to PlotsContainer.