### PR TITLE
PLFM-3499: Add env var for distribution id

### DIFF
--- a/apps/portals/adknowledgeportal/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/adknowledgeportal/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,1 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://prod-adknowledgeportalsynapse-org-websitebucket-1wcys549ufmd
+export CF_PRODUCTION_DIST_ID=E3V5LOR3RVT8MS

--- a/apps/portals/adknowledgeportal/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/adknowledgeportal/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,1 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging-adknowledgeportalsynapse-or-websitebucket-tgdvklhnhjfc
+export CF_STAGING_DIST_ID=E2K9BYXQN2MM76

--- a/apps/portals/arkportal/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/arkportal/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,1 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://prod-arkportal-synapse-org-websitebucket-1557e1kxr3if1
+export CF_PRODUCTION_DIST_ID=E53UUZGXFL713

--- a/apps/portals/arkportal/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/arkportal/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,1 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging-arkportal-synapse-org-websitebucket-148szg14ri4v4
+export CF_STAGING_DIST_ID=EJJ4MGTDA6BVU

--- a/apps/portals/bsmn/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/bsmn/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,1 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://prod.bsmn.synapse.org
+export CF_PRODUCTION_DIST_ID=E1615JO8VH4UJF

--- a/apps/portals/bsmn/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/bsmn/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,1 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging.bsmn.synapse.org
+export CF_STAGING_DIST_ID=EQOBFEPCBQ0K2

--- a/apps/portals/cancercomplexity/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/cancercomplexity/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,1 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://prod.cancercomplexity.synapse.org
+export CF_PRODUCTION_DIST_ID=E22NCIN36WXUIM

--- a/apps/portals/cancercomplexity/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/cancercomplexity/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,1 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging.cancercomplexity.synapse.org
+export CF_STAGING_DIST_ID=E2R3JZH26UN6SC

--- a/apps/portals/challengeportal/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/challengeportal/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,2 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://prod-challenges-synapse-org-websitebucket-gr83m4q9l1q
-
+export CF_PRODUCTION_DIST_ID=E2ECGO8UHOB343

--- a/apps/portals/challengeportal/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/challengeportal/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,2 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging-challenges-synapse-org-websitebucket-13q3n3sfkm04z
-
+export CF_STAGING_DIST_ID=EMQJ1QM9FGG2I

--- a/apps/portals/digitalhealth/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/digitalhealth/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,2 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://prod.dhealth.synapse.org
-export CF_PRODUCTION_DIST_ID=
+export CF_PRODUCTION_DIST_ID=E10U4765KQQW5P

--- a/apps/portals/digitalhealth/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/digitalhealth/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,1 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://prod.dhealth.synapse.org
+export CF_PRODUCTION_DIST_ID=

--- a/apps/portals/digitalhealth/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/digitalhealth/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,2 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging.dhealth.synapse.org
-export CF_STAGING_DIST_ID=
+export CF_STAGING_DIST_ID=E11CE5BFBTPKGU

--- a/apps/portals/digitalhealth/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/digitalhealth/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,1 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging.dhealth.synapse.org
+export CF_STAGING_DIST_ID=

--- a/apps/portals/elportal/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/elportal/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,1 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://prod-eliteportal-synapse-org-websitebucket-f9bag5pqbqc8
+export CF_PRODUCTION_DIST_ID=ELOO9GKN2R7DA

--- a/apps/portals/elportal/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/elportal/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,1 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging-eliteportal-synapse-org-websitebucket-enedr8ccgn9x
+export CF_STAGING_DIST_ID=E4H3REED377EG

--- a/apps/portals/genie/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/genie/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,1 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://prod-genie-synapse-org-websitebucket-xlukn82knv8g
+export CF_PRODUCTION_DIST_ID=E2WFBXCOBA5ZU5

--- a/apps/portals/genie/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/genie/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,1 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging-genie-synapse-org-websitebucket-8tvf8x9dwuqe
+export CF_STAGING_DIST_ID=E1ULMEK3W2VXOF

--- a/apps/portals/nf/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/nf/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,1 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://prod.nf.synapse.org
+export CF_PRODUCTION_DIST_ID=E28YRVVHKPHIB1

--- a/apps/portals/nf/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/nf/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,1 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging.nf.synapse.org
+export CF_STAGING_DIST_ID=E1I74M7N2K06XT

--- a/apps/portals/standards/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/standards/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,1 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://prod.standards.synapse.org
+export CF_PRODUCTION_DIST_ID=E1TUIXZC1K5CUN

--- a/apps/portals/standards/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/standards/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,1 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging.standards.synapse.org
+export CF_STAGING_DIST_ID=EZWEDLI9NN764

--- a/apps/portals/stopadportal/src/config/scripts/exportS3ProductionBucketName.sh
+++ b/apps/portals/stopadportal/src/config/scripts/exportS3ProductionBucketName.sh
@@ -1,1 +1,2 @@
 export S3_PRODUCTION_BUCK_LOCATION=s3://stopadportal.synapse.org
+export CF_PRODUCTION_DIST_ID=E3T3BUO9I33NZX

--- a/apps/portals/stopadportal/src/config/scripts/exportS3StagingBucketName.sh
+++ b/apps/portals/stopadportal/src/config/scripts/exportS3StagingBucketName.sh
@@ -1,1 +1,2 @@
 export S3_STAGING_BUCKET_LOCATION=s3://staging.stopadportal.synapse.org
+export CF_STAGING_DIST_ID=E27UC0961FPD8C


### PR DESCRIPTION
This PR adds an environment variable to specify the distribution ID for each portal (staging and prod).
Another PR will modify run.sh to create an invalidation for the distribution.


