### PR TITLE
Fixes https://github.com/bridge2ai/b2ai-standards-registry/issues/210

### DIFF
--- a/apps/portals/standards/src/config/columnAliases.ts
+++ b/apps/portals/standards/src/config/columnAliases.ts
@@ -1,8 +1,6 @@
 export default {
-  concerns_data_topic: 'Concerns Data Topic',
-  registration: 'Requires Registration?',
-  responsibleOrgName: 'Responsible Organization',
-  relevantOrgName: 'Relevant Organization',
-  name: 'Name',
+  organizations: 'Relevant Organizations',
+  standardName: 'Name of Standard',
   isOpen: 'Is Open?',
+  registration: 'Requires Registration?',
 }

--- a/apps/portals/standards/src/config/resources.ts
+++ b/apps/portals/standards/src/config/resources.ts
@@ -5,8 +5,13 @@ const DST_TABLE_ID = 'syn65676531'
 export const dataSql = `
     SELECT
         concat('[', acronym, '](/Explore/Standard/DetailsPage?id=', id, ')') as acronym,
-            name, category, collections, topic as topics, relevantOrgAcronym as organizations, isOpen, registration FROM ${DST_TABLE_ID}
+            name, category, collections, relevantOrgAcronym as organizations, isOpen, registration FROM ${DST_TABLE_ID}
 `
+// removed topic column above to address @jay-hodgson's comment
+//  https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/1612#discussion_r2029425831
+//  Topic still shows up as a facet on the explore page but not as a column,
+//  which seems fine. It's not limiting the number of rows displayed now.
+
 // concat('/Explore/Standard/DetailsPage?id=', id) as link, acronym,
 
 // for details page:
@@ -15,11 +20,12 @@ export const standardsDetailsPageSQL = `
             acronym,
             name as standardName,
             description,
+            URL as url,
             category,
             collections,
             topic as topics,
             relevantOrgAcronym as organizations,
-            responsibleOrgName as SDO,
+            COALESCE(responsibleOrgName, 'No responsible org listed') as SDO,
             isOpen,
             relatedTo,
             trainingResources,

--- a/apps/portals/standards/src/pages/StandardsDetailsPage.tsx
+++ b/apps/portals/standards/src/pages/StandardsDetailsPage.tsx
@@ -25,8 +25,8 @@ export const standardsCardSchema: GenericCardSchema = {
   title: 'acronym',
   subTitle: 'standardName',
   description: 'description',
-  link: 'URL',
-  secondaryLabels: ['SDO', 'collections', 'topic'],
+  link: 'url',
+  secondaryLabels: ['SDO', 'collections', 'topics'],
 }
 
 export const linkedStandardCardConfiguration: CardConfiguration = {
@@ -59,9 +59,9 @@ export const standardDetailsPageContent: DetailsPageContentType = [
                 rowData={context.rowData.values ?? []}
                 headers={context.rowSet?.headers ?? []}
                 displayedColumns={[
-                  'name',
-                  'responsibleOrgName',
-                  'relevantOrgName',
+                  'standardName',
+                  'SDO',
+                  'organizations',
                   'isOpen',
                   'registration',
                 ]}


### PR DESCRIPTION
- Fixed column names for secondary labels and About this standard.
- Got rid of topic in Explore view so it wouldn't keep limiting the number of rows displayed
- Missing SDO will appear as 'No responsible org listed'