### PR TITLE
[fix] Update the SQL operator for Related Grants

### DIFF
--- a/apps/portals/cancercomplexity/src/pages/DatasetsDetailsPage.tsx
+++ b/apps/portals/cancercomplexity/src/pages/DatasetsDetailsPage.tsx
@@ -63,7 +63,7 @@ export default function DatasetsDetailsPage() {
                       cardConfiguration={grantsCardConfiguration}
                       sql={grantsSql}
                       columnAliases={columnAliases}
-                      sqlOperator={ColumnSingleValueFilterOperator.EQUAL}
+                      sqlOperator={ColumnSingleValueFilterOperator.IN}
                       searchParams={{
                         grantNumber: value!,
                       }}

--- a/apps/portals/cancercomplexity/src/pages/EducationalResourcesDetailsPage.tsx
+++ b/apps/portals/cancercomplexity/src/pages/EducationalResourcesDetailsPage.tsx
@@ -54,7 +54,7 @@ export default function EducationalResourcesDetailsPage() {
                       cardConfiguration={grantsCardConfiguration}
                       sql={grantsSql}
                       columnAliases={columnAliases}
-                      sqlOperator={ColumnSingleValueFilterOperator.EQUAL}
+                      sqlOperator={ColumnSingleValueFilterOperator.IN}
                       searchParams={{
                         grantNumber: value!,
                       }}

--- a/apps/portals/cancercomplexity/src/pages/PublicationsDetailsPage.tsx
+++ b/apps/portals/cancercomplexity/src/pages/PublicationsDetailsPage.tsx
@@ -67,7 +67,7 @@ export default function PublicationsDetailsPage() {
                       cardConfiguration={grantsCardConfiguration}
                       sql={grantsSql}
                       columnAliases={columnAliases}
-                      sqlOperator={ColumnSingleValueFilterOperator.EQUAL}
+                      sqlOperator={ColumnSingleValueFilterOperator.IN}
                       searchParams={{
                         grantNumber: value!,
                       }}

--- a/apps/portals/cancercomplexity/src/pages/ToolsDetailsPage.tsx
+++ b/apps/portals/cancercomplexity/src/pages/ToolsDetailsPage.tsx
@@ -65,7 +65,7 @@ export default function ToolsDetailsPage() {
                       cardConfiguration={grantsCardConfiguration}
                       sql={grantsSql}
                       columnAliases={columnAliases}
-                      sqlOperator={ColumnSingleValueFilterOperator.EQUAL}
+                      sqlOperator={ColumnSingleValueFilterOperator.IN}
                       searchParams={{
                         grantNumber: value!,
                       }}

--- a/apps/portals/cancercomplexity/src/pages/ToolsDetailsPage.tsx
+++ b/apps/portals/cancercomplexity/src/pages/ToolsDetailsPage.tsx
@@ -103,7 +103,7 @@ export default function ToolsDetailsPage() {
                       cardConfiguration={publicationsCardConfiguration}
                       sql={publicationSql}
                       columnAliases={columnAliases}
-                      sqlOperator={ColumnSingleValueFilterOperator.EQUAL}
+                      sqlOperator={ColumnSingleValueFilterOperator.IN}
                       searchParams={{
                         pubMedId: value!,
                       }}


### PR DESCRIPTION
It was previously assumed that CCKP resources had a 1:1 relationship with grants.  But now there are resources that are linked to multiple grants, e.g. this [publication](https://www.cancercomplexity.synapse.org/Explore/Publications/DetailsPage?pubMedId=36280719) is linked to 2 grants: CA210173 and CA268083

This PR will address the need to show multiple grant cards as needed.

EDIT: the IN operator is now being used to list "Related Publications" on the Tools Details Page too

## Preview

![Screenshot 2025-05-09 at 4 53 31 PM](https://github.com/user-attachments/assets/b255b29e-c090-4ddb-9efa-57b57efb3cf0)



