### PR TITLE
default citation to nature for education and tools

### DIFF
--- a/apps/portals/cancercomplexity/src/config/synapseConfigs/education.ts
+++ b/apps/portals/cancercomplexity/src/config/synapseConfigs/education.ts
@@ -16,6 +16,7 @@ export const educationSchema: GenericCardSchema = {
   subTitle: 'topic',
   description: 'description',
   includeCitation: true,
+  defaultCitationFormat: 'nature',
   secondaryLabels: [
     'link',
     'activityType',

--- a/apps/portals/cancercomplexity/src/config/synapseConfigs/tools.ts
+++ b/apps/portals/cancercomplexity/src/config/synapseConfigs/tools.ts
@@ -14,6 +14,7 @@ export const toolsSchema: GenericCardSchema = {
   title: 'toolName',
   description: 'description',
   includeCitation: true,
+  defaultCitationFormat: 'nature',
   secondaryLabels: [
     'inputData',
     'inputFormat',


### PR DESCRIPTION
I forgot to update the default citation format to 'nature' for the education and tools pages.