### PR TITLE
Portals 3386 f/u - Fix download cart button

### DIFF
--- a/packages/synapse-react-client/src/components/EntityDownloadConfirmation/EntityDownloadConfirmation.tsx
+++ b/packages/synapse-react-client/src/components/EntityDownloadConfirmation/EntityDownloadConfirmation.tsx
@@ -68,7 +68,7 @@ export function EntityDownloadConfirmation({
     onIsLoadingChange(isLoading)
   }, [isLoading, onIsLoadingChange])
 
-  if (isLoading || (!isLoading && entity)) {
+  if (isLoading) {
     if (
       entityConcreteType !== 'org.sagebionetworks.repo.model.Folder' &&
       entityConcreteType !==

--- a/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
@@ -193,6 +193,9 @@ export function GenericCard(props: GenericCardProps) {
               marginLeft: 'auto',
               paddingTop: '21px',
               paddingRight: '40px',
+              display: 'flex',
+              flexDirection: 'row',
+              gap: '10px',
             }}
           >
             {cardTopButtons}


### PR DESCRIPTION
This PR fixes bad logic that prevented the Download button to trigger download cart logic. Also, it spaces card buttons horizontally instead of vertically