### PR TITLE
PORTALS-3422: Fix dropdown menu

### DIFF
--- a/apps/SageAccountWeb/src/components/AccountSettingsTopBar.tsx
+++ b/apps/SageAccountWeb/src/components/AccountSettingsTopBar.tsx
@@ -87,16 +87,17 @@ const AccountSettingsTopBar: React.FC<AccountSettingsTopBarProps> = ({
           id="menu-appbar"
           anchorEl={anchorEl}
           anchorOrigin={{
-            vertical: 'bottom',
+            vertical: 'top',
             horizontal: 'right',
           }}
           keepMounted
           transformOrigin={{
-            vertical: 'bottom',
+            vertical: 'top',
             horizontal: 'right',
           }}
           open={isOpen}
           onClose={handleClose}
+          sx={{ mt: '30px' }}
         >
           {accountSettingsPanelConfig.map((item: any, index: number) => (
             <MenuItem


### PR DESCRIPTION
Set the dropdown menu anchor to the top and add a top margin so it doesn't cover the button when opened.