### PR TITLE
Portals 3387: Fix download cart link on details page

### DIFF
--- a/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
@@ -132,7 +132,7 @@ export function GenericCard(props: GenericCardProps) {
 
   return (
     <div style={style} className={'SRC-portalCard'}>
-      {cardTopContent}
+      {/*cardTopContent*/}
       <div className={'SRC-portalCardMain'}>
         {icon}
         <div className="SRC-cardContent">

--- a/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
@@ -132,7 +132,6 @@ export function GenericCard(props: GenericCardProps) {
 
   return (
     <div style={style} className={'SRC-portalCard'}>
-      {/*cardTopContent*/}
       <div className={'SRC-portalCardMain'}>
         {icon}
         <div className="SRC-cardContent">

--- a/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/GenericCard.tsx
@@ -125,6 +125,7 @@ export function GenericCard(props: GenericCardProps) {
         target={titleLinkConfiguration?.target}
         isAlignToLeftNav={true}
         secondaryLabelLimit={secondaryLabelLimit}
+        cardTopContent={cardTopContent}
       />
     )
   }
@@ -209,6 +210,7 @@ export function GenericCard(props: GenericCardProps) {
           values={labels}
           columnIconOptions={columnIconOptions}
           className={useStylesForDisplayedImage ? undefined : 'hasIcon'}
+          cardTopContent={cardTopContent}
         />
       )}
     </div>

--- a/packages/synapse-react-client/src/components/HeaderCard.tsx
+++ b/packages/synapse-react-client/src/components/HeaderCard.tsx
@@ -20,6 +20,7 @@ export type HeaderCardProps = {
   target?: string
   icon: React.ReactNode
   headerCardVariant?: HeaderCardVariant
+  cardTopContent?: React.ReactNode
 }
 
 function HeaderCard(props: HeaderCardProps) {
@@ -36,6 +37,7 @@ function HeaderCard(props: HeaderCardProps) {
     target,
     icon,
     headerCardVariant = 'HeaderCard',
+    cardTopContent,
   } = props
 
   // store old document title and description so that we can restore when this component is removed
@@ -118,6 +120,7 @@ function HeaderCard(props: HeaderCardProps) {
                   }}
                 />
                 <div className="SRC-cardContent">
+                  {cardTopContent}
                   {values && (
                     <CardFooter
                       isHeader={true}

--- a/packages/synapse-react-client/src/components/row_renderers/utils/CardFooter.tsx
+++ b/packages/synapse-react-client/src/components/row_renderers/utils/CardFooter.tsx
@@ -143,9 +143,9 @@ class CardFooter extends Component<CardFooterProps, State> {
         data-testid="CardFooter"
         className={`SRC-cardMetadata ${this.props.className ?? ''}`}
       >
+        {cardTopContent}
         <table>
           <tbody>
-            {cardTopContent}
             {this.renderRows(valuesFiltered, limit, isDesktop)}
             {hasMoreValuesThanLimit && (
               <tr className="SRC-cardRow">

--- a/packages/synapse-react-client/src/components/row_renderers/utils/CardFooter.tsx
+++ b/packages/synapse-react-client/src/components/row_renderers/utils/CardFooter.tsx
@@ -20,6 +20,7 @@ type CardFooterProps = {
   secondaryLabelLimit?: number
   columnIconOptions?: ColumnIconConfigs
   className?: string
+  cardTopContent?: React.ReactNode
 }
 
 class CardFooter extends Component<CardFooterProps, State> {
@@ -131,7 +132,7 @@ class CardFooter extends Component<CardFooterProps, State> {
   }
 
   render() {
-    const { values, secondaryLabelLimit = 3 } = this.props
+    const { values, secondaryLabelLimit = 3, cardTopContent } = this.props
     const { isShowMoreOn, isDesktop } = this.state
     const valuesFiltered = values.filter(el => Boolean(el.value))
     const hasMoreValuesThanLimit = valuesFiltered.length > secondaryLabelLimit
@@ -144,6 +145,7 @@ class CardFooter extends Component<CardFooterProps, State> {
       >
         <table>
           <tbody>
+            {cardTopContent}
             {this.renderRows(valuesFiltered, limit, isDesktop)}
             {hasMoreValuesThanLimit && (
               <tr className="SRC-cardRow">


### PR DESCRIPTION
The "HOW TO DOWNLOAD" link works on a dataset card, but not in the dataset details page for CCKP. This fixes the issue by passing `cardTopContent` to `CardFooter` and `HeaderCard`.