### PR TITLE
PORTALS-3613

### DIFF
--- a/apps/portals/b2ai.standards/package.json
+++ b/apps/portals/b2ai.standards/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@mui/icons-material": "^5.17.1",
     "@mui/material": "^5.17.1",
     "@sage-bionetworks/synapse-portal-framework": "workspace:*",
     "@sage-bionetworks/synapse-types": "workspace:*",
@@ -17,6 +18,7 @@
     "vite": "^5.4.19"
   },
   "devDependencies": {
+    "@types/lodash-es": "^4.17.12",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "sass": "^1.87.0",

--- a/apps/portals/b2ai.standards/src/components/IsMatureIconMap.tsx
+++ b/apps/portals/b2ai.standards/src/components/IsMatureIconMap.tsx
@@ -11,7 +11,7 @@ const mapping: Record<string, ReactNode> = {
         'This standard has one or more implementations appropriate for production use, or has undergone a review process and has been determined to be in a mature state.'
       }
     >
-      <MatureStandardIcon sx={{ color: '#edc766' }} />
+      <MatureStandardIcon sx={{ color: 'tertiary.main' }} />
     </Tooltip>
   ),
 }

--- a/apps/portals/b2ai.standards/src/components/IsMatureIconMap.tsx
+++ b/apps/portals/b2ai.standards/src/components/IsMatureIconMap.tsx
@@ -1,0 +1,38 @@
+import Tooltip from '@mui/material/Tooltip'
+import isArray from 'lodash-es/isArray'
+import { ReactNode } from 'react'
+import { MapValueToReactComponentConfig } from 'synapse-react-client/components/CardContainerLogic/CardContainerLogic'
+import MatureStandardIcon from '@mui/icons-material/WorkspacePremiumTwoTone'
+
+const mapping: Record<string, ReactNode> = {
+  ['Yes']: (
+    <Tooltip
+      title={
+        'This standard has one or more implementations appropriate for production use, or has undergone a review process and has been determined to be in a mature state.'
+      }
+    >
+      <MatureStandardIcon sx={{ color: '#edc766' }} />
+    </Tooltip>
+  ),
+}
+
+const IsMatureIconMap: MapValueToReactComponentConfig['Component'] = ({
+  value,
+}) => {
+  let values = value
+
+  if (value == null) {
+    return <></>
+  }
+  if (!isArray(value)) {
+    values = [value]
+  }
+
+  return (
+    <div style={{ textAlign: 'center' }}>
+      {(values as string[]).map(val => mapping[val])}
+    </div>
+  )
+}
+
+export default IsMatureIconMap

--- a/apps/portals/b2ai.standards/src/config/resources.ts
+++ b/apps/portals/b2ai.standards/src/config/resources.ts
@@ -27,10 +27,10 @@ export const CHALLENGES_TABLE_COLUMN_NAMES = {
 // for the Explore page table:
 export const dataSql = `
     SELECT
+        isMature,
         concat('[', acronym, '](/Explore/Standard/DetailsPage?id=', id, ')') as acronym,
             name, category, collections, topic,
-            ${DST_TABLE_COLUMN_NAMES.RELEVANT_ORG_NAMES}, isOpen, registration, "usedInBridge2AI"
-            , hasAIApplication, isMature
+            ${DST_TABLE_COLUMN_NAMES.RELEVANT_ORG_NAMES}, isOpen, registration, "usedInBridge2AI", hasAIApplication
             FROM ${TABLE_IDS.DST_denormalized.id}
 `
 // removed topic column above to address @jay-hodgson's comment

--- a/apps/portals/b2ai.standards/src/config/synapseConfigs/data.ts
+++ b/apps/portals/b2ai.standards/src/config/synapseConfigs/data.ts
@@ -1,3 +1,4 @@
+import IsMatureIconMap from '@/components/IsMatureIconMap'
 import { ColumnSingleValueFilterOperator } from '@sage-bionetworks/synapse-types'
 import {
   LabelLinkConfig,
@@ -21,6 +22,11 @@ export const dataColumnLinks: LabelLinkConfig = [
     // If set, also show a tooltip
     // tooltipText?: string
   },
+  {
+    matchColumnName: 'isMature',
+    isMapValueToReactNodeConfig: true,
+    Component: IsMatureIconMap,
+  },
 ]
 
 export const dataQueryWrapperPlotNavProps: QueryWrapperPlotNavProps = {
@@ -34,7 +40,6 @@ export const dataQueryWrapperPlotNavProps: QueryWrapperPlotNavProps = {
     showDownloadColumn: false,
     columnLinks: dataColumnLinks,
   },
-
   facetsToPlot: [
     'topic',
     // 'Organizations',

--- a/packages/synapse-react-client/src/components/CardContainerLogic/CardContainerLogic.tsx
+++ b/packages/synapse-react-client/src/components/CardContainerLogic/CardContainerLogic.tsx
@@ -10,9 +10,10 @@ import { DEFAULT_PAGE_SIZE } from '@/utils/SynapseConstants'
 import {
   Query,
   QueryBundleRequest,
+  SelectColumn,
   SortDirection,
 } from '@sage-bionetworks/synapse-types'
-import { useMemo } from 'react'
+import React, { useMemo } from 'react'
 import ColumnFilter from '../ColumnFilter/ColumnFilter'
 import { IconSvgProps } from '../IconSvg'
 import QuerySortSelector from '../QuerySortSelector'
@@ -78,12 +79,25 @@ export type DescriptionConfig = {
   showFullDescriptionByDefault?: boolean
 }
 
+export type MapValueToReactComponentConfig = {
+  // The column to apply the mapping to
+  matchColumnName: string
+  Component: React.ComponentType<{
+    /* The value of the table cell. If the column is a _LIST type, then the LIST will be parsed and this will be a string array. */
+    value: string | string[] | null
+    selectColumn: SelectColumn
+  }>
+  // discriminator
+  isMapValueToReactNodeConfig: true
+}
+
 // Specify the indices in the values [] that should be rendered specially
 export type LabelLinkConfig = (
   | MarkdownLink
   | CardLink
   | ColumnSpecifiedLink
   | EntityImage
+  | MapValueToReactComponentConfig
 )[]
 
 export type ColumnIconConfigs = {

--- a/packages/synapse-react-client/src/components/GenericCard/CardUtils.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/CardUtils.tsx
@@ -8,7 +8,6 @@ import {
 import { TargetEnum } from '@/utils/html/TargetEnum'
 import {
   ColumnModel,
-  ColumnType,
   Entity,
   FileHandleAssociateType,
   FileHandleAssociation,
@@ -55,7 +54,7 @@ export const getValueOrMultiValue = ({
     return {
       str: '',
       strList: undefined,
-      columnModelType: undefined,
+      selectColumn: undefined,
     }
   }
   const selectedColumnOrUndefined =
@@ -72,7 +71,7 @@ export const getValueOrMultiValue = ({
       return {
         strList,
         str: val,
-        columnModelType: selectedColumnOrUndefined?.columnType,
+        selectColumn: selectedColumnOrUndefined,
       }
     } catch (e) {
       console.error(
@@ -83,12 +82,15 @@ export const getValueOrMultiValue = ({
       )
     }
   }
-  return { str: value, columnModelType: selectedColumnOrUndefined?.columnType }
+  return {
+    str: value,
+    selectColumn: selectedColumnOrUndefined,
+  }
 }
 type ValueOrMultiValue = {
   str: string
   strList?: string[]
-  columnModelType?: ColumnType
+  selectColumn?: SelectColumn
 }
 
 export function getCardLinkHref(

--- a/packages/synapse-react-client/src/components/GenericCard/SynapseCardLabel.test.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/SynapseCardLabel.test.tsx
@@ -250,4 +250,31 @@ describe('SynapseCardLabel tests', () => {
     const link = screen.getByRole('link')
     expect(link.getAttribute('href')).toEqual(`https://some-override-link.gov`)
   })
+
+  it('maps a string to a React node with MapValueToReactNodeConfig', () => {
+    const value = 'syn1234567'
+    render(
+      <SynapseCardLabel
+        value={value}
+        labelLink={{
+          isMapValueToReactNodeConfig: true,
+          matchColumnName: 'dataset',
+          Component: ({ value, selectColumn }) => {
+            return (
+              <p>
+                The value is {value} and the column is {selectColumn.name}
+              </p>
+            )
+          },
+        }}
+        isHeader={false}
+        selectColumns={selectColumns}
+        columnModels={undefined}
+        columnName={'dataset'}
+        rowData={[value]}
+      />,
+      { wrapper: createWrapper() },
+    )
+    screen.getByText('The value is syn1234567 and the column is dataset')
+  })
 })

--- a/packages/synapse-react-client/src/components/GenericCard/SynapseCardLabel.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/SynapseCardLabel.tsx
@@ -14,7 +14,10 @@ import { isEmpty } from 'lodash-es'
 import { CSSProperties, Fragment } from 'react'
 import { ColumnSpecifiedLink, MarkdownLink } from '../CardContainerLogic'
 import { TargetEnum } from '@/utils/html/TargetEnum'
-import { EntityImage } from '../CardContainerLogic/CardContainerLogic'
+import {
+  EntityImage,
+  MapValueToReactComponentConfig,
+} from '../CardContainerLogic/CardContainerLogic'
 import { EntityLink } from '../EntityLink'
 import MarkdownSynapse from '../Markdown/MarkdownSynapse'
 import { UserBadge } from '../UserCard/UserBadge'
@@ -29,6 +32,7 @@ type SynapseCardLabelProps = {
     | MarkdownLink
     | ColumnSpecifiedLink
     | EntityImage
+    | MapValueToReactComponentConfig
     | undefined
   selectColumns: SelectColumn[] | undefined
   columnModels: ColumnModel[] | undefined
@@ -52,12 +56,14 @@ export function SynapseCardLabel(props: SynapseCardLabelProps) {
   if (!value) {
     return <p>{value}</p>
   }
-  const { strList, str, columnModelType } = getValueOrMultiValue({
+  const { strList, str, selectColumn } = getValueOrMultiValue({
     columnName,
     value,
     selectColumns,
     columnModels,
   })
+
+  const columnModelType = selectColumn?.columnType
 
   if (!str) {
     // the array came back empty
@@ -105,7 +111,16 @@ export function SynapseCardLabel(props: SynapseCardLabelProps) {
   }
 
   let labelContent: JSX.Element
-  if ('isMarkdown' in labelLink && labelLink.isMarkdown) {
+
+  if (
+    'isMapValueToReactNodeConfig' in labelLink &&
+    labelLink.isMapValueToReactNodeConfig
+  ) {
+    const { Component } = labelLink
+    labelContent = (
+      <Component value={strList || str} selectColumn={selectColumn!} />
+    )
+  } else if ('isMarkdown' in labelLink && labelLink.isMarkdown) {
     if (strList) {
       labelContent = (
         <p>

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/SynapseTableCell.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/SynapseTableCell.tsx
@@ -19,7 +19,10 @@ import {
 import dayjs from 'dayjs'
 import { Fragment, memo } from 'react'
 import { ColumnSpecifiedLink, MarkdownLink } from '../../CardContainerLogic'
-import { EntityImage } from '../../CardContainerLogic/CardContainerLogic'
+import {
+  EntityImage,
+  MapValueToReactComponentConfig,
+} from '../../CardContainerLogic/CardContainerLogic'
 import DirectDownload from '../../DirectDownload/DirectDownload'
 import { EntityLink, EntityLinkProps } from '../../EntityLink'
 import { SynapseCardLabel } from '../../GenericCard'
@@ -37,7 +40,12 @@ export type SynapseTableCellProps = {
   columnType: ColumnType
   columnValue: string | null
   isBold: string
-  columnLinkConfig?: CardLink | MarkdownLink | ColumnSpecifiedLink | EntityImage
+  columnLinkConfig?:
+    | CardLink
+    | MarkdownLink
+    | ColumnSpecifiedLink
+    | EntityImage
+    | MapValueToReactComponentConfig
   columnName: string
   selectColumns?: SelectColumn[]
   columnModels?: ColumnModel[]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,6 +442,9 @@ importers:
 
   apps/portals/b2ai.standards:
     dependencies:
+      '@mui/icons-material':
+        specifier: ^5.17.1
+        version: 5.17.1(@mui/material@5.17.1(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
       '@mui/material':
         specifier: ^5.17.1
         version: 5.17.1(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -476,6 +479,9 @@ importers:
         specifier: ^5.4.19
         version: 5.4.19(@types/node@20.17.41)(sass@1.87.0)(terser@5.39.0)
     devDependencies:
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/react':
         specifier: 18.3.12
         version: 18.3.12


### PR DESCRIPTION
PORTALS-3613

For https://github.com/bridge2ai/b2ai-standards-registry/issues/300

- Add MapValueToReactComponentConfig to SynapseCardLabel, which provides a way to generically map a table value to a React Component implementation
- Add IsMatureIconMap component and integrate into Standards Portal as a MapValueToReactComponentConfig

![image](https://github.com/user-attachments/assets/2e36d171-0656-47c2-9c07-798eabb33852)
