### PR TITLE
PORTALS-3560 Add config for dataType buttons on dataset cards.

### DIFF
--- a/apps/portals/nf/src/config/synapseConfigs/datasets.ts
+++ b/apps/portals/nf/src/config/synapseConfigs/datasets.ts
@@ -5,6 +5,7 @@ import {
 } from 'synapse-react-client'
 import { datasetsSql } from '../resources'
 import { columnAliases as sharedColumnAliases } from './commonProps'
+import { studyColumnIconConfigs } from './studies'
 
 export const newDatasetsSql = `${datasetsSql} order by ROW_ID desc limit 3`
 export const datasetsRgbIndex = 8
@@ -62,6 +63,7 @@ export const datasetCardConfiguration: CardConfiguration = {
     URLColumnName: 'id',
     baseURL: 'Explore/Datasets/DetailsPage',
   },
+  columnIconOptions: studyColumnIconConfigs,
 }
 const datasets: QueryWrapperPlotNavProps = {
   rgbIndex: datasetsRgbIndex,


### PR DESCRIPTION
The download cart button has been added. Now adding support for data type icons after the NF backend schema changed the dataType column to stringList
<img width="784" alt="Screenshot 2025-04-29 at 2 57 55 PM" src="https://github.com/user-attachments/assets/01746bb1-6406-41d5-ada9-68ad3a756538" />
