### PR TITLE
PORTALS-3658 - Fix issues with Portal DOIs

### DIFF
--- a/apps/synapse-portal-framework/src/shared-config/DoiRedirectRoute.tsx
+++ b/apps/synapse-portal-framework/src/shared-config/DoiRedirectRoute.tsx
@@ -15,6 +15,10 @@ export type PortalResourceRedirector<
   resourceKey: TResourceTypeAttributes,
 ) => string
 
+// The request parameter that contains the Portal DOI ID
+// This is hard-coded by the Synapse backend.
+const OBJECT_ID_QUERY_PARAM = 'objectId'
+
 /**
  * Component to redirect the Portal DOI ID to the resource in the portal.
  * Portal DOI IDs are a JSON string with ordered attributes. A deserializer and redirector are provided to
@@ -30,7 +34,7 @@ function DoiRedirectComponent<TResourceType extends string>(props: {
 }) {
   const { redirector, deserializer } = props
   const [searchParams] = useSearchParams()
-  const doiId = searchParams.get('id')
+  const doiId = searchParams.get(OBJECT_ID_QUERY_PARAM)
 
   let redirectUrl: string = '/'
 

--- a/packages/synapse-client/src/util/waitForAsyncResult.test.ts
+++ b/packages/synapse-client/src/util/waitForAsyncResult.test.ts
@@ -1,4 +1,6 @@
+import { AsynchronousJobStatus } from '../generated/index'
 import { delay } from './fetchWithExponentialTimeout'
+import { SynapseClientError } from './SynapseClientError'
 import { waitForAsyncResult } from './waitForAsyncResult'
 
 vi.mock('./fetchWithExponentialTimeout')
@@ -26,5 +28,28 @@ describe('waitForAsyncResult', () => {
     expect(mockDelay).toHaveBeenNthCalledWith(3, 500)
     expect(mockDelay).toHaveBeenNthCalledWith(4, 1000)
     expect(mockDelay).toHaveBeenNthCalledWith(4, 1000)
+  })
+
+  test('throws error when the job fails', async () => {
+    const mockFailedResult: AsynchronousJobStatus = {
+      requestBody: {
+        concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+      },
+      jobState: 'FAILED',
+      errorMessage: 'Job failed',
+      errorDetails: 'Some error details',
+    }
+    const mockGetAsyncResult = vi.fn()
+    mockGetAsyncResult.mockResolvedValueOnce(mockFailedResult)
+
+    const result = waitForAsyncResult(mockGetAsyncResult)
+
+    await expect(result).rejects.toThrow(
+      new SynapseClientError(
+        400,
+        'Job failed',
+        'waitForAsyncResult - org.sagebionetworks.repo.model.table.QueryBundleRequest',
+      ),
+    )
   })
 })

--- a/packages/synapse-react-client/src/components/GenericCard/PortalDOI/PortalDOI.test.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/PortalDOI/PortalDOI.test.tsx
@@ -47,7 +47,8 @@ const mockDoiAssociation: DoiAssociation = {
   portalId: defaultProps.portalId,
   objectType: DoiObjectType.PORTAL_RESOURCE,
   objectId: defaultProps.resourceId,
-  doiUrl: `https://doi.org/10.test/${defaultProps.resourceId}`,
+  doiUri: `10.test/${defaultProps.resourceId}`,
+  doiUrl: `https://repo-mock.sagebase.org/doi/locate?some=params`,
   updatedOn: '2023-01-01T00:00:00.000Z',
   updatedBy: String(MOCK_USER_ID),
 }
@@ -75,8 +76,9 @@ describe('PortalDOI', () => {
     render(<PortalDOI {...defaultProps} />)
 
     // Check for DOI link, copy icon, and edit button
-    const link = screen.getByRole('link', { name: mockDoiAssociation.doiUrl })
-    expect(link).toHaveAttribute('href', mockDoiAssociation.doiUrl)
+    const expectedLink = `https://doi.org/${mockDoiAssociation.doiUri}`
+    const link = screen.getByRole('link', { name: expectedLink })
+    expect(link).toHaveAttribute('href', expectedLink)
     expect(screen.getByTestId('CopyToClipboardIcon')).toBeInTheDocument()
     const editButton = screen.getByRole('button', { name: 'Edit DOI' })
     expect(editButton).toBeInTheDocument()
@@ -124,8 +126,9 @@ describe('PortalDOI', () => {
     render(<PortalDOI {...defaultProps} />)
 
     // Check for DOI link and copy icon
-    const link = screen.getByRole('link', { name: mockDoiAssociation.doiUrl })
-    expect(link).toHaveAttribute('href', mockDoiAssociation.doiUrl)
+    const expectedLink = `https://doi.org/${mockDoiAssociation.doiUri}`
+    const link = screen.getByRole('link', { name: expectedLink })
+    expect(link).toHaveAttribute('href', expectedLink)
     expect(screen.getByTestId('CopyToClipboardIcon')).toBeInTheDocument()
 
     // Check that edit button and create link are NOT present

--- a/packages/synapse-react-client/src/components/GenericCard/PortalDOI/PortalDOI.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/PortalDOI/PortalDOI.tsx
@@ -36,6 +36,8 @@ function PortalDOI(props: PortalDOIProps) {
     return <Skeleton role="progressbar" width={150} />
   }
 
+  const doiOrgUrl = doi ? `https://doi.org/${doi.doiUri}` : undefined
+
   return (
     <>
       <CreateOrUpdateDoiModal
@@ -56,8 +58,8 @@ function PortalDOI(props: PortalDOIProps) {
       >
         {doi && (
           <>
-            <Link href={doi.doiUrl} target={'_blank'}>
-              {doi.doiUrl}
+            <Link href={doiOrgUrl} target={'_blank'}>
+              {doiOrgUrl}
             </Link>
             <CopyToClipboardIcon
               size="small"

--- a/packages/synapse-react-client/src/components/doi/CreateOrUpdateDoiModal.tsx
+++ b/packages/synapse-react-client/src/components/doi/CreateOrUpdateDoiModal.tsx
@@ -247,6 +247,7 @@ export function CreateOrUpdateDoiModal(props: CreateOrUpdateDoiModalProps) {
       requestDoi.objectId = objectId
       requestDoi.objectVersion = selectedVersionNumber
       requestDoi.etag = doi?.etag
+      requestDoi.portalId = portalId
       createOrUpdateDoi({
         doi: requestDoi,
         concreteType: 'org.sagebionetworks.repo.model.doi.v2.DoiRequest',
@@ -310,7 +311,7 @@ export function CreateOrUpdateDoiModal(props: CreateOrUpdateDoiModalProps) {
               if (e.target.value === -1) {
                 setSelectedVersionNumber(undefined)
               } else {
-                setSelectedVersionNumber(e.target.value as number)
+                setSelectedVersionNumber(e.target.value)
               }
             }}
           >


### PR DESCRIPTION
- waitForAsyncResult should throw error when fetching async job status
- In portal redirector, use `objectId` search param to match backend
- Show the correct DOI URL in the Portal UI