### PR TITLE
PORTALS-3351 - Custom matcher for React component mocks/spies

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/SelfSignAccessRequirementItem.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/RequirementItem/SelfSignAccessRequirementItem.test.tsx
@@ -123,9 +123,8 @@ async function testWikiToggle(expectedProps: MarkdownSynapseProps) {
   await userEvent.click(toggle)
 
   await screen.findByText(mockRenderedMarkdown)
-  expect(mockMarkdownSynapse).toHaveBeenCalledWith(
+  expect(mockMarkdownSynapse).toHaveBeenRenderedWithProps(
     expect.objectContaining(expectedProps),
-    expect.anything(),
   )
 
   toggle = await screen.findByRole('button', { name: 'Hide Terms' })
@@ -138,9 +137,8 @@ async function testWikiToggle(expectedProps: MarkdownSynapseProps) {
 
 async function testWikiShownWithoutToggle(expectedProps: MarkdownSynapseProps) {
   await screen.findByText(mockRenderedMarkdown)
-  expect(mockMarkdownSynapse).toHaveBeenCalledWith(
+  expect(mockMarkdownSynapse).toHaveBeenRenderedWithProps(
     expect.objectContaining(expectedProps),
-    expect.anything(),
   )
 
   expect(

--- a/packages/synapse-react-client/src/components/CardContainerLogic/CardContainerLogic.test.tsx
+++ b/packages/synapse-react-client/src/components/CardContainerLogic/CardContainerLogic.test.tsx
@@ -59,7 +59,7 @@ describe('it performs basic functionality', () => {
     renderComponent(props)
 
     await waitFor(() =>
-      expect(queryWrapperSpy).toHaveBeenCalledWith(
+      expect(queryWrapperSpy).toHaveBeenRenderedWithProps(
         expect.objectContaining<QueryWrapperProps>({
           isInfinite: true,
           initQueryRequest: expect.objectContaining<QueryBundleRequest>({
@@ -81,19 +81,17 @@ describe('it performs basic functionality', () => {
             },
           }),
         }),
-        expect.anything(),
       ),
     )
 
     await waitFor(() =>
-      expect(queryVisualizationWrapperSpy).toHaveBeenCalledWith(
+      expect(queryVisualizationWrapperSpy).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           rgbIndex: props.rgbIndex,
           unitDescription: props.unitDescription,
           columnAliases: props.columnAliases,
           noContentPlaceholderType: NoContentPlaceholderType.STATIC,
         }),
-        expect.anything(),
       ),
     )
 
@@ -106,10 +104,10 @@ describe('it performs basic functionality', () => {
     )
 
     await waitFor(() =>
-      expect(mockCardContainer).toHaveBeenCalledWith(
-        { ...props.cardConfiguration, rowSet: truncatedQueryResults },
-        expect.anything(),
-      ),
+      expect(mockCardContainer).toHaveBeenRenderedWithProps({
+        ...props.cardConfiguration,
+        rowSet: truncatedQueryResults,
+      }),
     )
   })
 })

--- a/packages/synapse-react-client/src/components/EntityFinder/EntityFinder.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityFinder/EntityFinder.test.tsx
@@ -304,7 +304,7 @@ describe('EntityFinder tests', () => {
       invokeSetConfigViaTree(configuration)
     })
 
-    expect(mockDetailsList).toHaveBeenCalledWith(
+    expect(mockDetailsList).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         configuration: configuration, // !
         selectableTypes: defaultProps.selectableTypes,
@@ -313,7 +313,6 @@ describe('EntityFinder tests', () => {
           ...defaultProps.selectableTypes!,
         ],
       }),
-      {},
     )
 
     const reference: Reference = {
@@ -325,13 +324,12 @@ describe('EntityFinder tests', () => {
       invokeToggleSelectionViaTable(reference)
     })
     await waitFor(() =>
-      expect(mockDetailsList).toHaveBeenLastCalledWith(
+      expect(mockDetailsList).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           selected: Map([
             [reference.targetId, { targetId: reference.targetId }],
           ]),
         }),
-        {},
       ),
     )
   })
@@ -376,7 +374,7 @@ describe('EntityFinder tests', () => {
       expect(() => screen.getByRole('table')).not.toThrow()
 
       await waitFor(() =>
-        expect(mockDetailsList).toBeCalledWith(
+        expect(mockDetailsList).toHaveBeenRenderedWithProps(
           expect.objectContaining({
             configuration: {
               type: EntityDetailsListDataConfigurationType.ENTITY_SEARCH,
@@ -393,11 +391,10 @@ describe('EntityFinder tests', () => {
               },
             },
           }),
-          {},
         ),
       )
       await waitFor(() =>
-        expect(mockDetailsList).toBeCalledWith(
+        expect(mockDetailsList).toHaveBeenRenderedWithProps(
           expect.objectContaining({
             configuration: {
               type: EntityDetailsListDataConfigurationType.ENTITY_SEARCH,
@@ -414,7 +411,6 @@ describe('EntityFinder tests', () => {
               },
             },
           }),
-          {},
         ),
       )
 
@@ -479,14 +475,13 @@ describe('EntityFinder tests', () => {
       await user.type(searchInput, '{enter}')
 
       await waitFor(() =>
-        expect(mockDetailsList).toBeCalledWith(
+        expect(mockDetailsList).toHaveBeenRenderedWithProps(
           expect.objectContaining({
             configuration: {
               type: EntityDetailsListDataConfigurationType.HEADER_LIST,
               headerList: entityHeaderResult.results,
             },
           }),
-          {},
         ),
       )
       expect(mockGetEntityHeaders).toBeCalledTimes(1)
@@ -496,14 +491,13 @@ describe('EntityFinder tests', () => {
       await user.type(searchInput, `${entityId}.${version}`)
       await user.type(searchInput, '{enter}')
       await waitFor(() =>
-        expect(mockDetailsList).toBeCalledWith(
+        expect(mockDetailsList).toHaveBeenRenderedWithProps(
           expect.objectContaining({
             configuration: {
               type: EntityDetailsListDataConfigurationType.HEADER_LIST,
               headerList: entityHeaderResultWithVersion.results,
             },
           }),
-          {},
         ),
       )
 

--- a/packages/synapse-react-client/src/components/EntityFinder/details/view/DetailsView.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityFinder/details/view/DetailsView.test.tsx
@@ -782,12 +782,11 @@ describe('DetailsView tests', () => {
 
         // The version number passed to renderers (such as the EntityBadgeIcons) should be undefined
         await waitFor(() =>
-          expect(mockEntityBadgeIcons).toHaveBeenLastCalledWith(
+          expect(mockEntityBadgeIcons).toHaveBeenLastRenderedWithProps(
             expect.objectContaining({
               entityId: entityHeaders[0].id,
               versionNumber: undefined,
             }),
-            expect.anything(),
           ),
         )
       })
@@ -822,12 +821,11 @@ describe('DetailsView tests', () => {
 
         // The version number passed to renderers (such as the EntityBadgeIcons) should be the selected version
         await waitFor(() =>
-          expect(mockEntityBadgeIcons).toHaveBeenLastCalledWith(
+          expect(mockEntityBadgeIcons).toHaveBeenLastRenderedWithProps(
             expect.objectContaining({
               entityId: entityHeaders[0].id,
               versionNumber: versionResult.results[1].versionNumber,
             }),
-            expect.anything(),
           ),
         )
       })
@@ -862,12 +860,11 @@ describe('DetailsView tests', () => {
 
         // The version number passed to renderers (such as the EntityBadgeIcons) should be the automatically selected version
         await waitFor(() =>
-          expect(mockEntityBadgeIcons).toHaveBeenLastCalledWith(
+          expect(mockEntityBadgeIcons).toHaveBeenLastRenderedWithProps(
             expect.objectContaining({
               entityId: entityHeaders[0].id,
               versionNumber: versionResult.results[0].versionNumber,
             }),
-            expect.anything(),
           ),
         )
       })

--- a/packages/synapse-react-client/src/components/EntityFinder/tree/EntityTree.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityFinder/tree/EntityTree.test.tsx
@@ -464,7 +464,7 @@ describe('EntityTree tests', () => {
     await waitFor(() => {
       expect(mockSetDetailsViewConfiguration).toBeCalled()
 
-      expect(mockVirtualizedTree).toHaveBeenLastCalledWith(
+      expect(mockVirtualizedTree).toHaveBeenLastRenderedWithProps(
         expect.objectContaining<VirtualizedTreeProps>({
           rootNodeConfiguration: {
             nodeText: 'Projects',
@@ -480,7 +480,6 @@ describe('EntityTree tests', () => {
           treeNodeType: defaultProps.treeNodeType,
           selectableTypes: defaultProps.selectableTypes,
         }),
-        {},
       )
     })
     // Select an entity using callback prop in child component
@@ -503,7 +502,7 @@ describe('EntityTree tests', () => {
     await waitFor(() => {
       expect(mockSetDetailsViewConfiguration).toBeCalled()
 
-      expect(mockVirtualizedTree).toHaveBeenLastCalledWith(
+      expect(mockVirtualizedTree).toHaveBeenLastRenderedWithProps(
         expect.objectContaining<VirtualizedTreeProps>({
           rootNodeConfiguration: {
             nodeText: 'Projects',
@@ -519,7 +518,6 @@ describe('EntityTree tests', () => {
           visibleTypes: defaultProps.visibleTypes,
           treeNodeType: defaultProps.treeNodeType,
         }),
-        {},
       )
     })
   })

--- a/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTable.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityHeaderTable/EntityHeaderTable.test.tsx
@@ -154,9 +154,8 @@ describe('EntityHeaderTable tests', () => {
     await user.click(openEntityFinderButton)
 
     await waitFor(() =>
-      expect(mockEntityFinderModal).toHaveBeenLastCalledWith(
+      expect(mockEntityFinderModal).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({ show: true }),
-        expect.anything(),
       ),
     )
 
@@ -171,9 +170,8 @@ describe('EntityHeaderTable tests', () => {
 
     await waitFor(() => {
       // The entity finder should have been hidden
-      expect(mockEntityFinderModal).toHaveBeenLastCalledWith(
+      expect(mockEntityFinderModal).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({ show: false }),
-        expect.anything(),
       )
       // And the items should have been added automatically
       expect(mockOnUpdate).toHaveBeenCalledWith([

--- a/packages/synapse-react-client/src/components/EntityUpload/EntityUpload.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityUpload/EntityUpload.test.tsx
@@ -195,20 +195,17 @@ describe('EntityUpload', () => {
     })
 
     await screen.findByTestId('FileUploadProgress')
-    expect(mockFileUploadProgress).toHaveBeenLastCalledWith(
-      {
-        status: 'UPLOADING',
-        fileName: 'file1.txt',
-        totalSizeInBytes: hookReturnValue.uploadProgress[0].file.size,
-        uploadedSizeInBytes: hookReturnValue.uploadProgress[0].file.size / 2,
-        onCancel: hookReturnValue.uploadProgress[0].cancel,
-        onPause: hookReturnValue.uploadProgress[0].pause,
-        onResume: hookReturnValue.uploadProgress[0].resume,
-        onRemove: hookReturnValue.uploadProgress[0].remove,
-        errorMessage: undefined,
-      },
-      expect.anything(),
-    )
+    expect(mockFileUploadProgress).toHaveBeenLastRenderedWithProps({
+      status: 'UPLOADING',
+      fileName: 'file1.txt',
+      totalSizeInBytes: hookReturnValue.uploadProgress[0].file.size,
+      uploadedSizeInBytes: hookReturnValue.uploadProgress[0].file.size / 2,
+      onCancel: hookReturnValue.uploadProgress[0].cancel,
+      onPause: hookReturnValue.uploadProgress[0].pause,
+      onResume: hookReturnValue.uploadProgress[0].resume,
+      onRemove: hookReturnValue.uploadProgress[0].remove,
+      errorMessage: undefined,
+    })
 
     await screen.findByText('Uploading 1 Item')
   })
@@ -369,14 +366,10 @@ describe('EntityUpload', () => {
     renderComponent()
 
     await waitFor(() => {
-      expect(mockProjectStorageLimitAlert).toHaveBeenCalledWith(
-        {
-          didUploadsExceedLimit: false,
-          usage:
-            mockSynapseStorageUploadDestination.projectStorageLocationUsage,
-        },
-        expect.anything(),
-      )
+      expect(mockProjectStorageLimitAlert).toHaveBeenLastRenderedWithProps({
+        didUploadsExceedLimit: false,
+        usage: mockSynapseStorageUploadDestination.projectStorageLocationUsage,
+      })
 
       expect(mockUseUploadFileEntities).toHaveBeenCalled()
     })
@@ -388,12 +381,9 @@ describe('EntityUpload', () => {
       onStorageLimitExceeded()
     })
 
-    expect(mockProjectStorageLimitAlert).toHaveBeenCalledWith(
-      {
-        didUploadsExceedLimit: true,
-        usage: mockSynapseStorageUploadDestination.projectStorageLocationUsage,
-      },
-      expect.anything(),
-    )
+    expect(mockProjectStorageLimitAlert).toHaveBeenLastRenderedWithProps({
+      didUploadsExceedLimit: true,
+      usage: mockSynapseStorageUploadDestination.projectStorageLocationUsage,
+    })
   })
 })

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditor.test.tsx
@@ -36,27 +36,24 @@ describe('EntityViewScopeEditor tests', () => {
     await screen.findByTestId('EntityHeaderTableMocked')
 
     await waitFor(() =>
-      expect(mockedEntityHeaderTable).toHaveBeenLastCalledWith(
-        {
-          references: [{ targetId: 'syn123' }],
-          isEditable: true,
-          onUpdate: expect.anything(),
-          removeSelectedRowsButtonText: 'Remove Selected Items from View Scope',
-          objectNameCopy: 'container',
-          hideTextFieldToPasteValue: true,
-          entityFinderConfiguration: {
-            selectMultiple: true,
-            versionSelection: VersionSelectionType.DISALLOWED,
-            initialScope: FinderScope.ALL_PROJECTS,
-            initialContainer: 'root',
-            selectableTypes: expect.arrayContaining([
-              EntityType.PROJECT,
-              EntityType.FOLDER,
-            ]),
-          },
+      expect(mockedEntityHeaderTable).toHaveBeenLastRenderedWithProps({
+        references: [{ targetId: 'syn123' }],
+        isEditable: true,
+        onUpdate: expect.anything(),
+        removeSelectedRowsButtonText: 'Remove Selected Items from View Scope',
+        objectNameCopy: 'container',
+        hideTextFieldToPasteValue: true,
+        entityFinderConfiguration: {
+          selectMultiple: true,
+          versionSelection: VersionSelectionType.DISALLOWED,
+          initialScope: FinderScope.ALL_PROJECTS,
+          initialContainer: 'root',
+          selectableTypes: expect.arrayContaining([
+            EntityType.PROJECT,
+            EntityType.FOLDER,
+          ]),
         },
-        expect.anything(),
-      ),
+      }),
     )
 
     const capturedOnUpdate = mockedEntityHeaderTable.mock.lastCall![0].onUpdate!
@@ -80,27 +77,24 @@ describe('EntityViewScopeEditor tests', () => {
     await screen.findByText('Empty! Add items to populate your view')
 
     await waitFor(() =>
-      expect(mockedEntityHeaderTable).toHaveBeenLastCalledWith(
-        {
-          references: [],
-          isEditable: true,
-          onUpdate: expect.anything(),
-          removeSelectedRowsButtonText: 'Remove Selected Items from View Scope',
-          objectNameCopy: 'container',
-          hideTextFieldToPasteValue: true,
-          entityFinderConfiguration: {
-            selectMultiple: true,
-            versionSelection: VersionSelectionType.DISALLOWED,
-            initialScope: FinderScope.ALL_PROJECTS,
-            initialContainer: 'root',
-            selectableTypes: expect.arrayContaining([
-              EntityType.PROJECT,
-              EntityType.FOLDER,
-            ]),
-          },
+      expect(mockedEntityHeaderTable).toHaveBeenLastRenderedWithProps({
+        references: [],
+        isEditable: true,
+        onUpdate: expect.anything(),
+        removeSelectedRowsButtonText: 'Remove Selected Items from View Scope',
+        objectNameCopy: 'container',
+        hideTextFieldToPasteValue: true,
+        entityFinderConfiguration: {
+          selectMultiple: true,
+          versionSelection: VersionSelectionType.DISALLOWED,
+          initialScope: FinderScope.ALL_PROJECTS,
+          initialContainer: 'root',
+          selectableTypes: expect.arrayContaining([
+            EntityType.PROJECT,
+            EntityType.FOLDER,
+          ]),
         },
-        expect.anything(),
-      ),
+      }),
     )
   })
 
@@ -118,28 +112,25 @@ describe('EntityViewScopeEditor tests', () => {
     await screen.findByTestId('EntityHeaderTableMocked')
 
     await waitFor(() =>
-      expect(mockedEntityHeaderTable).toHaveBeenLastCalledWith(
-        {
-          references: [{ targetId: 'syn123' }],
-          isEditable: true,
-          onUpdate: expect.anything(),
-          removeSelectedRowsButtonText: 'Remove Selected Items from View Scope',
-          objectNameCopy: 'project',
-          hideTextFieldToPasteValue: true,
-          entityFinderConfiguration: {
-            selectMultiple: true,
-            versionSelection: VersionSelectionType.DISALLOWED,
-            initialScope: FinderScope.ALL_PROJECTS,
-            initialContainer: 'root',
-            selectableTypes: expect.arrayContaining([
-              EntityType.PROJECT,
-              // Folders cannot be added to a Project View!
-              // EntityType.FOLDER,
-            ]),
-          },
+      expect(mockedEntityHeaderTable).toHaveBeenLastRenderedWithProps({
+        references: [{ targetId: 'syn123' }],
+        isEditable: true,
+        onUpdate: expect.anything(),
+        removeSelectedRowsButtonText: 'Remove Selected Items from View Scope',
+        objectNameCopy: 'project',
+        hideTextFieldToPasteValue: true,
+        entityFinderConfiguration: {
+          selectMultiple: true,
+          versionSelection: VersionSelectionType.DISALLOWED,
+          initialScope: FinderScope.ALL_PROJECTS,
+          initialContainer: 'root',
+          selectableTypes: expect.arrayContaining([
+            EntityType.PROJECT,
+            // Folders cannot be added to a Project View!
+            // EntityType.FOLDER,
+          ]),
         },
-        expect.anything(),
-      ),
+      }),
     )
   })
 })

--- a/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditorModal.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityViewScopeEditor/EntityViewScopeEditorModal.test.tsx
@@ -206,15 +206,12 @@ describe('EntityViewScopeEditorModal tests', () => {
     await user.click(foldersCheckbox)
 
     await waitFor(() => {
-      expect(mockEntityViewScopeEditor).toHaveBeenLastCalledWith(
-        {
-          scopeIds: ['syn123'],
-          disabled: false,
-          isProjectView: false,
-          onChange: expect.any(Function),
-        },
-        expect.anything(),
-      )
+      expect(mockEntityViewScopeEditor).toHaveBeenLastRenderedWithProps({
+        scopeIds: ['syn123'],
+        disabled: false,
+        isProjectView: false,
+        onChange: expect.any(Function),
+      })
     })
 
     const onChangePassedToEntityViewScopeEditor =

--- a/packages/synapse-react-client/src/components/FilePreview/EntityPreview.test.tsx
+++ b/packages/synapse-react-client/src/components/FilePreview/EntityPreview.test.tsx
@@ -39,11 +39,10 @@ describe('EntityPreview tests', () => {
 
     await screen.findByTestId('FileEntityPreview')
 
-    expect(FileEntityPreviewModule.default).toHaveBeenCalledWith(
+    expect(FileEntityPreviewModule.default).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         bundle: expect.anything(),
       }),
-      expect.anything(),
     )
   })
 

--- a/packages/synapse-react-client/src/components/FilePreview/FileEntityPreview.test.tsx
+++ b/packages/synapse-react-client/src/components/FilePreview/FileEntityPreview.test.tsx
@@ -147,12 +147,11 @@ describe('FileHandleContentRenderer tests', () => {
 
     await screen.findByTestId('FileHandleContentRenderer')
 
-    expect(FileHandleContentRendererModule.default).toHaveBeenCalledWith(
+    expect(FileHandleContentRendererModule.default).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         fileHandleAssociation,
         previewType: PreviewRendererType.HTML,
       }),
-      expect.anything(),
     )
   })
 
@@ -198,12 +197,11 @@ describe('FileHandleContentRenderer tests', () => {
 
     await screen.findByTestId('FileHandleContentRenderer')
 
-    expect(FileHandleContentRendererModule.default).toHaveBeenCalledWith(
+    expect(FileHandleContentRendererModule.default).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         fileHandleAssociation,
         previewType: PreviewRendererType.ZIP,
       }),
-      expect.anything(),
     )
   })
 

--- a/packages/synapse-react-client/src/components/GenericCard/PortalDOI/PortalDOI.test.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/PortalDOI/PortalDOI.test.tsx
@@ -85,14 +85,13 @@ describe('PortalDOI', () => {
     await userEvent.click(editButton)
 
     // Check if modal was called with open: true and correct props
-    expect(mockCreateOrUpdateDoiModal).toHaveBeenCalledWith(
+    expect(mockCreateOrUpdateDoiModal).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         open: true,
         objectType: 'PORTAL_RESOURCE',
         objectId: defaultProps.resourceId,
         portalId: defaultProps.portalId,
       }),
-      expect.anything(),
     )
     // Check if the mocked modal content is rendered
     expect(screen.getByTestId('CreateOrUpdateDoiModal')).toBeInTheDocument()
@@ -105,11 +104,10 @@ describe('PortalDOI', () => {
 
     // Check if modal was called again with open: false
     // The last call determines the final state rendered
-    expect(mockCreateOrUpdateDoiModal).toHaveBeenLastCalledWith(
+    expect(mockCreateOrUpdateDoiModal).toHaveBeenLastRenderedWithProps(
       expect.objectContaining({
         open: false,
       }),
-      expect.anything(),
     )
     // Check if the mocked modal content is removed
     expect(
@@ -160,14 +158,13 @@ describe('PortalDOI', () => {
     await userEvent.click(createLink)
 
     // Check if modal was called with open: true and correct props
-    expect(mockCreateOrUpdateDoiModal).toHaveBeenCalledWith(
+    expect(mockCreateOrUpdateDoiModal).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         open: true,
         objectType: 'PORTAL_RESOURCE',
         objectId: defaultProps.resourceId,
         portalId: defaultProps.portalId,
       }),
-      expect.anything(),
     )
     expect(screen.getByTestId('CreateOrUpdateDoiModal')).toBeInTheDocument()
   })

--- a/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
@@ -259,10 +259,7 @@ describe('TableRowGenericCard tests', () => {
       'TableEntity',
     )
     screen.getByTestId('IconSvg')
-    expect(mockIconSvg).toHaveBeenCalledWith(
-      { icon: 'folder' },
-      expect.anything(),
-    )
+    expect(mockIconSvg).toHaveBeenRenderedWithProps({ icon: 'folder' })
   })
 
   describe('Renders a FileHandleLink when the title is a file handle', () => {
@@ -284,18 +281,15 @@ describe('TableRowGenericCard tests', () => {
         'EntityView',
       )
       await screen.findByTestId('FileHandleLink')
-      expect(mockFileHandleLink).toHaveBeenCalledWith(
-        {
-          showDownloadIcon: true,
-          fileHandleAssociation: {
-            fileHandleId: MOCKED_LINK,
-            associateObjectId: MOCKED_ID,
-            associateObjectType: FileHandleAssociateType.FileEntity,
-          },
-          displayValue: MOCKED_TITLE,
+      expect(mockFileHandleLink).toHaveBeenRenderedWithProps({
+        showDownloadIcon: true,
+        fileHandleAssociation: {
+          fileHandleId: MOCKED_LINK,
+          associateObjectId: MOCKED_ID,
+          associateObjectType: FileHandleAssociateType.FileEntity,
         },
-        expect.anything(),
-      )
+        displayValue: MOCKED_TITLE,
+      })
     })
 
     test('Renders a FileHandleLink with a table associate type', async () => {
@@ -308,18 +302,15 @@ describe('TableRowGenericCard tests', () => {
         'TableEntity',
       )
       await screen.findByTestId('FileHandleLink')
-      expect(mockFileHandleLink).toHaveBeenCalledWith(
-        {
-          showDownloadIcon: true,
-          fileHandleAssociation: {
-            fileHandleId: MOCKED_LINK,
-            associateObjectId: mockTableEntityData.id,
-            associateObjectType: FileHandleAssociateType.TableEntity,
-          },
-          displayValue: MOCKED_TITLE,
+      expect(mockFileHandleLink).toHaveBeenRenderedWithProps({
+        showDownloadIcon: true,
+        fileHandleAssociation: {
+          fileHandleId: MOCKED_LINK,
+          associateObjectId: mockTableEntityData.id,
+          associateObjectType: FileHandleAssociateType.TableEntity,
         },
-        expect.anything(),
-      )
+        displayValue: MOCKED_TITLE,
+      })
     })
   })
 
@@ -346,16 +337,13 @@ describe('TableRowGenericCard tests', () => {
         'EntityView',
       )
       await screen.findByTestId('ImageFileHandle')
-      expect(mockImageFileHandle).toHaveBeenCalledWith(
-        {
-          fileHandleAssociation: {
-            fileHandleId: MOCKED_IMAGE_FILE_HANDLE_ID,
-            associateObjectId: MOCKED_ID,
-            associateObjectType: FileHandleAssociateType.FileEntity,
-          },
+      expect(mockImageFileHandle).toHaveBeenRenderedWithProps({
+        fileHandleAssociation: {
+          fileHandleId: MOCKED_IMAGE_FILE_HANDLE_ID,
+          associateObjectId: MOCKED_ID,
+          associateObjectType: FileHandleAssociateType.FileEntity,
         },
-        expect.anything(),
-      )
+      })
     })
     test('Renders a ImageFileHandle with a table associate type', async () => {
       renderComponent(
@@ -371,16 +359,13 @@ describe('TableRowGenericCard tests', () => {
         'TableEntity',
       )
       await screen.findByTestId('ImageFileHandle')
-      expect(mockImageFileHandle).toHaveBeenCalledWith(
-        {
-          fileHandleAssociation: {
-            fileHandleId: MOCKED_IMAGE_FILE_HANDLE_ID,
-            associateObjectId: mockTableEntityData.id,
-            associateObjectType: FileHandleAssociateType.TableEntity,
-          },
+      expect(mockImageFileHandle).toHaveBeenRenderedWithProps({
+        fileHandleAssociation: {
+          fileHandleId: MOCKED_IMAGE_FILE_HANDLE_ID,
+          associateObjectId: mockTableEntityData.id,
+          associateObjectType: FileHandleAssociateType.TableEntity,
         },
-        expect.anything(),
-      )
+      })
     })
   })
 
@@ -514,13 +499,10 @@ describe('TableRowGenericCard tests', () => {
     await screen.findByText('DOI')
     await screen.findByTestId('PortalDOI')
 
-    expect(PortalDOI).toHaveBeenCalledWith(
-      {
-        portalId: '12345',
-        resourceId: 'someDoiString',
-      },
-      expect.anything(),
-    )
+    expect(PortalDOI).toHaveBeenRenderedWithProps({
+      portalId: '12345',
+      resourceId: 'someDoiString',
+    })
   })
 
   test('PortalDOI is not shown when showDoiCardLabel is false', () => {

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.test.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.test.tsx
@@ -247,15 +247,12 @@ describe('MarkdownSynapse tests', () => {
       }
       renderComponent(props)
       await screen.findByRole('img')
-      expect(mockMarkdownSynapseImage).toHaveBeenCalledWith(
-        {
-          align: 'None',
-          responsive: 'true',
-          synapseId: 'syn7809125',
-          version: '2',
-        },
-        expect.anything(),
-      )
+      expect(mockMarkdownSynapseImage).toHaveBeenRenderedWithProps({
+        align: 'None',
+        responsive: 'true',
+        synapseId: 'syn7809125',
+        version: '2',
+      })
     })
 
     it('renders an image from a file handleId', async () => {
@@ -273,16 +270,13 @@ describe('MarkdownSynapse tests', () => {
       }
       renderComponent(props)
       await screen.findByRole('img')
-      expect(mockMarkdownSynapseImage).toHaveBeenCalledWith(
-        {
-          align: 'None',
-          altText: '',
-          fileName: 'joy.svg',
-          responsive: 'true',
-          scale: '100',
-        },
-        expect.anything(),
-      )
+      expect(mockMarkdownSynapseImage).toHaveBeenRenderedWithProps({
+        align: 'None',
+        altText: '',
+        fileName: 'joy.svg',
+        responsive: 'true',
+        scale: '100',
+      })
     })
   })
 

--- a/packages/synapse-react-client/src/components/OAuthClientManagement/CreateOAuthClient.test.tsx
+++ b/packages/synapse-react-client/src/components/OAuthClientManagement/CreateOAuthClient.test.tsx
@@ -190,12 +190,11 @@ describe('Create OAuth Client', () => {
     await user.click(deleteButton)
 
     expect(updateOAuthClientSpy).not.toHaveBeenCalled()
-    expect(mockWarningDialog).toHaveBeenLastCalledWith(
+    expect(mockWarningDialog).toHaveBeenLastRenderedWithProps(
       expect.objectContaining({
         title: warningHeader,
         content: warningBody,
       }),
-      expect.anything(),
     )
   })
 
@@ -312,12 +311,11 @@ describe('Create OAuth Client', () => {
     await user.click(saveButton)
 
     expect(updateOAuthClientSpy).not.toHaveBeenCalled()
-    expect(mockWarningDialog).toHaveBeenLastCalledWith(
+    expect(mockWarningDialog).toHaveBeenLastRenderedWithProps(
       expect.objectContaining({
         title: warningHeader,
         content: warningBody,
       }),
-      expect.anything(),
     )
   })
 })

--- a/packages/synapse-react-client/src/components/SubmissionViewScopeEditor/SubmissionViewScopeEditor.test.tsx
+++ b/packages/synapse-react-client/src/components/SubmissionViewScopeEditor/SubmissionViewScopeEditor.test.tsx
@@ -30,15 +30,12 @@ describe('SubmissionViewScopeEditor tests', () => {
     await screen.findByTestId('EvaluationFinderMocked')
 
     await waitFor(() => {
-      expect(mockEvaluationFinder).toHaveBeenLastCalledWith(
-        {
-          activeOnly: false,
-          accessType: ACCESS_TYPE.READ_PRIVATE_SUBMISSION,
-          selectedIds: evaluationIds,
-          onChange: onChange,
-        },
-        expect.anything(),
-      )
+      expect(mockEvaluationFinder).toHaveBeenLastRenderedWithProps({
+        activeOnly: false,
+        accessType: ACCESS_TYPE.READ_PRIVATE_SUBMISSION,
+        selectedIds: evaluationIds,
+        onChange: onChange,
+      })
     })
 
     const onChangePassedToEvaluationFinder =

--- a/packages/synapse-react-client/src/components/SubmissionViewScopeEditor/SubmissionViewScopeEditorModal.test.tsx
+++ b/packages/synapse-react-client/src/components/SubmissionViewScopeEditor/SubmissionViewScopeEditorModal.test.tsx
@@ -64,7 +64,6 @@ describe('SubmissionViewScopeEditorModal tests', () => {
         name: `Evaluation ${id}`,
       })
     })
-
     const { saveButton, cancelButton } = await setUp({
       entityId: mockTableEntity.id,
       open: true,
@@ -74,15 +73,12 @@ describe('SubmissionViewScopeEditorModal tests', () => {
     await screen.findByTestId('EvaluationFinderMocked')
 
     await waitFor(() => {
-      expect(mockEvaluationFinder).toHaveBeenLastCalledWith(
-        {
-          activeOnly: false,
-          accessType: ACCESS_TYPE.READ_PRIVATE_SUBMISSION,
-          selectedIds: ['123', '456'],
-          onChange: expect.anything(),
-        },
-        expect.anything(),
-      )
+      expect(mockEvaluationFinder).toHaveBeenLastRenderedWithProps({
+        activeOnly: false,
+        accessType: ACCESS_TYPE.READ_PRIVATE_SUBMISSION,
+        selectedIds: ['123', '456'],
+        onChange: expect.anything(),
+      })
     })
 
     expect(await screen.findByRole('dialog')).toBeVisible()
@@ -160,19 +156,16 @@ describe('SubmissionViewScopeEditorModal tests', () => {
     const newScopeIds = ['123', '456', '789']
 
     await waitFor(() => {
-      expect(mockEvaluationFinder).toHaveBeenLastCalledWith(
-        {
-          activeOnly: false,
-          accessType: ACCESS_TYPE.READ_PRIVATE_SUBMISSION,
-          selectedIds: ['123', '456'],
-          onChange: expect.anything(),
-        },
-        expect.anything(),
-      )
+      expect(mockEvaluationFinder).toHaveBeenLastRenderedWithProps({
+        activeOnly: false,
+        accessType: ACCESS_TYPE.READ_PRIVATE_SUBMISSION,
+        selectedIds: ['123', '456'],
+        onChange: expect.anything(),
+      })
     })
     const mockSubmissionView = {
       ...mockTableEntityInstance,
-      sceopIds: newScopeIds,
+      scopeIds: newScopeIds,
     }
 
     mockUpdateEntity.mockResolvedValue(mockSubmissionView)

--- a/packages/synapse-react-client/src/components/SynapseForm/SynapseFormWrapper.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseForm/SynapseFormWrapper.test.tsx
@@ -235,12 +235,11 @@ describe('SynapseFormWrapper', () => {
 
       await screen.findByTestId('SynapseForm')
 
-      expect(mockSynapseForm).toBeCalledWith(
+      expect(mockSynapseForm).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           formTitle: props.formTitle,
           isWizardMode: true,
         }),
-        expect.anything(),
       )
     })
 
@@ -250,7 +249,7 @@ describe('SynapseFormWrapper', () => {
 
       await screen.findByTestId('SynapseForm')
 
-      expect(mockSynapseForm).toBeCalledWith(
+      expect(mockSynapseForm).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           formTitle: 'Another Title',
           formData: expect.objectContaining({
@@ -258,7 +257,6 @@ describe('SynapseFormWrapper', () => {
           }),
           isWizardMode: undefined,
         }),
-        expect.anything(),
       )
     })
   })

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/SynapseTableCell.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/SynapseTableCell.test.tsx
@@ -223,13 +223,12 @@ describe('SynapseTableCell tests', () => {
       })
 
       await screen.findByTestId('EntityLink')
-      expect(mockEntityLink).toHaveBeenCalledWith(
+      expect(mockEntityLink).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           entity: String(mockRowId),
           displayTextField: 'name',
           showIcon: false,
         }),
-        expect.anything(),
       )
     })
 
@@ -244,13 +243,12 @@ describe('SynapseTableCell tests', () => {
 
       await screen.findByTestId('EntityLink')
       // Verify that the ID is passed
-      expect(mockEntityLink).toHaveBeenCalledWith(
+      expect(mockEntityLink).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           entity: mockEntityIdValue,
           displayTextField: 'id',
           showIcon: false,
         }),
-        expect.anything(),
       )
     })
 
@@ -265,13 +263,12 @@ describe('SynapseTableCell tests', () => {
 
       await screen.findByTestId('EntityLink')
       // Verify that the ID is passed
-      expect(mockEntityLink).toHaveBeenCalledWith(
+      expect(mockEntityLink).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           entity: mockEntityIdValue,
           displayTextField: 'name',
           showIcon: false,
         }),
-        expect.anything(),
       )
     })
 
@@ -286,13 +283,12 @@ describe('SynapseTableCell tests', () => {
 
       await screen.findByTestId('EntityIdList')
       // Verify that the ID is passed
-      expect(mockEntityIdListComponent).toHaveBeenCalledWith(
+      expect(mockEntityIdListComponent).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           entityIdList: EXPECTED_PARSED_ENTITYID_LIST,
           displayTextField: 'id',
           showIcon: false,
         }),
-        expect.anything(),
       )
     })
 
@@ -307,13 +303,12 @@ describe('SynapseTableCell tests', () => {
 
       await screen.findByTestId('EntityIdList')
       // Verify that the ID is passed
-      expect(mockEntityIdListComponent).toHaveBeenCalledWith(
+      expect(mockEntityIdListComponent).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           entityIdList: EXPECTED_PARSED_ENTITYID_LIST,
           displayTextField: 'name',
           showIcon: false,
         }),
-        expect.anything(),
       )
     })
   })

--- a/packages/synapse-react-client/src/components/SynapseTable/datasets/DatasetItemsEditor.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/datasets/DatasetItemsEditor.test.tsx
@@ -533,12 +533,11 @@ describe('Dataset Items Editor tests', () => {
     expect(mockFileReference.targetVersionNumber).not.toEqual(1)
     // The data rows, including the entity badge icons, should be showing the current selected version's data
     await waitFor(() =>
-      expect(mockEntityBadgeIcons).toHaveBeenLastCalledWith(
+      expect(mockEntityBadgeIcons).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           entityId: mockFileReference.targetId,
           versionNumber: mockFileReference.targetVersionNumber,
         }),
-        expect.anything(),
       ),
     )
 
@@ -547,12 +546,11 @@ describe('Dataset Items Editor tests', () => {
 
     // The version passed to the icons should now be v1
     await waitFor(() =>
-      expect(mockEntityBadgeIcons).toHaveBeenLastCalledWith(
+      expect(mockEntityBadgeIcons).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           entityId: mockFileReference.targetId,
           versionNumber: 1,
         }),
-        expect.anything(),
       ),
     )
 
@@ -793,13 +791,12 @@ describe('Dataset Items Editor tests', () => {
       expect(mockOnUnsavedChangesFn).toHaveBeenCalledWith(true)
 
       // Verify that the Entity Finder is configured to select Datasets
-      expect(mockEntityFinder).toHaveBeenLastCalledWith(
+      expect(mockEntityFinder).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           configuration: expect.objectContaining({
             selectableTypes: [EntityType.DATASET],
           }),
         }),
-        expect.anything(),
       )
 
       await clickSave(user)

--- a/packages/synapse-react-client/src/components/SynapseTable/export/ExportToAnalysisPlatformDialog.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/export/ExportToAnalysisPlatformDialog.test.tsx
@@ -104,14 +104,13 @@ describe('ExportToAnalysisPlatformDialog tests', () => {
       await screen.findByTestId('ExternalPlatformActionsRequiredPrecheck')
 
       // Verify the mock component received the correct props and updates the confirm button
-      expect(mockExternalPlatformActionsRequiredPrecheck).toHaveBeenCalledWith(
-        {
-          selectedPlatform: platformCase.platform,
-          onConfirmButtonPropsChange: expect.any(Function),
-          onSuccessfulExport: expect.any(Function),
-        },
-        expect.anything(),
-      )
+      expect(
+        mockExternalPlatformActionsRequiredPrecheck,
+      ).toHaveBeenRenderedWithProps({
+        selectedPlatform: platformCase.platform,
+        onConfirmButtonPropsChange: expect.any(Function),
+        onSuccessfulExport: expect.any(Function),
+      })
 
       const finalConfirmButtonText = 'mock confirm button text'
       const finalConfirmButtonClickHandler = vi.fn()

--- a/packages/synapse-react-client/src/components/SynapseTable/export/ExternalPlatformActionsRequiredPrecheck.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/export/ExternalPlatformActionsRequiredPrecheck.test.tsx
@@ -187,16 +187,13 @@ describe('ExternalPlatformActionsRequiredPrecheck', () => {
       )
 
       // Actions required component reports 0 actions required
-      expect(MockTableQueryActionsRequired).toHaveBeenLastCalledWith(
-        {
-          queryBundleRequest: queryRequest,
-          columnModels: columnModels,
-          onNumberOfRequiredActionsChanged: expect.any(Function),
-          onViewSharingSettingsClicked:
-            mockQueryContext.onViewSharingSettingsClicked,
-        },
-        expect.anything(),
-      )
+      expect(MockTableQueryActionsRequired).toHaveBeenLastRenderedWithProps({
+        queryBundleRequest: queryRequest,
+        columnModels: columnModels,
+        onNumberOfRequiredActionsChanged: expect.any(Function),
+        onViewSharingSettingsClicked:
+          mockQueryContext.onViewSharingSettingsClicked,
+      })
       act(() => {
         MockTableQueryActionsRequired.mock.lastCall![0]
           .onNumberOfRequiredActionsChanged!(0)
@@ -253,16 +250,13 @@ describe('ExternalPlatformActionsRequiredPrecheck', () => {
     await screen.findByText(`Before sending the selected data to CAVATICA:`)
 
     // Actions required component reports 0 actions required
-    expect(MockTableQueryActionsRequired).toHaveBeenLastCalledWith(
-      {
-        queryBundleRequest: queryRequest,
-        columnModels: columnModels,
-        onNumberOfRequiredActionsChanged: expect.any(Function),
-        onViewSharingSettingsClicked:
-          mockQueryContext.onViewSharingSettingsClicked,
-      },
-      expect.anything(),
-    )
+    expect(MockTableQueryActionsRequired).toHaveBeenLastRenderedWithProps({
+      queryBundleRequest: queryRequest,
+      columnModels: columnModels,
+      onNumberOfRequiredActionsChanged: expect.any(Function),
+      onViewSharingSettingsClicked:
+        mockQueryContext.onViewSharingSettingsClicked,
+    })
     act(() => {
       MockTableQueryActionsRequired.mock.lastCall![0]
         .onNumberOfRequiredActionsChanged!(0)
@@ -322,16 +316,13 @@ describe('ExternalPlatformActionsRequiredPrecheck', () => {
     await screen.findByText(`Before sending the selected data to CAVATICA:`)
 
     // Actions required component reports one action required
-    expect(MockTableQueryActionsRequired).toHaveBeenLastCalledWith(
-      {
-        queryBundleRequest: queryRequest,
-        columnModels: columnModels,
-        onNumberOfRequiredActionsChanged: expect.any(Function),
-        onViewSharingSettingsClicked:
-          mockQueryContext.onViewSharingSettingsClicked,
-      },
-      expect.anything(),
-    )
+    expect(MockTableQueryActionsRequired).toHaveBeenLastRenderedWithProps({
+      queryBundleRequest: queryRequest,
+      columnModels: columnModels,
+      onNumberOfRequiredActionsChanged: expect.any(Function),
+      onViewSharingSettingsClicked:
+        mockQueryContext.onViewSharingSettingsClicked,
+    })
     act(() => {
       MockTableQueryActionsRequired.mock.lastCall![0]
         .onNumberOfRequiredActionsChanged!(1)

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.test.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/DefaultValueField.test.tsx
@@ -191,17 +191,15 @@ describe('DefaultValueField', () => {
     )
     expect(datePickerFields).toHaveLength(2)
 
-    expect(mockDateTimePicker).toHaveBeenCalledWith(
+    expect(mockDateTimePicker).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         value: dayjs(DATE_ONE),
       }),
-      expect.anything(),
     )
-    expect(mockDateTimePicker).toHaveBeenCalledWith(
+    expect(mockDateTimePicker).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         value: dayjs(DATE_TWO),
       }),
-      expect.anything(),
     )
 
     await userEvent.click(screen.getByRole('button', { name: 'OK' }))

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/MultiValueField.test.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ColumnModelFormFields/MultiValueField.test.tsx
@@ -58,13 +58,12 @@ describe('MultiValueField', () => {
       ColumnTypeEnum.STRING,
     )
     await waitFor(() =>
-      expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
+      expect(mockJsonArrayEditorModal).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           arrayItemDefinition: stringDefinition,
           value: ['foo', 'bar'],
           isShowingModal: false,
         }),
-        expect.anything(),
       ),
     )
 
@@ -72,11 +71,10 @@ describe('MultiValueField', () => {
     await userEvent.click(textField)
 
     await waitFor(() =>
-      expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
+      expect(mockJsonArrayEditorModal).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           isShowingModal: true,
         }),
-        expect.anything(),
       ),
     )
 
@@ -85,11 +83,10 @@ describe('MultiValueField', () => {
       mockJsonArrayEditorModal.mock.lastCall![0].onCancel()
     })
     await waitFor(() =>
-      expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
+      expect(mockJsonArrayEditorModal).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           isShowingModal: false,
         }),
-        expect.anything(),
       ),
     )
 
@@ -97,11 +94,10 @@ describe('MultiValueField', () => {
     await userEvent.click(textField)
 
     await waitFor(() =>
-      expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
+      expect(mockJsonArrayEditorModal).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           isShowingModal: true,
         }),
-        expect.anything(),
       ),
     )
 
@@ -110,11 +106,10 @@ describe('MultiValueField', () => {
       mockJsonArrayEditorModal.mock.lastCall![0].onConfirm(['baz', 'qux'])
     })
     await waitFor(() => {
-      expect(mockJsonArrayEditorModal).toHaveBeenCalledWith(
+      expect(mockJsonArrayEditorModal).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           isShowingModal: false,
         }),
-        expect.anything(),
       )
 
       expect(onChange).toHaveBeenCalledWith(['baz', 'qux'])

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ImportTableColumnsButton.test.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/ImportTableColumnsButton.test.tsx
@@ -90,11 +90,10 @@ describe('ImportTableColumnsButton', () => {
     })
 
     // The entity finder should not be visible at first
-    expect(mockEntityFinderModal).toHaveBeenLastCalledWith(
+    expect(mockEntityFinderModal).toHaveBeenLastRenderedWithProps(
       expect.objectContaining({
         show: false,
       }),
-      expect.anything(),
     )
 
     // Click the button
@@ -102,11 +101,10 @@ describe('ImportTableColumnsButton', () => {
 
     // The (mocked) entity finder should appear
     await waitFor(() => {
-      expect(mockEntityFinderModal).toHaveBeenLastCalledWith(
+      expect(mockEntityFinderModal).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           show: true,
         }),
-        expect.anything(),
       )
     })
 
@@ -134,11 +132,10 @@ describe('ImportTableColumnsButton', () => {
     )
 
     // The entity finder should be hidden
-    expect(mockEntityFinderModal).toHaveBeenLastCalledWith(
+    expect(mockEntityFinderModal).toHaveBeenLastRenderedWithProps(
       expect.objectContaining({
         show: false,
       }),
-      expect.anything(),
     )
   })
 
@@ -148,11 +145,10 @@ describe('ImportTableColumnsButton', () => {
     })
 
     // The entity finder should not be visible at first
-    expect(mockEntityFinderModal).toHaveBeenLastCalledWith(
+    expect(mockEntityFinderModal).toHaveBeenLastRenderedWithProps(
       expect.objectContaining({
         show: false,
       }),
-      expect.anything(),
     )
 
     // Click the button
@@ -160,11 +156,10 @@ describe('ImportTableColumnsButton', () => {
 
     // The (mocked) entity finder should appear
     await waitFor(() => {
-      expect(mockEntityFinderModal).toHaveBeenLastCalledWith(
+      expect(mockEntityFinderModal).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           show: true,
         }),
-        expect.anything(),
       )
     })
 
@@ -181,11 +176,10 @@ describe('ImportTableColumnsButton', () => {
     expect(mockOnAddColumns).not.toHaveBeenCalled()
 
     // The entity finder should be hidden
-    expect(mockEntityFinderModal).toHaveBeenLastCalledWith(
+    expect(mockEntityFinderModal).toHaveBeenLastRenderedWithProps(
       expect.objectContaining({
         show: false,
       }),
-      expect.anything(),
     )
   })
 })

--- a/packages/synapse-react-client/src/components/dataaccess/AccessHistoryDashboard.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/AccessHistoryDashboard.test.tsx
@@ -144,23 +144,21 @@ describe('AccessHistoryDashboard tests', () => {
     await screen.findByLabelText('Filter by Access Requirement Name')
 
     await screen.findByTestId(SUBMISSION_TABLE_TEST_ID)
-    expect(mockAccessRequestSubmissionTable).toHaveBeenCalledWith(
+    expect(mockAccessRequestSubmissionTable).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         accessRequirementId: undefined,
         accessorId: '',
         showStatus: true,
         showSubmitter: true,
       }),
-      expect.anything(),
     )
 
     await screen.findByTestId(APPROVAL_TABLE_TEST_ID)
-    expect(mockAccessApprovalsTable).toHaveBeenCalledWith(
+    expect(mockAccessApprovalsTable).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         accessRequirementId: undefined,
         accessorId: '',
       }),
-      expect.anything(),
     )
   })
 
@@ -183,14 +181,13 @@ describe('AccessHistoryDashboard tests', () => {
     await screen.findByLabelText('Filter by Access Requirement Name')
 
     await screen.findByTestId(SUBMISSION_TABLE_TEST_ID)
-    expect(mockAccessRequestSubmissionTable).toHaveBeenCalledWith(
+    expect(mockAccessRequestSubmissionTable).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         accessRequirementId: undefined,
         accessorId: '',
         showStatus: true,
         showSubmitter: true,
       }),
-      expect.anything(),
     )
 
     expect(screen.queryByTestId(APPROVAL_TABLE_TEST_ID)).not.toBeInTheDocument()
@@ -212,22 +209,20 @@ describe('AccessHistoryDashboard tests', () => {
         new URLSearchParams(getLocation().search).get('accessorId'),
       ).toEqual(MOCK_USER_ID.toString())
 
-      expect(mockAccessRequestSubmissionTable).toHaveBeenCalledWith(
+      expect(mockAccessRequestSubmissionTable).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           accessRequirementId: undefined,
           accessorId: MOCK_USER_ID.toString(),
           showStatus: true,
           showSubmitter: true,
         }),
-        expect.anything(),
       )
 
-      expect(mockAccessApprovalsTable).toHaveBeenCalledWith(
+      expect(mockAccessApprovalsTable).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           accessRequirementId: undefined,
           accessorId: MOCK_USER_ID.toString(),
         }),
-        expect.anything(),
       )
     })
   })
@@ -267,22 +262,20 @@ describe('AccessHistoryDashboard tests', () => {
         new URLSearchParams(getLocation().search).get('accessRequirementId'),
       ).toEqual(mockAccessRequirement.id.toString())
 
-      expect(mockAccessRequestSubmissionTable).toHaveBeenLastCalledWith(
+      expect(mockAccessRequestSubmissionTable).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           accessRequirementId: mockAccessRequirement.id.toString(),
           accessorId: MOCK_USER_ID.toString(),
           showStatus: true,
           showSubmitter: true,
         }),
-        expect.anything(),
       )
 
-      expect(mockAccessApprovalsTable).toHaveBeenCalledWith(
+      expect(mockAccessApprovalsTable).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           accessRequirementId: mockAccessRequirement.id.toString(),
           accessorId: MOCK_USER_ID.toString(),
         }),
-        expect.anything(),
       )
     })
   })
@@ -295,22 +288,20 @@ describe('AccessHistoryDashboard tests', () => {
     renderComponent(initialEntries)
 
     await waitFor(() => {
-      expect(mockAccessRequestSubmissionTable).toHaveBeenCalledWith(
+      expect(mockAccessRequestSubmissionTable).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           accessRequirementId: mockAccessRequirement.id.toString(),
           accessorId: MOCK_USER_ID.toString(),
           showStatus: true,
           showSubmitter: true,
         }),
-        expect.anything(),
       )
 
-      expect(mockAccessApprovalsTable).toHaveBeenCalledWith(
+      expect(mockAccessApprovalsTable).toHaveBeenRenderedWithProps(
         expect.objectContaining({
           accessRequirementId: mockAccessRequirement.id.toString(),
           accessorId: MOCK_USER_ID.toString(),
         }),
-        expect.anything(),
       )
     })
   })

--- a/packages/synapse-react-client/src/components/dataaccess/AccessSubmissionDashboard.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/AccessSubmissionDashboard.test.tsx
@@ -101,13 +101,12 @@ describe('AccessSubmissionDashboard tests', () => {
 
     expect(await screen.findAllByRole('combobox')).toHaveLength(3)
     await screen.findByTestId(SUBMISSION_TABLE_TEST_ID)
-    expect(mockAccessRequestSubmissionTable).toHaveBeenCalledWith(
+    expect(mockAccessRequestSubmissionTable).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         accessRequirementId: undefined,
         accessorId: undefined,
         reviewerId: undefined,
       }),
-      expect.anything(),
     )
   })
 
@@ -132,13 +131,12 @@ describe('AccessSubmissionDashboard tests', () => {
         new URLSearchParams(getLocation().search).get('accessRequirementId'),
       ).toEqual(mockAccessRequirement.id.toString())
 
-      expect(mockAccessRequestSubmissionTable).toHaveBeenLastCalledWith(
+      expect(mockAccessRequestSubmissionTable).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           accessRequirementId: mockAccessRequirement.id.toString(),
           accessorId: undefined,
           reviewerId: undefined,
         }),
-        expect.anything(),
       )
     })
   })
@@ -157,13 +155,12 @@ describe('AccessSubmissionDashboard tests', () => {
         new URLSearchParams(getLocation().search).get('accessorId'),
       ).toEqual(MOCK_USER_ID.toString())
 
-      expect(mockAccessRequestSubmissionTable).toHaveBeenLastCalledWith(
+      expect(mockAccessRequestSubmissionTable).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           accessRequirementId: undefined,
           accessorId: MOCK_USER_ID.toString(),
           reviewerId: undefined,
         }),
-        expect.anything(),
       )
     })
   })
@@ -182,13 +179,12 @@ describe('AccessSubmissionDashboard tests', () => {
         new URLSearchParams(getLocation().search).get('reviewerId'),
       ).toEqual(MOCK_USER_ID.toString())
 
-      expect(mockAccessRequestSubmissionTable).toHaveBeenLastCalledWith(
+      expect(mockAccessRequestSubmissionTable).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           accessRequirementId: undefined,
           accessorId: undefined,
           reviewerId: MOCK_USER_ID.toString(),
         }),
-        expect.anything(),
       )
     })
   })
@@ -202,13 +198,12 @@ describe('AccessSubmissionDashboard tests', () => {
     renderComponent(initialEntries)
 
     await waitFor(() =>
-      expect(mockAccessRequestSubmissionTable).toHaveBeenLastCalledWith(
+      expect(mockAccessRequestSubmissionTable).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           accessRequirementId: MOCK_AR_ID.toString(),
           accessorId: MOCK_USER_ID.toString(),
           reviewerId: MOCK_USER_ID.toString(),
         }),
-        expect.anything(),
       ),
     )
   })

--- a/packages/synapse-react-client/src/components/dataaccess/RejectDataAccessRequestModal.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/RejectDataAccessRequestModal.test.tsx
@@ -67,19 +67,16 @@ describe('RejectDataAccessRequestModal', () => {
     renderComponent()
 
     await waitFor(() => {
-      expect(mockCannedRejectionDialog).toHaveBeenCalledWith(
-        {
-          open: true,
-          defaultMessageAppend: DEFAULT_MESSAGE_APPEND,
-          defaultMessagePrefix: DEFAULT_MESSAGE_PREPEND,
-          error: null,
-          onClose: expect.any(Function),
-          onConfirm: expect.any(Function),
-          rejectionFormPromptCopy: REJECTION_FORM_PROMPT_COPY,
-          tableId: REJECT_SUBMISSION_CANNED_RESPONSES_TABLE,
-        },
-        expect.anything(),
-      )
+      expect(mockCannedRejectionDialog).toHaveBeenRenderedWithProps({
+        open: true,
+        defaultMessageAppend: DEFAULT_MESSAGE_APPEND,
+        defaultMessagePrefix: DEFAULT_MESSAGE_PREPEND,
+        error: null,
+        onClose: expect.any(Function),
+        onConfirm: expect.any(Function),
+        rejectionFormPromptCopy: REJECTION_FORM_PROMPT_COPY,
+        tableId: REJECT_SUBMISSION_CANNED_RESPONSES_TABLE,
+      })
     })
 
     const onConfirmCallback =

--- a/packages/synapse-react-client/src/components/dataaccess/RejectProfileValidationRequestModal.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/RejectProfileValidationRequestModal.test.tsx
@@ -79,20 +79,17 @@ describe('RejectProfileValidationRequestModal', () => {
     const { user } = renderComponent()
 
     await waitFor(() => {
-      expect(mockCannedRejectionDialog).toHaveBeenCalledWith(
-        {
-          open: true,
-          defaultMessageAppend: DEFAULT_MESSAGE_APPEND,
-          defaultMessagePrefix: DEFAULT_MESSAGE_PREPEND,
-          error: null,
-          onClose: expect.any(Function),
-          onConfirm: expect.any(Function),
-          rejectionFormPromptCopy: REJECTION_FORM_PROMPT_COPY,
-          tableId: REJECT_VALIDATION_CANNED_RESPONSES_TABLE,
-          children: expect.anything(),
-        },
-        expect.anything(),
-      )
+      expect(mockCannedRejectionDialog).toHaveBeenRenderedWithProps({
+        open: true,
+        defaultMessageAppend: DEFAULT_MESSAGE_APPEND,
+        defaultMessagePrefix: DEFAULT_MESSAGE_PREPEND,
+        error: null,
+        onClose: expect.any(Function),
+        onConfirm: expect.any(Function),
+        rejectionFormPromptCopy: REJECTION_FORM_PROMPT_COPY,
+        tableId: REJECT_VALIDATION_CANNED_RESPONSES_TABLE,
+        children: expect.anything(),
+      })
     })
 
     // Verify internal notes field is rendered (by the mock)
@@ -134,20 +131,17 @@ describe('RejectProfileValidationRequestModal', () => {
     })
 
     await waitFor(() => {
-      expect(mockCannedRejectionDialog).toHaveBeenCalledWith(
-        {
-          open: true,
-          defaultMessageAppend: DEFAULT_MESSAGE_APPEND,
-          defaultMessagePrefix: DEFAULT_MESSAGE_PREPEND,
-          error: null,
-          onClose: expect.any(Function),
-          onConfirm: expect.any(Function),
-          rejectionFormPromptCopy: REJECTION_FORM_PROMPT_COPY,
-          tableId: REJECT_VALIDATION_CANNED_RESPONSES_TABLE,
-          children: expect.anything(),
-        },
-        expect.anything(),
-      )
+      expect(mockCannedRejectionDialog).toHaveBeenRenderedWithProps({
+        open: true,
+        defaultMessageAppend: DEFAULT_MESSAGE_APPEND,
+        defaultMessagePrefix: DEFAULT_MESSAGE_PREPEND,
+        error: null,
+        onClose: expect.any(Function),
+        onConfirm: expect.any(Function),
+        rejectionFormPromptCopy: REJECTION_FORM_PROMPT_COPY,
+        tableId: REJECT_VALIDATION_CANNED_RESPONSES_TABLE,
+        children: expect.anything(),
+      })
     })
 
     // Generate the email using the mocked modal

--- a/packages/synapse-react-client/src/components/dataaccess/SubmissionPage/SubmissionPage.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/SubmissionPage/SubmissionPage.test.tsx
@@ -313,14 +313,11 @@ describe('Submission Page tests', () => {
     await userEvent.click(rejectButton)
 
     // The modal should be shown
-    expect(mockRejectDataAccessRequestModal).toHaveBeenLastCalledWith(
-      {
-        open: true, // !
-        submissionId: SUBMITTED_SUBMISSION_ID,
-        onClose: expect.anything(),
-      },
-      expect.anything(),
-    )
+    expect(mockRejectDataAccessRequestModal).toHaveBeenLastRenderedWithProps({
+      open: true, // !
+      submissionId: SUBMITTED_SUBMISSION_ID,
+      onClose: expect.anything(),
+    })
   })
 
   it('Does not render action buttons for an APPROVED submission', () => {
@@ -422,15 +419,12 @@ describe('Submission Page tests', () => {
 
       await userEvent.click(cancelRequestButton)
 
-      expect(mockCancelSubmissionModal).toHaveBeenLastCalledWith(
-        {
-          open: true,
-          submissionId: String(SUBMITTED_SUBMISSION_ID),
-          accessRequirementId: String(mockManagedACTAccessRequirement.id),
-          onClose: expect.any(Function),
-        },
-        expect.anything(),
-      )
+      expect(mockCancelSubmissionModal).toHaveBeenLastRenderedWithProps({
+        open: true,
+        submissionId: String(SUBMITTED_SUBMISSION_ID),
+        accessRequirementId: String(mockManagedACTAccessRequirement.id),
+        onClose: expect.any(Function),
+      })
       expect(mockAccessRequirementList).not.toHaveBeenCalled()
     })
 
@@ -458,18 +452,14 @@ describe('Submission Page tests', () => {
 
       await userEvent.click(updateRequestButton)
 
-      expect(mockAccessRequirementList).toHaveBeenLastCalledWith(
-        {
-          renderAsModal: true,
-          accessRequirementFromProps: [mockManagedACTAccessRequirement],
-          onHide: expect.any(Function),
-          onSubmissionCreated: expect.any(Function),
-        },
-        expect.anything(),
-      )
-      expect(mockCancelSubmissionModal).not.toHaveBeenCalledWith(
+      expect(mockAccessRequirementList).toHaveBeenLastRenderedWithProps({
+        renderAsModal: true,
+        accessRequirementFromProps: [mockManagedACTAccessRequirement],
+        onHide: expect.any(Function),
+        onSubmissionCreated: expect.any(Function),
+      })
+      expect(mockCancelSubmissionModal).not.toHaveBeenRenderedWithProps(
         expect.objectContaining({ open: true }),
-        expect.anything(),
       )
     })
 
@@ -497,18 +487,14 @@ describe('Submission Page tests', () => {
 
       await userEvent.click(updateRequestButton)
 
-      expect(mockAccessRequirementList).toHaveBeenLastCalledWith(
-        {
-          renderAsModal: true,
-          accessRequirementFromProps: [mockManagedACTAccessRequirement],
-          onHide: expect.any(Function),
-          onSubmissionCreated: expect.any(Function),
-        },
-        expect.anything(),
-      )
-      expect(mockCancelSubmissionModal).not.toHaveBeenCalledWith(
+      expect(mockAccessRequirementList).toHaveBeenLastRenderedWithProps({
+        renderAsModal: true,
+        accessRequirementFromProps: [mockManagedACTAccessRequirement],
+        onHide: expect.any(Function),
+        onSubmissionCreated: expect.any(Function),
+      })
+      expect(mockCancelSubmissionModal).not.toHaveBeenRenderedWithProps(
         expect.objectContaining({ open: true }),
-        expect.anything(),
       )
     })
 
@@ -537,18 +523,14 @@ describe('Submission Page tests', () => {
 
       await userEvent.click(modifyRequestButton)
 
-      expect(mockAccessRequirementList).toHaveBeenLastCalledWith(
-        {
-          renderAsModal: true,
-          accessRequirementFromProps: [mockManagedACTAccessRequirement],
-          onHide: expect.any(Function),
-          onSubmissionCreated: expect.any(Function),
-        },
-        expect.anything(),
-      )
-      expect(mockCancelSubmissionModal).not.toHaveBeenCalledWith(
+      expect(mockAccessRequirementList).toHaveBeenLastRenderedWithProps({
+        renderAsModal: true,
+        accessRequirementFromProps: [mockManagedACTAccessRequirement],
+        onHide: expect.any(Function),
+        onSubmissionCreated: expect.any(Function),
+      })
+      expect(mockCancelSubmissionModal).not.toHaveBeenRenderedWithProps(
         expect.objectContaining({ open: true }),
-        expect.anything(),
       )
     })
 
@@ -579,18 +561,14 @@ describe('Submission Page tests', () => {
 
       await userEvent.click(modifyRequestButton)
 
-      expect(mockAccessRequirementList).toHaveBeenLastCalledWith(
-        {
-          renderAsModal: true,
-          accessRequirementFromProps: [mockManagedACTAccessRequirement],
-          onHide: expect.any(Function),
-          onSubmissionCreated: expect.any(Function),
-        },
-        expect.anything(),
-      )
-      expect(mockCancelSubmissionModal).not.toHaveBeenCalledWith(
+      expect(mockAccessRequirementList).toHaveBeenLastRenderedWithProps({
+        renderAsModal: true,
+        accessRequirementFromProps: [mockManagedACTAccessRequirement],
+        onHide: expect.any(Function),
+        onSubmissionCreated: expect.any(Function),
+      })
+      expect(mockCancelSubmissionModal).not.toHaveBeenRenderedWithProps(
         expect.objectContaining({ open: true }),
-        expect.anything(),
       )
     })
 

--- a/packages/synapse-react-client/src/components/entity/page/title_bar/EntityPageTitleBar.test.tsx
+++ b/packages/synapse-react-client/src/components/entity/page/title_bar/EntityPageTitleBar.test.tsx
@@ -121,12 +121,9 @@ describe('Entity Page Title Bar', () => {
     // Component is mocked and interactions are tested separately
     renderComponent(defaultProps)
     await screen.findByTestId(FAVORITE_BUTTON_TEST_ID)
-    expect(FavoriteButtonModule.default).toHaveBeenCalledWith(
-      {
-        entityId: defaultProps.entityId,
-      },
-      expect.anything(),
-    )
+    expect(FavoriteButtonModule.default).toHaveBeenRenderedWithProps({
+      entityId: defaultProps.entityId,
+    })
   })
   it('Shows version info component', async () => {
     // Component is mocked and interactions are tested separately
@@ -134,36 +131,33 @@ describe('Entity Page Title Bar', () => {
     await screen.findByTestId(TITLE_BAR_VERSION_INFO_TEST_ID)
     expect(
       TitleBarVersionInfoModule.EntityTitleBarVersionInfo,
-    ).toHaveBeenCalledWith(
+    ).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         entityId: defaultProps.entityId,
         versionNumber: defaultProps.versionNumber,
         toggleShowVersionHistory: toggleShowVersionHistory,
       }),
-      expect.anything(),
     )
   })
   it('Shows the action menu', async () => {
     // Component is mocked and interactions are tested separately
     renderComponent(defaultProps)
     await screen.findByTestId(ENTITY_ACTION_MENU_TEST_ID)
-    expect(EntityActionMenuModule.default).toHaveBeenCalledWith(
+    expect(EntityActionMenuModule.default).toHaveBeenRenderedWithProps(
       defaultProps.entityActionMenuProps,
-      expect.anything(),
     )
   })
   it('Shows the properties', async () => {
     // Component is mocked and interactions are tested separately
     renderComponent(defaultProps)
     await screen.findByTestId(TITLE_BAR_PROPERTIES_TEST_ID)
-    expect(TitleBarPropertiesModule.default).toHaveBeenCalledWith(
+    expect(TitleBarPropertiesModule.default).toHaveBeenRenderedWithProps(
       expect.objectContaining({
         entityId: defaultProps.entityId,
         versionNumber: defaultProps.versionNumber,
         onActMemberClickAddConditionsForUse:
           defaultProps.onActMemberClickAddConditionsForUse,
       }),
-      expect.anything(),
     )
   })
 })

--- a/packages/synapse-react-client/src/components/widgets/query-filter/CombinedRangeFacetFilter.test.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/CombinedRangeFacetFilter.test.tsx
@@ -243,21 +243,19 @@ describe('CombinedRangeFacetFilter tests', () => {
   it('should collapse content when toggled', async () => {
     await init({ ...props })
 
-    expect(MockCollapse).toHaveBeenLastCalledWith(
+    expect(MockCollapse).toHaveBeenLastRenderedWithProps(
       expect.objectContaining({
         in: true,
       }),
-      expect.anything(),
     )
 
     // toggle collapse via button
     await userEvent.click(screen.getByRole('button', { name: 'Collapse Menu' }))
 
-    expect(MockCollapse).toHaveBeenLastCalledWith(
+    expect(MockCollapse).toHaveBeenLastRenderedWithProps(
       expect.objectContaining({
         in: false,
       }),
-      expect.anything(),
     )
   })
 

--- a/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilter.test.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilter.test.tsx
@@ -176,11 +176,10 @@ describe('RangeFacetFilter tests', () => {
     init({ ...props })
 
     await waitFor(() => {
-      expect(MockCollapse).toHaveBeenLastCalledWith(
+      expect(MockCollapse).toHaveBeenLastRenderedWithProps(
         expect.objectContaining({
           in: true,
         }),
-        expect.anything(),
       )
     })
 
@@ -189,11 +188,10 @@ describe('RangeFacetFilter tests', () => {
       await screen.findByRole('button', { name: 'Collapse Menu' }),
     )
 
-    expect(MockCollapse).toHaveBeenLastCalledWith(
+    expect(MockCollapse).toHaveBeenLastRenderedWithProps(
       expect.objectContaining({
         in: false,
       }),
-      expect.anything(),
     )
   })
 

--- a/packages/synapse-react-client/src/testutils/ComponentToBePassedPropsCustomMatcher.ts
+++ b/packages/synapse-react-client/src/testutils/ComponentToBePassedPropsCustomMatcher.ts
@@ -1,0 +1,60 @@
+import { Mock } from 'vitest'
+
+/**
+ * Custom matchers for testing whether mock/spy React components have been rendered with specific props.
+ */
+
+expect.extend({
+  toHaveBeenRendered(mockComponent: Mock) {
+    try {
+      expect(mockComponent).toHaveBeenCalled()
+    } catch (error) {
+      return {
+        pass: false,
+        message: () => `Component was not rendered:\n  ${error.message}`,
+      }
+    }
+    return {
+      pass: true,
+      message: () => 'Component was rendered',
+    }
+  },
+  toHaveBeenRenderedWithProps(mockComponent: Mock, expectedProps: unknown) {
+    try {
+      expect(mockComponent).toHaveBeenCalledWith(
+        expectedProps,
+        expect.anything(),
+      )
+    } catch (error) {
+      return {
+        pass: false,
+        message: () =>
+          `Component was not rendered with expected props:\n  ${error.message}`,
+      }
+    }
+
+    return {
+      pass: true,
+      message: () => 'Component was rendered with expected props',
+    }
+  },
+  toHaveBeenLastRenderedWithProps(mockComponent: Mock, expectedProps: unknown) {
+    try {
+      expect(mockComponent).toHaveBeenLastCalledWith(
+        expectedProps,
+        expect.anything(),
+      )
+    } catch (error) {
+      return {
+        pass: false,
+        message: () =>
+          `Component was not last rendered with expected props:\n  ${error.message}`,
+      }
+    }
+
+    return {
+      pass: true,
+      message: () => 'Component was last rendered with expected props',
+    }
+  },
+})

--- a/packages/synapse-react-client/src/testutils/vitest.d.ts
+++ b/packages/synapse-react-client/src/testutils/vitest.d.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type,@typescript-eslint/no-empty-interface */
+import 'vitest'
+
+interface CustomMatchers<R = unknown> {
+  toHaveBeenRendered: () => R
+  toHaveBeenRenderedWithProps: (props: unknown) => R
+  toHaveBeenLastRenderedWithProps: (props: unknown) => R
+}
+
+declare module 'vitest' {
+  interface Matchers<T = any> extends CustomMatchers<T> {}
+}

--- a/packages/synapse-react-client/src/testutils/vitest.setup.ts
+++ b/packages/synapse-react-client/src/testutils/vitest.setup.ts
@@ -1,5 +1,6 @@
 // import jest-dom for Testing Library matchers (compatible with Vitest)
 import '@testing-library/jest-dom/vitest'
+import './ComponentToBePassedPropsCustomMatcher'
 import { ResizeObserver } from '@juggle/resize-observer'
 import './muiDatePickerMock'
 import { setupIntersectionMocking } from 'react-intersection-observer/test-utils'


### PR DESCRIPTION
Create a [custom matcher](https://vitest.dev/guide/extending-matchers) for checking whether React components have rendered.

The motivation for this change is that the details of how/when components are rendered is abstracted by React and subject to change with React upgrades. For instance, these assertions all break on upgrade to React 19. Doing this refactor here will limit the scope of required changes upon React 19 upgrade (essentially making it a 2-line change instead of changing every test file touched in this PR).

This custom matcher is also more expressive, so our test code can more clearly indicate when an assertion is checked against a component.

