### PR TITLE
Small styling tweaks and include DiscussionThread component in SynapseComponents

### DIFF
--- a/packages/synapse-react-client/src/components/Forum/DiscussionReply.tsx
+++ b/packages/synapse-react-client/src/components/Forum/DiscussionReply.tsx
@@ -14,6 +14,7 @@ import WarningDialog from '../SynapseForm/WarningDialog'
 import { displayToast } from '../ToastMessage/ToastMessage'
 import { UserBadge } from '../UserCard/UserBadge'
 import { ForumThreadEditor } from './ForumThreadEditor'
+import { Box } from '@mui/material'
 
 export type DiscussionReplyProps = {
   reply: DiscussionReplyBundle
@@ -63,7 +64,14 @@ export function DiscussionReply(props: DiscussionReplyProps) {
                   <span>
                     posted {formatDate(dayjs(reply.createdOn), 'M/D/YYYY')}
                   </span>
-                  <div style={{ float: 'right' }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      justifyContent: 'flex-end',
+                      marginTop: { xs: '8px', sm: 0 },
+                      float: { sm: 'right' },
+                    }}
+                  >
                     <button onClick={() => onClickLink()}>
                       <IconSvg icon="link" />
                     </button>
@@ -77,7 +85,7 @@ export function DiscussionReply(props: DiscussionReplyProps) {
                         <IconSvg icon="delete" />
                       </button>
                     )}
-                  </div>
+                  </Box>
                 </div>
               </div>
               <ForumThreadEditor

--- a/packages/synapse-react-client/src/components/Forum/DiscussionThread.tsx
+++ b/packages/synapse-react-client/src/components/Forum/DiscussionThread.tsx
@@ -180,7 +180,12 @@ export function DiscussionThread(props: DiscussionThreadProps) {
       ) : (
         <></>
       )}
-      <div className="control-container">
+      <Box
+        sx={{
+          float: 'right',
+          margin: { xs: '8px 0', sm: '0 24px 0 0' },
+        }}
+      >
         {threadData?.isDeleted ? (
           <button onClick={() => setShowRestoreModal(true)}>
             <IconSvg icon="restore" label="Restore deleted thread" />
@@ -227,7 +232,7 @@ export function DiscussionThread(props: DiscussionThreadProps) {
             ) : null}
           </>
         )}
-      </div>
+      </Box>
       <Box sx={{ mt: 2, mb: 3 }}>
         {!showReplyEditor1 ? (
           <TextField

--- a/packages/synapse-react-client/src/umd.index.ts
+++ b/packages/synapse-react-client/src/umd.index.ts
@@ -18,6 +18,7 @@ import { EvaluationCard } from './components/Evaluation/EvaluationCard'
 import { EvaluationEditorPage } from './components/Evaluation/EvaluationEditorPage'
 import FavoritesPage from './components/favorites/FavoritesPage'
 import ForumSearch from './components/ForumSearch/ForumSearch'
+import { DiscussionThread } from './components/Forum/DiscussionThread'
 import FullWidthAlert from './components/FullWidthAlert/FullWidthAlert'
 import { HasAccessV2 as HasAccess } from './components/HasAccess/HasAccessV2'
 import { HelpPopover } from './components/HelpPopover/HelpPopover'
@@ -160,6 +161,7 @@ const SynapseComponents = {
   StandaloneQueryWrapper,
   ChangePassword,
   ForumSearch,
+  DiscussionThread,
   ReviewerDashboard,
   ProvenanceGraph,
   TrashCanList,


### PR DESCRIPTION
Before:
<img width="266" alt="Screenshot 2025-04-01 at 2 29 05 PM" src="https://github.com/user-attachments/assets/771c8ea3-880f-4435-8cce-48961c5d45b4" />

After:
<img width="225" alt="Screenshot 2025-04-01 at 3 40 49 PM" src="https://github.com/user-attachments/assets/87907fe7-dd73-4baa-ae7a-173a1b6340cf" />
