### PR TITLE
Acronym column should link to the standard

### DIFF
--- a/apps/portals/standards/src/config/resources.ts
+++ b/apps/portals/standards/src/config/resources.ts
@@ -1,1 +1,25 @@
-export const dataSql = `SELECT * FROM syn65676531`
+const DST_TABLE_ID = 'syn65676531'
+// can replace with specific version if wanted
+
+// for the Explore page table:
+export const dataSql = `
+    SELECT
+        concat('[', acronym, '](/Explore/Standard/DetailsPage?id=', id, ')') as acronym,
+            name, category, collections, topic as topics, relevantOrgAcronym as organizations, isOpen, registration FROM ${DST_TABLE_ID}
+`
+// concat('/Explore/Standard/DetailsPage?id=', id) as link, acronym,
+
+// for details page:
+export const standardsDetailsPageSQL = `
+    SELECT  acronym,
+            name as standardName,
+            description,
+            category,
+            collections,
+            topic as topics,
+            relevantOrgAcronym as orranizations,
+            responsibleOrgName as SDO,
+            isOpen,
+            registration
+    FROM ${DST_TABLE_ID}
+`

--- a/apps/portals/standards/src/config/synapseConfigs/data.ts
+++ b/apps/portals/standards/src/config/synapseConfigs/data.ts
@@ -9,11 +9,24 @@ import { dataSql } from '../resources'
 
 const dataRgbIndex = 0
 export const dataColumnLinks: LabelLinkConfig = [
-  {
+  /* {
     isMarkdown: false,
     baseURL: 'Explore/Standard/DetailsPage',
-    URLColumnName: 'id',
     matchColumnName: 'id',
+    URLColumnName: 'id',
+  },
+  {
+    isMarkdown: false,
+    matchColumnName: 'acronym',
+    linkColumnName: 'link',
+  },
+  */
+  {
+    isMarkdown: true,
+    // the column whose value will be used for the markdown
+    matchColumnName: 'acronym',
+    // If set, also show a tooltip
+    // tooltipText?: string
   },
 ]
 
@@ -32,6 +45,7 @@ export const dataQueryWrapperPlotNavProps: QueryWrapperPlotNavProps = {
   facetsToPlot: [
     'topic',
     // 'Organizations',
+    'relevantOrgName',
   ],
   initialPlotType: 'BAR',
 }


### PR DESCRIPTION
Fixes https://github.com/bridge2ai/b2ai-standards-registry/issues/251

    From apps/portals/standards/src/config/synapseConfigs/data.ts:

    export const dataColumnLinks: LabelLinkConfig = [
 __this seems to be the usual way, but can't have different col in the url and the link text:__

    {
      isMarkdown: false,
      baseURL: 'Explore/Standard/DetailsPage',
      matchColumnName: 'id',
      URLColumnName: 'id',
    },
 __this is simple and works, but then the link column also shows up the the explore table, which we don't want:__

    {
      isMarkdown: false,
      matchColumnName: 'acronym',
      linkColumnName: 'link',
    },

 __this is with markdown:__

      {
        isMarkdown: true,
        matchColumnName: 'acronym',
      },
  
It requires acronym to be defined in dataSql like:

     concat('[', acronym, '](/Explore/Standard/DetailsPage?id=', id, ')') as acronym
