### PR TITLE
SWC-7230 - Improvements in forum components for e2e

### DIFF
--- a/packages/synapse-react-client/src/components/Forum/DiscussionReply.tsx
+++ b/packages/synapse-react-client/src/components/Forum/DiscussionReply.tsx
@@ -73,7 +73,12 @@ export function DiscussionReply(props: DiscussionReplyProps) {
   }, [reply.id])
 
   return (
-    <div className="reply-container" id={`reply._${reply.id}`} ref={replyRef}>
+    <div
+      className="reply-container"
+      id={`reply._${reply.id}`}
+      ref={replyRef}
+      role={'article'}
+    >
       {isLoading ? (
         <SkeletonTable numCols={1} numRows={4} />
       ) : (
@@ -95,6 +100,7 @@ export function DiscussionReply(props: DiscussionReplyProps) {
                   />
                   <span>
                     posted {formatDate(dayjs(reply.createdOn), 'M/D/YYYY')}
+                    {reply.isEdited ? <i>{' (Edited)'}</i> : null}
                   </span>
                   <Box
                     sx={{
@@ -109,12 +115,12 @@ export function DiscussionReply(props: DiscussionReplyProps) {
                     </button>
                     {isCurrentUserAuthor && (
                       <button onClick={() => setShowReplyModal(true)}>
-                        <IconSvg icon="edit" />
+                        <IconSvg icon="edit" label={'Edit reply'} />
                       </button>
                     )}
                     {entityBundle?.permissions.canModerate && (
                       <button onClick={() => setShowDeleteModal(true)}>
-                        <IconSvg icon="delete" />
+                        <IconSvg icon="delete" label={'Delete reply'} />
                       </button>
                     )}
                   </Box>

--- a/packages/synapse-react-client/src/components/Forum/DiscussionThread.tsx
+++ b/packages/synapse-react-client/src/components/Forum/DiscussionThread.tsx
@@ -8,7 +8,14 @@ import {
 import { useSubscription } from '@/synapse-queries/subscription/useSubscription'
 import { formatDate } from '@/utils/functions/DateFormatter'
 import { SRC_SIGN_IN_CLASS } from '@/utils/SynapseConstants'
-import { Box, Button, TextField, Typography } from '@mui/material'
+import {
+  Box,
+  Button,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material'
 import {
   ALL_ENTITY_BUNDLE_FIELDS,
   ObjectType,
@@ -123,33 +130,31 @@ export function DiscussionThread(props: DiscussionThreadProps) {
   }
 
   return (
-    <div className="DiscussionThread">
+    <div className="DiscussionThread" role={'article'}>
       {threadData && threadBody ? (
         <>
-          <Box
-            sx={theme => ({
-              textAlign: 'center',
-              [theme.breakpoints.down('sm')]: {
-                display: 'flex',
-                marginBottom: defaultMargin,
-                button: {
-                  whiteSpace: 'nowrap',
-                },
-              },
-            })}
-          >
-            <Button
-              variant={orderByDatePosted ? 'contained' : 'outlined'}
-              onClick={() => setOrderByDatePosted(true)}
+          <Box sx={{ mb: 2, textAlign: 'right' }}>
+            <Typography component={'span'} sx={{ mr: 1 }}>
+              Sort:
+            </Typography>
+            <ToggleButtonGroup
+              color={'primary'}
+              exclusive
+              value={orderByDatePosted ? 'datePosted' : 'mostRecent'}
             >
-              Date Posted
-            </Button>
-            <Button
-              variant={orderByDatePosted ? 'outlined' : 'contained'}
-              onClick={() => setOrderByDatePosted(false)}
-            >
-              Most Recent
-            </Button>
+              <ToggleButton
+                value={'datePosted'}
+                onClick={() => setOrderByDatePosted(true)}
+              >
+                Date Posted
+              </ToggleButton>
+              <ToggleButton
+                value={'mostRecent'}
+                onClick={() => setOrderByDatePosted(false)}
+              >
+                Most Recent
+              </ToggleButton>
+            </ToggleButtonGroup>
           </Box>
           <UserBadge
             userId={threadData.createdBy}
@@ -190,6 +195,7 @@ export function DiscussionThread(props: DiscussionThreadProps) {
           </div>
           <span>
             posted {formatDate(dayjs(threadData.createdOn), 'M/D/YYYY')}
+            {threadData.isEdited ? <i>{' (Edited)'}</i> : null}
           </span>
           <ForumThreadEditor
             isReply={false}

--- a/packages/synapse-react-client/src/components/Forum/ForumThreadEditor.tsx
+++ b/packages/synapse-react-client/src/components/Forum/ForumThreadEditor.tsx
@@ -116,11 +116,15 @@ export function ForumThreadEditor(props: ForumThreadEditorProps) {
           onChange={e => setTitle(e.target.value)}
         />
       )}
-      <MarkdownEditor text={text} setText={setText} />
+      <MarkdownEditor
+        placeholder={'Write a reply...'}
+        text={text}
+        setText={setText}
+      />
     </div>
   )
 
-  const confirmButtonText = updateIsPending ? 'Saving' : 'Save'
+  const confirmButtonText = updateIsPending ? 'Saving' : 'Post'
 
   return (
     <>
@@ -143,7 +147,9 @@ export function ForumThreadEditor(props: ForumThreadEditorProps) {
       ) : (
         <>
           {editorContent}
-          <Box display="flex" justifyContent="flex-end">
+          <Box
+            sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, my: 1 }}
+          >
             <ConfirmationButtons
               onCancel={onClose}
               onConfirm={() => onSave(text, title)}

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownEditor.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownEditor.tsx
@@ -1,3 +1,11 @@
+import {
+  Box,
+  IconButton,
+  Tab,
+  Tabs,
+  TextField,
+  Typography,
+} from '@mui/material'
 import { useRef, useState, useEffect } from 'react'
 import {
   commandList,
@@ -22,8 +30,7 @@ export function MarkdownEditor({
   text,
   setText,
 }: MarkdownEditorProps) {
-  const [currentTab, setCurrentTab] =
-    useState<(typeof MarkdownEditorTabs)[number]>('WRITE')
+  const [currentTab, setCurrentTab] = useState<number>(0)
   const [selectionStart, setSelectionStart] = useState<number>(0)
   const [isShowingTagModal, setIsShowingTagModal] = useState<boolean>(false)
   const [tagModalWithKeyboard, setTagModalWithKeyboard] =
@@ -120,57 +127,76 @@ export function MarkdownEditor({
   return (
     <div className="MarkdownEditor">
       <div className="MarkdownEditorControls">
-        <div className="Tabs">
+        <Tabs
+          textColor="secondary"
+          indicatorColor="secondary"
+          value={currentTab}
+          onChange={(_e, newValue) => setCurrentTab(newValue)}
+        >
           {MarkdownEditorTabs.map(tabName => {
-            return (
-              <button
-                className="Tab"
-                role="tab"
-                aria-selected={tabName === currentTab}
-                key={tabName}
-                onClick={e => {
-                  e.stopPropagation()
-                  setCurrentTab(tabName)
-                }}
-              >
-                {tabName}
-              </button>
-            )
+            return <Tab label={tabName} key={tabName} />
           })}
-        </div>
-        {currentTab === 'WRITE' && (
+        </Tabs>
+        {MarkdownEditorTabs[currentTab] === 'WRITE' && (
           <div className="MarkdownEditorControlsToolbar">
             {commandList.map(type => {
               return (
-                <button key={type} onClick={() => handleCommands(type)}>
-                  <IconSvg icon={type} label={startCase(type)} />
-                </button>
+                <IconButton
+                  size={'small'}
+                  key={type}
+                  onClick={() => handleCommands(type)}
+                  sx={{ width: '32px', height: '32px' }}
+                >
+                  <IconSvg
+                    sx={{ fontSize: 'inherit' }}
+                    icon={type}
+                    label={startCase(type)}
+                  />
+                </IconButton>
               )
             })}
-            <button onClick={() => setIsShowingTagModal(true)}>
-              <IconSvg icon="tag" label="Mention" />
-            </button>
+            <IconButton
+              size={'small'}
+              onClick={() => setIsShowingTagModal(true)}
+              sx={{ width: '32px', height: '32px' }}
+            >
+              <IconSvg
+                sx={{ fontSize: 'inherit' }}
+                icon="tag"
+                label="Mention"
+              />
+            </IconButton>
           </div>
         )}
       </div>
       <div>
-        {currentTab === 'WRITE' ? (
-          <textarea
+        {MarkdownEditorTabs[currentTab] === 'WRITE' ? (
+          <TextField
             aria-label="markdown"
             onChange={e => {
               setText(e.target.value)
               handleTagModal(e.target.value)
             }}
             style={{ width: '100%' }}
-            rows={6}
+            multiline
+            minRows={6}
             value={text}
-            ref={textAreaRef}
+            inputRef={textAreaRef}
             placeholder={placeholder}
+            sx={{
+              textarea: {
+                resize: 'vertical',
+              },
+            }}
           />
-        ) : text ? (
-          <MarkdownSynapse markdown={text} />
         ) : (
-          'Nothing to preview'
+          <Box sx={{ mx: 1, my: 2 }}>
+            {text ? (
+              <MarkdownSynapse markdown={text} />
+            ) : (
+              <Typography>Nothing to preview</Typography>
+            )}
+          </Box>
         )}
       </div>
 

--- a/packages/synapse-react-client/src/style/components/_markdown-editor.scss
+++ b/packages/synapse-react-client/src/style/components/_markdown-editor.scss
@@ -6,26 +6,11 @@
       display: flex;
     }
     width: 100%;
-    .Tabs {
-      @include SrcMixins.underline-tabs();
-      justify-content: flex-start;
-      box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.05);
-      display: inline-flex;
-      .Tab {
-        flex-grow: 0;
-        height: 45px;
-        padding-left: 30px;
-        padding-right: 30px;
-        border-radius: 0px;
-        display: flex;
-        align-items: center;
-        text-decoration: none !important;
-      }
-    }
     .MarkdownEditorControlsToolbar {
-      margin: auto;
-      margin-left: auto;
-      margin-right: 0;
+      display: flex;
+      gap: 4px;
+      flex-wrap: wrap;
+      margin: auto 0 auto auto;
       @media (max-width: 768px) {
         margin: 16px 0;
       }

--- a/packages/synapse-react-client/src/theme/DefaultTheme.tsx
+++ b/packages/synapse-react-client/src/theme/DefaultTheme.tsx
@@ -426,6 +426,13 @@ export const defaultMuiThemeOptions: ThemeOptions = {
         },
       },
     },
+    MuiToggleButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'var(--synapse-button-text-transform)' as any,
+        },
+      },
+    },
     MuiTooltip: {
       defaultProps: {
         arrow: true,


### PR DESCRIPTION
Made some changes while attempting to get E2E tests working in SWC-7230, and also fix some awkward spacing issues

- Modify MarkdownEditor to use MUI tabs, use IconButton for buttons, make layout more mobile-friendly, add some spacing between elements, use MUI TextField for editor
- Add `article` roles to thread/reply containers
- Add missing labels for thread/reply buttons
- Add missing "Edited" label for edited thread/reply
- Use MUI ToggleButtonGroup for reply sorting
- Add placeholder to MarkdownEditor in reply mode
- Revert button text changes where E2E tests failed (e.g. Save -> Post)
- Invalidate follower query for a thread after posting a reply