### PR TITLE
PORTALS-3567

### DIFF
--- a/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearch.test.tsx
+++ b/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearch.test.tsx
@@ -226,8 +226,8 @@ describe('FullTextSearch tests', () => {
             {
               concreteType:
                 'org.sagebionetworks.repo.model.table.TextMatchesQueryFilter',
-              // verify distance of 13 is used
-              searchExpression: `"${searchQuery}" @13`,
+              // verify distance of 14 (wordcount + 1) is used
+              searchExpression: `"${searchQuery}" @14`,
               searchMode: 'BOOLEAN',
             },
           ],

--- a/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearch.test.tsx
+++ b/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearch.test.tsx
@@ -194,7 +194,7 @@ describe('FullTextSearch tests', () => {
     it('adds the appropriate filter when searching in BOOLEAN mode where the search term word length is larger than distance', () => {
       const columnModels = mockQueryResultBundle.columnModels
       const searchQuery =
-        '    a long search term sentence  that exceeds the     distance set by the config       '
+        '    a long search-term sentence  that exceeds the     distance set (by the config)       '
       const setSearchText = jest.fn()
       const booleanModeDistance = 3
       const ftsConfig: FTSConfig = {
@@ -226,8 +226,8 @@ describe('FullTextSearch tests', () => {
             {
               concreteType:
                 'org.sagebionetworks.repo.model.table.TextMatchesQueryFilter',
-              // verify distance of 14 (wordcount + 1) is used
-              searchExpression: `"${searchQuery}" @14`,
+              // verify distance of 13 (wordcount as split by non-word characters) is used
+              searchExpression: `"${searchQuery}" @13`,
               searchMode: 'BOOLEAN',
             },
           ],

--- a/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearchUtils.ts
+++ b/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearchUtils.ts
@@ -41,7 +41,7 @@ export function getTextMatchesQueryFilter(
   let searchExpression = searchText
   if (textMatchesMode == 'BOOLEAN') {
     const searchTextWordLength = searchText.trim().split(/\s+/).length
-    const distanceToUse = Math.max(distance, searchTextWordLength)
+    const distanceToUse = Math.max(distance, searchTextWordLength + 1)
     searchExpression = `"${searchText.replaceAll('"', '')}" @${distanceToUse}`
   }
   const textMatchesQueryFilter: TextMatchesQueryFilter = {

--- a/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearchUtils.ts
+++ b/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearchUtils.ts
@@ -9,6 +9,7 @@ import {
 import * as React from 'react'
 import { getFileColumnModelId } from '../SynapseTable/SynapseTableUtils'
 import { FTSConfig } from '../SynapseTable/SearchV2'
+import { getWordCount } from '../TextField/TextFieldWithWordLimit'
 
 /**
  * Expects a search expression of the form: "searchText" @3
@@ -41,10 +42,7 @@ export function getTextMatchesQueryFilter(
   let searchExpression = searchText
   if (textMatchesMode == 'BOOLEAN') {
     //split by non-word character and ignore empty strings
-    const searchTextWordLength = searchText
-      .trim()
-      .split(/\W+/)
-      .filter(word => word.length > 0).length
+    const searchTextWordLength = getWordCount(searchText)
     const distanceToUse = Math.max(distance, searchTextWordLength)
     searchExpression = `"${searchText.replaceAll('"', '')}" @${distanceToUse}`
   }

--- a/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearchUtils.ts
+++ b/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearchUtils.ts
@@ -40,8 +40,12 @@ export function getTextMatchesQueryFilter(
   const { textMatchesMode, distance = 0 } = ftsConfig
   let searchExpression = searchText
   if (textMatchesMode == 'BOOLEAN') {
-    const searchTextWordLength = searchText.trim().split(/\s+/).length
-    const distanceToUse = Math.max(distance, searchTextWordLength + 1)
+    //split by non-word character and ignore empty strings
+    const searchTextWordLength = searchText
+      .trim()
+      .split(/\W+/)
+      .filter(word => word.length > 0).length
+    const distanceToUse = Math.max(distance, searchTextWordLength)
     searchExpression = `"${searchText.replaceAll('"', '')}" @${distanceToUse}`
   }
   const textMatchesQueryFilter: TextMatchesQueryFilter = {


### PR DESCRIPTION
Updated logic to calculate distance based on splitting search string using non-word characters (and filtering out empty strings).  This works for real-world cases, such as "Gene expression data, somatic mutation calls (VCF files from Mutect2 plus Platypus), copy-number calls (Sequenza and QDNAseq), the fraction of mutated microsatellites (MSIsensor), ATAC-seq insertion counts and allele counts of somatic SNVs in all sample types."