### PR TITLE
PORTALS-3420 - Add wrappers to improve testability

### DIFF
--- a/packages/synapse-react-client/src/components/CardContainer/CardContainer.tsx
+++ b/packages/synapse-react-client/src/components/CardContainer/CardContainer.tsx
@@ -1,3 +1,10 @@
+import { Box } from '@mui/material'
+import {
+  ColumnTypeEnum,
+  EntityHeader,
+  Row,
+  RowSet,
+} from '@sage-bionetworks/synapse-types'
 import { Suspense } from 'react'
 import useGetInfoFromIds from '../../utils/hooks/useGetInfoFromIds'
 import {
@@ -8,27 +15,20 @@ import {
   OBSERVATION_CARD,
   RELEASE_CARD,
 } from '../../utils/SynapseConstants'
-import {
-  ColumnTypeEnum,
-  EntityHeader,
-  Row,
-  RowSet,
-} from '@sage-bionetworks/synapse-types'
 import { CardConfiguration } from '../CardContainerLogic'
 import GenericCard from '../GenericCard'
 import loadingScreen from '../LoadingScreen/LoadingScreen'
 import { useQueryContext } from '../QueryContext'
 import { useQueryVisualizationContext } from '../QueryVisualizationWrapper'
-import { Dataset, Funder } from '../row_renderers'
+import { useSuspenseGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
 import { ReleaseCard } from '../ReleaseCard'
+import { Dataset, Funder } from '../row_renderers'
 import {
   LoadingObservationCard,
   ObservationCard,
 } from '../row_renderers/ObservationCard'
 import TotalQueryResults from '../TotalQueryResults'
 import UserCardList from '../UserCardList/UserCardList'
-import { Box } from '@mui/material'
-import { useSuspenseQuery } from '@tanstack/react-query'
 
 const defaultListSx = { display: 'block' }
 const releaseCardMediumListSx = {
@@ -92,8 +92,7 @@ function CardContainerInternal(props: CardContainerProps) {
   } = props
   const { NoContentPlaceholder } = useQueryVisualizationContext()
   const queryContext = useQueryContext()
-  const { queryMetadataQueryOptions } = queryContext
-  const { data: queryMetadata } = useSuspenseQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useSuspenseGetQueryMetadata()
   const queryVisualizationContext = useQueryVisualizationContext()
 
   const dataRows: Row[] = rowSet.rows

--- a/packages/synapse-react-client/src/components/ColumnFilter/ColumnFilter.tsx
+++ b/packages/synapse-react-client/src/components/ColumnFilter/ColumnFilter.tsx
@@ -1,16 +1,16 @@
-import { SyntheticEvent } from 'react'
-import { useQueryContext } from '../QueryContext/QueryContext'
+import { Autocomplete, TextField } from '@mui/material'
 import {
   FacetColumnResultValues,
   FacetColumnValuesRequest,
 } from '@sage-bionetworks/synapse-types'
-import { useQuery } from '@tanstack/react-query'
-import { Autocomplete, TextField } from '@mui/material'
+import { SyntheticEvent } from 'react'
+import { UniqueFacetIdentifier } from '../../utils'
 import {
   facetObjectMatchesDefinition,
   getCorrespondingSelectedFacet,
 } from '../../utils/functions/queryUtils'
-import { UniqueFacetIdentifier } from '../../utils'
+import { useQueryContext } from '../QueryContext/QueryContext'
+import { useGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
 
 export type FilterProps = {
   topLevelEnumeratedFacetToFilter: UniqueFacetIdentifier
@@ -19,12 +19,11 @@ export type FilterProps = {
 function ColumnFilter(props: FilterProps) {
   const queryContext = useQueryContext()
   const {
-    queryMetadataQueryOptions,
     getCurrentQueryRequest,
     addValueToSelectedFacet,
     removeSelectedFacet,
   } = queryContext
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useGetQueryMetadata()
   const { topLevelEnumeratedFacetToFilter } = props
 
   const currentQuery = getCurrentQueryRequest()

--- a/packages/synapse-react-client/src/components/FeaturedDataTabs/FacetPlotsCard.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedDataTabs/FacetPlotsCard.tsx
@@ -1,22 +1,3 @@
-import { Fragment, Suspense, useMemo } from 'react'
-import Plotly from 'plotly.js-basic-dist'
-import { SizeMe } from 'react-sizeme'
-import {
-  ColumnTypeEnum,
-  FacetColumnResult,
-  FacetColumnResultValueCount,
-  FacetColumnResultValues,
-} from '@sage-bionetworks/synapse-types'
-import Plot from '../Plot/Plot'
-import {
-  extractPlotDataArray,
-  getPlotStyle,
-  PlotType,
-} from '../widgets/facet-nav/FacetNavPanel'
-import { getFacets } from '../widgets/facet-nav/useFacetPlots'
-import { useSynapseContext } from '../../utils/context/SynapseContext'
-import { useQueryVisualizationContext } from '../QueryVisualizationWrapper'
-import { ShowMore } from '../row_renderers/utils'
 import {
   Box,
   Button,
@@ -25,7 +6,30 @@ import {
   Skeleton,
   Typography,
 } from '@mui/material'
+import {
+  ColumnTypeEnum,
+  FacetColumnResult,
+  FacetColumnResultValueCount,
+  FacetColumnResultValues,
+} from '@sage-bionetworks/synapse-types'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { times } from 'lodash-es'
+import Plotly from 'plotly.js-basic-dist'
+import { Fragment, Suspense, useMemo } from 'react'
+import { SizeMe } from 'react-sizeme'
+import { useSynapseContext } from '../../utils/context/SynapseContext'
+import Plot from '../Plot/Plot'
+import { useQueryVisualizationContext } from '../QueryVisualizationWrapper'
+import { useSuspenseGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
+import { ShowMore } from '../row_renderers/utils'
+import { SkeletonParagraph, SkeletonTable } from '../Skeleton'
+import {
+  extractPlotDataArray,
+  getPlotStyle,
+  PlotType,
+} from '../widgets/facet-nav/FacetNavPanel'
 import { FacetPlotLegendTable } from '../widgets/facet-nav/FacetPlotLegendTable'
+import { getFacets } from '../widgets/facet-nav/useFacetPlots'
 import {
   FACET_PLOTS_CARD_CLASSNAME,
   FACET_PLOTS_CARD_PLOT_CONTAINER_CLASSNAME,
@@ -33,10 +37,6 @@ import {
   FacetPlotsCardPlotContainer,
   FacetPlotsCardTitleContainer,
 } from './FacetPlotsCardGrid'
-import { SkeletonParagraph, SkeletonTable } from '../Skeleton'
-import { times } from 'lodash-es'
-import { useQueryContext } from '../QueryContext'
-import { useSuspenseQuery } from '@tanstack/react-query'
 
 export type FacetPlotsCardProps = {
   title?: string
@@ -101,8 +101,7 @@ function FacetPlotsCard(props: FacetPlotsCardProps) {
     plotType = 'PIE',
   } = props
   const { accessToken } = useSynapseContext()
-  const { queryMetadataQueryOptions } = useQueryContext()
-  const { data: queryMetadata } = useSuspenseQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useSuspenseGetQueryMetadata()
   const { getColumnDisplayName } = useQueryVisualizationContext()
 
   const facetDataArray = useMemo(() => {

--- a/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearch.tsx
+++ b/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearch.tsx
@@ -1,11 +1,11 @@
 import { Collapse, TextField } from '@mui/material'
 import { ChangeEvent, SyntheticEvent, useRef, useState } from 'react'
-import { useQueryContext } from '../QueryContext'
-import { useQueryVisualizationContext } from '../QueryVisualizationWrapper'
 import { HelpPopover } from '../HelpPopover/HelpPopover'
 import IconSvg from '../IconSvg/IconSvg'
 import { IconSvgButton } from '../IconSvgButton'
-import { useQuery } from '@tanstack/react-query'
+import { useQueryContext } from '../QueryContext'
+import { useQueryVisualizationContext } from '../QueryVisualizationWrapper'
+import { useGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
 import { updateQueryUsingSearchTerm } from './FullTextSearchUtils'
 
 // See PLFM-7011
@@ -20,12 +20,12 @@ export function FullTextSearch({
   helpMessage = 'This search bar is powered by MySQL Full Text Search.',
   helpUrl,
 }: FullTextSearchProps) {
-  const { executeQueryRequest, queryMetadataQueryOptions } = useQueryContext()
+  const { executeQueryRequest } = useQueryContext()
   const { showSearchBar } = useQueryVisualizationContext()
   const [searchText, setSearchText] = useState('')
   const searchInputRef = useRef<HTMLInputElement>(null)
 
-  const { data } = useQuery(queryMetadataQueryOptions)
+  const { data } = useGetQueryMetadata()
   const columnModels = data?.columnModels
 
   const search = (event: SyntheticEvent<HTMLFormElement>) => {

--- a/packages/synapse-react-client/src/components/QueryVisualizationWrapper/QueryVisualizationWrapper.tsx
+++ b/packages/synapse-react-client/src/components/QueryVisualizationWrapper/QueryVisualizationWrapper.tsx
@@ -1,12 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { useDeepCompareMemoize } from 'use-deep-compare-effect'
+import { getDisplayValue } from '../../utils/functions/getDataFromFromStorage'
+import { unCamelCase } from '../../utils/functions/unCamelCase'
+import useMutuallyExclusiveState from '../../utils/hooks/useMutuallyExclusiveState'
 import { useQueryContext } from '../QueryContext'
+import { useGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
 import { NoContentPlaceholderType } from '../SynapseTable'
 import { unCamelCase } from '../../utils/functions/unCamelCase'
 import { getDisplayValue } from '../../utils/functions/getDataFromFromStorage'
 import useMutuallyExclusiveState from '../../utils/hooks/useMutuallyExclusiveState'
 import NoContentPlaceholderComponent from './NoContentPlaceholder'
-import { useQuery } from '@tanstack/react-query'
 import {
   QueryVisualizationContextProvider,
   QueryVisualizationContextType,
@@ -76,9 +80,8 @@ export function QueryVisualizationWrapper(
     hasFacetedSelectColumn,
     hasResettableFilters,
     rowDataQueryOptions,
-    queryMetadataQueryOptions,
   } = useQueryContext()
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useGetQueryMetadata()
 
   // Get the selectColumns from either query so that creating the context isn't bottlenecked by one or the other
   // Use the previous result as placeholder data so we don't reset the selectColumns unless they have actually changed.
@@ -87,8 +90,7 @@ export function QueryVisualizationWrapper(
     select: data => data.responseBody?.queryResult?.queryResults.headers,
     placeholderData: prevData => prevData,
   })
-  const { data: selectColumnsFromMetadata } = useQuery({
-    ...queryMetadataQueryOptions,
+  const { data: selectColumnsFromMetadata } = useGetQueryMetadata({
     select: data => data.responseBody?.selectColumns,
     placeholderData: prevData => prevData,
   })

--- a/packages/synapse-react-client/src/components/QueryWrapper/QueryWrapper.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapper/QueryWrapper.tsx
@@ -1,31 +1,31 @@
-import { PropsWithChildren, useCallback, useEffect, useMemo } from 'react'
-import { useDeepCompareMemoize } from 'use-deep-compare-effect'
-import { hasResettableFilters as hasResettableFiltersUtil } from '../../utils/functions/queryUtils'
 import {
   QueryBundleRequest,
   QueryResultBundle,
 } from '@sage-bionetworks/synapse-types'
+import { Provider, useSetAtom } from 'jotai'
+import { noop } from 'lodash-es'
+import { PropsWithChildren, useCallback, useEffect, useMemo } from 'react'
+import { useDeepCompareMemoize } from 'use-deep-compare-effect'
+import { LockedColumn } from '../../utils'
+import { hasResettableFilters as hasResettableFiltersUtil } from '../../utils/functions/queryUtils'
+import useImmutableTableQuery from '../../utils/hooks/useImmutableTableQuery/useImmutableTableQuery'
+import { ConfirmationDialog } from '../ConfirmationDialog'
 import {
   CombineRangeFacetConfig,
   QueryContextProvider,
   QueryContextType,
 } from '../QueryContext/QueryContext'
-import useImmutableTableQuery from '../../utils/hooks/useImmutableTableQuery/useImmutableTableQuery'
-import { ConfirmationDialog } from '../ConfirmationDialog'
+import { useTableQueryUseQueryOptions } from './TableQueryUseQueryOptions'
 import {
-  hasSelectedRowsAtom,
   isRowSelectionUIFloatingAtom,
   isRowSelectionVisibleAtom,
   rowSelectionPrimaryKeyAtom,
   selectedRowsAtom,
+  useHasSelectedRowsAtomValue,
 } from './TableRowSelectionState'
-import { Provider, useAtomValue, useSetAtom } from 'jotai'
-import { LockedColumn } from '../../utils'
-import { noop } from 'lodash-es'
-import useOnQueryDataChange from './useOnQueryDataChange'
-import { useTableQueryUseQueryOptions } from './TableQueryUseQueryOptions'
 import useComputeRowSelectionPrimaryKey from './useComputeRowSelectionPrimaryKey'
 import useHasFacetedSelectColumn from './useHasFacetedSelectColumn'
+import useOnQueryDataChange from './useOnQueryDataChange'
 
 export type QueryWrapperProps = PropsWithChildren<{
   initQueryRequest: QueryBundleRequest
@@ -74,7 +74,7 @@ function QueryWrapperInternal(props: QueryWrapperProps) {
     fileVersionColumnName,
   } = props
 
-  const hasSelectedRows = useAtomValue(hasSelectedRowsAtom)
+  const hasSelectedRows = useHasSelectedRowsAtomValue()
 
   const immutableTableQueryResult = useImmutableTableQuery({
     initQueryRequest,
@@ -118,9 +118,7 @@ function QueryWrapperInternal(props: QueryWrapperProps) {
     queryMetadataQueryOptions,
   } = useTableQueryUseQueryOptions(lastQueryRequest, lockedColumn)
 
-  const hasFacetedSelectColumn = useHasFacetedSelectColumn(
-    queryMetadataQueryOptions,
-  )
+  const hasFacetedSelectColumn = useHasFacetedSelectColumn()
 
   const hasResettableFilters = useMemo(() => {
     const request = getCurrentQueryRequest()
@@ -140,7 +138,6 @@ function QueryWrapperInternal(props: QueryWrapperProps) {
   const rowSelectionPrimaryKey = useComputeRowSelectionPrimaryKey({
     entityId,
     versionNumber,
-    queryMetadataQueryOptions,
     rowSelectionPrimaryKeyFromProps,
   })
   const setRowSelectionPrimaryKey = useSetAtom(rowSelectionPrimaryKeyAtom)

--- a/packages/synapse-react-client/src/components/QueryWrapper/TableRowSelectionState.test.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapper/TableRowSelectionState.test.tsx
@@ -1,7 +1,8 @@
-import { act, renderHook } from '@testing-library/react'
-import { mockQueryResultBundle } from '../../mocks/mockFileViewQuery'
 import { Row } from '@sage-bionetworks/synapse-types'
+import { act, renderHook } from '@testing-library/react'
+import { Provider, useAtom, useAtomValue } from 'jotai'
 import { cloneDeep } from 'lodash-es'
+import { mockQueryResultBundle } from '../../mocks/mockFileViewQuery'
 import {
   hasSelectedRowsAtom,
   isRowSelectedAtom,
@@ -9,15 +10,15 @@ import {
   rowSelectionPrimaryKeyAtom,
   selectedRowsAtom,
 } from './TableRowSelectionState'
-import { Provider, useAtomValue, useSetAtom } from 'jotai'
 
 function useTableRowSelectionState() {
-  const isRowSelectionVisible = useAtomValue(isRowSelectionVisibleAtom)
-  const setIsRowSelectionVisible = useSetAtom(isRowSelectionVisibleAtom)
-  const rowSelectionPrimaryKey = useAtomValue(rowSelectionPrimaryKeyAtom)
-  const setRowSelectionPrimaryKey = useSetAtom(rowSelectionPrimaryKeyAtom)
-  const selectedRows = useAtomValue(selectedRowsAtom)
-  const setSelectedRows = useSetAtom(selectedRowsAtom)
+  const [isRowSelectionVisible, setIsRowSelectionVisible] = useAtom(
+    isRowSelectionVisibleAtom,
+  )
+  const [rowSelectionPrimaryKey, setRowSelectionPrimaryKey] = useAtom(
+    rowSelectionPrimaryKeyAtom,
+  )
+  const [selectedRows, setSelectedRows] = useAtom(selectedRowsAtom)
   const isRowSelected = useAtomValue(isRowSelectedAtom)
   const hasSelectedRows = useAtomValue(hasSelectedRowsAtom)
   return {

--- a/packages/synapse-react-client/src/components/QueryWrapper/TableRowSelectionState.ts
+++ b/packages/synapse-react-client/src/components/QueryWrapper/TableRowSelectionState.ts
@@ -1,6 +1,6 @@
 import { Row, SelectColumn } from '@sage-bionetworks/synapse-types'
+import { atom, useAtomValue } from 'jotai'
 import { isEqual } from 'lodash-es'
-import { atom } from 'jotai'
 
 export function getRowSelectionEqualityComparator(
   row: Row,
@@ -50,9 +50,22 @@ export const isRowSelectionUIFloatingAtom = atom<boolean>(true)
  */
 export const rowSelectionPrimaryKeyAtom = atom<string[] | undefined>(undefined)
 /**
+ * A unique key that identifies a row. If two selected rows have the same key values, then they are considered equal and would both be selected/deselected together.
+ */
+export function useRowSelectionPrimaryKeyAtomValue() {
+  return useAtomValue(rowSelectionPrimaryKeyAtom)
+}
+
+/**
  * The set of selected rows
  */
 export const selectedRowsAtom = atom<Row[]>([])
+/**
+ * The set of selected rows
+ */
+export function useSelectedRowsAtomValue() {
+  return useAtomValue(selectedRowsAtom)
+}
 
 /**
  * Can be used to determine if a row is selected. If a `rowSelectionPrimaryKey` is defined, then the row is selected if it has a matching PK.
@@ -74,3 +87,9 @@ export const isRowSelectedAtom = atom(
  * Whether rows are currently selected
  */
 export const hasSelectedRowsAtom = atom(get => get(selectedRowsAtom).length > 0)
+/**
+ * Whether rows are currently selected
+ */
+export function useHasSelectedRowsAtomValue() {
+  return useAtomValue(hasSelectedRowsAtom)
+}

--- a/packages/synapse-react-client/src/components/QueryWrapper/ViewMoreQueryResultsButton.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapper/ViewMoreQueryResultsButton.tsx
@@ -1,9 +1,8 @@
-import { useEffect } from 'react'
 import { Box } from '@mui/material'
-import WideButton from '../styled/WideButton'
+import { useEffect } from 'react'
 import { SynapseSpinner } from '../LoadingScreen/LoadingScreen'
-import { useQueryContext } from '../QueryContext'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import WideButton from '../styled/WideButton'
+import { useSuspenseGetQueryMetadata } from './useGetQueryMetadata'
 
 export type ViewMoreQueryResultsButtonProps = {
   hasNextPage: boolean
@@ -25,10 +24,9 @@ export function ViewMoreQueryResultsButton(
     initialLimitIsApplied,
     onRemoveInitialLimit,
   } = props
-  const { queryMetadataQueryOptions } = useQueryContext()
   const {
     data: { queryCount },
-  } = useSuspenseQuery(queryMetadataQueryOptions)
+  } = useSuspenseGetQueryMetadata()
 
   useEffect(() => {
     if (

--- a/packages/synapse-react-client/src/components/QueryWrapper/useComputeRowSelectionPrimaryKey.ts
+++ b/packages/synapse-react-client/src/components/QueryWrapper/useComputeRowSelectionPrimaryKey.ts
@@ -1,28 +1,21 @@
-import { useMemo } from 'react'
-import { getDefaultPrimaryKey } from '../SynapseTable/SynapseTableUtils'
-import { useGetEntity } from '../../synapse-queries'
 import { Table } from '@sage-bionetworks/synapse-types'
-import { useQuery } from '@tanstack/react-query'
-import { QueryContextType } from '../QueryContext'
+import { useMemo } from 'react'
+import { useGetEntity } from '../../synapse-queries'
+import { getDefaultPrimaryKey } from '../SynapseTable/SynapseTableUtils'
+import { useGetQueryMetadata } from './useGetQueryMetadata'
 
 type UseComputeRowSelectionPrimaryKeyOptions = {
   entityId: string
   versionNumber?: number
   rowSelectionPrimaryKeyFromProps?: string[]
-  queryMetadataQueryOptions: QueryContextType['queryMetadataQueryOptions']
 }
 
 export default function useComputeRowSelectionPrimaryKey(
   options: UseComputeRowSelectionPrimaryKeyOptions,
 ) {
-  const {
-    rowSelectionPrimaryKeyFromProps,
-    entityId,
-    versionNumber,
-    queryMetadataQueryOptions,
-  } = options
+  const { rowSelectionPrimaryKeyFromProps, entityId, versionNumber } = options
   const { data: entity } = useGetEntity<Table>(entityId, versionNumber)
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useGetQueryMetadata()
 
   return useMemo(() => {
     if (rowSelectionPrimaryKeyFromProps) {

--- a/packages/synapse-react-client/src/components/QueryWrapper/useGetQueryMetadata.ts
+++ b/packages/synapse-react-client/src/components/QueryWrapper/useGetQueryMetadata.ts
@@ -1,0 +1,70 @@
+import { SynapseClientError } from '@sage-bionetworks/synapse-client'
+import {
+  AsynchronousJobStatus,
+  QueryBundleRequest,
+  QueryResultBundle,
+} from '@sage-bionetworks/synapse-types'
+import {
+  useQuery,
+  UseQueryOptions,
+  useSuspenseQuery,
+} from '@tanstack/react-query'
+import { useQueryContext } from '../QueryContext/index'
+
+/**
+ * Get the metadata (columns, count, i.e. not row data) for the query in the current QueryContext (provided by
+ * QueryWrapper)
+ */
+export function useGetQueryMetadata<
+  TSelect = Omit<QueryResultBundle, 'queryResult'>,
+>(
+  optionsOverrides?: Partial<
+    UseQueryOptions<
+      AsynchronousJobStatus<QueryBundleRequest, QueryResultBundle>,
+      SynapseClientError,
+      TSelect
+    >
+  >,
+) {
+  const { queryMetadataQueryOptions } = useQueryContext()
+
+  const mergedOptions = {
+    ...queryMetadataQueryOptions,
+    ...optionsOverrides,
+  } as UseQueryOptions<
+    AsynchronousJobStatus<QueryBundleRequest, QueryResultBundle>,
+    SynapseClientError,
+    TSelect
+  >
+
+  return useQuery(mergedOptions)
+}
+
+/**
+ * Get the metadata (columns, count, i.e. not row data) for the query in the current QueryContext (provided by
+ * QueryWrapper). Suspends the component tree if the query data is not yet loaded.
+ */
+export function useSuspenseGetQueryMetadata<
+  TSelect = Omit<QueryResultBundle, 'queryResult'>,
+>(
+  optionsOverrides?: Partial<
+    UseQueryOptions<
+      AsynchronousJobStatus<QueryBundleRequest, QueryResultBundle>,
+      SynapseClientError,
+      TSelect
+    >
+  >,
+) {
+  const { queryMetadataQueryOptions } = useQueryContext()
+
+  const mergedOptions = {
+    ...queryMetadataQueryOptions,
+    ...optionsOverrides,
+  } as UseQueryOptions<
+    AsynchronousJobStatus<QueryBundleRequest, QueryResultBundle>,
+    SynapseClientError,
+    TSelect
+  >
+
+  return useSuspenseQuery(mergedOptions)
+}

--- a/packages/synapse-react-client/src/components/QueryWrapper/useHasFacetedSelectColumn.ts
+++ b/packages/synapse-react-client/src/components/QueryWrapper/useHasFacetedSelectColumn.ts
@@ -1,11 +1,8 @@
-import { QueryContextType } from '../QueryContext'
-import { useQuery } from '@tanstack/react-query'
 import { hasFacetedSelectColumn as hasFacetedSelectColumnUtil } from '../../utils/functions/queryUtils'
+import { useGetQueryMetadata } from './useGetQueryMetadata'
 
-export default function useHasFacetedSelectColumn(
-  queryMetadataQueryOptions: QueryContextType['queryMetadataQueryOptions'],
-): boolean {
-  const { data: queryMetadata, isLoading } = useQuery(queryMetadataQueryOptions)
+export default function useHasFacetedSelectColumn(): boolean {
+  const { data: queryMetadata, isLoading } = useGetQueryMetadata()
 
   if (!queryMetadata) {
     // if loading, return true - the facet UI will be shown in a loading state

--- a/packages/synapse-react-client/src/components/QueryWrapper/useOnQueryDataChange.ts
+++ b/packages/synapse-react-client/src/components/QueryWrapper/useOnQueryDataChange.ts
@@ -1,11 +1,12 @@
-import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
-import { useQuery } from '@tanstack/react-query'
 import {
   QueryBundleRequest,
   QueryResultBundle,
 } from '@sage-bionetworks/synapse-types'
-import { useTableQueryUseQueryOptions } from './TableQueryUseQueryOptions'
+import { useQuery } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
+import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
+import { useTableQueryUseQueryOptions } from './TableQueryUseQueryOptions'
+import { useGetQueryMetadata } from './useGetQueryMetadata'
 
 type UseOnQueryDataChangeOptions = {
   queryBundleRequest: QueryBundleRequest
@@ -20,16 +21,15 @@ export default function useOnQueryDataChange(
   options: UseOnQueryDataChangeOptions,
 ) {
   const { queryBundleRequest, onChange } = options
-  const { rowDataQueryOptions, queryMetadataQueryOptions } =
+  const { rowDataQueryOptions } =
     useTableQueryUseQueryOptions(queryBundleRequest)
 
   const { data: rowData, isLoading: rowDataIsLoading } = useQuery({
     ...rowDataQueryOptions,
     select: asyncJobResponse => asyncJobResponse.responseBody,
   })
-  const { data: queryMetadata, isLoading: queryMetadataIsLoading } = useQuery(
-    queryMetadataQueryOptions,
-  )
+  const { data: queryMetadata, isLoading: queryMetadataIsLoading } =
+    useGetQueryMetadata()
 
   // SWC requires the entire QueryResultBundle to enable editing table data, so merge the data back into one object before
   // passing it to the onChange callback

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/LastUpdatedOn.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/LastUpdatedOn.tsx
@@ -1,15 +1,13 @@
+import { Skeleton, Typography } from '@mui/material'
 import dayjs from 'dayjs'
 import { Suspense } from 'react'
 import { formatDate } from '../../utils/functions/DateFormatter'
-import { Skeleton, Typography } from '@mui/material'
 import { useQueryVisualizationContext } from '../QueryVisualizationWrapper'
-import { useSuspenseQuery } from '@tanstack/react-query'
-import { useQueryContext } from '../QueryContext'
+import { useSuspenseGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
 
 function LastUpdatedOn() {
-  const { queryMetadataQueryOptions } = useQueryContext()
   const { showLastUpdatedOn } = useQueryVisualizationContext()
-  const { data: queryMetadata } = useSuspenseQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useSuspenseGetQueryMetadata()
 
   return showLastUpdatedOn && queryMetadata && queryMetadata.lastUpdatedOn ? (
     <div

--- a/packages/synapse-react-client/src/components/SynapseTable/RowSelection/RowSelectionControls.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/RowSelection/RowSelectionControls.tsx
@@ -30,14 +30,9 @@ export type RowSelectionControlsProps = {
  */
 export function RowSelectionControls(props: RowSelectionControlsProps) {
   const { customControls = [], showExportToCavatica = false, remount } = props
-  const {
-    entityId,
-    versionNumber,
-    getCurrentQueryRequest,
-    queryMetadataQueryOptions,
-  } = useQueryContext()
+  const { entityId, versionNumber, getCurrentQueryRequest } = useQueryContext()
   const { data: entity } = useGetEntity<Table>(entityId, versionNumber)
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useGetQueryMetadata()
   const [selectedRows, setSelectedRows] = useAtom(selectedRowsAtom)
 
   const { setIsShowingExportToCavaticaModal, setShowDownloadConfirmation } =

--- a/packages/synapse-react-client/src/components/SynapseTable/SearchV2.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SearchV2.tsx
@@ -1,13 +1,5 @@
 import { Collapse } from '@mui/material'
 import {
-  Component,
-  createRef,
-  FormEvent,
-  RefObject,
-  SyntheticEvent,
-} from 'react'
-import { CSSTransition } from 'react-transition-group'
-import {
   ColumnModel,
   ColumnMultiValueFunction,
   ColumnMultiValueFunctionQueryFilter,
@@ -16,15 +8,23 @@ import {
   ColumnTypeEnum,
   QueryFilter,
 } from '@sage-bionetworks/synapse-types'
-import { QueryVisualizationContextType } from '../QueryVisualizationWrapper'
-import { QueryContextType } from '../QueryContext'
-import IconSvg from '../IconSvg/IconSvg'
+import {
+  Component,
+  createRef,
+  FormEvent,
+  RefObject,
+  SyntheticEvent,
+} from 'react'
+import { CSSTransition } from 'react-transition-group'
 import {
   isColumnMultiValueFunctionQueryFilter,
   isColumnSingleValueQueryFilter,
   LockedColumn,
 } from '../../utils'
-import { useQuery } from '@tanstack/react-query'
+import IconSvg from '../IconSvg/IconSvg'
+import { QueryContextType } from '../QueryContext'
+import { QueryVisualizationContextType } from '../QueryVisualizationWrapper'
+import { useGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
 
 type SearchState = {
   show: boolean
@@ -346,8 +346,6 @@ class _Search extends Component<InternalSearchProps, SearchState> {
 }
 
 export default function Search(props: SearchV2Props) {
-  const { data: queryMetadata } = useQuery(
-    props.queryContext.queryMetadataQueryOptions,
-  )
+  const { data: queryMetadata } = useGetQueryMetadata()
   return <_Search {...props} columnModels={queryMetadata?.columnModels} />
 }

--- a/packages/synapse-react-client/src/components/SynapseTable/SendToCavaticaConfirmationDialog.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SendToCavaticaConfirmationDialog.tsx
@@ -11,8 +11,6 @@ import {
   ActionRequiredCount,
   ColumnModel,
 } from '@sage-bionetworks/synapse-types'
-import { useQuery } from '@tanstack/react-query'
-import { useAtomValue } from 'jotai'
 import { useMemo, useState } from 'react'
 import { useGetActionsRequiredForTableQuery } from '../../synapse-queries/entity/useActionsRequiredForTableQuery'
 import { useExportToCavatica } from '../../synapse-queries/entity/useExportToCavatica'
@@ -24,10 +22,11 @@ import { ActionRequiredListItem } from '../DownloadCart/ActionRequiredListItem'
 import { useQueryContext } from '../QueryContext'
 import { useQueryVisualizationContext } from '../QueryVisualizationWrapper'
 import {
-  hasSelectedRowsAtom,
-  rowSelectionPrimaryKeyAtom,
-  selectedRowsAtom,
+  useHasSelectedRowsAtomValue,
+  useRowSelectionPrimaryKeyAtomValue,
+  useSelectedRowsAtomValue,
 } from '../QueryWrapper/TableRowSelectionState'
+import { useGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
 import { SkeletonParagraph } from '../Skeleton'
 import { getNumberOfResultsToInvokeActionCopy } from './TopLevelControls/TopLevelControlsUtils'
 
@@ -46,16 +45,15 @@ export default function SendToCavaticaConfirmationDialog(
     getCurrentQueryRequest,
     onViewSharingSettingsClicked,
     hasResettableFilters,
-    queryMetadataQueryOptions,
     fileIdColumnName,
     fileVersionColumnName,
     fileNameColumnName,
   } = useQueryContext()
 
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
-  const selectedRows = useAtomValue(selectedRowsAtom)
-  const rowSelectionPrimaryKey = useAtomValue(rowSelectionPrimaryKeyAtom)
-  const hasSelectedRows = useAtomValue(hasSelectedRowsAtom)
+  const { data: queryMetadata } = useGetQueryMetadata()
+  const selectedRows = useSelectedRowsAtomValue()
+  const rowSelectionPrimaryKey = useRowSelectionPrimaryKeyAtomValue()
+  const hasSelectedRows = useHasSelectedRowsAtomValue()
 
   const {
     isShowingExportToCavaticaModal,

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableRenderers.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableRenderers.tsx
@@ -5,7 +5,6 @@ import {
   FacetColumnResultValues,
   Row,
 } from '@sage-bionetworks/synapse-types'
-import { useQuery } from '@tanstack/react-query'
 import {
   CellContext,
   createColumnHelper,
@@ -24,6 +23,7 @@ import {
   isRowSelectedAtom,
   selectedRowsAtom,
 } from '../QueryWrapper/TableRowSelectionState'
+import { useGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
 import ColumnHeader from '../TanStackTable/ColumnHeader'
 import { EnumFacetFilter } from '../widgets/query-filter/EnumFacetFilter/EnumFacetFilter'
 import EntityIDColumnCopyIcon from './EntityIDColumnCopyIcon'
@@ -201,8 +201,8 @@ export function TableDataColumnHeader(
   props: HeaderContext<Row, string | null>,
 ) {
   const { column } = props
-  const { queryMetadataQueryOptions, lockedColumn } = useQueryContext()
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
+  const { lockedColumn } = useQueryContext()
+  const { data: queryMetadata } = useGetQueryMetadata()
   const columnModels = queryMetadata?.columnModels ?? []
   const selectColumns = queryMetadata?.selectColumns ?? []
   const selectColumn = selectColumns.find(sc => sc.name === column.id)

--- a/packages/synapse-react-client/src/components/SynapseTable/TablePagination.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/TablePagination.tsx
@@ -1,11 +1,4 @@
 import {
-  ChangeEvent,
-  ComponentProps,
-  forwardRef,
-  Ref,
-  useCallback,
-} from 'react'
-import {
   MenuItem,
   Pagination,
   PaginationItem,
@@ -14,25 +7,26 @@ import {
   SelectChangeEvent,
   Typography,
 } from '@mui/material'
+import {
+  ChangeEvent,
+  ComponentProps,
+  forwardRef,
+  Ref,
+  useCallback,
+} from 'react'
 import { useQueryContext } from '../QueryContext'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useSuspenseGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
 
 import { usePrefetchTableRows } from './usePrefetchTableData'
 
 export const TablePagination = () => {
-  const {
-    queryMetadataQueryOptions,
-    goToPage,
-    pageSize,
-    setPageSize,
-    currentPage,
-  } = useQueryContext()
+  const { goToPage, pageSize, setPageSize, currentPage } = useQueryContext()
 
   const prefetchPage = usePrefetchTableRows()
 
   const {
     data: { queryCount, maxRowsPerPage },
-  } = useSuspenseQuery(queryMetadataQueryOptions)
+  } = useSuspenseGetQueryMetadata()
 
   const maxPageSize = maxRowsPerPage ?? pageSize
 

--- a/packages/synapse-react-client/src/components/SynapseTable/TopLevelControls/TopLevelControls.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/TopLevelControls/TopLevelControls.tsx
@@ -1,6 +1,4 @@
-import { cloneDeep } from 'lodash-es'
-import { Fragment, ReactNode, useMemo, useState } from 'react'
-import { SQL_EDITOR } from '../../../utils/SynapseConstants'
+import { Button, Divider, Tooltip, Typography } from '@mui/material'
 import {
   Query,
   QueryBundleRequest,
@@ -8,30 +6,33 @@ import {
   Row,
   Table,
 } from '@sage-bionetworks/synapse-types'
-import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
+import { useAtomValue } from 'jotai'
+import { cloneDeep } from 'lodash-es'
+import { Fragment, ReactNode, useMemo, useState } from 'react'
+import { useGetEntity } from '../../../synapse-queries'
+import { SQL_EDITOR } from '../../../utils/SynapseConstants'
+import IconSvg from '../../IconSvg'
+import MissingQueryResultsWarning from '../../MissingQueryResultsWarning/MissingQueryResultsWarning'
 import { useQueryContext } from '../../QueryContext'
 import { ElementWithTooltip } from '../../widgets/ElementWithTooltip'
-import { ColumnSelection, DownloadOptions } from '../table-top'
 import { Button, Divider, Tooltip, Typography } from '@mui/material'
 import QueryCount from '../../QueryCount/QueryCount'
-import MissingQueryResultsWarning from '../../MissingQueryResultsWarning/MissingQueryResultsWarning'
-import { Cavatica } from '../../../assets/icons/Cavatica'
+import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
+import {
+  isRowSelectionVisibleAtom,
+  useHasSelectedRowsAtomValue,
+  useSelectedRowsAtomValue,
+} from '../../QueryWrapper/TableRowSelectionState'
+import { useGetQueryMetadata } from '../../QueryWrapper/useGetQueryMetadata'
+import { ElementWithTooltip } from '../../widgets/ElementWithTooltip'
 import { RowSelectionControls } from '../RowSelection/RowSelectionControls'
 import SendToCavaticaConfirmationDialog from '../SendToCavaticaConfirmationDialog'
+import { ColumnSelection, DownloadOptions } from '../table-top'
+import CustomControlButton from './CustomControlButton'
 import {
   getNumberOfResultsToInvokeAction,
   getNumberOfResultsToInvokeActionCopy,
 } from './TopLevelControlsUtils'
-import IconSvg from '../../IconSvg'
-import { useAtomValue } from 'jotai'
-import {
-  hasSelectedRowsAtom,
-  isRowSelectionVisibleAtom,
-  selectedRowsAtom,
-} from '../../QueryWrapper/TableRowSelectionState'
-import CustomControlButton from './CustomControlButton'
-import { useQuery } from '@tanstack/react-query'
-import { useGetEntity } from '../../../synapse-queries'
 
 const SEND_TO_CAVATICA_BUTTON_ID = 'SendToCavaticaTopLevelControlButton'
 
@@ -96,11 +97,11 @@ const TopLevelControls = (props: TopLevelControlsProps) => {
     queryMetadataQueryOptions,
   } = useQueryContext()
   const { data: entity } = useGetEntity<Table>(entityId, versionNumber)
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useGetQueryMetadata()
   const { lockedColumn } = useQueryContext()
   const isRowSelectionVisible = useAtomValue(isRowSelectionVisibleAtom)
-  const selectedRows = useAtomValue(selectedRowsAtom)
-  const hasSelectedRows = useAtomValue(hasSelectedRowsAtom)
+  const selectedRows = useSelectedRowsAtomValue()
+  const hasSelectedRows = useHasSelectedRowsAtomValue()
 
   const {
     setShowSearchBar,

--- a/packages/synapse-react-client/src/components/SynapseTable/table-top/DownloadOptions.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/table-top/DownloadOptions.tsx
@@ -1,7 +1,5 @@
 import { MenuItem, Tooltip } from '@mui/material'
 import { Table } from '@sage-bionetworks/synapse-types'
-import { useQuery } from '@tanstack/react-query'
-import { useAtomValue } from 'jotai'
 import { ReactNode, useMemo, useState } from 'react'
 import { useGetEntity } from '../../../synapse-queries'
 import { useSynapseContext } from '../../../utils'
@@ -11,9 +9,10 @@ import ModalDownload from '../../ModalDownload/ModalDownload'
 import ProgrammaticTableDownload from '../../ProgrammaticTableDownload/ProgrammaticTableDownload'
 import { useQueryContext } from '../../QueryContext'
 import {
-  hasSelectedRowsAtom,
-  selectedRowsAtom,
+  useHasSelectedRowsAtomValue,
+  useSelectedRowsAtomValue,
 } from '../../QueryWrapper/TableRowSelectionState'
+import { useGetQueryMetadata } from '../../QueryWrapper/useGetQueryMetadata'
 import { ElementWithTooltip } from '../../widgets/ElementWithTooltip'
 import { getFileColumnModelId } from '../SynapseTableUtils'
 import { getNumberOfResultsToAddToDownloadListCopy } from '../TopLevelControls/TopLevelControlsUtils'
@@ -31,13 +30,12 @@ export function DownloadOptions(props: DownloadOptionsProps) {
     versionNumber,
     getCurrentQueryRequest,
     hasResettableFilters,
-    queryMetadataQueryOptions,
   } = useQueryContext()
   const { data: entity } = useGetEntity<Table>(entityId, versionNumber)
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useGetQueryMetadata()
 
-  const selectedRows = useAtomValue(selectedRowsAtom)
-  const hasSelectedRows = useAtomValue(hasSelectedRowsAtom)
+  const selectedRows = useSelectedRowsAtomValue()
+  const hasSelectedRows = useHasSelectedRowsAtomValue()
 
   const queryBundleRequest = useMemo(
     () => getCurrentQueryRequest(),

--- a/packages/synapse-react-client/src/components/SynapseTable/usePrefetchTableData.ts
+++ b/packages/synapse-react-client/src/components/SynapseTable/usePrefetchTableData.ts
@@ -8,7 +8,9 @@ import {
   RowSet,
   Table,
 } from '@sage-bionetworks/synapse-types'
-import { isEntityViewOrDataset, isFileViewOrDataset } from './SynapseTableUtils'
+import { useQueryClient } from '@tanstack/react-query'
+import { cloneDeep } from 'lodash-es'
+import { useCallback, useMemo } from 'react'
 import {
   useGetEntity,
   useGetEntityHeaders,
@@ -16,21 +18,19 @@ import {
   useGetRestrictionInformationBatch,
   useGetUserGroupHeaders,
 } from '../../synapse-queries'
-import { getFieldIndex, getTypeIndices } from '../../utils/functions/queryUtils'
-import { useQueryContext } from '../QueryContext'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useMemo } from 'react'
 import { useSynapseContext } from '../../utils'
+import { getFieldIndex, getTypeIndices } from '../../utils/functions/queryUtils'
 import { goToPage as transformQueryToGoToPage } from '../../utils/hooks/useImmutableTableQuery/TableQueryReducerActions'
-import { cloneDeep } from 'lodash-es'
+import { useQueryContext } from '../QueryContext'
 import { getTableQueryUseQueryOptions } from '../QueryWrapper/TableQueryUseQueryOptions'
+import { useGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
+import { isEntityViewOrDataset, isFileViewOrDataset } from './SynapseTableUtils'
 
 function usePrefetchFileHandleData(rowSet: RowSet) {
-  const { entityId, versionNumber, queryMetadataQueryOptions } =
-    useQueryContext()
+  const { entityId, versionNumber } = useQueryContext()
 
   const { data: entity } = useGetEntity<Table>(entityId, versionNumber)
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useGetQueryMetadata()
 
   const fileHandleIdColumnIndices = getTypeIndices(
     ColumnTypeEnum.FILEHANDLEID,
@@ -88,10 +88,9 @@ function usePrefetchFileHandleData(rowSet: RowSet) {
 }
 
 function useGetEntitiesInTable(rowSet: RowSet) {
-  const { entityId, versionNumber, queryMetadataQueryOptions } =
-    useQueryContext()
+  const { entityId, versionNumber } = useQueryContext()
   const { data: entity } = useGetEntity<Table>(entityId, versionNumber)
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useGetQueryMetadata()
 
   let entitiesInTable: ReferenceList = []
 
@@ -168,8 +167,7 @@ function usePrefetchEntityData(entitiesToPrefetch: ReferenceList) {
 }
 
 function usePrefetchUserGroupHeaderData(rowSet: RowSet) {
-  const { queryMetadataQueryOptions } = useQueryContext()
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useGetQueryMetadata()
 
   const userIdColumnIndices = getTypeIndices(
     ColumnTypeEnum.USERID,

--- a/packages/synapse-react-client/src/components/TotalQueryResults.tsx
+++ b/packages/synapse-react-client/src/components/TotalQueryResults.tsx
@@ -1,13 +1,13 @@
-import { CSSProperties, Suspense } from 'react'
-import { SkeletonInlineBlock } from './Skeleton'
 import { FacetColumnRequest } from '@sage-bionetworks/synapse-types'
-import { useQueryVisualizationContext } from './QueryVisualizationWrapper'
-import { useQueryContext } from './QueryContext'
-import IconSvg from './IconSvg/IconSvg'
-import SelectionCriteriaPills from './widgets/facet-nav/SelectionCriteriaPills'
 import pluralize from 'pluralize'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { CSSProperties, Suspense } from 'react'
 import { SynapseErrorBoundary } from './error'
+import IconSvg from './IconSvg/IconSvg'
+import { useQueryContext } from './QueryContext'
+import { useQueryVisualizationContext } from './QueryVisualizationWrapper'
+import { useSuspenseGetQueryMetadata } from './QueryWrapper/useGetQueryMetadata'
+import { SkeletonInlineBlock } from './Skeleton'
+import SelectionCriteriaPills from './widgets/facet-nav/SelectionCriteriaPills'
 
 export type TotalQueryResultsProps = {
   style?: CSSProperties
@@ -19,9 +19,8 @@ export type TotalQueryResultsProps = {
 
 function TotalQueryResults(props: TotalQueryResultsProps) {
   const { style, frontText, endText = '', hideIfUnfiltered = false } = props
-  const { resetQuery, hasResettableFilters, queryMetadataQueryOptions } =
-    useQueryContext()
-  const { data: queryMetadata } = useSuspenseQuery(queryMetadataQueryOptions)
+  const { resetQuery, hasResettableFilters } = useQueryContext()
+  const { data: queryMetadata } = useSuspenseGetQueryMetadata()
   const { unitDescription } = useQueryVisualizationContext()
 
   const total = queryMetadata?.queryCount

--- a/packages/synapse-react-client/src/components/download_list/TableQueryDownloadConfirmation.tsx
+++ b/packages/synapse-react-client/src/components/download_list/TableQueryDownloadConfirmation.tsx
@@ -1,37 +1,30 @@
 import { useMemo } from 'react'
-import { SynapseConstants, useSynapseContext } from '../../utils'
 import {
   useAddQueryToDownloadList,
   useGetQueryResultBundleWithAsyncStatus,
 } from '../../synapse-queries'
-import { displayToast } from '../ToastMessage'
-import { DownloadConfirmationUI } from './DownloadConfirmationUI'
+import { SynapseConstants, useSynapseContext } from '../../utils'
+import { getPrimaryKeyINFilter } from '../../utils/functions/QueryFilterUtils'
 import { useQueryContext } from '../QueryContext'
 import { useQueryVisualizationContext } from '../QueryVisualizationWrapper'
-import { displayFilesWereAddedToDownloadListSuccess } from './DownloadConfirmationUtils'
-import { getPrimaryKeyINFilter } from '../../utils/functions/QueryFilterUtils'
-import { getFileColumnModelId } from '../SynapseTable/SynapseTableUtils'
-import { useAtomValue } from 'jotai'
 import {
-  hasSelectedRowsAtom,
-  rowSelectionPrimaryKeyAtom,
-  selectedRowsAtom,
+  useHasSelectedRowsAtomValue,
+  useRowSelectionPrimaryKeyAtomValue,
+  useSelectedRowsAtomValue,
 } from '../QueryWrapper/TableRowSelectionState'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useSuspenseGetQueryMetadata } from '../QueryWrapper/useGetQueryMetadata'
+import { getFileColumnModelId } from '../SynapseTable/SynapseTableUtils'
+import { displayToast } from '../ToastMessage'
+import { DownloadConfirmationUI } from './DownloadConfirmationUI'
+import { displayFilesWereAddedToDownloadListSuccess } from './DownloadConfirmationUtils'
 
 export function TableQueryDownloadConfirmation() {
-  const {
-    getCurrentQueryRequest,
-    queryMetadataQueryOptions,
-    fileIdColumnName,
-    fileVersionColumnName,
-  } = useQueryContext()
-  const { data: originalQueryMetadata } = useSuspenseQuery(
-    queryMetadataQueryOptions,
-  )
-  const hasSelectedRows = useAtomValue(hasSelectedRowsAtom)
-  const selectedRows = useAtomValue(selectedRowsAtom)
-  const rowSelectionPrimaryKey = useAtomValue(rowSelectionPrimaryKeyAtom)
+  const { getCurrentQueryRequest, fileIdColumnName, fileVersionColumnName } =
+    useQueryContext()
+  const { data: originalQueryMetadata } = useSuspenseGetQueryMetadata()
+  const hasSelectedRows = useHasSelectedRowsAtomValue()
+  const selectedRows = useSelectedRowsAtomValue()
+  const rowSelectionPrimaryKey = useRowSelectionPrimaryKeyAtomValue()
   const { setShowDownloadConfirmation } = useQueryVisualizationContext()
 
   const downloadStatsQueryBundleRequest = useMemo(() => {

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNavPanel.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNavPanel.tsx
@@ -26,8 +26,8 @@ import { ConfirmationDialog } from '../../ConfirmationDialog/ConfirmationDialog'
 import loadingScreen from '../../LoadingScreen/LoadingScreen'
 import Plot from '../../Plot/Plot'
 import PlotPanelHeader from '../../Plot/PlotPanelHeader'
-import { useQueryContext } from '../../QueryContext'
 import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
+import { useGetQueryMetadata } from '../../QueryWrapper/useGetQueryMetadata'
 import StyledFormControl from '../../styled/StyledFormControl'
 import { EnumFacetFilter } from '../query-filter/EnumFacetFilter/EnumFacetFilter'
 import { FacetPlotLegendList } from './FacetPlotLegendList'
@@ -295,10 +295,8 @@ function FacetNavPanel(props: FacetNavPanelProps) {
     onSetPlotType,
   } = props
   const { accessToken } = useSynapseContext()
-  const { queryMetadataQueryOptions } = useQueryContext()
-  const { data: queryMetadata, isLoading: isLoadingQueryMetadata } = useQuery(
-    queryMetadataQueryOptions,
-  )
+  const { data: queryMetadata, isLoading: isLoadingQueryMetadata } =
+    useGetQueryMetadata()
 
   const { getColumnDisplayName } = useQueryVisualizationContext()
 

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/PlotsContainer.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/PlotsContainer.tsx
@@ -1,20 +1,19 @@
-import { facetObjectMatchesDefinition } from '../../../utils/functions/queryUtils'
+import { Box, Button } from '@mui/material'
+import { PlotType as PlotlyPlotType } from 'plotly.js-basic-dist'
+import { Suspense, useEffect, useMemo, useState } from 'react'
 import { UniqueFacetIdentifier } from '../../../utils'
-import { useQueryContext } from '../../QueryContext'
+import { facetObjectMatchesDefinition } from '../../../utils/functions/queryUtils'
 import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
+import { useSuspenseGetQueryMetadata } from '../../QueryWrapper/useGetQueryMetadata'
 import QueryWrapperSynapsePlot, {
   QueryWrapperSynapsePlotProps,
 } from '../../QueryWrapperPlotNav/QueryWrapperSynapsePlot'
-import { Suspense, useEffect, useMemo, useState } from 'react'
-import useFacetPlots, { getFacets } from './useFacetPlots'
 import FacetNavPanel, {
   FacetNavPanelProps,
   PlotType,
 } from '../facet-nav/FacetNavPanel'
-import { Box, Button } from '@mui/material'
-import { PlotType as PlotlyPlotType } from 'plotly.js-basic-dist'
-import { useSuspenseQuery } from '@tanstack/react-query'
 import { PlotsContainerSkeleton } from './PlotsContainerSkeleton'
+import useFacetPlots, { getFacets } from './useFacetPlots'
 
 const DEFAULT_VISIBLE_PLOTS = 2
 type ShowMoreState = 'MORE' | 'LESS' | 'NONE'
@@ -137,8 +136,7 @@ function PlotsContainer(props: PlotsContainerProps) {
     customPlots = DEFAULT_CUSTOM_PLOTS,
     initialPlotType = DEFAULT_PLOT_TYPE,
   } = props
-  const { queryMetadataQueryOptions } = useQueryContext()
-  const { data: queryMetadata } = useSuspenseQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useSuspenseGetQueryMetadata()
   const { showPlots: showPlotVisualization } = useQueryVisualizationContext()
   const [plotUiStateArray, setPlotUiStateArray] = useState<UiPlotState[]>([])
   const facetNavPanelPropsArray = useFacetPlots(facetsToPlot)

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/SelectionCriteriaPills.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/SelectionCriteriaPills.tsx
@@ -1,4 +1,3 @@
-import { QueryContextType, useQueryContext } from '../../QueryContext'
 import {
   ColumnModel,
   ColumnMultiValueFunctionQueryFilter,
@@ -8,13 +7,8 @@ import {
   QueryFilter,
   TextMatchesQueryFilter,
 } from '@sage-bionetworks/synapse-types'
-import SelectionCriteriaPill, {
-  SelectionCriteriaPillProps,
-} from './SelectionCriteriaPill'
-import {
-  QueryVisualizationContextType,
-  useQueryVisualizationContext,
-} from '../../QueryVisualizationWrapper'
+import pluralize from 'pluralize'
+import { ReadonlyDeep } from 'type-fest'
 import {
   isColumnMultiValueFunctionQueryFilter,
   isColumnSingleValueQueryFilter,
@@ -23,13 +17,19 @@ import {
   isTextMatchesQueryFilter,
   LockedColumn,
 } from '../../../utils'
-import pluralize from 'pluralize'
-import { ReadonlyDeep } from 'type-fest'
 import {
   FRIENDLY_VALUE_NOT_SET,
   VALUE_NOT_SET,
 } from '../../../utils/SynapseConstants'
-import { useQuery } from '@tanstack/react-query'
+import { QueryContextType, useQueryContext } from '../../QueryContext'
+import {
+  QueryVisualizationContextType,
+  useQueryVisualizationContext,
+} from '../../QueryVisualizationWrapper'
+import { useGetQueryMetadata } from '../../QueryWrapper/useGetQueryMetadata'
+import SelectionCriteriaPill, {
+  SelectionCriteriaPillProps,
+} from './SelectionCriteriaPill'
 
 const MAX_VALUES_IN_FILTER_FOR_INDIVIDUAL_PILLS = 4
 
@@ -278,8 +278,8 @@ function SelectionCriteriaPills() {
   const queryContext = useQueryContext()
   const lockedColumn = queryContext.lockedColumn
   const queryVisualizationContext = useQueryVisualizationContext()
-  const { currentQueryRequest, queryMetadataQueryOptions } = queryContext
-  const { data: queryMetadata } = useQuery(queryMetadataQueryOptions)
+  const { currentQueryRequest } = queryContext
+  const { data: queryMetadata } = useGetQueryMetadata()
 
   const queryFilterPillProps = getPillPropsFromQueryFilters(
     currentQueryRequest.query?.additionalFilters ?? [],

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/useFacetPlots.ts
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/useFacetPlots.ts
@@ -5,12 +5,12 @@ import {
   FacetColumnResultValues,
   QueryResultBundle,
 } from '@sage-bionetworks/synapse-types'
+import { useCallback, useMemo } from 'react'
 import { isSingleNotSetValue } from '../../../utils/functions/queryUtils'
-import { useMemo, useCallback } from 'react'
-import { FacetNavPanelProps } from './FacetNavPanel'
 import { useQueryContext } from '../../QueryContext'
+import { useSuspenseGetQueryMetadata } from '../../QueryWrapper/useGetQueryMetadata'
 import { applyChangesToValuesColumn } from '../query-filter/FacetFilterControls'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { FacetNavPanelProps } from './FacetNavPanel'
 
 // Custom hook for generating properties for FacetNavPanel components with filter controls based on the given facets
 export default function useFacetPlots(
@@ -19,13 +19,9 @@ export default function useFacetPlots(
   FacetNavPanelProps,
   'applyChangesToFacetFilter' | 'applyChangesToGraphSlice' | 'facetToPlot'
 >[] {
-  const {
-    getCurrentQueryRequest,
-    executeQueryRequest,
-    queryMetadataQueryOptions,
-  } = useQueryContext()
+  const { getCurrentQueryRequest, executeQueryRequest } = useQueryContext()
 
-  const { data: queryMetadata } = useSuspenseQuery(queryMetadataQueryOptions)
+  const { data: queryMetadata } = useSuspenseGetQueryMetadata()
 
   const lastQueryRequest = useMemo(
     () => getCurrentQueryRequest(),

--- a/packages/synapse-react-client/src/utils/functions/QueryFilterUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/QueryFilterUtils.ts
@@ -6,6 +6,12 @@ import {
   SelectColumn,
 } from '@sage-bionetworks/synapse-types'
 
+/**
+ * Given a list of selected rows, return a QueryFilter that will only return those rows
+ * @param primaryKeyColumnNames
+ * @param selectedRows
+ * @param selectColumns
+ */
 export function getPrimaryKeyINFilter(
   primaryKeyColumnNames: string[],
   selectedRows: Row[],


### PR DESCRIPTION
Refactor to create simple hook wrappers to get row selection Jotai atom values and the ReactQuery result for queryMetadata. This refactor improve testability by simplifying the process to create mocks. Without the wrappers, we would have to mock `useQuery` or `useAtomValue` and the mock implementation would have to add logic to handle the different atoms or query options.

With the wrapper, we can simply mock the wrapper without writing complex mock logic for external dependencies.