### PR TITLE
Add deployment to staging for portals

### DIFF
--- a/.github/workflows/deploy-ark-portal.yml
+++ b/.github/workflows/deploy-ark-portal.yml
@@ -1,0 +1,21 @@
+name: 'Deploy ARK portal'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**' # temporarily track GH Actions changes to test
+      - 'apps/portals/arkportal/**'
+      - 'apps/synapse-portal-framework/**'
+      - 'packages/synapse-react-client/**'
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/build-and-deploy-portal.yml
+    with:
+      portal-name: arkportal
+      branch-or-tag: main

--- a/.github/workflows/deploy-bsmn-portal.yml
+++ b/.github/workflows/deploy-bsmn-portal.yml
@@ -1,0 +1,21 @@
+name: 'Deploy BSMN portal'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**' # temporarily track GH Actions changes to test
+      - 'apps/portals/bsmn/**'
+      - 'apps/synapse-portal-framework/**'
+      - 'packages/synapse-react-client/**'
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/build-and-deploy-portal.yml
+    with:
+      portal-name: bsmn
+      branch-or-tag: main

--- a/.github/workflows/deploy-cancercomplexity-portal.yml
+++ b/.github/workflows/deploy-cancercomplexity-portal.yml
@@ -1,0 +1,21 @@
+name: 'Deploy Cancer Complexity portal'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**' # temporarily track GH Actions changes to test
+      - 'apps/portals/cancercomplexity/**'
+      - 'apps/synapse-portal-framework/**'
+      - 'packages/synapse-react-client/**'
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/build-and-deploy-portal.yml
+    with:
+      portal-name: cancercomplexity
+      branch-or-tag: main

--- a/.github/workflows/deploy-digitalhealth-portal.yml
+++ b/.github/workflows/deploy-digitalhealth-portal.yml
@@ -1,0 +1,21 @@
+name: 'Deploy DigitalHealth portal'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**' # temporarily track GH Actions changes to test
+      - 'apps/portals/digitalhealth/**'
+      - 'apps/synapse-portal-framework/**'
+      - 'packages/synapse-react-client/**'
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/build-and-deploy-portal.yml
+    with:
+      portal-name: digitalhealth
+      branch-or-tag: main

--- a/.github/workflows/deploy-elite-portal.yml
+++ b/.github/workflows/deploy-elite-portal.yml
@@ -1,0 +1,21 @@
+name: 'Deploy EL portal'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**' # temporarily track GH Actions changes to test
+      - 'apps/portals/elportal/**'
+      - 'apps/synapse-portal-framework/**'
+      - 'packages/synapse-react-client/**'
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/build-and-deploy-portal.yml
+    with:
+      portal-name: elportal
+      branch-or-tag: main

--- a/.github/workflows/deploy-genie-portal.yml
+++ b/.github/workflows/deploy-genie-portal.yml
@@ -1,0 +1,21 @@
+name: 'Deploy Genie portal'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**' # temporarily track GH Actions changes to test
+      - 'apps/portals/genie/**'
+      - 'apps/synapse-portal-framework/**'
+      - 'packages/synapse-react-client/**'
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/build-and-deploy-portal.yml
+    with:
+      portal-name: genie
+      branch-or-tag: main

--- a/.github/workflows/deploy-nf-portal.yml
+++ b/.github/workflows/deploy-nf-portal.yml
@@ -1,0 +1,21 @@
+name: 'Deploy NF portal'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**' # temporarily track GH Actions changes to test
+      - 'apps/portals/nf/**'
+      - 'apps/synapse-portal-framework/**'
+      - 'packages/synapse-react-client/**'
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/build-and-deploy-portal.yml
+    with:
+      portal-name: nf
+      branch-or-tag: main

--- a/.github/workflows/deploy-standards-portal.yml
+++ b/.github/workflows/deploy-standards-portal.yml
@@ -1,0 +1,21 @@
+name: 'Deploy Standards portal'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**' # temporarily track GH Actions changes to test
+      - 'apps/portals/standards/**'
+      - 'apps/synapse-portal-framework/**'
+      - 'packages/synapse-react-client/**'
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/build-and-deploy-portal.yml
+    with:
+      portal-name: standards
+      branch-or-tag: main

--- a/.github/workflows/deploy-stopad-portal.yml
+++ b/.github/workflows/deploy-stopad-portal.yml
@@ -1,0 +1,21 @@
+name: 'Deploy StopAD portal'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/**' # temporarily track GH Actions changes to test
+      - 'apps/portals/stopadportal/**'
+      - 'apps/synapse-portal-framework/**'
+      - 'packages/synapse-react-client/**'
+
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/build-and-deploy-portal.yml
+    with:
+      portal-name: stopadportal
+      branch-or-tag: main


### PR DESCRIPTION
This PR adds GH workflows deployments for all the portals (AdKnowledge and Challenges already existed).
Don't merge. Need to disable jobs on Jenkins.