### PR TITLE
SWC-7291

### DIFF
--- a/packages/synapse-react-client/src/components/SageResourcesPopover/SageResourcesPopover.tsx
+++ b/packages/synapse-react-client/src/components/SageResourcesPopover/SageResourcesPopover.tsx
@@ -24,7 +24,7 @@ export function SageResourcesPopover({
 }: SageResourcesPopoverProps) {
   const theme = useTheme()
   const open = Boolean(anchorEl)
-  const hostname = 'www.synapse.org'
+  const hostname = window.location.hostname
   const additionalFilters: ColumnSingleValueQueryFilter[] | undefined =
     filterByType
       ? [
@@ -89,7 +89,13 @@ export function SageResourcesPopover({
           <Grid item xs={12} lg={9}>
             <Grid container>
               {sourceAppConfigs
-                ?.filter(config => !config.appURL.includes(hostname))
+                ?.filter(config => {
+                  if (config.appURL.toLowerCase().startsWith('http')) {
+                    const url = new URL(config.appURL)
+                    return url.hostname !== hostname
+                  }
+                  return true
+                })
                 .map(config => {
                   if (config.isPublicized) {
                     return (

--- a/packages/synapse-react-client/src/components/SageResourcesPopover/SageResourcesPopover.tsx
+++ b/packages/synapse-react-client/src/components/SageResourcesPopover/SageResourcesPopover.tsx
@@ -25,19 +25,26 @@ export function SageResourcesPopover({
   const theme = useTheme()
   const open = Boolean(anchorEl)
   const hostname = window.location.hostname
-  const additionalFilters: ColumnSingleValueQueryFilter[] | undefined =
-    filterByType
-      ? [
-          {
-            isDefiningCondition: false,
-            concreteType:
-              'org.sagebionetworks.repo.model.table.ColumnSingleValueQueryFilter',
-            columnName: 'portalType',
-            operator: ColumnSingleValueFilterOperator.EQUAL,
-            values: [filterByType],
-          },
-        ]
-      : undefined
+
+  const additionalFilters: ColumnSingleValueQueryFilter[] = [
+    {
+      concreteType:
+        'org.sagebionetworks.repo.model.table.ColumnSingleValueQueryFilter',
+      columnName: 'isPublicized',
+      operator: ColumnSingleValueFilterOperator.EQUAL,
+      values: ['true'],
+    },
+  ]
+  if (filterByType) {
+    additionalFilters.push({
+      isDefiningCondition: false,
+      concreteType:
+        'org.sagebionetworks.repo.model.table.ColumnSingleValueQueryFilter',
+      columnName: 'portalType',
+      operator: ColumnSingleValueFilterOperator.EQUAL,
+      values: [filterByType],
+    })
+  }
   const sourceAppConfigs = useSourceAppConfigs(
     sourceAppConfigTableID,
     additionalFilters,
@@ -96,53 +103,47 @@ export function SageResourcesPopover({
                   }
                   return true
                 })
-                .map(config => {
-                  if (config.isPublicized) {
-                    return (
-                      <Grid
-                        item
-                        xs={12}
-                        sm={6}
-                        lg={4}
-                        className="sourceAppItem"
-                        key={config.appId}
+                .map(config => (
+                  <Grid
+                    item
+                    xs={12}
+                    sm={6}
+                    lg={4}
+                    className="sourceAppItem"
+                    key={config.appId}
+                    sx={{
+                      p: '30px',
+                      border: '1px solid #F1F3F5',
+                      '&:hover': {
+                        backgroundColor: '#d7dee433',
+                        cursor: 'pointer',
+                      },
+                    }}
+                  >
+                    <div
+                      onClick={() => {
+                        window.open(config.appURL, '_blank')
+                        onClose()
+                      }}
+                    >
+                      <Box
                         sx={{
-                          p: '30px',
-                          border: '1px solid #F1F3F5',
-                          '&:hover': {
-                            backgroundColor: '#d7dee433',
-                            cursor: 'pointer',
+                          pb: '10px',
+                          img: {
+                            maxHeight: '50px',
+                            height: '50px',
+                            maxWidth: '100%',
                           },
                         }}
                       >
-                        <div
-                          onClick={() => {
-                            window.open(config.appURL, '_blank')
-                            onClose()
-                          }}
-                        >
-                          <Box
-                            sx={{
-                              pb: '10px',
-                              img: {
-                                maxHeight: '50px',
-                                height: '50px',
-                                maxWidth: '100%',
-                              },
-                            }}
-                          >
-                            {config.logo}
-                          </Box>
-                          <Typography variant="body1" sx={{ fontWeight: 500 }}>
-                            {config.shortDescription}
-                          </Typography>
-                        </div>
-                      </Grid>
-                    )
-                  } else {
-                    return false
-                  }
-                })}
+                        {config.logo}
+                      </Box>
+                      <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                        {config.shortDescription}
+                      </Typography>
+                    </div>
+                  </Grid>
+                ))}
             </Grid>
           </Grid>
         </Grid>

--- a/packages/synapse-react-client/src/components/SageResourcesPopover/SageResourcesPopover.tsx
+++ b/packages/synapse-react-client/src/components/SageResourcesPopover/SageResourcesPopover.tsx
@@ -1,20 +1,47 @@
 import { useSourceAppConfigs } from '@/utils/hooks'
 import { Box, Button, Grid, Popover, Typography, useTheme } from '@mui/material'
+import {
+  ColumnSingleValueQueryFilter,
+  ColumnSingleValueFilterOperator,
+} from '@sage-bionetworks/synapse-types'
 
 export type SageResourcesPopoverProps = {
   sourceAppConfigTableID?: string
   anchorEl: HTMLElement | null
   onClose: () => void
+  resourceName?: string
+  description?: string
+  filterByType?: 'SynapsePortal' | 'SageSolution'
 }
 
 export function SageResourcesPopover({
   sourceAppConfigTableID = 'syn45291362',
   anchorEl,
   onClose,
+  resourceName = 'Portals',
+  description = 'Community data portals in Sage Bionetworks serve as specialized platforms designed to facilitate open data sharing and collaboration among researchers.',
+  filterByType,
 }: SageResourcesPopoverProps) {
   const theme = useTheme()
   const open = Boolean(anchorEl)
-  const sourceAppConfigs = useSourceAppConfigs(sourceAppConfigTableID)
+  const hostname = 'www.synapse.org'
+  const additionalFilters: ColumnSingleValueQueryFilter[] | undefined =
+    filterByType
+      ? [
+          {
+            isDefiningCondition: false,
+            concreteType:
+              'org.sagebionetworks.repo.model.table.ColumnSingleValueQueryFilter',
+            columnName: 'portalType',
+            operator: ColumnSingleValueFilterOperator.EQUAL,
+            values: [filterByType],
+          },
+        ]
+      : undefined
+  const sourceAppConfigs = useSourceAppConfigs(
+    sourceAppConfigTableID,
+    additionalFilters,
+  )
   return (
     <>
       <Popover
@@ -38,12 +65,10 @@ export function SageResourcesPopover({
                 variant="headline1"
                 sx={{ fontSize: '40px', pb: '30px', fontWeight: 600 }}
               >
-                Portals
+                {resourceName}
               </Typography>
               <Typography variant="body1" sx={{ pb: '10px', fontWeight: 500 }}>
-                Community data portals in Sage Bionetworks serve as specialized
-                platforms designed to facilitate open data sharing and
-                collaboration among researchers.
+                {description}
               </Typography>
               <Button
                 type="button"
@@ -57,59 +82,61 @@ export function SageResourcesPopover({
                 }}
                 href="https://accounts.synapse.org/sageresources"
               >
-                See All Solutions
+                See All {resourceName}
               </Button>
             </Box>
           </Grid>
           <Grid item xs={12} lg={9}>
             <Grid container>
-              {sourceAppConfigs?.map(config => {
-                if (config.isPublicized) {
-                  return (
-                    <Grid
-                      item
-                      xs={12}
-                      sm={6}
-                      lg={4}
-                      className="sourceAppItem"
-                      key={config.appId}
-                      sx={{
-                        p: '30px',
-                        border: '1px solid #F1F3F5',
-                        '&:hover': {
-                          backgroundColor: '#d7dee433',
-                          cursor: 'pointer',
-                        },
-                      }}
-                    >
-                      <div
-                        onClick={() => {
-                          window.open(config.appURL, '_blank')
-                          onClose()
+              {sourceAppConfigs
+                ?.filter(config => !config.appURL.includes(hostname))
+                .map(config => {
+                  if (config.isPublicized) {
+                    return (
+                      <Grid
+                        item
+                        xs={12}
+                        sm={6}
+                        lg={4}
+                        className="sourceAppItem"
+                        key={config.appId}
+                        sx={{
+                          p: '30px',
+                          border: '1px solid #F1F3F5',
+                          '&:hover': {
+                            backgroundColor: '#d7dee433',
+                            cursor: 'pointer',
+                          },
                         }}
                       >
-                        <Box
-                          sx={{
-                            pb: '10px',
-                            img: {
-                              maxHeight: '50px',
-                              height: '50px',
-                              maxWidth: '100%',
-                            },
+                        <div
+                          onClick={() => {
+                            window.open(config.appURL, '_blank')
+                            onClose()
                           }}
                         >
-                          {config.logo}
-                        </Box>
-                        <Typography variant="body1" sx={{ fontWeight: 500 }}>
-                          {config.shortDescription}
-                        </Typography>
-                      </div>
-                    </Grid>
-                  )
-                } else {
-                  return false
-                }
-              })}
+                          <Box
+                            sx={{
+                              pb: '10px',
+                              img: {
+                                maxHeight: '50px',
+                                height: '50px',
+                                maxWidth: '100%',
+                              },
+                            }}
+                          >
+                            {config.logo}
+                          </Box>
+                          <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                            {config.shortDescription}
+                          </Typography>
+                        </div>
+                      </Grid>
+                    )
+                  } else {
+                    return false
+                  }
+                })}
             </Grid>
           </Grid>
         </Grid>

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseHomepageNavBar.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseHomepageNavBar.tsx
@@ -86,6 +86,13 @@ export function SynapseHomepageNavBar({
     setPortalResourcesAnchorEl(null)
   }
 
+  // Sage solutions dropdown
+  const [sageSolutionsAnchorEl, setSageSolutionsAnchorEl] =
+    useState<HTMLElement | null>(null)
+  const handleCloseSageSolutions = () => {
+    setSageSolutionsAnchorEl(null)
+  }
+
   const onLoginClicked = () => {
     // Navigate to the LoginPlace, which will set a cookie that will be used to redirect back from OneSage
     gotoPlace(LOGIN_LINK)
@@ -129,6 +136,12 @@ export function SynapseHomepageNavBar({
             onClick={event => setPortalResourcesAnchorEl(event.currentTarget)}
           >
             Portals
+          </Button>
+          <Button
+            sx={navTextButtonSx}
+            onClick={event => setSageSolutionsAnchorEl(event.currentTarget)}
+          >
+            Solutions
           </Button>
           <Button
             sx={{ ...navTextButtonSx, mr: '15px' }}
@@ -177,6 +190,14 @@ export function SynapseHomepageNavBar({
       <SageResourcesPopover
         anchorEl={portalResourcesAnchorEl}
         onClose={handleClosePortalResources}
+        filterByType="SynapsePortal"
+      />
+      <SageResourcesPopover
+        anchorEl={sageSolutionsAnchorEl}
+        onClose={handleCloseSageSolutions}
+        filterByType="SageSolution"
+        resourceName="Solutions"
+        description="Innovative tools of the Synapse ecosystem to accelerate data curation and crowd-sourced data science competitions"
       />
       {isSmallView && (
         <Box
@@ -249,6 +270,14 @@ export function SynapseHomepageNavBar({
               }}
             >
               Portals
+            </StyledMenuItem>
+            <StyledMenuItem
+              onClick={event => {
+                setSageSolutionsAnchorEl(event.currentTarget)
+                handleCloseSageSolutions()
+              }}
+            >
+              Solutions
             </StyledMenuItem>
             <StyledMenuItem
               onClick={() => {

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/__snapshots__/SynapseHomepageV2.test.tsx.snap
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/__snapshots__/SynapseHomepageV2.test.tsx.snap
@@ -100,6 +100,13 @@ exports[`SynapseHomepageV2 Snapshot test Basic home page 1`] = `
         >
           Portals
         </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-144rw15-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Solutions
+        </button>
         <a
           class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-116jjic-MuiButtonBase-root-MuiButton-root"
           href="https://sagebionetworks.org/"

--- a/packages/synapse-react-client/src/utils/hooks/useSourceAppConfigs.tsx
+++ b/packages/synapse-react-client/src/utils/hooks/useSourceAppConfigs.tsx
@@ -3,6 +3,7 @@ import { useGetQueryResultBundleWithAsyncStatus } from '@/synapse-queries'
 import Palettes from '@/theme/palette/Palettes'
 import { PaletteOptions } from '@mui/material'
 import { BUNDLE_MASK_QUERY_RESULTS } from '../SynapseConstants'
+import { QueryFilter } from '@sage-bionetworks/synapse-types'
 
 export type SourceAppConfig = {
   appId: string // app ID used in the query params
@@ -31,12 +32,14 @@ export const STATIC_SOURCE_APP_CONFIG: SourceAppConfig = {
 
 export const useSourceAppConfigs = (
   sourceAppConfigTableID: string,
+  additionalFilters?: QueryFilter[],
 ): SourceAppConfig[] | undefined => {
   const { data: tableQueryResult } = useGetQueryResultBundleWithAsyncStatus({
     entityId: sourceAppConfigTableID,
     query: {
       sql: `SELECT * FROM ${sourceAppConfigTableID}`,
       limit: 75,
+      additionalFilters,
     },
     partMask: BUNDLE_MASK_QUERY_RESULTS,
     concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',


### PR DESCRIPTION
Added `portalType` to the [Sage Apps table](https://www.synapse.org/Synapse:syn45291362).  Use it to filter source apps.  Currently it has a controlled vocabulary of 2 values, 'SynapsePortal' and 'SageSolution'.  New filter applied to query when the dropdown is shown.