### PR TITLE
PORTALS-3245: stopadportal: Text wrapping oddly on Full Application > Submit screen

### DIFF
--- a/packages/synapse-react-client/src/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
+++ b/packages/synapse-react-client/src/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
@@ -206,9 +206,7 @@
 
   .step-exclude-directions {
     font-style: italic;
-
     vertical-align: middle;
-    @include SrcMixins.calc(line-height, '#{SrcVariables.$space-unit} * 2');
     @include SrcMixins.calc(height, '#{SrcVariables.$space-unit} * 2');
     button.btn-link {
       color: SrcVariables.$primary-action-color;


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/PORTALS-3245

Should be safe to remove line height styling and have it default like the other texts in the form. Images below show the three texts that are affected.

<img width="355" alt="Screenshot 2025-05-02 at 9 43 18 AM" src="https://github.com/user-attachments/assets/537801f0-3f81-4357-8008-c8fc0a38a44c" />
<img width="400" alt="Screenshot 2025-05-01 at 4 52 50 PM" src="https://github.com/user-attachments/assets/681ea266-29af-45c4-955f-7ae57a61cded" />
<img width="400" alt="Screenshot 2025-05-01 at 4 52 39 PM" src="https://github.com/user-attachments/assets/27960e1b-56b0-4aab-b0a5-1fcc1a551732" />
