### PR TITLE
Improvements to TypeScript configuration

### DIFF
--- a/apps/SageAccountWeb/tsconfig.json
+++ b/apps/SageAccountWeb/tsconfig.json
@@ -5,7 +5,6 @@
     "baseUrl": "src",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "resolveJsonModule": true,
     "isolatedModules": true,
     "noFallthroughCasesInSwitch": true,
     "useUnknownInCatchVariables": false,

--- a/apps/portals/adknowledgeportal/tsconfig.json
+++ b/apps/portals/adknowledgeportal/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/portals/ampals/tsconfig.json
+++ b/apps/portals/ampals/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/portals/arkportal/tsconfig.json
+++ b/apps/portals/arkportal/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/portals/b2ai.standards/tsconfig.json
+++ b/apps/portals/b2ai.standards/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/portals/bsmn/tsconfig.json
+++ b/apps/portals/bsmn/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/portals/cancercomplexity/tsconfig.json
+++ b/apps/portals/cancercomplexity/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/portals/challenges/tsconfig.json
+++ b/apps/portals/challenges/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/portals/digitalhealth/tsconfig.json
+++ b/apps/portals/digitalhealth/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/portals/eliteportal/tsconfig.json
+++ b/apps/portals/eliteportal/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/portals/genie/tsconfig.json
+++ b/apps/portals/genie/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/portals/nf/tsconfig.json
+++ b/apps/portals/nf/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/portals/stopadportal/tsconfig.json
+++ b/apps/portals/stopadportal/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": "../../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/apps/synapse-oauth-signin/tsconfig.json
+++ b/apps/synapse-oauth-signin/tsconfig.json
@@ -5,7 +5,6 @@
     "baseUrl": "src",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "resolveJsonModule": true,
     "isolatedModules": true,
     "noFallthroughCasesInSwitch": true,
     "useUnknownInCatchVariables": false,

--- a/apps/synapse-portal-framework/tsconfig.json
+++ b/apps/synapse-portal-framework/tsconfig.json
@@ -1,18 +1,12 @@
 {
   "extends": "../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
-    "baseUrl": ".",
-    "outDir": "../../node_modules/.cache/.tsc_cache/synapse-portal-framework/build",
-    "noEmit": false,
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "resolveJsonModule": true,
     "isolatedModules": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": false,
-    "moduleResolution": "bundler",
     "types": ["vite/client"],
     "paths": {
       "@/*": ["./src/*"],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "nx run-many --target=lint --quiet",
     "test": "nx run-many --target=test --coverage",
     "clean": "nx run-many --target=clean",
-    "type-check": "nx run-many --target=type-check"
+    "type-check": "tsc --build"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.3",

--- a/packages/markdown-it-container/test/cjs.cjs
+++ b/packages/markdown-it-container/test/cjs.cjs
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 
 const assert = require('node:assert')
-const fn = require('../')
+const fn = require('../index.cjs')
 
 describe('CJS', () => {
   it('require', () => {

--- a/packages/markdown-it-container/tsconfig.json
+++ b/packages/markdown-it-container/tsconfig.json
@@ -6,8 +6,7 @@
     "target": "esnext",
     "strictNullChecks": false,
     "noImplicitAny": false,
-    "allowJs": true,
-    "types": ["vitest/globals"]
+    "allowJs": true
   },
   "include": ["index.mjs", "test/**/*"]
 }

--- a/packages/markdown-it-synapse-table/tsconfig.json
+++ b/packages/markdown-it-synapse-table/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": ".",
-    "outDir": "../../node_modules/.cache/.tsc_cache/markdown-it-synapse-table/build",
-    "noEmit": false,
     "target": "esnext",
     "strictNullChecks": false,
     "noImplicitAny": false,

--- a/packages/markdown-it-synapse/tsconfig.json
+++ b/packages/markdown-it-synapse/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": ".",
-    "outDir": "../../node_modules/.cache/.tsc_cache/markdown-it-synapse/build",
-    "noEmit": false,
     "target": "esnext",
     "strictNullChecks": false,
     "noImplicitAny": false,

--- a/packages/synapse-client/tsconfig.json
+++ b/packages/synapse-client/tsconfig.json
@@ -1,14 +1,10 @@
 {
   "extends": "../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
     "outDir": "./dist",
-    "module": "esnext",
     "target": "esnext",
-    "moduleResolution": "bundler",
     "allowJs": false,
-    "noEmit": false,
     "emitDeclarationOnly": false,
     "isolatedModules": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/synapse-react-client/tsconfig.json
+++ b/packages/synapse-react-client/tsconfig.json
@@ -1,14 +1,9 @@
 {
   "extends": "../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "./src",
-    "outDir": "../../node_modules/.cache/.tsc_cache/synapse-react-client/build",
-    "module": "esnext",
     "target": "esnext",
-    "moduleResolution": "bundler",
     "allowJs": true,
-    "noEmit": false,
     "isolatedModules": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {

--- a/packages/synapse-types/tsconfig.json
+++ b/packages/synapse-types/tsconfig.json
@@ -1,14 +1,9 @@
 {
   "extends": "../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
     "rootDir": "src",
     "outDir": "./dist",
-    "module": "esnext",
-    "target": "esnext",
-    "moduleResolution": "bundler",
-    "noEmit": false
+    "target": "esnext"
   },
   "include": ["./src/*.ts", "./src/**/*.ts"]
 }

--- a/packages/vite-config/tsconfig.json
+++ b/packages/vite-config/tsconfig.json
@@ -1,13 +1,9 @@
 {
   "extends": "../../shared/tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "src",
     "outDir": "dist",
-    "module": "esnext",
-    "target": "esnext",
-    "moduleResolution": "bundler",
-    "noEmit": false
+    "target": "esnext"
   },
   "include": ["src/**/*"]
 }

--- a/shared/tsconfig.base.json
+++ b/shared/tsconfig.base.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
-    "outDir": "${configDir}/build",
-    "noEmit": true,
+    "outDir": "${configDir}/node_modules/.cache/.tsc_cache/build",
     "strict": true,
-    "composite": false,
+    "composite": true,
     "declaration": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,31 @@
   "include": [],
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build",
-    "allowJs": true,
-    "composite": false
-  }
+    "allowJs": true
+  },
+  "references": [
+    { "path": "./apps/portals/adknowledgeportal" },
+    { "path": "./apps/portals/ampals" },
+    { "path": "./apps/portals/arkportal" },
+    { "path": "./apps/portals/b2ai.standards" },
+    { "path": "./apps/portals/bsmn" },
+    { "path": "./apps/portals/cancercomplexity" },
+    { "path": "./apps/portals/challenges" },
+    { "path": "./apps/portals/digitalhealth" },
+    { "path": "./apps/portals/eliteportal" },
+    { "path": "./apps/portals/genie" },
+    { "path": "./apps/portals/nf" },
+    { "path": "./apps/portals/stopadportal" },
+    { "path": "./apps/portals-e2e" },
+    { "path": "./apps/SageAccountWeb" },
+    { "path": "./apps/synapse-oauth-signin" },
+    { "path": "./apps/synapse-portal-framework" },
+    { "path": "./packages/markdown-it-container" },
+    { "path": "./packages/markdown-it-synapse" },
+    { "path": "./packages/markdown-it-synapse-table" },
+    { "path": "./packages/synapse-client" },
+    { "path": "./packages/synapse-react-client" },
+    { "path": "./packages/synapse-types" },
+    { "path": "./packages/vite-config" }
+  ]
 }


### PR DESCRIPTION
- All packages now emit to a cached folder (if not already emitting consumed JS)
- Reference all packages in top level tsconfig, use tsc --build instead of Nx to build full project.
- Removed redundant properties defined in base tsconfig