### PR TITLE
AMP ALS: Center Our ALS Resources Content on XL screens

### DIFF
--- a/packages/synapse-react-client/src/components/GoalsV3/GoalsV3.tsx
+++ b/packages/synapse-react-client/src/components/GoalsV3/GoalsV3.tsx
@@ -118,8 +118,9 @@ const GoalsV3 = ({ entityId, svgComponentMap }: GoalsV3Props) => {
         <Box
           sx={{
             display: 'flex',
-            gap: '10px',
+            gap: showDesktop ? '10px' : '0',
             flexDirection: showDesktop ? 'row' : 'column',
+            justifyContent: 'center',
           }}
         >
           {goalsDataArray.map((row, index) => (


### PR DESCRIPTION
Related Jira: https://sagebionetworks.jira.com/browse/PORTALS-3445?focusedCommentId=247278

Content not centered on extra large screens.

Before:
<img width="959" alt="Screenshot 2025-04-23 at 11 16 50 AM" src="https://github.com/user-attachments/assets/965e2b54-5d3a-4f71-aed8-84641c180bf3" />

After:
<img width="572" alt="Screenshot 2025-04-23 at 11 37 13 AM" src="https://github.com/user-attachments/assets/26c4ea4e-4f06-4814-8acf-7348e348689a" />
