### PR TITLE
PORTALS-3435: pass target and source branch to sonar scan to pick up changed files

### DIFF
--- a/.github/workflows/sonarqube-scan-pr.yml
+++ b/.github/workflows/sonarqube-scan-pr.yml
@@ -23,4 +23,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: packages/synapse-react-client
-          args: '-Dsonar.pullrequest.key=${{ github.event.pull_request.number }}'
+          args: |
+            '-Dsonar.pullrequest.key=${{ github.event.pull_request.number }}' \
+            '-Dsonar.branch.target=${{ github.base_ref }}' \
+            '-Dsonar.branch.name=${{ github.ref }}'


### PR DESCRIPTION
While the sonar scan is now running on PR and commenting its analysis, it has yet to pick up code changes. Perhaps passing branch information in addition to the PR number will give the scan the information it needs to compare code.