### PR TITLE
Allow pnpm v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "engines": {
     "node": ">=22 <23",
-    "pnpm": ">=9 <10"
+    "pnpm": ">=9 <=10"
   },
   "scripts": {
     "prepare": "husky",


### PR DESCRIPTION
Update the engines field in package.json to allow pnpm v10. Fixes the following error installing new packages
`Expected version: >=9 <10
Got: 10.11.1`