### PR TITLE
PORTALS-3422 - use showWebhooks to display or hide webhooks menu entry

### DIFF
--- a/apps/SageAccountWeb/src/components/AccountSettings.tsx
+++ b/apps/SageAccountWeb/src/components/AccountSettings.tsx
@@ -235,13 +235,7 @@ export const AccountSettings = () => {
 
   return (
     <div className="account-settings-page">
-      <AccountSettingsTopBar
-        accountSettingsPanelConfig={
-          showWebhooks
-            ? menuConfigArray
-            : menuConfigArray.filter(item => item.ref !== webhooksRef)
-        }
-      />
+      <AccountSettingsTopBar accountSettingsPanelConfig={menuConfigArray} />
       <div className="panel-wrapper-bg with-account-setting">
         <Container
           maxWidth="md"
@@ -249,19 +243,14 @@ export const AccountSettings = () => {
         >
           <Box sx={{ display: 'flex', my: { xs: '10px', sm: '60px' } }}>
             <Paper component="nav" className="account-setting-panel nav-panel">
-              {menuConfigArray.map((item, index) => {
-                if (item.ref === webhooksRef && showWebhooks === false) {
-                  return null
-                }
-                return (
-                  <ListItemButton
-                    key={index}
-                    onClick={() => handleScroll(item.ref)}
-                  >
-                    {item.label}
-                  </ListItemButton>
-                )
-              })}
+              {menuConfigArray.map((item, index) => (
+                <ListItemButton
+                  key={index}
+                  onClick={() => handleScroll(item.ref)}
+                >
+                  {item.label}
+                </ListItemButton>
+              ))}
             </Paper>
 
             <div>

--- a/apps/SageAccountWeb/src/components/AccountSettings.tsx
+++ b/apps/SageAccountWeb/src/components/AccountSettings.tsx
@@ -220,7 +220,7 @@ export const AccountSettings = () => {
     { label: 'Webhooks', ref: webhooksRef },
     { label: 'Privacy Preferences', ref: cookieManagementRef },
     { label: 'Sign Out', ref: signOutSectionRef },
-  ]
+  ].filter(item => item.label !== 'Webhooks' || showWebhooks)
 
   const handleScroll = (ref: RefObject<HTMLDivElement>) => {
     ref.current?.scrollIntoView({ behavior: 'smooth' })

--- a/apps/SageAccountWeb/src/components/AccountSettings.tsx
+++ b/apps/SageAccountWeb/src/components/AccountSettings.tsx
@@ -235,7 +235,13 @@ export const AccountSettings = () => {
 
   return (
     <div className="account-settings-page">
-      <AccountSettingsTopBar accountSettingsPanelConfig={menuConfigArray} />
+      <AccountSettingsTopBar
+        accountSettingsPanelConfig={
+          showWebhooks
+            ? menuConfigArray
+            : menuConfigArray.filter(item => item.ref !== webhooksRef)
+        }
+      />
       <div className="panel-wrapper-bg with-account-setting">
         <Container
           maxWidth="md"
@@ -243,14 +249,19 @@ export const AccountSettings = () => {
         >
           <Box sx={{ display: 'flex', my: { xs: '10px', sm: '60px' } }}>
             <Paper component="nav" className="account-setting-panel nav-panel">
-              {menuConfigArray.map((item, index) => (
-                <ListItemButton
-                  key={index}
-                  onClick={() => handleScroll(item.ref)}
-                >
-                  {item.label}
-                </ListItemButton>
-              ))}
+              {menuConfigArray.map((item, index) => {
+                if (item.ref === webhooksRef && showWebhooks === false) {
+                  return null
+                }
+                return (
+                  <ListItemButton
+                    key={index}
+                    onClick={() => handleScroll(item.ref)}
+                  >
+                    {item.label}
+                  </ListItemButton>
+                )
+              })}
             </Paper>
 
             <div>


### PR DESCRIPTION
PORTALS-3422 - Fix a regression created in [PR1526](https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/1526) by removing the webhooks menu entry when not in experimental mode.