### PR TITLE
Portals 3553 - Add test coverage to sonar scan

### DIFF
--- a/packages/synapse-react-client/jest.config.cjs
+++ b/packages/synapse-react-client/jest.config.cjs
@@ -42,5 +42,5 @@ module.exports = {
       },
     ],
   ],
-  coverageReporters: ['text-summary', 'html', 'locv'],
+  coverageReporters: ['text-summary', 'html', 'lcov'],
 }

--- a/packages/synapse-react-client/jest.config.cjs
+++ b/packages/synapse-react-client/jest.config.cjs
@@ -42,5 +42,5 @@ module.exports = {
       },
     ],
   ],
-  coverageReporters: ['text-summary', 'html'],
+  coverageReporters: ['text-summary', 'html', 'locv'],
 }

--- a/packages/synapse-react-client/sonar-project.properties
+++ b/packages/synapse-react-client/sonar-project.properties
@@ -1,3 +1,4 @@
 sonar.projectKey=sage-bionetworks_synapse-web-monorepo_src
 sonar.organization=sage-bionetworks
 sonar.project.monorepo.enabled=true
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info


### PR DESCRIPTION
Point the sonar properties to an `lcov` reporter for SRC `test:coverage` to get coverage analysis. This may need to be merged and scanned on the main branch for [the report to show up](https://sonarcloud.io/project/overview?id=sage-bionetworks_synapse-web-monorepo_src).