### PR TITLE
Trim list of searchExampleTerms for Bridge2AI Standards Explorer

### DIFF
--- a/apps/synapse-portal-framework/src/components/b2ai.standards/StandardsHeader.tsx
+++ b/apps/synapse-portal-framework/src/components/b2ai.standards/StandardsHeader.tsx
@@ -12,14 +12,11 @@ export type StandardsHeaderProps = {
 const StandardsHeader = (props: StandardsHeaderProps) => {
   const searchPlaceholder = 'Search for a biomedical data standard'
   const searchExampleTerms = [
-    'MRI data processing',
-    'Waveform interoperability',
     'Ophthalmic imaging',
     'Integration',
     'Acquisition',
     'File formats',
     'Ontologies',
-    'Lab automation',
   ]
 
   const content = (


### PR DESCRIPTION
Some of the current search example terms don't currently work (they don't return any results) on the Standards Explorer site.
I'd like to remove them for now.