### PR TITLE
SWC-7242 - Update endpoint override var

### DIFF
--- a/apps/SageAccountWeb/index.html
+++ b/apps/SageAccountWeb/index.html
@@ -50,10 +50,8 @@
           REPO: 'https://repo-staging.prod.sagebase.org',
           PORTAL: 'https://staging.synapse.org/',
         }
-        window.SRC = {
-            OVERRIDE_ENDPOINT_CONFIG: devEndpoint,
-            // OVERRIDE_ENDPOINT_CONFIG: stagingEndpoint,
-        }
+        window.SRC_OVERRIDE_ENDPOINT_CONFIG = devEndpoint;
+        // window.SRC_OVERRIDE_ENDPOINT_CONFIG = stagingEndpoint;
       </script> -->
     <script type="module" src="./src/index.tsx"></script>
 </head>

--- a/apps/SageAccountWeb/src/AppInitializer.tsx
+++ b/apps/SageAccountWeb/src/AppInitializer.tsx
@@ -39,7 +39,7 @@ function AppInitializer(props: { children?: ReactNode }) {
         ;(window as any).SRC = {}
       }
 
-      ;(window as any).SRC.OVERRIDE_ENDPOINT_CONFIG = isStaging
+      ;(window as any).SRC_OVERRIDE_ENDPOINT_CONFIG = isStaging
         ? stagingConfig
         : devConfig
     }

--- a/apps/portals/adknowledgeportal/index.html
+++ b/apps/portals/adknowledgeportal/index.html
@@ -13,9 +13,7 @@
         REPO: 'https://repo-staging.prod.sagebase.org',
         PORTAL: 'https://staging.synapse.org/',
       }
-      window.SRC = {
-        OVERRIDE_ENDPOINT_CONFIG: endpoint
-      }
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG = endpoint;
     </script> -->
     <script type="module" src='./src/index.tsx'></script>
   </head>

--- a/apps/portals/arkportal/index.html
+++ b/apps/portals/arkportal/index.html
@@ -13,9 +13,7 @@
         REPO: 'https://repo-staging.prod.sagebase.org',
         PORTAL: 'https://staging.synapse.org/',
       }
-      window.SRC = {
-        OVERRIDE_ENDPOINT_CONFIG: endpoint
-      }
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG = endpoint;
     </script> -->
     <script type="module" src='./src/index.tsx'></script>
   </head>

--- a/apps/portals/bsmn/index.html
+++ b/apps/portals/bsmn/index.html
@@ -13,9 +13,7 @@
         REPO: 'https://repo-staging.prod.sagebase.org',
         PORTAL: 'https://staging.synapse.org/',
       }
-      window.SRC = {
-        OVERRIDE_ENDPOINT_CONFIG: endpoint
-      }
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG = endpoint
     </script> -->
     <script type="module" src='./src/index.tsx'></script>
   </head>

--- a/apps/portals/cancercomplexity/index.html
+++ b/apps/portals/cancercomplexity/index.html
@@ -13,9 +13,7 @@
         REPO: 'https://repo-staging.prod.sagebase.org',
         PORTAL: 'https://staging.synapse.org/',
       }
-      window.SRC = {
-        OVERRIDE_ENDPOINT_CONFIG: endpoint
-      }
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG = endpoint;
     </script> -->
     <script type="module" src='./src/index.tsx'></script>
   </head>

--- a/apps/portals/challengeportal/index.html
+++ b/apps/portals/challengeportal/index.html
@@ -13,9 +13,7 @@
         REPO: 'https://repo-staging.prod.sagebase.org',
         PORTAL: 'https://staging.synapse.org/',
       }
-      window.SRC = {
-        OVERRIDE_ENDPOINT_CONFIG: endpoint
-      }
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG = endpoint;
     </script> -->
     <script type="module" src='./src/index.tsx'></script>
   </head>

--- a/apps/portals/digitalhealth/index.html
+++ b/apps/portals/digitalhealth/index.html
@@ -13,9 +13,7 @@
         REPO: 'https://repo-staging.prod.sagebase.org',
         PORTAL: 'https://staging.synapse.org/',
       }
-      window.SRC = {
-        OVERRIDE_ENDPOINT_CONFIG: endpoint
-      }
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG = endpoint;
     </script> -->
     <script type="module" src='./src/index.tsx'></script>
   </head>

--- a/apps/portals/elportal/index.html
+++ b/apps/portals/elportal/index.html
@@ -13,9 +13,7 @@
         REPO: 'https://repo-staging.prod.sagebase.org',
         PORTAL: 'https://staging.synapse.org/',
       }
-      window.SRC = {
-        OVERRIDE_ENDPOINT_CONFIG: endpoint
-      }
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG = endpoint;
     </script> -->
     <script type="module" src='./src/index.tsx'></script>
   </head>

--- a/apps/portals/genie/index.html
+++ b/apps/portals/genie/index.html
@@ -13,9 +13,7 @@
         REPO: 'https://repo-staging.prod.sagebase.org',
         PORTAL: 'https://staging.synapse.org/',
       }
-      window.SRC = {
-        OVERRIDE_ENDPOINT_CONFIG: endpoint
-      }
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG = endpoint;
     </script> -->
     <script type="module" src='./src/index.tsx'></script>
   </head>

--- a/apps/portals/nf/index.html
+++ b/apps/portals/nf/index.html
@@ -13,9 +13,7 @@
         REPO: 'https://repo-staging.prod.sagebase.org',
         PORTAL: 'https://staging.synapse.org/',
       }
-      window.SRC = {
-        OVERRIDE_ENDPOINT_CONFIG: endpoint
-      }
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG = endpoint;
     </script> -->
     <script type="module" src='./src/index.tsx'></script>
   </head>

--- a/apps/portals/standards/index.html
+++ b/apps/portals/standards/index.html
@@ -13,9 +13,7 @@
         REPO: 'https://repo-staging.prod.sagebase.org',
         PORTAL: 'https://staging.synapse.org/',
       }
-      window.SRC = {
-        OVERRIDE_ENDPOINT_CONFIG: endpoint
-      }
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG = endpoint;
     </script> -->
     <script type="module" src='./src/index.tsx'></script>
   </head>

--- a/apps/portals/stopadportal/index.html
+++ b/apps/portals/stopadportal/index.html
@@ -13,9 +13,7 @@
         REPO: 'https://repo-staging.prod.sagebase.org',
         PORTAL: 'https://staging.synapse.org/',
       }
-      window.SRC = {
-        OVERRIDE_ENDPOINT_CONFIG: endpoint
-      }
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG = endpoint;
     </script> -->
     <script type="module" src='./src/index.tsx'></script>
   </head>

--- a/apps/synapse-oauth-signin/src/AppInitializer.tsx
+++ b/apps/synapse-oauth-signin/src/AppInitializer.tsx
@@ -47,7 +47,7 @@ function AppInitializer(props: PropsWithChildren<Record<string, unknown>>) {
         ;(window as any).SRC = {}
       }
 
-      ;(window as any).SRC.OVERRIDE_ENDPOINT_CONFIG = isStaging
+      ;(window as any).SRC_OVERRIDE_ENDPOINT_CONFIG = isStaging
         ? stagingConfig
         : devConfig
     }

--- a/packages/synapse-react-client/README.md
+++ b/packages/synapse-react-client/README.md
@@ -47,7 +47,7 @@ const inExperimentalMode = false
 Specifying the following in the window object will override request endpoints:
 
 ```js
-window.SRC.OVERRIDE_ENDPOINT_CONFIG = {
+window.SRC_OVERRIDE_ENDPOINT_CONFIG = {
   PORTAL: '<endpoint>',
   REPO: '<endpoint>',
 }

--- a/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
+++ b/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
@@ -51,9 +51,7 @@ const storybookQueryClient = new QueryClient(defaultQueryClientConfig)
 
 function overrideEndpoint(stack: SynapseStack) {
   const endpointConfig = STACK_MAP[stack]
-  ;(window as any)['SRC'] = {
-    OVERRIDE_ENDPOINT_CONFIG: endpointConfig,
-  }
+  ;(window as any)['SRC_OVERRIDE_ENDPOINT_CONFIG'] = endpointConfig
 }
 
 /**

--- a/packages/synapse-react-client/src/utils/functions/getEndpoint.test.ts
+++ b/packages/synapse-react-client/src/utils/functions/getEndpoint.test.ts
@@ -34,10 +34,8 @@ describe('getting endpoints works', () => {
       REPO: 'REPO_CUSTOM_ENDPOINT',
       PORTAL: 'PORTAL_CUSTOM_ENDPOINT',
     }
-    // @ts-ignore
-    window.SRC = {}
-    // @ts-ignore
-    window.SRC.OVERRIDE_ENDPOINT_CONFIG = OVERRIDE_ENDPOINT_CONFIG
+    // @ts-expect-error
+    window.SRC_OVERRIDE_ENDPOINT_CONFIG = OVERRIDE_ENDPOINT_CONFIG
     expect(getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)).toEqual(
       OVERRIDE_ENDPOINT_CONFIG.REPO,
     )
@@ -46,10 +44,8 @@ describe('getting endpoints works', () => {
     )
   })
   it('throws an error when the custom object does not have the right keys', () => {
-    // @ts-ignore
-    window.SRC = {}
-    // @ts-ignore
-    window.SRC.OVERRIDE_ENDPOINT_CONFIG = {
+    // @ts-expect-error
+    window.SRC_OVERRIDE_ENDPOINT_CONFIG = {
       PORTALZ: 'PORTAL_ENDPOINT',
     }
     // https://jestjs.io/docs/en/expect.html#tothrowerror

--- a/packages/synapse-react-client/src/utils/functions/getEndpoint.ts
+++ b/packages/synapse-react-client/src/utils/functions/getEndpoint.ts
@@ -40,10 +40,10 @@ export const PRODUCTION_ENDPOINT_CONFIG: EndpointObject = {
 // Given an endpoint will return the specific stack object
 export const getEndpoint = (endpoint: BackendDestinationEnum): string => {
   let endpoint_config = PRODUCTION_ENDPOINT_CONFIG
-  // @ts-ignore if overriding endpoint config
-  if (window.SRC && window.SRC.OVERRIDE_ENDPOINT_CONFIG) {
-    // @ts-ignore
-    endpoint_config = window.SRC && window.SRC.OVERRIDE_ENDPOINT_CONFIG
+  // @ts-expect-error if overriding endpoint config
+  if (window.SRC_OVERRIDE_ENDPOINT_CONFIG) {
+    // @ts-expect-error
+    endpoint_config = window.SRC_OVERRIDE_ENDPOINT_CONFIG
   }
   const { PORTAL, REPO } = endpoint_config
   if (!PORTAL || !REPO) {


### PR DESCRIPTION
Change endpoint override global variable to not be inside of SRC. When synapse-react-client is imported as SRC using a namespace import (`import * as SRC from synapse-react-client`), `SRC` becomes an immutable object, making it impossible to set an override.

Do not merge, a corresponding PR in SWC must also be created and merged in coordination with this PR.