### PR TITLE
Added dataTypes as facet, col, and details page metadata

### DIFF
--- a/apps/portals/b2ai.standards/src/config/resources.ts
+++ b/apps/portals/b2ai.standards/src/config/resources.ts
@@ -3,7 +3,7 @@ import { FTSConfig } from 'synapse-react-client/components/SynapseTable/SearchV2
 export const TABLE_IDS = {
   Challenges: { name: 'Challenges', id: 'syn65913973' },
   CurrentTableVersions: { name: 'CurrentTableVersions', id: 'syn66330007' },
-  DST_denormalized: { name: 'DST_denormalized', id: 'syn65676531.54' },
+  DST_denormalized: { name: 'DST_denormalized', id: 'syn65676531.55' },
   DataSet: { name: 'DataSet', id: 'syn66330217' },
   DataStandardOrTool: { name: 'DataStandardOrTool', id: 'syn63096833' },
   DataSubstrate: { name: 'DataSubstrate', id: 'syn63096834' },
@@ -29,8 +29,9 @@ export const dataSql = `
     SELECT
         isMature,
         concat('[', acronym, '](/Explore/Standard/DetailsPage?id=', id, ')') as acronym,
-            name, category, collections, topic,
-            ${DST_TABLE_COLUMN_NAMES.RELEVANT_ORG_NAMES}, isOpen, registration, "usedInBridge2AI", hasAIApplication
+            name, category, collections, topic, dataTypes,
+            ${DST_TABLE_COLUMN_NAMES.RELEVANT_ORG_NAMES}, isOpen, registration, "usedInBridge2AI"
+            , hasAIApplication
             FROM ${TABLE_IDS.DST_denormalized.id}
 `
 // removed topic column above to address @jay-hodgson's comment
@@ -49,7 +50,8 @@ export const standardsDetailsPageSQL = `
             URL as url,
             category,
             collections,
-            topic as topics,
+            topic,
+            dataTypes,
             ${DST_TABLE_COLUMN_NAMES.RELEVANT_ORG_NAMES},
             responsibleOrgName as SDO,
             isOpen,

--- a/apps/portals/b2ai.standards/src/pages/StandardsDetailsPage.tsx
+++ b/apps/portals/b2ai.standards/src/pages/StandardsDetailsPage.tsx
@@ -29,7 +29,7 @@ export const standardsCardSchema: TableToGenericCardMapping = {
   subTitle: 'standardName',
   description: 'description',
   link: 'url',
-  secondaryLabels: ['SDO', 'collections', 'topics'],
+  secondaryLabels: ['SDO', 'collections', 'topics', 'dataTypes'],
 }
 
 export const linkedStandardCardConfiguration: CardConfiguration = {


### PR DESCRIPTION
- This is for https://github.com/bridge2ai/b2ai-standards-registry/issues/309
- Updated DST-denormalized to v55