### PR TITLE
code review changes from #1760

### DIFF
--- a/apps/SageAccountWeb/src/components/ProfileValidation/ProfileFieldsEditor.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/ProfileFieldsEditor.tsx
@@ -95,6 +95,7 @@ export const ProfileFieldsEditor = (props: ProfileFieldsEditorProps) => {
           <RORInstitutionField
             onChange={value => handleCompanyChange(value || '')}
             value={values.company || ''}
+            error={!!errors.company}
           />
         </StyledFormControl>
         <StyledFormControl

--- a/packages/synapse-react-client/src/components/RORInstitutionField/RORInstitutionField.test.tsx
+++ b/packages/synapse-react-client/src/components/RORInstitutionField/RORInstitutionField.test.tsx
@@ -5,7 +5,7 @@ import {
   getUseQuerySuccessMock,
 } from '@/testutils/ReactQueryMockUtils'
 import { SynapseClientError } from '@sage-bionetworks/synapse-client'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 jest.mock('@/synapse-queries/ror')
@@ -65,6 +65,14 @@ const mockUseSearchRegistry = jest.mocked(useSearchRegistry).mockReturnValue(
 )
 
 describe('RORInstitutionField', () => {
+  const user = userEvent.setup({ advanceTimers: jest.runAllTimers })
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   it('displays the value prop', () => {
     const value1 = 'some value'
     const value2 = 'some other value'
@@ -82,7 +90,7 @@ describe('RORInstitutionField', () => {
     render(<RORInstitutionField onChange={mockOnChange} />)
 
     const input = screen.getByRole('combobox')
-    await userEvent.type(input, 'my organization')
+    await user.type(input, 'my organization')
 
     expect(input).toHaveValue('my organization')
     expect(mockOnChange).toHaveBeenLastCalledWith('my organization')
@@ -94,12 +102,16 @@ describe('RORInstitutionField', () => {
     render(<RORInstitutionField onChange={mockOnChange} />)
 
     const input = screen.getByRole('combobox')
-    await userEvent.type(input, 'sage bionetworks')
+    await user.type(input, 'sage bionetworks')
+
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
 
     const option = await screen.findByRole('option', {
       name: 'Sage Bionetworks',
     })
-    await userEvent.click(option)
+    await user.click(option)
     expect(mockOnChange).toHaveBeenLastCalledWith('Sage Bionetworks')
   })
 
@@ -118,7 +130,13 @@ describe('RORInstitutionField', () => {
     render(<RORInstitutionField onChange={mockOnChange} />)
 
     const input = screen.getByRole('combobox')
-    await userEvent.type(input, 'my organization')
+    await user.type(input, 'my organization')
+
+    // Simulate the debounce so the API call is attempted
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+
     await waitFor(() => {
       expect(screen.queryByRole('option')).not.toBeInTheDocument()
     })

--- a/packages/synapse-react-client/src/components/RORInstitutionField/RORInstitutionField.tsx
+++ b/packages/synapse-react-client/src/components/RORInstitutionField/RORInstitutionField.tsx
@@ -1,6 +1,12 @@
 import { ROROrganization } from '@/ror-client/types/ROROrganization'
 import { useSearchRegistry } from '@/synapse-queries/ror'
-import { Autocomplete, Box, TextField, Typography } from '@mui/material'
+import {
+  Autocomplete,
+  Box,
+  TextField,
+  TextFieldProps,
+  Typography,
+} from '@mui/material'
 import { useDebouncedEffect } from '@react-hookz/web'
 import noop from 'lodash-es/noop'
 import { useState } from 'react'
@@ -8,12 +14,11 @@ import { useState } from 'react'
 export type RORLinkedInstitutionFieldProps = {
   value?: string
   onChange?: (value: string | undefined, rorIdentifier?: string) => void
+  error?: TextFieldProps['error']
 }
 
 function getOrganizationDisplayName(organization: ROROrganization) {
-  return organization.names.find(name =>
-    name.types.includes('ror_display'),
-  )!
+  return organization.names.find(name => name.types.includes('ror_display'))!
 }
 
 /**
@@ -25,7 +30,7 @@ function getOrganizationDisplayName(organization: ROROrganization) {
 export default function RORInstitutionField(
   props: RORLinkedInstitutionFieldProps,
 ) {
-  const { value: valueFromProps, onChange = noop } = props
+  const { value: valueFromProps, onChange = noop, error } = props
 
   const isControlled = valueFromProps !== undefined
 
@@ -66,6 +71,7 @@ export default function RORInstitutionField(
           {...params}
           label="Current Affiliation"
           placeholder={'Type to search, or enter free text.'}
+          error={error}
         />
       )}
       inputValue={isControlled ? valueFromProps : internalInputValue}


### PR DESCRIPTION
https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/1760

- Pass `error` along to RORInstitutionField
- useFakeTimers in test with debounced API call