### PR TITLE
SWC-7256: "We partner with scientific leaders" needs more space at the top

### DIFF
--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseHomepageV2.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseHomepageV2.tsx
@@ -284,33 +284,35 @@ export function SynapseHomepageV2({ gotoPlace }: SynapseHomepageV2Props) {
       {inView && (
         <Box>
           <Box>
-            <Typography
-              variant="headline1"
-              sx={{
-                ...defaultHomepageText,
-                textAlign: 'center',
-                mt: '100px',
-                fontSize: { xs: '32px', md: '40px' },
-                lineHeight: '42px',
-                mb: '30px',
-              }}
-            >
-              We partner with scientific leaders
-            </Typography>
-            <Box sx={{ m: 'auto', maxWidth: '750px' }}>
+            <Box sx={{ padding: { xs: '45px 40px', md: '80px 25px' } }}>
               <Typography
                 variant="headline1"
                 sx={{
-                  ...homepageBodyText,
+                  ...defaultHomepageText,
                   textAlign: 'center',
-                  mb: '60px',
+                  mt: '100px',
+                  fontSize: { xs: '32px', md: '40px' },
+                  lineHeight: '42px',
+                  mb: '30px',
                 }}
               >
-                Synapse is your ecosystem for responsible data sharing,
-                innovative data reuse, and collaboration.
+                We partner with scientific leaders
               </Typography>
+              <Box sx={{ m: 'auto', maxWidth: '750px' }}>
+                <Typography
+                  variant="headline1"
+                  sx={{
+                    ...homepageBodyText,
+                    textAlign: 'center',
+                    mb: '60px',
+                  }}
+                >
+                  Synapse is your ecosystem for responsible data sharing,
+                  innovative data reuse, and collaboration.
+                </Typography>
+              </Box>
+              <SynapsePartners />
             </Box>
-            <SynapsePartners />
             <Box
               sx={{
                 pb: {
@@ -453,8 +455,7 @@ export function SynapseHomepageV2({ gotoPlace }: SynapseHomepageV2Props) {
               sx={{
                 ...h2Sx,
                 textAlign: 'center',
-                pt: '75px',
-                pb: '75px',
+                padding: { xs: '45px 0', md: '75px 0' },
               }}
             >
               Featured datasets

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/__snapshots__/SynapseHomepageV2.test.tsx.snap
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/__snapshots__/SynapseHomepageV2.test.tsx.snap
@@ -448,110 +448,114 @@ exports[`SynapseHomepageV2 Snapshot test Basic home page 1`] = `
       <div
         class="MuiBox-root css-0"
       >
-        <h1
-          class="MuiTypography-root MuiTypography-headline1 css-bypmur-MuiTypography-root"
-        >
-          We partner with scientific leaders
-        </h1>
         <div
-          class="MuiBox-root css-wntgvd"
+          class="MuiBox-root css-9tr5ma"
         >
           <h1
-            class="MuiTypography-root MuiTypography-headline1 css-gacos-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-headline1 css-bypmur-MuiTypography-root"
           >
-            Synapse is your ecosystem for responsible data sharing, innovative data reuse, and collaboration.
+            We partner with scientific leaders
           </h1>
-        </div>
-        <div
-          class="MuiBox-root css-16vxqzz"
-        >
           <div
-            class="MuiBox-root css-4tws0t"
+            class="MuiBox-root css-wntgvd"
           >
-            <a
-              href="https://sloan.org/"
-              rel="noreferrer"
-              target="_blank"
+            <h1
+              class="MuiTypography-root MuiTypography-headline1 css-gacos-MuiTypography-root"
             >
-              <svg />
-            </a>
-            <a
-              href="https://www.aacr.org/"
-              rel="noreferrer"
-              target="_blank"
+              Synapse is your ecosystem for responsible data sharing, innovative data reuse, and collaboration.
+            </h1>
+          </div>
+          <div
+            class="MuiBox-root css-16vxqzz"
+          >
+            <div
+              class="MuiBox-root css-4tws0t"
             >
-              <svg />
-            </a>
-            <a
-              href="https://www.cancerresearch.org/"
-              rel="noreferrer"
-              target="_blank"
-            >
-              <svg />
-            </a>
-            <a
-              href="https://www.ctf.org/"
-              rel="noreferrer"
-              target="_blank"
-            >
-              <svg />
-            </a>
-            <a
-              href="https://gilbertfamilyfoundation.org/"
-              rel="noreferrer"
-              target="_blank"
-            >
-              <svg />
-            </a>
-            <a
-              href="http://grayfoundation.org/"
-              rel="noreferrer"
-              target="_blank"
-            >
-              <svg />
-            </a>
-            <a
-              href="https://mlcommons.org/"
-              rel="noreferrer"
-              target="_blank"
-            >
-              <svg />
-            </a>
-            <a
-              href="https://www.cancer.gov/"
-              rel="noreferrer"
-              target="_blank"
-            >
-              <svg />
-            </a>
-            <a
-              href="https://www.nhlbi.nih.gov/"
-              rel="noreferrer"
-              target="_blank"
-            >
-              <svg />
-            </a>
-            <a
-              href="https://www.nia.nih.gov/"
-              rel="noreferrer"
-              target="_blank"
-            >
-              <svg />
-            </a>
-            <a
-              href="https://www.nimh.nih.gov/"
-              rel="noreferrer"
-              target="_blank"
-            >
-              <svg />
-            </a>
-            <a
-              href="https://www.n-tap.org/"
-              rel="noreferrer"
-              target="_blank"
-            >
-              <svg />
-            </a>
+              <a
+                href="https://sloan.org/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+              <a
+                href="https://www.aacr.org/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+              <a
+                href="https://www.cancerresearch.org/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+              <a
+                href="https://www.ctf.org/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+              <a
+                href="https://gilbertfamilyfoundation.org/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+              <a
+                href="http://grayfoundation.org/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+              <a
+                href="https://mlcommons.org/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+              <a
+                href="https://www.cancer.gov/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+              <a
+                href="https://www.nhlbi.nih.gov/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+              <a
+                href="https://www.nia.nih.gov/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+              <a
+                href="https://www.nimh.nih.gov/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+              <a
+                href="https://www.n-tap.org/"
+                rel="noreferrer"
+                target="_blank"
+              >
+                <svg />
+              </a>
+            </div>
           </div>
         </div>
         <div
@@ -804,7 +808,7 @@ exports[`SynapseHomepageV2 Snapshot test Basic home page 1`] = `
         class="MuiBox-root css-gngfd0"
       >
         <h1
-          class="MuiTypography-root MuiTypography-headline1 css-p75j6w-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-headline1 css-l1zt5l-MuiTypography-root"
         >
           Featured datasets
         </h1>


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/SWC-7256?atlOrigin=eyJpIjoiNTQwYmQ0OGVhZDQ1NDIxN2E2ZWM0Y2E4Yzc5YTI4MzgiLCJwIjoiaiJ9

<img width="950" alt="Screenshot 2025-06-02 at 1 55 55 PM" src="https://github.com/user-attachments/assets/0ed13c40-9e8b-480d-a86b-34149b105af0" />
<img width="315" alt="Screenshot 2025-06-02 at 1 55 39 PM" src="https://github.com/user-attachments/assets/1c7835c1-7a96-4b28-be0c-cb7cdc6100f6" />

Featured Datasets on mobile had really big padding so I reduced it a little:

<img width="315" alt="Screenshot 2025-06-02 at 1 56 15 PM" src="https://github.com/user-attachments/assets/ac8ac1db-cb0e-4e5f-b24b-fcdd8c051830" />
