### PR TITLE
Workflow to run sonarcloud scan on PR

### DIFF
--- a/.github/workflows/sonarqube-scan-pr.yml
+++ b/.github/workflows/sonarqube-scan-pr.yml
@@ -18,7 +18,7 @@ jobs:
           # Disabling shallow clones is recommended for improving the relevancy of reporting
           fetch-depth: 0
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5.0.0
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:

--- a/.github/workflows/sonarqube-scan-pr.yml
+++ b/.github/workflows/sonarqube-scan-pr.yml
@@ -2,7 +2,7 @@ on:
   # Warning: using the pull_request_target event without the cautionary measures may allow
   # unauthorized GitHub users to open a “pwn request” and exfiltrate secrets.
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
 
 name: SonarCloud Code Scan
 jobs:

--- a/.github/workflows/sonarqube-scan-pr.yml
+++ b/.github/workflows/sonarqube-scan-pr.yml
@@ -1,0 +1,25 @@
+on:
+  # Warning: using the pull_request_target event without the cautionary measures may allow
+  # unauthorized GitHub users to open a “pwn request” and exfiltrate secrets.
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+
+name: SonarCloud Code Scan
+jobs:
+  # For monorepos, create one job per project and specify the directory
+  sonarqube-src:
+    environment: ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository && 'sonar-pr' || 'none' }}
+    name: scan-synapse-react-client
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Disabling shallow clones is recommended for improving the relevancy of reporting
+          fetch-depth: 0
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: packages/synapse-react-client


### PR DESCRIPTION
Add a workflow to run sonarcloud scans from a PR using the main repo's sonar-pr environment to get the sonar token. This is necessary to securely run workflows from forks. 