### PR TITLE
PORTALS-3387: Remove 'account required' text from 'how to download' label

### DIFF
--- a/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.tsx
@@ -376,7 +376,7 @@ export function TableRowGenericCard(props: TableRowGenericCardProps) {
         columnDisplayName: 'HOW TO DOWNLOAD',
         value: (
           <Link onClick={() => setShowDownloadConfirmation(val => !val)}>
-            Click here to add to Synapse download cart (account required)
+            Click here to add to Synapse download cart
           </Link>
         ),
       })


### PR DESCRIPTION
Address a follow-up suggestion during validation