### PR TITLE
SWC-7055 - Track global editing state

### DIFF
--- a/packages/synapse-react-client/src/components/AclEditor/useUpdateAcl.test.ts
+++ b/packages/synapse-react-client/src/components/AclEditor/useUpdateAcl.test.ts
@@ -1,14 +1,27 @@
 import { server } from '@/mocks/msw/server'
 import { MOCK_USER_ID, MOCK_USER_ID_2 } from '@/mocks/user/mock_user_profile'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { useGlobalIsEditingContext } from '@/utils/context/GlobalIsEditingContext'
 import { ACCESS_TYPE } from '@sage-bionetworks/synapse-types'
 import { act, renderHook as _renderHook, waitFor } from '@testing-library/react'
 import useUpdateAcl from './useUpdateAcl'
+
+vi.mock('@/utils/context/GlobalIsEditingContext', async importOriginal => ({
+  ...(await importOriginal()),
+  useGlobalIsEditingContext: vi.fn(),
+}))
 
 describe('useUpdateAcl', () => {
   function renderHook() {
     const mockOnChange = vi.fn()
     const mockOnError = vi.fn()
+
+    const mockSetIsEditing = vi.fn()
+    vi.mocked(useGlobalIsEditingContext).mockReturnValue({
+      setIsEditing: mockSetIsEditing,
+      isEditing: false,
+    })
+
     const renderHookResult = _renderHook(
       () =>
         useUpdateAcl({
@@ -22,6 +35,7 @@ describe('useUpdateAcl', () => {
       ...renderHookResult,
       mockOnChange,
       mockOnError,
+      mockSetIsEditing,
     }
   }
 
@@ -30,22 +44,24 @@ describe('useUpdateAcl', () => {
   afterAll(() => server.close())
 
   it('handles adding a new resource access item', async () => {
-    const { result } = renderHook()
+    const { result, mockSetIsEditing } = renderHook()
     expect(result.current.resourceAccessList).toHaveLength(0)
+    expect(mockSetIsEditing).not.toHaveBeenCalledWith(true)
 
     act(() => {
       result.current.addResourceAccessItem(MOCK_USER_ID, [ACCESS_TYPE.READ])
     })
 
-    await waitFor(() =>
+    await waitFor(() => {
       expect(result.current.resourceAccessList).toEqual([
         { principalId: MOCK_USER_ID, accessType: [ACCESS_TYPE.READ] },
-      ]),
-    )
+      ])
+      expect(mockSetIsEditing).toHaveBeenLastCalledWith(true)
+    })
   })
 
   it('handles updating a resource access item', async () => {
-    const { result } = renderHook()
+    const { result, mockSetIsEditing } = renderHook()
     expect(result.current.resourceAccessList).toHaveLength(0)
 
     // Set up the ACL
@@ -54,11 +70,12 @@ describe('useUpdateAcl', () => {
         { principalId: MOCK_USER_ID, accessType: [ACCESS_TYPE.READ] },
       ])
     })
-    await waitFor(() =>
+    await waitFor(() => {
       expect(result.current.resourceAccessList).toEqual([
         { principalId: MOCK_USER_ID, accessType: [ACCESS_TYPE.READ] },
-      ]),
-    )
+      ])
+      expect(mockSetIsEditing).not.toHaveBeenCalledWith(true)
+    })
 
     // Method under test
     act(() => {
@@ -68,18 +85,19 @@ describe('useUpdateAcl', () => {
       ])
     })
 
-    await waitFor(() =>
+    await waitFor(() => {
       expect(result.current.resourceAccessList).toEqual([
         {
           principalId: MOCK_USER_ID,
           accessType: [ACCESS_TYPE.READ, ACCESS_TYPE.UPDATE],
         },
-      ]),
-    )
+      ])
+      expect(mockSetIsEditing).toHaveBeenLastCalledWith(true)
+    })
   })
 
   it('handles deleting a resource access item', async () => {
-    const { result } = renderHook()
+    const { result, mockSetIsEditing } = renderHook()
     expect(result.current.resourceAccessList).toHaveLength(0)
 
     // Set up the ACL
@@ -88,22 +106,26 @@ describe('useUpdateAcl', () => {
         { principalId: MOCK_USER_ID, accessType: [ACCESS_TYPE.READ] },
       ])
     })
-    await waitFor(() =>
+    await waitFor(() => {
       expect(result.current.resourceAccessList).toEqual([
         { principalId: MOCK_USER_ID, accessType: [ACCESS_TYPE.READ] },
-      ]),
-    )
+      ])
+      expect(mockSetIsEditing).not.toHaveBeenCalledWith(true)
+    })
 
     // Method under test
     act(() => {
       result.current.removeResourceAccessItem(MOCK_USER_ID)
     })
 
-    await waitFor(() => expect(result.current.resourceAccessList).toEqual([]))
+    await waitFor(() => {
+      expect(result.current.resourceAccessList).toEqual([])
+      expect(mockSetIsEditing).toHaveBeenLastCalledWith(true)
+    })
   })
 
   it('sorts the resourceAccessList when the form has not been edited', async () => {
-    const { result } = renderHook()
+    const { result, mockSetIsEditing } = renderHook()
     expect(result.current.resourceAccessList).toHaveLength(0)
 
     // Set up the ACL - users with equal permissions should be sorted alphabetically by username
@@ -117,18 +139,19 @@ describe('useUpdateAcl', () => {
     })
 
     // Verify that the entries were sorted
-    await waitFor(() =>
+    await waitFor(() => {
       expect(result.current.resourceAccessList).toEqual([
         // @AnotherUser
         { principalId: MOCK_USER_ID_2, accessType: [ACCESS_TYPE.READ] },
         // @myUserName
         { principalId: MOCK_USER_ID, accessType: [ACCESS_TYPE.READ] },
-      ]),
-    )
+      ])
+      expect(mockSetIsEditing).not.toHaveBeenCalledWith(true)
+    })
   })
 
   it('does not sort after making edits', async () => {
-    const { result } = renderHook()
+    const { result, mockSetIsEditing } = renderHook()
     expect(result.current.resourceAccessList).toHaveLength(0)
 
     // Set up the ACL
@@ -138,11 +161,12 @@ describe('useUpdateAcl', () => {
         { principalId: MOCK_USER_ID, accessType: [ACCESS_TYPE.READ] },
       ])
     })
-    await waitFor(() =>
+    await waitFor(() => {
       expect(result.current.resourceAccessList).toEqual([
         { principalId: MOCK_USER_ID, accessType: [ACCESS_TYPE.READ] },
-      ]),
-    )
+      ])
+      expect(mockSetIsEditing).not.toHaveBeenCalledWith(true)
+    })
 
     // Individually adding @AnotherUser should NOT trigger a sort, since the editor is 'dirty'.
     act(() => {
@@ -150,14 +174,15 @@ describe('useUpdateAcl', () => {
     })
 
     // Verify that the entries are not sorted
-    await waitFor(() =>
+    await waitFor(() => {
       expect(result.current.resourceAccessList).toEqual([
         // @myUserName
         { principalId: MOCK_USER_ID, accessType: [ACCESS_TYPE.READ] },
         // @AnotherUser
         { principalId: MOCK_USER_ID_2, accessType: [ACCESS_TYPE.READ] },
-      ]),
-    )
+      ])
+      expect(mockSetIsEditing).toHaveBeenLastCalledWith(true)
+    })
 
     // Verify that if we reset the dirty state, the list is re-sorted
     act(() => {
@@ -165,13 +190,14 @@ describe('useUpdateAcl', () => {
     })
 
     // Verify that the entries are sorted
-    await waitFor(() =>
+    await waitFor(() => {
       expect(result.current.resourceAccessList).toEqual([
         // @AnotherUser
         { principalId: MOCK_USER_ID_2, accessType: [ACCESS_TYPE.READ] },
         // @myUserName
         { principalId: MOCK_USER_ID, accessType: [ACCESS_TYPE.READ] },
-      ]),
-    )
+      ])
+      expect(mockSetIsEditing).toHaveBeenLastCalledWith(false)
+    })
   })
 })

--- a/packages/synapse-react-client/src/components/AclEditor/useUpdateAcl.ts
+++ b/packages/synapse-react-client/src/components/AclEditor/useUpdateAcl.ts
@@ -1,3 +1,4 @@
+import { useGlobalIsEditingContext } from '@/utils/context/GlobalIsEditingContext'
 import { ACCESS_TYPE, ResourceAccess } from '@sage-bionetworks/synapse-types'
 import {
   Dispatch,
@@ -50,6 +51,16 @@ export default function useUpdateAcl(
     onError = noop,
   } = options
   const [isDirty, setIsDirty] = useState(false)
+  const { setIsEditing } = useGlobalIsEditingContext()
+
+  // When the form is dirty, set the global editing state to true
+  useEffect(() => {
+    setIsEditing(isDirty)
+    return () => {
+      setIsEditing(false)
+    }
+  }, [isDirty, setIsEditing])
+
   const [resourceAccessList, setResourceAccessList] = useState<
     ResourceAccess[]
   >(initialResourceAccessList)

--- a/packages/synapse-react-client/src/components/Dialog/ConfirmCloseWithoutSavingDialog.tsx
+++ b/packages/synapse-react-client/src/components/Dialog/ConfirmCloseWithoutSavingDialog.tsx
@@ -1,0 +1,34 @@
+import { SetOptional } from 'type-fest'
+import {
+  ConfirmationDialog,
+  ConfirmationDialogProps,
+} from '../ConfirmationDialog/ConfirmationDialog'
+
+export type ConfirmCloseWithoutSavingDialogProps = SetOptional<
+  ConfirmationDialogProps,
+  'title' | 'content' | 'confirmButtonProps'
+>
+
+function ConfirmCloseWithoutSavingDialog(
+  props: ConfirmCloseWithoutSavingDialogProps,
+) {
+  const {
+    title = 'Close without saving?',
+    content = 'Are you sure you want to close the editor without saving your changes?',
+    confirmButtonProps = {
+      children: 'Close without saving',
+      color: 'error',
+    },
+    ...rest
+  } = props
+  return (
+    <ConfirmationDialog
+      title={title}
+      content={content}
+      confirmButtonProps={confirmButtonProps}
+      {...rest}
+    />
+  )
+}
+
+export default ConfirmCloseWithoutSavingDialog

--- a/packages/synapse-react-client/src/components/doi/CreateOrUpdateDoiModal.test.tsx
+++ b/packages/synapse-react-client/src/components/doi/CreateOrUpdateDoiModal.test.tsx
@@ -20,12 +20,14 @@ import userEvent from '@testing-library/user-event'
 import { CreateOrUpdateDoiModal } from './CreateOrUpdateDoiModal'
 import { displayToast } from '../ToastMessage'
 import { useGetPortal } from '@/synapse-queries/portal/usePortal'
+import { useGlobalIsEditingContext } from '@/utils/context/GlobalIsEditingContext'
 
 vi.mock('@/synapse-queries/doi/useDOI')
 vi.mock('@/synapse-queries/entity/useEntity')
 vi.mock('@/synapse-queries/user/useUserBundle')
 vi.mock('@/components/ToastMessage/ToastMessage')
 vi.mock('@/synapse-queries/portal/usePortal')
+vi.mock('@/utils/context/GlobalIsEditingContext')
 
 const mockUseCreateOrUpdateDOI = vi
   .mocked(useCreateOrUpdateDOI)
@@ -52,6 +54,11 @@ const mockUseGetPortal = vi
   .mockReturnValue(getUseQueryIdleMock())
 
 const mockDisplayToast = vi.mocked(displayToast)
+const mockSetIsEditing = vi.fn()
+vi.mocked(useGlobalIsEditingContext).mockReturnValue({
+  isEditing: false,
+  setIsEditing: mockSetIsEditing,
+})
 
 describe('CreateOrUpdateDoiModal', () => {
   const defaultProps = {
@@ -331,5 +338,17 @@ describe('CreateOrUpdateDoiModal', () => {
     const publisherField = await screen.findByLabelText('Publisher')
     expect(publisherField).toHaveValue(mockPortalName)
     expect(publisherField).toBeDisabled()
+  })
+
+  it('Sets global editing state when open', () => {
+    const { rerender } = render(
+      <CreateOrUpdateDoiModal {...defaultProps} open={true} />,
+    )
+
+    expect(mockSetIsEditing).toHaveBeenLastCalledWith(true)
+
+    rerender(<CreateOrUpdateDoiModal {...defaultProps} open={false} />)
+
+    expect(mockSetIsEditing).toHaveBeenLastCalledWith(false)
   })
 })

--- a/packages/synapse-react-client/src/components/doi/CreateOrUpdateDoiModal.tsx
+++ b/packages/synapse-react-client/src/components/doi/CreateOrUpdateDoiModal.tsx
@@ -1,3 +1,4 @@
+import ConfirmCloseWithoutSavingDialog from '@/components/Dialog/ConfirmCloseWithoutSavingDialog'
 import { DialogBase } from '@/components/DialogBase'
 import { doiFormSchema, doiFormUiSchema } from '@/components/doi/DoiFormSchemas'
 import { JsonSchemaForm } from '@/components/JsonSchemaForm/JsonSchemaForm'
@@ -11,6 +12,7 @@ import {
 } from '@/synapse-queries/entity/useEntity'
 import { useGetPortal } from '@/synapse-queries/portal/usePortal'
 import { useGetCurrentUserProfile } from '@/synapse-queries/user/useUserBundle'
+import { useGlobalIsEditingContext } from '@/utils/context/GlobalIsEditingContext'
 import {
   convertToEntityType,
   entityTypeToFriendlyName,
@@ -116,6 +118,25 @@ export function CreateOrUpdateDoiModal(props: CreateOrUpdateDoiModalProps) {
     defaultVersionNumber,
     portalId,
   } = props
+
+  const [showConfirmCloseModal, setShowConfirmCloseDialog] = useState(false)
+  const { isEditing, setIsEditing } = useGlobalIsEditingContext()
+  useEffect(() => {
+    setIsEditing(open)
+
+    return () => {
+      setIsEditing(false)
+    }
+  }, [open, setIsEditing])
+
+  function handleClose() {
+    if (isEditing) {
+      setShowConfirmCloseDialog(true)
+    } else {
+      onClose()
+    }
+  }
+
   const [selectedVersionNumber, setSelectedVersionNumber] =
     useState(defaultVersionNumber)
 
@@ -367,12 +388,24 @@ export function CreateOrUpdateDoiModal(props: CreateOrUpdateDoiModalProps) {
   )
 
   return (
-    <DialogBase
-      open={open}
-      onCancel={onClose}
-      title={'Create or Update a DOI'}
-      content={dialogContent}
-      actions={dialogActions}
-    />
+    <>
+      <ConfirmCloseWithoutSavingDialog
+        open={showConfirmCloseModal}
+        onCancel={() => {
+          setShowConfirmCloseDialog(false)
+        }}
+        onConfirm={() => {
+          setShowConfirmCloseDialog(false)
+          onClose()
+        }}
+      />
+      <DialogBase
+        open={open}
+        onCancel={handleClose}
+        title={'Create or Update a DOI'}
+        content={dialogContent}
+        actions={dialogActions}
+      />
+    </>
   )
 }

--- a/packages/synapse-react-client/src/utils/context/GlobalIsEditingContext.tsx
+++ b/packages/synapse-react-client/src/utils/context/GlobalIsEditingContext.tsx
@@ -1,0 +1,71 @@
+import noop from 'lodash-es/noop'
+import {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useSyncExternalStore,
+} from 'react'
+
+type GlobalIsEditingContextType = {
+  /** If true, the user is editing a resource and should be presented with a warning before navigating away or performing
+   * some other action that will destroy the unsaved changes */
+  isEditing: boolean
+  /** Function to set the editing state. This should be called when the user starts or stops editing a resource */
+  setIsEditing: (value: boolean) => void
+}
+
+const GlobalIsEditingContext = createContext<GlobalIsEditingContextType>({
+  isEditing: false,
+  setIsEditing: noop,
+})
+
+type UnsubscribeFn = () => void
+type SubscribeFn = (callback: () => void) => UnsubscribeFn
+export type IsEditingStore = {
+  subscribe: SubscribeFn
+  getSnapshot: () => boolean
+  setIsEditing: (value: boolean) => void
+}
+type GlobalIsEditingContextProviderProps = PropsWithChildren<IsEditingStore>
+
+/**
+ * Provider for context that tracks whether the user is currently editing a resource, to be used to prevent the user from
+ * navigating away before changes are saved.
+ *
+ * This context provider does not itself implement the logic to prevent navigation, but provides an interface for
+ * synchronizing with the editing state tracked in the application.
+ */
+export function GlobalIsEditingContextProvider(
+  props: GlobalIsEditingContextProviderProps,
+) {
+  const { subscribe, getSnapshot, setIsEditing, children } = props
+
+  const isEditing = useSyncExternalStore(subscribe, getSnapshot, () => false)
+
+  return (
+    <GlobalIsEditingContext.Provider value={{ isEditing, setIsEditing }}>
+      {children}
+    </GlobalIsEditingContext.Provider>
+  )
+}
+
+/**
+ * Hook to access the global editing context so the application can prevent navigation away from a page if a resource is being edited.
+ */
+export function useGlobalIsEditingContext(): GlobalIsEditingContextType {
+  const context = useContext(GlobalIsEditingContext)
+  if (context === undefined) {
+    console.warn(
+      'useGlobalIsEditingContext should be used within a GlobalIsEditingContextProvider. Editing state will not be tracked!',
+    )
+    return {
+      isEditing: false,
+      setIsEditing: () => {
+        console.warn(
+          'setIsEditing called outside of a GlobalIsEditingContextProvider. Editing state will not be tracked!',
+        )
+      },
+    }
+  }
+  return context
+}


### PR DESCRIPTION
- Add context to synchronize React with global editing state
- Use isEditing context in ACL Editors
- Use isEditing context in DOI editor
- Add confirmation to closing EntityAclEditorModal if dirty
- Add confirmation to closing DOI modal (not currently tracking dirty state)