### PR TITLE
PORTALS-3435: use  instead of  to assign -Dsonar.pullrequest.key

### DIFF
--- a/.github/workflows/sonarqube-scan-pr.yml
+++ b/.github/workflows/sonarqube-scan-pr.yml
@@ -23,4 +23,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: packages/synapse-react-client
-          args: '-Dsonar.pullrequest.key: ${{ github.event.pull_request.number }}'
+          args: '-Dsonar.pullrequest.key=${{ github.event.pull_request.number }}'


### PR DESCRIPTION
@tschaffter the original workflow failed because I assigned the env variable incorrectly using `:` instead of `=`