### PR TITLE
SWC-7342

### DIFF
--- a/packages/synapse-react-client/src/components/JSONArrayEditor/JSONArrayEditor.tsx
+++ b/packages/synapse-react-client/src/components/JSONArrayEditor/JSONArrayEditor.tsx
@@ -14,7 +14,7 @@ import { GenericObjectType, RJSFSchema } from '@rjsf/utils'
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema'
 import { ParseError } from 'papaparse'
 import { Ref, useCallback, useMemo, useState } from 'react'
-import { getTransformErrors } from '../SchemaDrivenAnnotationEditor/AnnotationEditorUtils'
+import { transformErrors } from '../SchemaDrivenAnnotationEditor/AnnotationEditorUtils'
 import useParseCsv, { UseParseCsvError } from './useParseCsv'
 
 const DEFAULT_ARRAY_ITEM_DEFINITION: JSONSchema7Definition = { type: 'string' }
@@ -73,10 +73,6 @@ function JSONArrayEditor<T = unknown>(props: JSONArrayEditorProps<T>) {
       }
     }
   }, [onChange, pastedValues, value, parse])
-
-  const transformErrors = useMemo(() => {
-    return getTransformErrors()
-  }, [])
 
   return (
     <Box

--- a/packages/synapse-react-client/src/components/JsonSchemaForm/templates/ArrayFieldTemplate.tsx
+++ b/packages/synapse-react-client/src/components/JsonSchemaForm/templates/ArrayFieldTemplate.tsx
@@ -58,12 +58,15 @@ function ArrayFieldTemplate<
    */
   useEffect(() => {
     if (
+      // Do not manipulate if the widget is hidden (e.g. 'scopeIds' in an EntityView)
+      // FIXME: We should probably remove this hook and migrate to a design that accommodates empty arrays.
+      uiOptions.widget !== 'hidden' &&
       props.items.length === 0 &&
       !formContext?.allowRemovingLastItemInArray
     ) {
       props.onAddClick()
     }
-  }, [props, formContext?.allowRemovingLastItemInArray])
+  }, [props, formContext?.allowRemovingLastItemInArray, uiOptions.widget])
 
   return (
     <Box id={idSchema.$id} className={props.className}>

--- a/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/AnnotationEditorUtils.ts
+++ b/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/AnnotationEditorUtils.ts
@@ -1,10 +1,8 @@
 import { AdditionalPropertiesSchemaField } from '@/components/SchemaDrivenAnnotationEditor/field/AdditionalPropertiesSchemaField'
-import { entityJsonKeys } from '@/utils/functions/EntityTypeUtils'
 import { RJSFValidationError } from '@rjsf/utils'
-import { ENTITY_CONCRETE_TYPE } from '@sage-bionetworks/synapse-types'
 import { JSONSchema7 } from 'json-schema'
 import jsonpath from 'jsonpath'
-import { flatMap, groupBy, isEmpty } from 'lodash-es'
+import { flatMap, groupBy, isEmpty, isObject } from 'lodash-es'
 
 /**
  * Generates a JSON schema for the form UI based on the provided validation schema and entity schema base properties.
@@ -14,15 +12,23 @@ import { flatMap, groupBy, isEmpty } from 'lodash-es'
  * This method combines the validation schema with the entity schema base properties to create a new schema that will yield
  * the expected form with desired logic.
  * @param validationSchema
- * @param entitySchemaBaseProperties
+ * @param entitySchema
  */
 export function getJsonSchemaForForm(
   validationSchema: JSONSchema7 = {},
-  entitySchemaBaseProperties: JSONSchema7['properties'] = undefined,
+  entitySchema: JSONSchema7 = {},
 ): JSONSchema7 {
+  const entitySchemaProperties =
+    getPossibleTopLevelPropertiesInObjectSchema(entitySchema)
+
   return {
     $schema: 'http://json-schema.org/draft-07/schema#',
-    // Spread the validation schema to ensure definitions are included
+    // Merge definitions
+    definitions: {
+      ...entitySchema.definitions,
+      ...validationSchema.definitions,
+    },
+    // Spread the validation schema to ensure all other references are included
     // The definitions get lost if we simply put the entire schema in `allOf`
     ...validationSchema,
     allOf: [
@@ -30,7 +36,7 @@ export function getJsonSchemaForForm(
       // Add in the entity properties
       {
         type: 'object',
-        properties: entitySchemaBaseProperties,
+        properties: entitySchemaProperties,
       },
     ],
     // Always allow adding additional annotations (though it may violate the validationSchema)
@@ -115,65 +121,51 @@ export function getFriendlyPropertyName(error: RJSFValidationError): string {
   }
 }
 
-export function getTransformErrors(concreteType?: ENTITY_CONCRETE_TYPE) {
-  return (errors: RJSFValidationError[]): RJSFValidationError[] => {
-    // Transform the errors in the following ways:
-    // - Simplify the set of errors when failing to select an enumeration defined with an anyOf (SWC-5724)
-    // - Show a custom error message when using a property that collides with an internal entity property (SWC-5678)
+export function transformErrors(
+  errors: RJSFValidationError[],
+): RJSFValidationError[] {
+  // Transform the errors in the following ways:
+  // - Simplify the set of errors when failing to select an enumeration defined with an anyOf (SWC-5724)
+  // - Show a custom error message when using a property that collides with an internal entity property (SWC-5678)
 
-    // Fixing anyOf errors
-    // Group the errors by the property that the error applies to
-    const grouped = groupBy(errors, error => error.property)
-    Object.keys(grouped).map(property => {
-      const errorGroup = grouped[property]
+  // Fixing anyOf errors
+  // Group the errors by the property that the error applies to
+  const grouped = groupBy(errors, error => error.property)
+  Object.keys(grouped).map(property => {
+    const errorGroup = grouped[property]
 
-      // First, see if it is an anyOf error
-      const hasAnyOfError = errorGroup.some(
-        e => e.message === 'should match some schema in anyOf',
-      )
+    // First, see if it is an anyOf error
+    const hasAnyOfError = errorGroup.some(
+      e => e.message === 'should match some schema in anyOf',
+    )
 
-      // We determine if it's an anyOf *enum* error if all error messages in the property match one of these three messages:
-      const isEnumError =
-        hasAnyOfError &&
-        errorGroup.every(error => {
-          if (error.message === 'should be string') {
-            return true
-          } else if (error.message === 'should be equal to constant') {
-            return true
-          } else if (error.message === 'should match some schema in anyOf') {
-            return true
-          } else {
-            return false
-          }
-        })
-
-      // If it's an anyOf enum error, we just modify the first message and drop the rest
-      if (isEnumError && errorGroup.length > 0) {
-        errorGroup[0].message = 'should be equal to one of the allowed values'
-        grouped[property] = [errorGroup[0]]
-      }
-    })
-
-    // Ungroup the errors after potentially modifying them
-    errors = flatMap(grouped)
-
-    // Custom error message if the custom annotation key collides with an internal entity property
-    if (concreteType) {
-      errors = errors.map(error => {
-        const propertyName = getFriendlyPropertyName(error)
-        if (
-          propertyName &&
-          entityJsonKeys[concreteType].includes(propertyName)
-        ) {
-          error.message = `"${propertyName}" is a reserved internal key and cannot be used.`
+    // We determine if it's an anyOf *enum* error if all error messages in the property match one of these three messages:
+    const isEnumError =
+      hasAnyOfError &&
+      errorGroup.every(error => {
+        if (error.message === 'should be string') {
+          return true
+        } else if (error.message === 'should be equal to constant') {
+          return true
+        } else if (error.message === 'should match some schema in anyOf') {
+          return true
+        } else {
+          return false
         }
-        return error
       })
-    }
 
-    // Return the transformed errors.
-    return errors
-  }
+    // If it's an anyOf enum error, we just modify the first message and drop the rest
+    if (isEnumError && errorGroup.length > 0) {
+      errorGroup[0].message = 'should be equal to one of the allowed values'
+      grouped[property] = [errorGroup[0]]
+    }
+  })
+
+  // Ungroup the errors after potentially modifying them
+  errors = flatMap(grouped)
+
+  // Return the transformed errors.
+  return errors
 }
 
 /**
@@ -211,7 +203,7 @@ export function shouldLiveValidate(
  * which is compatible with how Synapse Annotations are defined.
  * @param resolvedSchema
  */
-export function getAllPropertiesInFlatObjectSchema(
+export function getPossibleTopLevelPropertiesInObjectSchema(
   resolvedSchema: JSONSchema7,
 ): JSONSchema7['properties'] {
   const allProperties = {}
@@ -219,7 +211,10 @@ export function getAllPropertiesInFlatObjectSchema(
   for (const propertiesObject of foundPropertiesObjects) {
     Object.assign(allProperties, propertiesObject)
   }
-
+  // Use the schema.properties to override any properties defined in definitions
+  if (isObject(resolvedSchema.properties)) {
+    Object.assign(allProperties, resolvedSchema.properties)
+  }
   return allProperties
 }
 

--- a/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/AnnotationEditorUtils.ts
+++ b/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/AnnotationEditorUtils.ts
@@ -23,14 +23,14 @@ export function getJsonSchemaForForm(
 
   return {
     $schema: 'http://json-schema.org/draft-07/schema#',
-    // Merge definitions
+    // Spread the validation schema to ensure all other references are included
+    // Top level properties like "$defs" get lost if we simply put the entire schema in `allOf`
+    ...validationSchema,
+    // JSON Schemas for Synapse types use "definitions", so it should be manually merged.
     definitions: {
       ...entitySchema.definitions,
       ...validationSchema.definitions,
     },
-    // Spread the validation schema to ensure all other references are included
-    // The definitions get lost if we simply put the entire schema in `allOf`
-    ...validationSchema,
     allOf: [
       ...(validationSchema.allOf || []),
       // Add in the entity properties

--- a/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/SchemaDrivenAnnotationEditor.tsx
+++ b/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/SchemaDrivenAnnotationEditor.tsx
@@ -19,14 +19,7 @@ import { JSONSchema7 } from 'json-schema'
 import { omitBy } from 'lodash-es'
 import isEmpty from 'lodash-es/isEmpty'
 import noop from 'lodash-es/noop'
-import {
-  RefObject,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { RefObject, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ConfirmationButtons,
   ConfirmationDialog,
@@ -36,11 +29,11 @@ import { SynapseSpinner } from '../LoadingScreen/LoadingScreen'
 import {
   dropNullishArrayValues,
   dropNullValues,
-  getAllPropertiesInFlatObjectSchema,
+  getPossibleTopLevelPropertiesInObjectSchema,
   getFriendlyPropertyName,
   getJsonSchemaForForm,
   getSchemaIdForConcreteType,
-  getTransformErrors,
+  transformErrors,
   getUiSchemaForForm,
   shouldLiveValidate,
 } from './AnnotationEditorUtils'
@@ -143,11 +136,6 @@ export function SchemaDrivenAnnotationEditor(
     undefined,
   )
 
-  const transformErrors = useCallback(
-    getTransformErrors(entityJson?.concreteType),
-    [entityJson?.concreteType],
-  )
-
   useEffect(() => {
     if (data?.entity) {
       // Put the annotations into a state variable so it can be modified by the form.
@@ -183,13 +171,14 @@ export function SchemaDrivenAnnotationEditor(
     })
 
   const entitySchemaBaseProperties: JSONSchema7['properties'] = useMemo(
-    () => getAllPropertiesInFlatObjectSchema(schemaForEntityType ?? {}),
+    () =>
+      getPossibleTopLevelPropertiesInObjectSchema(schemaForEntityType ?? {}),
     [schemaForEntityType],
   )
 
   const formSchema = useMemo(
-    () => getJsonSchemaForForm(validationSchema, entitySchemaBaseProperties),
-    [entitySchemaBaseProperties, validationSchema],
+    () => getJsonSchemaForForm(validationSchema, schemaForEntityType),
+    [validationSchema, schemaForEntityType],
   )
 
   const uiSchema = useMemo(

--- a/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/field/SynapseAnnotationsRJSFObjectField.tsx
+++ b/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/field/SynapseAnnotationsRJSFObjectField.tsx
@@ -11,7 +11,7 @@ import { JSONSchema7Definition } from 'json-schema'
 import { useEffect } from 'react'
 import {
   convertToArray,
-  getAllPropertiesInFlatObjectSchema,
+  getPossibleTopLevelPropertiesInObjectSchema,
 } from '../AnnotationEditorUtils'
 
 /**
@@ -34,7 +34,7 @@ export function SynapseAnnotationsRJSFObjectField<
    */
   useEffect(() => {
     const newFormData: Record<string, any> = { ...formData }
-    const allProperties = getAllPropertiesInFlatObjectSchema(schema)
+    const allProperties = getPossibleTopLevelPropertiesInObjectSchema(schema)
     if (allProperties) {
       Object.entries(allProperties).forEach(([key, propertySchema]) => {
         // Since the annotations object is flat, we can safely use the property name as the key (no nested properties)

--- a/packages/synapse-react-client/src/utils/functions/EntityTypeUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/EntityTypeUtils.ts
@@ -364,6 +364,7 @@ export const entityJsonKeys: Record<ENTITY_CONCRETE_TYPE, string[]> = {
     ...entityRefCollectionViewKeys,
     'size',
     'checksum',
+    'count',
   ],
   [DATASET_COLLECTION_CONCRETE_TYPE_VALUE]: [...entityRefCollectionViewKeys],
   [ENTITY_VIEW_CONCRETE_TYPE_VALUE]: [


### PR DESCRIPTION
- Fix issue where merging the properties in the base entity schema did not properly use the most recently defined schema properties. The logic used for this utility is still not perfect; a failing test was added.
- Add logic to handle case where an array item was automatically added to entity-specific properties (e.g. EntityView.scopeIds) when it should not be. Note added to revisit, since it would be safer to account for empty arrays in the UI rather than keeping special logic to try to hide them.
- Remove unused logic in transformErrors and remove now-unnecessary closure