### PR TITLE
restore sonar scan using PR number instead of branch name to enable P…

### DIFF
--- a/.github/workflows/sonarqube-scan-pr.yml
+++ b/.github/workflows/sonarqube-scan-pr.yml
@@ -24,5 +24,4 @@ jobs:
         with:
           projectBaseDir: packages/synapse-react-client
           args: |
-            '-Dsonar.branch.target=${{ github.base_ref }}' \
-            '-Dsonar.branch.name=${{ github.head_ref }}'
+            '-Dsonar.pullrequest.key=${{ github.event.pull_request.number }}'


### PR DESCRIPTION
…R comments.

I tried running the sonar scan by providing either PR number or branch. Using the PR number has the best github integration because it leaves comments. However, both options are still failing to reliably pick up code changes.