### PR TITLE
PORTALS-3157

### DIFF
--- a/apps/portals/adknowledgeportal/src/config/navbarConfig.ts
+++ b/apps/portals/adknowledgeportal/src/config/navbarConfig.ts
@@ -48,4 +48,5 @@ export const navbarConfig: NavbarConfig = {
       path: 'https://help.adknowledgeportal.org/apd/',
     },
   ],
+  isPortalsDropdownEnabled: false,
 }

--- a/apps/portals/ampals/src/config/navbarConfig.ts
+++ b/apps/portals/ampals/src/config/navbarConfig.ts
@@ -53,4 +53,5 @@ export const navbarConfig: NavbarConfig = {
       path: 'https://help.ampals.org/help/',
     },
   ],
+  isPortalsDropdownEnabled: false,
 }

--- a/apps/portals/arkportal/src/config/navbarConfig.ts
+++ b/apps/portals/arkportal/src/config/navbarConfig.ts
@@ -28,4 +28,5 @@ export const navbarConfig: NavbarConfig = {
       path: 'https://help.arkportal.org/help/',
     },
   ],
+  isPortalsDropdownEnabled: false,
 }

--- a/apps/portals/bsmn/src/config/navbarConfig.ts
+++ b/apps/portals/bsmn/src/config/navbarConfig.ts
@@ -30,4 +30,5 @@ export const navbarConfig: NavbarConfig = {
       path: '/About',
     },
   ],
+  isPortalsDropdownEnabled: false,
 }

--- a/apps/portals/cancercomplexity/src/config/navbarConfig.ts
+++ b/apps/portals/cancercomplexity/src/config/navbarConfig.ts
@@ -53,4 +53,5 @@ export const navbarConfig: NavbarConfig = {
       path: 'https://help.cancercomplexity.synapse.org/',
     },
   ],
+  isPortalsDropdownEnabled: false,
 }

--- a/apps/portals/challenges/src/config/navbarConfig.ts
+++ b/apps/portals/challenges/src/config/navbarConfig.ts
@@ -8,4 +8,5 @@ export const navbarConfig: NavbarConfig = {
       children: [{ name: 'Listed Challenges', path: '/#Listed Challenges' }],
     },
   ],
+  isPortalsDropdownEnabled: false,
 }

--- a/apps/portals/digitalhealth/src/config/navbarConfig.ts
+++ b/apps/portals/digitalhealth/src/config/navbarConfig.ts
@@ -32,4 +32,5 @@ export const navbarConfig: NavbarConfig = {
       path: 'https://help.dhealth.synapse.org/doc/',
     },
   ],
+  isPortalsDropdownEnabled: false,
 }

--- a/apps/portals/eliteportal/src/config/navbarConfig.ts
+++ b/apps/portals/eliteportal/src/config/navbarConfig.ts
@@ -51,4 +51,5 @@ export const navbarConfig: NavbarConfig = {
       path: 'https://help.eliteportal.org/help/',
     },
   ],
+  isPortalsDropdownEnabled: true,
 }

--- a/apps/portals/genie/src/config/navbarConfig.ts
+++ b/apps/portals/genie/src/config/navbarConfig.ts
@@ -33,4 +33,5 @@ export const navbarConfig: NavbarConfig = {
       path: '/Help',
     },
   ],
+  isPortalsDropdownEnabled: false,
 }

--- a/apps/portals/nf/src/config/navbarConfig.ts
+++ b/apps/portals/nf/src/config/navbarConfig.ts
@@ -96,4 +96,5 @@ export const navbarConfig: NavbarConfig = {
     { name: 'News', path: 'https://news.nfdataportal.org/' },
     { name: 'Help', path: 'https://help.nf.synapse.org/NFdocs/' },
   ],
+  isPortalsDropdownEnabled: false,
 }

--- a/apps/portals/standards/src/config/navbarConfig.ts
+++ b/apps/portals/standards/src/config/navbarConfig.ts
@@ -23,4 +23,5 @@ export const navbarConfig: NavbarConfig = {
       path: 'https://github.com/bridge2ai/b2ai-standards-registry/tree/main?tab=readme-ov-file#user-documentation',
     },
   ],
+  isPortalsDropdownEnabled: false,
 }

--- a/apps/portals/stopadportal/src/config/navbarConfig.ts
+++ b/apps/portals/stopadportal/src/config/navbarConfig.ts
@@ -25,4 +25,5 @@ export const navbarConfig: NavbarConfig = {
       ],
     },
   ],
+  isPortalsDropdownEnabled: false,
 }

--- a/apps/synapse-portal-framework/src/components/navbar/Navbar.tsx
+++ b/apps/synapse-portal-framework/src/components/navbar/Navbar.tsx
@@ -1,6 +1,5 @@
 import { RESPONSIVE_SIDE_PADDING } from '@/utils'
 import { Box, Button, Divider, Menu, MenuItem } from '@mui/material'
-import { FeatureFlagEnum } from '@sage-bionetworks/synapse-types'
 import { MouseEvent, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 import {

--- a/apps/synapse-portal-framework/src/components/navbar/Navbar.tsx
+++ b/apps/synapse-portal-framework/src/components/navbar/Navbar.tsx
@@ -11,7 +11,10 @@ import {
   SynapseQueries,
   useSynapseContext,
 } from 'synapse-react-client'
-import { BackendDestinationEnum, getEndpoint } from 'synapse-react-client/utils/functions/index'
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from 'synapse-react-client/utils/functions/index'
 import NavLink from '../NavLink'
 import NavUserLink from '../NavUserLink'
 import { usePortalContext } from '../PortalContext'
@@ -30,6 +33,7 @@ export type NavbarConfig = {
     path: string
     children?: { name: string; path: string }[]
   }[]
+  isPortalsDropdownEnabled: boolean
 }
 
 const synapseQuickLinks: SynapseSettingLink[] = [
@@ -56,9 +60,7 @@ export default function Navbar() {
   const isSignedIn = !!accessToken
   const navigate = useNavigate()
   const { data: userProfile } = SynapseQueries.useGetCurrentUserProfile()
-  const isPortalsDropdownEnabled = SynapseQueries.useGetFeatureFlag(
-    FeatureFlagEnum.PORTALS_DROPDOWN,
-  )
+  const { isPortalsDropdownEnabled } = navbarConfig
   const [showMenu, setShowMenu] = useState(false)
   const openBtnRef = useRef<HTMLDivElement>(null)
 

--- a/packages/synapse-types/src/FeatureFlags.ts
+++ b/packages/synapse-types/src/FeatureFlags.ts
@@ -16,9 +16,6 @@ export enum FeatureFlagEnum {
   // If enabled, show the chatbot entrypoint from the new Synapse Homepage
   HOMEPAGE_CHATBOT = 'HOMEPAGE_CHATBOT',
 
-  // If enabled, show the Portals dropdown on the portal site (to discover other portals)
-  PORTALS_DROPDOWN = 'PORTALS_DROPDOWN',
-
   // If enabled, account settings will link to a page to manage webhooks
   WEBHOOKS_UI = 'WEBHOOKS_UI',
 }


### PR DESCRIPTION
Enable the PORTALS nav item on ELITE, do not show on other portals (for now).

I think the flag can also be removed from the stack builder (like [the AR modal wizard flag](https://github.com/Sage-Bionetworks/Synapse-Stack-Builder/pull/701/files)), since undefined should be the same as 'false'.