### PR TITLE
PORTALS-3435: Add automated SonarCloud scans

### DIFF
--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-name: Main Workflow
+name: SonarCloud Code Scan
 jobs:
   # For monorepos, create one job per project and specify the directory
   sonarqube-src:
-    name: sonarqube-src
+    name: scan-synapse-react-client
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened]
 
 name: Main Workflow
 jobs:

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+name: Main Workflow
+jobs:
+  sonarqube:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Disabling shallow clones is recommended for improving the relevancy of reporting
+          fetch-depth: 0
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -6,7 +6,9 @@ on:
 
 name: Main Workflow
 jobs:
-  sonarqube:
+  # For monorepos, create one job per project and specify the directory
+  sonarqube-src:
+    name: sonarqube-src
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,3 +19,5 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v5.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: packages/synapse-react-client

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,3 @@
 sonar.projectKey=Sage-Bionetworks_synapse-web-monorepo
 sonar.organization=sage-bionetworks
+sonar.project.monorepo.enabled=true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.projectKey=Sage-Bionetworks_synapse-web-monorepo
+sonar.organization=sage-bionetworks


### PR DESCRIPTION
Add minimal sonarqube scan workflow and properties file. Need to add `SONAR_TOKEN` secret to repo and have IT import this repository into Sage's SonarCloud account.