### PR TITLE
Standards Registry: Katie suggested using "relevantOrgName" (organizations) rather than responsibleOrgName

### DIFF
--- a/apps/portals/standards/src/pages/HomePage.tsx
+++ b/apps/portals/standards/src/pages/HomePage.tsx
@@ -30,10 +30,10 @@ export default function HomePage() {
                 explorePagePath: '/Explore',
                 exploreObjectType: 'Standards',
                 plotsConfig: {
-                  sql: `${dataSql} where responsibleOrgName is not null`,
+                  sql: `${dataSql} where organizations is not null`,
                   configs: [
                     {
-                      facetsToPlot: ['topic', 'responsibleOrgName'],
+                      facetsToPlot: ['topic', 'organizations'],
                       unitDescription: 'standard',
                       plotType: 'BAR',
                       columnAliases: columnAliases,


### PR DESCRIPTION
<img width="1496" alt="Screenshot 2025-04-11 at 10 11 48 AM" src="https://github.com/user-attachments/assets/a25e0632-56ef-4948-a140-f677e74aa220" />
