### PR TITLE
PORTALS-3429

### DIFF
--- a/apps/portals/adknowledgeportal/src/config/routesConfig.tsx
+++ b/apps/portals/adknowledgeportal/src/config/routesConfig.tsx
@@ -57,6 +57,7 @@ const routes: RouteObject[] = [
                 modelADStrainsSelectedFacet.facetValue
               }"]}]}`,
             }}
+            replace={true}
           />
         ),
       },
@@ -69,7 +70,7 @@ const routes: RouteObject[] = [
       {
         // PORTALS-2919: Redirect DataAccess/Instructions to /Data Access
         path: 'DataAccess/Instructions',
-        element: <Navigate to="/Data Access" />,
+        element: <Navigate to="/Data Access" replace={true} />,
       },
       {
         path: 'Explore',

--- a/apps/synapse-portal-framework/src/components/RedirectWithQuery.tsx
+++ b/apps/synapse-portal-framework/src/components/RedirectWithQuery.tsx
@@ -11,6 +11,7 @@ export default function RedirectWithQuery(props: NavigateProps) {
   return (
     <Navigate
       {...props}
+      replace={true}
       to={{
         pathname: props.to as string,
         search,


### PR DESCRIPTION
PORTALS-3429

- Update `Navigate` calls to use `replace: true` if used in a redirect context