### PR TITLE
PORTALS-3423

### DIFF
--- a/apps/portals/arkportal/src/config/style/_style_overrides.scss
+++ b/apps/portals/arkportal/src/config/style/_style_overrides.scss
@@ -52,9 +52,6 @@ $ARK-gray-800: #3c3c42 !default;
 $ARK-gray-900: #1d1d22 !default;
 
 .Goals {
-  &__Desktop {
-    gap: 30px;
-  }
   &__Card {
     position: relative;
     background: #fff;

--- a/apps/portals/elportal/src/pages/HomePageV2.tsx
+++ b/apps/portals/elportal/src/pages/HomePageV2.tsx
@@ -162,105 +162,129 @@ export default function HomePage() {
         }}
       >
         <ELGettingStarted />
+      </SectionLayout>
+      <SectionLayout
+        ContainerProps={{
+          className: 'home-spacer',
+          maxWidth: false,
+          style: { padding: 0 },
+        }}
+      >
         <GoalsV2 entityId={goalsV2Table} dataLink="/Explore/Data" />
+      </SectionLayout>
+      <SectionLayout>
+        <PortalSectionHeader
+          title="Explore the Data"
+          buttonText="View All Studies"
+          link="/Explore/Studies"
+          centered
+          sx={{ marginBottom: '90px' }}
+        />
+        <UpsetPlot
+          sql={upsetPlotSql}
+          rgbIndex={0}
+          maxBarCount={20}
+          setName="Set size"
+          combinationName="Intersection size"
+          onClick={handleUpsetPlotClick}
+          // summaryLinkText='Explore All Data'
+          // summaryLink='/Explore/Data'
+        />
+      </SectionLayout>
+      <div className={'home-bg-dark'}>
         <SectionLayout ContainerProps={{ className: 'home-spacer' }}>
-          <PortalSectionHeader
-            title="Explore the Data"
-            buttonText="View All Studies"
-            link="/Explore/Studies"
-            centered
-            sx={{ marginBottom: '90px' }}
-          />
-          <UpsetPlot
-            sql={upsetPlotSql}
-            rgbIndex={0}
-            maxBarCount={20}
-            setName="Set size"
-            combinationName="Intersection size"
-            onClick={handleUpsetPlotClick}
-            // summaryLinkText='Explore All Data'
-            // summaryLink='/Explore/Data'
+          <FeaturedDataTabs
+            sql={dataSql}
+            rgbIndex={3}
+            configs={[
+              {
+                title: 'Human Studies',
+                icon: 'PERSON',
+                explorePagePath: '/Explore/Studies',
+                exploreObjectType: 'Studies',
+                plotsConfig: {
+                  configs: [
+                    {
+                      title: 'The Long Life Family Study',
+                      description:
+                        'The Long Life Family Study (LLFS) investigates genetic and familial factors in exceptional longevity. Families were recruited based on a Family Longevity Selection Score (FLOSS) of ≥7. Over 4,953 individuals from 539 families were phenotyped through in-home visits in the U.S. and Denmark with centralized assays and standardized protocols.',
+                      facetsToPlot: ['dataTypes'],
+                      selectFacetColumnName: 'Study',
+                      selectFacetColumnValue: 'LLFS',
+                      detailsPagePath:
+                        '/Explore/Studies/DetailsPage?studyKey=LLFS',
+                      unitDescription: 'Files',
+                      plotType: 'STACKED_HORIZONTAL_BAR',
+                    },
+                    {
+                      title: 'ADAMTS7 Study',
+                      description:
+                        'The Characterization of gene associations with aging-related traits with a genetically-predicted transcriptome-wide association study (ADAMTS7) provides analyses of candidate genes and the association of Longevity-Associated Variants (LAVs) with aging-related traits and diseases.',
+                      facetsToPlot: ['dataTypes'],
+                      selectFacetColumnName: 'Study',
+                      selectFacetColumnValue: 'ADAMTS7',
+                      detailsPagePath:
+                        '/Explore/Studies/DetailsPage?studyKey=ADAMTS7',
+                      unitDescription: 'Files',
+                      plotType: 'STACKED_HORIZONTAL_BAR',
+                    },
+                  ],
+                },
+              },
+              {
+                title: 'Translational Studies',
+                icon: 'TRANSLATIONAL',
+                explorePagePath: '/Explore/Studies',
+                exploreObjectType: 'Studies',
+                plotsConfig: {
+                  configs: [
+                    {
+                      title: 'MRGWAS',
+                      description:
+                        'The Mendelian randomization of human longevity using genetically-predicted exposures from the GWAS catalog (MRGWAS) study provides analysis results of a two Sample Mendelian Randomization used to analyze the relationship between significantly associated GWAS  traits and five distinct definitions of longevity.',
+                      facetsToPlot: ['dataTypes'],
+                      selectFacetColumnName: 'Study',
+                      selectFacetColumnValue: 'MRGWAS',
+                      detailsPagePath:
+                        '/Explore/Studies/DetailsPage?studyKey=MRGWAS',
+                      unitDescription: 'Files',
+                      plotType: 'STACKED_HORIZONTAL_BAR',
+                    },
+                    {
+                      title: 'Aging-PheWAS',
+                      description:
+                        'This study is a collection of genetically-predicted tissue-specific gene expression associations with a collection of aging-related traits and outcomes.',
+                      facetsToPlot: ['dataTypes'],
+                      selectFacetColumnName: 'Study',
+                      selectFacetColumnValue: 'Aging-PheWAS',
+                      detailsPagePath:
+                        '/Explore/Studies/DetailsPage?studyKey=Aging-PheWAS',
+                      unitDescription: 'Files',
+                      plotType: 'STACKED_HORIZONTAL_BAR',
+                    },
+                  ],
+                },
+              },
+            ]}
           />
         </SectionLayout>
-        <div className={'home-bg-dark'}>
-          <SectionLayout ContainerProps={{ className: 'home-spacer' }}>
-            <FeaturedDataTabs
-              sql={dataSql}
-              rgbIndex={3}
-              configs={[
-                {
-                  title: 'Human Studies',
-                  icon: 'PERSON',
-                  explorePagePath: '/Explore/Studies',
-                  exploreObjectType: 'Studies',
-                  plotsConfig: {
-                    configs: [
-                      {
-                        title: 'The Long Life Family Study',
-                        description:
-                          'The Long Life Family Study (LLFS) investigates genetic and familial factors in exceptional longevity. Families were recruited based on a Family Longevity Selection Score (FLOSS) of ≥7. Over 4,953 individuals from 539 families were phenotyped through in-home visits in the U.S. and Denmark with centralized assays and standardized protocols.',
-                        facetsToPlot: ['dataTypes'],
-                        selectFacetColumnName: 'Study',
-                        selectFacetColumnValue: 'LLFS',
-                        detailsPagePath:
-                          '/Explore/Studies/DetailsPage?studyKey=LLFS',
-                        unitDescription: 'Files',
-                        plotType: 'STACKED_HORIZONTAL_BAR',
-                      },
-                      {
-                        title: 'ADAMTS7 Study',
-                        description:
-                          'The Characterization of gene associations with aging-related traits with a genetically-predicted transcriptome-wide association study (ADAMTS7) provides analyses of candidate genes and the association of Longevity-Associated Variants (LAVs) with aging-related traits and diseases.',
-                        facetsToPlot: ['dataTypes'],
-                        selectFacetColumnName: 'Study',
-                        selectFacetColumnValue: 'ADAMTS7',
-                        detailsPagePath:
-                          '/Explore/Studies/DetailsPage?studyKey=ADAMTS7',
-                        unitDescription: 'Files',
-                        plotType: 'STACKED_HORIZONTAL_BAR',
-                      },
-                    ],
-                  },
-                },
-                {
-                  title: 'Translational Studies',
-                  icon: 'TRANSLATIONAL',
-                  explorePagePath: '/Explore/Studies',
-                  exploreObjectType: 'Studies',
-                  plotsConfig: {
-                    configs: [
-                      {
-                        title: 'MRGWAS',
-                        description:
-                          'The Mendelian randomization of human longevity using genetically-predicted exposures from the GWAS catalog (MRGWAS) study provides analysis results of a two Sample Mendelian Randomization used to analyze the relationship between significantly associated GWAS  traits and five distinct definitions of longevity.',
-                        facetsToPlot: ['dataTypes'],
-                        selectFacetColumnName: 'Study',
-                        selectFacetColumnValue: 'MRGWAS',
-                        detailsPagePath:
-                          '/Explore/Studies/DetailsPage?studyKey=MRGWAS',
-                        unitDescription: 'Files',
-                        plotType: 'STACKED_HORIZONTAL_BAR',
-                      },
-                      {
-                        title: 'Aging-PheWAS',
-                        description:
-                          'This study is a collection of genetically-predicted tissue-specific gene expression associations with a collection of aging-related traits and outcomes.',
-                        facetsToPlot: ['dataTypes'],
-                        selectFacetColumnName: 'Study',
-                        selectFacetColumnValue: 'Aging-PheWAS',
-                        detailsPagePath:
-                          '/Explore/Studies/DetailsPage?studyKey=Aging-PheWAS',
-                        unitDescription: 'Files',
-                        plotType: 'STACKED_HORIZONTAL_BAR',
-                      },
-                    ],
-                  },
-                },
-              ]}
-            />
-          </SectionLayout>
-        </div>
+      </div>
+      <SectionLayout
+        ContainerProps={{
+          className: 'home-spacer',
+          maxWidth: false,
+          style: { padding: 0 },
+        }}
+      >
         <ELContributeYourData />
+      </SectionLayout>
+      <SectionLayout
+        ContainerProps={{
+          className: 'home-spacer',
+          maxWidth: false,
+          style: { padding: 0 },
+        }}
+      >
         <PortalFeatureHighlights
           image={analyzetheclouds}
           title="Analyze on the Cloud"

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.Desktop.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.Desktop.tsx
@@ -14,7 +14,7 @@ export default function GoalsV2Desktop({
   return (
     <Card
       sx={{
-        width: 200,
+        maxWidth: '200px',
         height: 'auto',
         backgroundColor: 'transparent',
         borderColor: 'transparent',

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.Desktop.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.Desktop.tsx
@@ -14,6 +14,7 @@ export default function GoalsV2Desktop({
   return (
     <Card
       sx={{
+        width: '200px',
         maxWidth: '200px',
         height: 'auto',
         backgroundColor: 'transparent',

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
@@ -102,10 +102,12 @@ export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
       }
     }) ?? []
 
+  const ContentComponent = showDesktop ? GoalsV2Desktop : GoalsV2Mobile
+
   return (
     <Box
       sx={{
-        height: '560px',
+        minHeight: '560px',
         padding: { xs: '40px', lg: '80px' },
       }}
     >
@@ -121,19 +123,17 @@ export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
       />
       {goalError && <ErrorBanner error={goalError} />}
       <div className={`Goals`}>
-        {showDesktop && (
-          <EvenlyDistributedWrappedContainer>
-            {goalsDataArray.map((row, index) => (
-              <GoalsV2Desktop key={index} {...row} />
-            ))}
-          </EvenlyDistributedWrappedContainer>
-        )}
-        {!showDesktop &&
-          goalsDataArray.map((row, index) => (
-            <Box sx={{ display: 'grid' }}>
-              <GoalsV2Mobile key={index} {...row} />
-            </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            flexDirection: showDesktop ? 'row' : 'column',
+          }}
+        >
+          {goalsDataArray.map((row, index) => (
+            <ContentComponent key={index} {...row} />
           ))}
+        </Box>
       </div>
     </Box>
   )

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
@@ -1,15 +1,14 @@
+import { alpha, Box } from '@mui/material'
 import { QueryBundleRequest } from '@sage-bionetworks/synapse-types'
-import { SynapseConstants } from '../../utils'
-import { ErrorBanner } from '../error/ErrorBanner'
 import useGetQueryResultBundle from '../../synapse-queries/entity/useGetQueryResultBundle'
-import useShowDesktop from '../../utils/hooks/useShowDesktop'
-import { EvenlyDistributedWrappedContainer } from '../styled/EvenlyDistributedWrappedContainer'
-import GoalsV2Mobile from './GoalsV2.Mobile'
-import GoalsV2Desktop from './GoalsV2.Desktop'
+import { SynapseConstants } from '../../utils'
 import { getFieldIndex } from '../../utils/functions/queryUtils'
-import { Box, alpha } from '@mui/material'
 import useGetGoalData from '../../utils/hooks/useGetGoalData'
+import useShowDesktop from '../../utils/hooks/useShowDesktop'
+import { ErrorBanner } from '../error/ErrorBanner'
 import PortalSectionHeader from '../PortalSectionHeader'
+import GoalsV2Desktop from './GoalsV2.Desktop'
+import GoalsV2Mobile from './GoalsV2.Mobile'
 
 export type GoalsV2Props = {
   entityId: string

--- a/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV2/GoalsV2.tsx
@@ -3,6 +3,7 @@ import { SynapseConstants } from '../../utils'
 import { ErrorBanner } from '../error/ErrorBanner'
 import useGetQueryResultBundle from '../../synapse-queries/entity/useGetQueryResultBundle'
 import useShowDesktop from '../../utils/hooks/useShowDesktop'
+import { EvenlyDistributedWrappedContainer } from '../styled/EvenlyDistributedWrappedContainer'
 import GoalsV2Mobile from './GoalsV2.Mobile'
 import GoalsV2Desktop from './GoalsV2.Desktop'
 import { getFieldIndex } from '../../utils/functions/queryUtils'
@@ -119,18 +120,20 @@ export const GoalsV2: React.FC<GoalsV2Props> = (props: GoalsV2Props) => {
         })}
       />
       {goalError && <ErrorBanner error={goalError} />}
-      <div className={`Goals${showDesktop ? '__Desktop' : ''}`}>
-        {goalsDataArray.map((row, index) => {
-          return showDesktop ? (
-            <div>
+      <div className={`Goals`}>
+        {showDesktop && (
+          <EvenlyDistributedWrappedContainer>
+            {goalsDataArray.map((row, index) => (
               <GoalsV2Desktop key={index} {...row} />
-            </div>
-          ) : (
+            ))}
+          </EvenlyDistributedWrappedContainer>
+        )}
+        {!showDesktop &&
+          goalsDataArray.map((row, index) => (
             <Box sx={{ display: 'grid' }}>
               <GoalsV2Mobile key={index} {...row} />
             </Box>
-          )
-        })}
+          ))}
       </div>
     </Box>
   )

--- a/packages/synapse-react-client/src/components/styled/EvenlyDistributedWrappedContainer.stories.tsx
+++ b/packages/synapse-react-client/src/components/styled/EvenlyDistributedWrappedContainer.stories.tsx
@@ -1,0 +1,61 @@
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Typography,
+} from '@mui/material'
+import { Meta, StoryObj } from '@storybook/react'
+import { EvenlyDistributedWrappedContainer } from './EvenlyDistributedWrappedContainer'
+import times from 'lodash-es/times'
+
+const meta: Meta = {
+  title: 'UI/EvenlyDistributedWrappedContainer',
+  component: EvenlyDistributedWrappedContainer,
+  argTypes: {
+    nItems: { type: 'number' },
+  },
+  render: (args, context) => {
+    return (
+      <EvenlyDistributedWrappedContainer {...args}>
+        {times(args.nItems).map(i => (
+          <CardExample />
+        ))}
+      </EvenlyDistributedWrappedContainer>
+    )
+  },
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+function CardExample() {
+  return (
+    <Card>
+      <CardContent>
+        <Typography gutterBottom sx={{ color: 'text.secondary', fontSize: 14 }}>
+          Word of the Day
+        </Typography>
+        <Typography sx={{ color: 'text.secondary', mb: 1.5 }}>
+          adjective
+        </Typography>
+        <Typography variant="body2">
+          well meaning and kindly.
+          <br />
+          {'"a benevolent smile"'}
+        </Typography>
+      </CardContent>
+      <CardActions>
+        <Button size="small">Learn More</Button>
+      </CardActions>
+    </Card>
+  )
+}
+
+export const CheckboxDemo: Story = {
+  name: 'Evenly Distributed Wrapped Container',
+  args: {
+    nItems: 4,
+  },
+}

--- a/packages/synapse-react-client/src/components/styled/EvenlyDistributedWrappedContainer.test.ts
+++ b/packages/synapse-react-client/src/components/styled/EvenlyDistributedWrappedContainer.test.ts
@@ -1,0 +1,67 @@
+import { chunkItemsIntoEvenlyDistributedGroups } from './EvenlyDistributedWrappedContainer'
+
+describe('EvenlyDistributedWrappedContainer', () => {
+  test('chunkItemsIntoEvenlyDistributedGroups', () => {
+    // 0 - 3 items
+    expect(chunkItemsIntoEvenlyDistributedGroups<number>([])).toEqual([])
+    expect(chunkItemsIntoEvenlyDistributedGroups([1])).toEqual([[1]])
+    expect(chunkItemsIntoEvenlyDistributedGroups([1, 2])).toEqual([[1, 2]])
+    expect(chunkItemsIntoEvenlyDistributedGroups([1, 2, 3])).toEqual([
+      [1, 2, 3],
+    ])
+
+    // % 4 === 0 items (4, 8)
+    expect(chunkItemsIntoEvenlyDistributedGroups([1, 2, 3, 4])).toEqual([
+      [1, 2, 3, 4],
+    ])
+    expect(
+      chunkItemsIntoEvenlyDistributedGroups([1, 2, 3, 4, 5, 6, 7, 8]),
+    ).toEqual([
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+    ])
+
+    // % 4 === 1 items (5, 9)
+    expect(chunkItemsIntoEvenlyDistributedGroups([1, 2, 3, 4, 5])).toEqual([
+      [1, 2, 3],
+      [4, 5],
+    ])
+    expect(
+      chunkItemsIntoEvenlyDistributedGroups([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    ).toEqual([
+      [1, 2, 3, 4],
+      [5, 6, 7],
+      [8, 9],
+    ])
+
+    // % 4 === 2 items (6, 10)
+    expect(chunkItemsIntoEvenlyDistributedGroups([1, 2, 3, 4, 5, 6])).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+    ])
+    expect(
+      chunkItemsIntoEvenlyDistributedGroups([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    ).toEqual([
+      [1, 2, 3, 4],
+      [5, 6, 7],
+      [8, 9, 10],
+    ])
+
+    // % 4 === 3 items (7, 11)
+    expect(
+      chunkItemsIntoEvenlyDistributedGroups([1, 2, 3, 4, 5, 6, 7]),
+    ).toEqual([
+      [1, 2, 3, 4],
+      [5, 6, 7],
+    ])
+    expect(
+      chunkItemsIntoEvenlyDistributedGroups([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+      ]),
+    ).toEqual([
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+      [9, 10, 11],
+    ])
+  })
+})

--- a/packages/synapse-react-client/src/components/styled/EvenlyDistributedWrappedContainer.tsx
+++ b/packages/synapse-react-client/src/components/styled/EvenlyDistributedWrappedContainer.tsx
@@ -4,6 +4,7 @@ import { chunk } from 'lodash-es'
 import { ReactNode } from 'react'
 
 const MAX_ITEMS_PER_ROW = 4
+const DEFAULT_SPACING = 3
 
 type EvenlyDistributedWrappedContainerProps = {
   children: ReactNode[]
@@ -11,7 +12,7 @@ type EvenlyDistributedWrappedContainerProps = {
 
 const FlexContainer: StyledComponent<BoxProps> = styled(Box)(({ theme }) => ({
   display: 'flex',
-  rowGap: theme.spacing(3),
+  rowGap: theme.spacing(DEFAULT_SPACING),
   columnGap: 'min(2%, 16px)',
   flexWrap: 'wrap',
   justifyContent: 'space-evenly',
@@ -74,7 +75,8 @@ export function EvenlyDistributedWrappedContainer(
   const chunks = chunkItemsIntoEvenlyDistributedGroups(children)
 
   return chunks.map((row, index) => {
-    const spaceRowsSx = index !== chunks.length - 1 ? { mb: 3 } : {}
+    const spaceRowsSx =
+      index !== chunks.length - 1 ? { mb: DEFAULT_SPACING } : {}
     return <FlexContainer sx={spaceRowsSx}>{row}</FlexContainer>
   })
 }

--- a/packages/synapse-react-client/src/components/styled/EvenlyDistributedWrappedContainer.tsx
+++ b/packages/synapse-react-client/src/components/styled/EvenlyDistributedWrappedContainer.tsx
@@ -1,0 +1,80 @@
+import { StyledComponent } from '@emotion/styled'
+import { Box, BoxProps, styled } from '@mui/material'
+import { chunk } from 'lodash-es'
+import { ReactNode } from 'react'
+
+const MAX_ITEMS_PER_ROW = 4
+
+type EvenlyDistributedWrappedContainerProps = {
+  children: ReactNode[]
+}
+
+const FlexContainer: StyledComponent<BoxProps> = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  rowGap: theme.spacing(3),
+  columnGap: 'min(2%, 16px)',
+  flexWrap: 'wrap',
+  justifyContent: 'space-evenly',
+  '& > *': {
+    flexGrow: 0.25,
+    flexBasis: '23%',
+  },
+}))
+
+export function chunkItemsIntoEvenlyDistributedGroups<T = unknown>(
+  items: Array<T>,
+) {
+  if (
+    // There are less than 4 items
+    items.length < MAX_ITEMS_PER_ROW ||
+    // The number of items is divisible by 4
+    items.length % MAX_ITEMS_PER_ROW === 0 ||
+    // The last chunk has 3 items
+    items.length % MAX_ITEMS_PER_ROW === 3
+  ) {
+    // The first n-1 rows will have 4 items, and the last row will have 3-4 items
+    return chunk(items, MAX_ITEMS_PER_ROW)
+  }
+
+  if (items.length % MAX_ITEMS_PER_ROW === 2) {
+    // All rows will have 4, last 2 rows will have 3 items
+    const last2Rows = chunk(items.slice(-6), 3)
+    const rest = chunk(items.slice(0, -6), MAX_ITEMS_PER_ROW)
+    return [...rest, ...last2Rows]
+  }
+
+  if (items.length % MAX_ITEMS_PER_ROW === 1) {
+    // All rows will have 4, last 2 rows will have 3 and 2 items respectively
+    const last2Rows = chunk(items.slice(-5), 3)
+    const rest = chunk(items.slice(0, -5), MAX_ITEMS_PER_ROW)
+    return [...rest, ...last2Rows]
+  }
+
+  console.error(
+    `chunkItemsIntoEvenlyDistributedGroups: Invalid number of items: ${items?.length}`,
+  )
+
+  return []
+}
+
+/**
+ * This component will evenly distribute the children in a wrapped container with a maximum of 4 items per row.
+ * If the number of children is not divisible by 4, the last row(s) will have 3 or 2 items. No row will have 1 item
+ * (unless only one item is provided). This is not possible with pure CSS flex, so this component will use JavaScript
+ * to render the children in chunks.
+ *
+ * @param props
+ * @constructor
+ */
+export function EvenlyDistributedWrappedContainer(
+  props: EvenlyDistributedWrappedContainerProps,
+) {
+  const { children } = props
+
+  const chunks = chunkItemsIntoEvenlyDistributedGroups(children)
+
+  return chunks.map((row, index) => {
+    const spaceRowsSx = index !== chunks.length - 1 ? { mb: 3 } : {}
+    return <FlexContainer sx={spaceRowsSx}>{row}</FlexContainer>
+  })
+}

--- a/packages/synapse-react-client/src/style/components/_goals.scss
+++ b/packages/synapse-react-client/src/style/components/_goals.scss
@@ -19,14 +19,10 @@
 }
 
 .Goals {
-  &__Desktop {
-    @extend %space-between;
-  }
   &__Card {
     p {
       margin: 0px !important;
     }
-    flex: 1;
     display: flex;
     flex-direction: column;
     box-shadow: SRC.$box-shadow-soft;


### PR DESCRIPTION
- Update Goals v1 desktop to support layout of 5+ items
- Add new EvenlyDistributedWrappedContainer component to evenly distribute items across multiple flex wrappers such that no row has just one item. I do not believe that these constraints are possible to implement with pure CSS, so this component handles splitting and rendering multiple flex containers to display content in a 'balanced' layout.

Demo:

[Screencast from 02-17-2025 12:36:49 PM.webm](https://github.com/user-attachments/assets/98c81844-6543-4eda-afb3-720d0e7e6368)


Example layout in ARK Portal:

![image](https://github.com/user-attachments/assets/16d7fa2b-fb15-4b81-aac4-a9c9c49cc6f5)

