### PR TITLE
PORTALS-3351 - Replace imports to `react-dom/test-utils`

### DIFF
--- a/packages/synapse-react-client/src/components/FeaturedToolsList/FeaturedToolsList.test.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedToolsList/FeaturedToolsList.test.tsx
@@ -2,8 +2,7 @@ import syn26344826Json from '@/mocks/query/syn26344826.json'
 import SynapseClient from '@/synapse-client'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
 import { QueryResultBundle } from '@sage-bionetworks/synapse-types'
-import { render, waitFor } from '@testing-library/react'
-import { act } from 'react-dom/test-utils'
+import { act, render, waitFor } from '@testing-library/react'
 import FeaturedToolsList from './FeaturedToolsList'
 
 jest.mock('../../synapse-client', () => ({

--- a/packages/synapse-react-client/src/components/Plot/SynapsePlot.test.tsx
+++ b/packages/synapse-react-client/src/components/Plot/SynapsePlot.test.tsx
@@ -1,9 +1,14 @@
 import mockSyn26438037Counts from '@/mocks/query/syn26438037Counts.json'
+import * as SynapseClient from '@/synapse-client/SynapseClient'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
 import { QueryResultBundle } from '@sage-bionetworks/synapse-types'
-import { Queries, render, RenderResult, screen } from '@testing-library/react'
-import { act } from 'react-dom/test-utils'
-import { SynapseClient } from '../../index'
+import {
+  act,
+  Queries,
+  render,
+  RenderResult,
+  screen,
+} from '@testing-library/react'
 import SynapsePlot, { SynapsePlotProps } from './SynapsePlot'
 
 const customPlotClickCallback = jest.fn()


### PR DESCRIPTION
Import moved in React 19, but we should use the `@testing-library/react` alias