### PR TITLE
SWC-7329 - Fix import issue in dev mode

### DIFF
--- a/packages/synapse-react-client/src/components/Plot/Plot.tsx
+++ b/packages/synapse-react-client/src/components/Plot/Plot.tsx
@@ -1,5 +1,5 @@
 import { PlotParams } from 'react-plotly.js'
-import createPlotlyComponent from 'react-plotly.js/factory'
+import createPlotlyComponent from './safe-react-plotly-factory'
 import { lazy, Suspense } from 'react'
 
 // Lazy-load plotly.js since it is very large!

--- a/packages/synapse-react-client/src/components/Plot/safe-react-plotly-factory.ts
+++ b/packages/synapse-react-client/src/components/Plot/safe-react-plotly-factory.ts
@@ -1,0 +1,15 @@
+import _createPlotlyComponent from 'react-plotly.js/factory'
+
+// We want to bundle browser-compatible code, but use ESM (`"type": "module"` in package.json) when we use Node (e.g. tests).
+// esbuild (used by Vite in development mode) has a quirk where this will cause packages react-plotly.js/factory to be
+// imported in 'node mode', which breaks imports in the browser.
+// For further explanation and source of workaround, see: https://github.com/evanw/esbuild/issues/2480#issuecomment-1970337003
+
+const safeESModule = <T>(a: T | { default: T }): T => {
+  const b = a as any
+  return b.__esModule || b[Symbol.toStringTag] === 'Module' ? b.default : b
+}
+
+const createPlotlyComponent = safeESModule(_createPlotlyComponent)
+
+export default createPlotlyComponent


### PR DESCRIPTION
SWC-7329

Use workaround for browser-bundling + server-side ESM quirk in esbuild.

See https://github.com/evanw/esbuild/issues/2480#issuecomment-1970337003 for more info & workaround reference