### PR TITLE
PORTALS-3572: set to valid utf-8 charset

### DIFF
--- a/packages/synapse-react-client/src/synapse-client/HttpClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/HttpClient.ts
@@ -26,7 +26,7 @@ export const doPost = <T>(
     headers: {
       Accept: '*/*',
       'Access-Control-Request-Headers': 'authorization',
-      'Content-Type': 'application/json; charset=utf8',
+      'Content-Type': 'application/json; charset=UTF-8',
       ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
     },
     method: 'POST',
@@ -89,7 +89,7 @@ export const doPut = <T>(
     headers: {
       Accept: '*/*',
       'Access-Control-Request-Headers': 'authorization',
-      'Content-Type': 'application/json; charset=utf8',
+      'Content-Type': 'application/json; charset=UTF-8',
       ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
     },
     method: 'PUT',


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc9110#field.content-type
utf8 is not a valid alias (but seems to be accepted!)