### PR TITLE
move SonarQube config into project directories instead of monorepo root

### DIFF
--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -19,3 +19,5 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v5.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: packages/synapse-react-client

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -10,6 +10,7 @@ jobs:
   sonarqube-src:
     name: scan-synapse-react-client
     runs-on: ubuntu-latest
+    secrets: inherit
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -17,8 +17,6 @@ jobs:
           fetch-depth: 0
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v5.0.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           projectBaseDir: packages/synapse-react-client
-        secrets: inherit

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -10,7 +10,6 @@ jobs:
   sonarqube-src:
     name: scan-synapse-react-client
     runs-on: ubuntu-latest
-    secrets: inherit
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,3 +21,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: packages/synapse-react-client
+        secrets: inherit

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -17,6 +17,5 @@ jobs:
           fetch-depth: 0
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v5.0.0
-        with:
+        env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          projectBaseDir: packages/synapse-react-client

--- a/packages/synapse-react-client/sonar-project.properties
+++ b/packages/synapse-react-client/sonar-project.properties
@@ -1,3 +1,3 @@
-sonar.projectKey=Sage-Bionetworks_synapse-web-monorepo
+sonar.projectKey=sage-bionetworks_synapse-web-monorepo_src
 sonar.organization=sage-bionetworks
 sonar.project.monorepo.enabled=true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,3 @@
+sonar.projectKey=sage-bionetworks_synapse-web-monorepo
+sonar.organization=sage-bionetworks
+sonar.project.monorepo.enabled=true


### PR DESCRIPTION
for SonarQube monorepo scans, each project can be analyzed separately by providing individual configs and a project-specific key.