### PR TITLE
SWC-6990 - Optimize bundle size

### DIFF
--- a/packages/synapse-react-client/src/SWC.index.ts
+++ b/packages/synapse-react-client/src/SWC.index.ts
@@ -5,68 +5,16 @@
  * If you wish to export a component or other object to be used by SynapseWebClient, you should add it to this file.
  */
 
-import UserAccessRequestHistoryPlace from '@/components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryPlace'
-import { EntityUploadModal } from './components/EntityUpload/EntityUploadModal'
-import { SkeletonButton } from './components/Skeleton/SkeletonButton'
-import { AccountLevelBadges } from './components/AccountLevelBadges/AccountLevelBadges'
-import ChangePassword from './components/ChangePassword/ChangePassword'
-import { ReviewerDashboard } from './components/dataaccess/ReviewerDashboard'
-import { FolderDownloadConfirmation } from './components/download_list/FolderDownloadConfirmation'
-import DirectProgrammaticDownload from './components/DownloadCart/DirectProgrammaticDownload'
-import { DownloadCartPage } from './components/DownloadCart/DownloadCartPage'
-import ShowDownloadV2 from './components/DownloadCart/ShowDownloadV2'
-import { SchemaDrivenAnnotationEditor } from './components/SchemaDrivenAnnotationEditor/SchemaDrivenAnnotationEditor'
-import { EntityCitation } from './components/EntityCitation'
-import { EntityModal } from './components/entity/metadata/EntityModal'
-import { EntityBadgeIcons } from './components/EntityBadgeIcons/EntityBadgeIcons'
-import EntityForm from './components/EntityForm/EntityForm'
-import { EntityTypeIcon } from './components/EntityIcon'
-import { EntityFinder } from './components/EntityFinder/EntityFinder'
-import ErrorPage from './components/error/ErrorPage'
-import { EvaluationCard } from './components/Evaluation/EvaluationCard'
-import { EvaluationEditorPage } from './components/Evaluation/EvaluationEditorPage'
-import FavoritesPage from './components/favorites/FavoritesPage'
-import ForumSearch from './components/ForumSearch/ForumSearch'
-import { DiscussionThread } from './components/Forum/DiscussionThread'
-import FullWidthAlert from './components/FullWidthAlert/FullWidthAlert'
-import { HasAccessV2 as HasAccess } from './components/HasAccess/HasAccessV2'
-import { HelpPopover } from './components/HelpPopover/HelpPopover'
-import IconSvg from './components/IconSvg/IconSvg'
-import StandaloneLoginForm from './components/Authentication/StandaloneLoginForm'
-import PageProgress from './components/PageProgress/PageProgress'
-import { AccessTokenPage } from './components/AccessTokenPage/AccessTokenPage'
-import { ProgrammaticInstructionsModal } from './components/ProgrammaticInstructionsModal/ProgrammaticInstructionsModal'
-import QueryWrapperPlotNav from './components/QueryWrapperPlotNav/QueryWrapperPlotNav'
-import StatisticsPlot from './components/StatisticsPlot'
-import {
-  SynapseHomepageV2,
-  SynapsePlansPage,
-} from './components/SynapseHomepageV2'
-import { SynapseNavDrawer } from './components/SynapseNavDrawer/SynapseNavDrawer'
-import { DatasetItemsEditor } from './components/SynapseTable/datasets/DatasetItemsEditor'
-import StandaloneQueryWrapper from './components/StandaloneQueryWrapper/StandaloneQueryWrapper'
-import ProgrammaticTableDownload from './components/ProgrammaticTableDownload/ProgrammaticTableDownload'
-import TermsAndConditions from './components/TermsAndConditions/TermsAndConditions'
+import { lazy } from 'react'
+import { version } from '../package.json'
 import {
   displayToast,
   SynapseToastContainer,
 } from './components/ToastMessage/ToastMessage'
-import { TrashCanList } from './components/trash/TrashCanList'
-import { OAuthManagement } from './components/OAuthClientManagement/OAuthManagement'
-import UserCard from './components/UserCard/UserCard'
-import UserProfileLinks from './components/UserProfileLinks/UserProfileLinks'
-import CertificationQuiz from './components/CertificationQuiz/CertificationQuiz'
-import ProvenanceGraph from './components/ProvenanceGraph/ProvenanceGraph'
-import IDUReport from './components/IDUReport/IDUReport'
-import HtmlPreview from './components/FilePreview/HtmlPreview/HtmlPreview'
-import EntityPageBreadcrumbs from './components/entity/page/breadcrumbs/EntityPageBreadcrumbs'
-import EntityActionMenu from './components/entity/page/action_menu/EntityActionMenu'
-import EntityPageTitleBar from './components/entity/page/title_bar/EntityPageTitleBar'
-import { CreatedByModifiedBy } from './components/entity/page/CreatedByModifiedBy'
 import SynapseClient, { HttpClient } from './synapse-client'
 import * as SynapseQueries from './synapse-queries'
-import { SynapseConstants } from './utils'
 import Palettes from './theme/palette/Palettes'
+import { SynapseConstants } from './utils'
 import { sendAnalyticsEvent } from './utils/analytics/sendAnalyticsEvent'
 import {
   sendSearchQuerySubmittedEvent,
@@ -74,43 +22,15 @@ import {
   sendSearchResultReturnedEvent,
   sendSearchResultsReturnedEvent,
 } from './utils/analytics/sendSearchEvent'
+import { FullContextProvider } from './utils/context/FullContextProvider'
 import {
   SynapseContextConsumer,
   SynapseContextProvider,
   useSynapseContext,
 } from './utils/context/SynapseContext'
-import TwoFactorBackupCodes from './components/Authentication/TwoFactorBackupCodes'
-import TwoFactorEnrollmentForm from './components/Authentication/TwoFactorEnrollmentForm'
-import TwoFactorAuthSettingsPanel from './components/Authentication/TwoFactorAuthSettingsPanel'
-import { FullContextProvider } from './utils/context/FullContextProvider'
-import SubscriptionPage from './components/SubscriptionPage'
-import OrientationBanner from './components/OrientationBanner/OrientationBanner'
-import AccessRequirementList from './components/AccessRequirementList/AccessRequirementList'
 import { BackendDestinationEnum } from './utils/functions'
-import TableColumnSchemaForm from './components/TableColumnSchemaEditor/TableColumnSchemaForm'
-import EntityHeaderTable from './components/EntityHeaderTable'
-import AccessRequirementRelatedProjectsList from './components/AccessRequirementRelatedProjectsList'
-import CreateTableViewWizard from './components/CreateTableViewWizard/CreateTableViewWizard'
-import TableColumnSchemaEditor from './components/TableColumnSchemaEditor/TableColumnSchemaEditor'
-import SqlDefinedTableEditorModal from './components/SqlDefinedTableEditor/SqlDefinedTableEditorModal'
-import EntityViewScopeEditorModal from './components/EntityViewScopeEditor/EntityViewScopeEditorModal'
-import SubmissionViewScopeEditorModal from './components/SubmissionViewScopeEditor/SubmissionViewScopeEditorModal'
-import AvailableEvaluationQueueList from './components/ChallengeSubmission/AvailableEvaluationQueueList'
-import AccessRequirementAclEditor from './components/AccessRequirementAclEditor'
-import CreateOrUpdateAccessRequirementWizard from './components/CreateOrUpdateAccessRequirementWizard'
-import { SynapseFooter } from './components/SynapseFooter/SynapseFooter'
-import { GoogleAnalytics } from './components/GoogleAnalytics/GoogleAnalytics'
-import { CookiesNotification } from './components/CookiesNotification'
-import { getCurrentCookiePreferences } from './utils/hooks'
-import EntityAclEditorModal from './components/EntityAclEditor/EntityAclEditorModal'
-import SynapseChat from './components/SynapseChat/SynapseChat'
-import { version } from '../package.json'
 import { xssOptions } from './utils/functions/SanitizeHtmlUtils'
-import { RejectProfileValidationRequestModal } from './components/dataaccess/RejectProfileValidationRequestModal'
-import { GovernanceMarkdownGithub } from './components/Markdown/MarkdownGithub'
-import { MarkdownGithubLatestTag } from './components/Markdown/MarkdownGithub'
-import { ProjectDataAvailability } from './components/ProjectStorage/ProjectDataAvailability'
-import { CreateOrUpdateDoiModal } from './components/doi/CreateOrUpdateDoiModal'
+import { getCurrentCookiePreferences } from './utils/hooks'
 
 // Also include scss in the bundle
 import './style/main.scss'
@@ -127,88 +47,166 @@ const SynapseContext = {
 }
 
 const SynapseComponents = {
-  Login: StandaloneLoginForm,
-  EntityForm,
-  UserCard,
-  StatisticsPlot,
-  HasAccess,
-  EvaluationCard,
-  EvaluationEditorPage,
-  AccessTokenPage,
-  AccountLevelBadges,
-  TermsAndConditions,
-  PageProgress,
-  SynapseHomepageV2,
-  SynapsePlansPage,
-  SynapseFooter,
-  EntityFinder,
-  ErrorPage,
-  EntityBadgeIcons,
-  DownloadCartPage,
-  ShowDownloadV2,
-  DownloadConfirmation: FolderDownloadConfirmation,
-  FullWidthAlert: FullWidthAlert,
-  SchemaDrivenAnnotationEditor,
-  SynapseNavDrawer,
-  FavoritesPage,
-  EntityCitation,
-  EntityModal,
   SynapseToastContainer,
   displayToast,
-  IconSvg,
-  UserProfileLinks,
-  DatasetItemsEditor,
-  EntityTypeIcon,
-  HelpPopover,
-  ProgrammaticTableDownload,
-  DirectProgrammaticDownload,
-  ProgrammaticInstructionsModal,
-  SkeletonButton,
-  QueryWrapperPlotNav,
-  StandaloneQueryWrapper,
-  ChangePassword,
-  ForumSearch,
-  DiscussionThread,
-  ReviewerDashboard,
-  ProvenanceGraph,
-  TrashCanList,
-  OAuthManagement,
-  CertificationQuiz,
-  HtmlPreview,
-  IDUReport,
-  EntityPageBreadcrumbs,
-  EntityActionMenu,
-  EntityPageTitleBar,
-  CreatedByModifiedBy,
-  TwoFactorAuthSettingsPanel,
-  TwoFactorBackupCodes,
-  TwoFactorEnrollmentForm,
-  SubscriptionPage,
-  OrientationBanner,
-  AvailableEvaluationQueueList,
-  AccessRequirementList,
-  TableColumnSchemaForm,
-  EntityHeaderTable,
-  AccessRequirementRelatedProjectsList,
-  CreateTableViewWizard,
-  TableColumnSchemaEditor,
-  SqlDefinedTableEditorModal,
-  EntityViewScopeEditorModal,
-  SubmissionViewScopeEditorModal,
-  AccessRequirementAclEditor,
-  CreateOrUpdateAccessRequirementWizard,
-  GoogleAnalytics,
-  CookiesNotification,
   getCurrentCookiePreferences,
-  EntityAclEditorModal,
-  SynapseChat,
-  RejectProfileValidationRequestModal,
-  GovernanceMarkdownGithub,
-  MarkdownGithubLatestTag,
-  ProjectDataAvailability,
-  EntityUploadModal,
-  CreateOrUpdateDoiModal,
-  UserAccessRequestHistoryPlace,
+  EntityForm: lazy(() => import('./components/EntityForm/EntityForm')),
+  UserCard: lazy(() => import('./components/UserCard/UserCard')),
+  StatisticsPlot: lazy(() => import('./components/StatisticsPlot')),
+  HasAccess: lazy(() => import('./components/HasAccess/HasAccessV2')),
+  EvaluationCard: lazy(() => import('./components/Evaluation/EvaluationCard')),
+  EvaluationEditorPage: lazy(
+    () => import('./components/Evaluation/EvaluationEditorPage'),
+  ),
+  AccountLevelBadges: lazy(
+    () => import('./components/AccountLevelBadges/AccountLevelBadges'),
+  ),
+  PageProgress: lazy(() => import('./components/PageProgress/PageProgress')),
+  SynapseHomepageV2: lazy(
+    () => import('./components/SynapseHomepageV2/SynapseHomepageV2'),
+  ),
+  SynapsePlansPage: lazy(
+    () => import('./components/SynapseHomepageV2/SynapsePlansPage'),
+  ),
+  SynapseFooter: lazy(() => import('./components/SynapseFooter/SynapseFooter')),
+  EntityFinder: lazy(() => import('./components/EntityFinder/EntityFinder')),
+  ErrorPage: lazy(() => import('./components/error/ErrorPage')),
+  EntityBadgeIcons: lazy(
+    () => import('./components/EntityBadgeIcons/EntityBadgeIcons'),
+  ),
+  DownloadCartPage: lazy(
+    () => import('./components/DownloadCart/DownloadCartPage'),
+  ),
+  DownloadConfirmation: lazy(
+    () => import('./components/download_list/FolderDownloadConfirmation'),
+  ),
+  FullWidthAlert: lazy(
+    () => import('./components/FullWidthAlert/FullWidthAlert'),
+  ),
+  SynapseNavDrawer: lazy(
+    () => import('./components/SynapseNavDrawer/SynapseNavDrawer'),
+  ),
+  FavoritesPage: lazy(() => import('./components/favorites/FavoritesPage')),
+  EntityCitation: lazy(() => import('./components/EntityCitation')),
+  EntityModal: lazy(() => import('./components/entity/metadata/EntityModal')),
+  IconSvg: lazy(() => import('./components/IconSvg/IconSvg')),
+  UserProfileLinks: lazy(
+    () => import('./components/UserProfileLinks/UserProfileLinks'),
+  ),
+  DatasetItemsEditor: lazy(
+    () => import('./components/SynapseTable/datasets/DatasetItemsEditor'),
+  ),
+  EntityTypeIcon: lazy(() => import('./components/EntityIcon')),
+  HelpPopover: lazy(() => import('./components/HelpPopover/HelpPopover')),
+  SkeletonButton: lazy(() => import('./components/Skeleton/SkeletonButton')),
+  QueryWrapperPlotNav: lazy(
+    () => import('./components/QueryWrapperPlotNav/QueryWrapperPlotNav'),
+  ),
+  StandaloneQueryWrapper: lazy(
+    () => import('./components/StandaloneQueryWrapper/StandaloneQueryWrapper'),
+  ),
+  ForumSearch: lazy(() => import('./components/ForumSearch/ForumSearch')),
+  DiscussionThread: lazy(() => import('./components/Forum/DiscussionThread')),
+  ReviewerDashboard: lazy(
+    () => import('./components/dataaccess/ReviewerDashboard'),
+  ),
+  ProvenanceGraph: lazy(
+    () => import('./components/ProvenanceGraph/ProvenanceGraph'),
+  ),
+  TrashCanList: lazy(() => import('./components/trash/TrashCanList')),
+  OAuthManagement: lazy(
+    () => import('./components/OAuthClientManagement/OAuthManagement'),
+  ),
+  CertificationQuiz: lazy(
+    () => import('./components/CertificationQuiz/CertificationQuiz'),
+  ),
+  HtmlPreview: lazy(
+    () => import('./components/FilePreview/HtmlPreview/HtmlPreview'),
+  ),
+  IDUReport: lazy(() => import('./components/IDUReport/IDUReport')),
+  EntityPageBreadcrumbs: lazy(
+    () => import('./components/entity/page/breadcrumbs/EntityPageBreadcrumbs'),
+  ),
+  EntityActionMenu: lazy(
+    () => import('./components/entity/page/action_menu/EntityActionMenu'),
+  ),
+  EntityPageTitleBar: lazy(
+    () => import('./components/entity/page/title_bar/EntityPageTitleBar'),
+  ),
+  CreatedByModifiedBy: lazy(
+    () => import('./components/entity/page/CreatedByModifiedBy'),
+  ),
+  SubscriptionPage: lazy(() => import('./components/SubscriptionPage')),
+  OrientationBanner: lazy(
+    () => import('./components/OrientationBanner/OrientationBanner'),
+  ),
+  AvailableEvaluationQueueList: lazy(
+    () =>
+      import('./components/ChallengeSubmission/AvailableEvaluationQueueList'),
+  ),
+  AccessRequirementList: lazy(
+    () => import('./components/AccessRequirementList/AccessRequirementList'),
+  ),
+  EntityHeaderTable: lazy(() => import('./components/EntityHeaderTable')),
+  AccessRequirementRelatedProjectsList: lazy(
+    () => import('./components/AccessRequirementRelatedProjectsList'),
+  ),
+  CreateTableViewWizard: lazy(
+    () => import('./components/CreateTableViewWizard/CreateTableViewWizard'),
+  ),
+  TableColumnSchemaEditor: lazy(
+    () =>
+      import('./components/TableColumnSchemaEditor/TableColumnSchemaEditor'),
+  ),
+  SqlDefinedTableEditorModal: lazy(
+    () =>
+      import('./components/SqlDefinedTableEditor/SqlDefinedTableEditorModal'),
+  ),
+  EntityViewScopeEditorModal: lazy(
+    () =>
+      import('./components/EntityViewScopeEditor/EntityViewScopeEditorModal'),
+  ),
+  SubmissionViewScopeEditorModal: lazy(
+    () =>
+      import(
+        './components/SubmissionViewScopeEditor/SubmissionViewScopeEditorModal'
+      ),
+  ),
+  AccessRequirementAclEditor: lazy(
+    () => import('./components/AccessRequirementAclEditor'),
+  ),
+  CreateOrUpdateAccessRequirementWizard: lazy(
+    () => import('./components/CreateOrUpdateAccessRequirementWizard'),
+  ),
+  GoogleAnalytics: lazy(
+    () => import('./components/GoogleAnalytics/GoogleAnalytics'),
+  ),
+  CookiesNotification: lazy(() => import('./components/CookiesNotification')),
+  EntityAclEditorModal: lazy(
+    () => import('./components/EntityAclEditor/EntityAclEditorModal'),
+  ),
+  SynapseChat: lazy(() => import('./components/SynapseChat/SynapseChat')),
+  RejectProfileValidationRequestModal: lazy(
+    () => import('./components/dataaccess/RejectProfileValidationRequestModal'),
+  ),
+  GovernanceMarkdownGithub: lazy(
+    () => import('./components/Markdown/MarkdownGithub'),
+  ),
+  ProjectDataAvailability: lazy(
+    () => import('./components/ProjectStorage/ProjectDataAvailability'),
+  ),
+  EntityUploadModal: lazy(
+    () => import('./components/EntityUpload/EntityUploadModal'),
+  ),
+  CreateOrUpdateDoiModal: lazy(
+    () => import('./components/doi/CreateOrUpdateDoiModal'),
+  ),
+  UserAccessRequestHistoryPlace: lazy(
+    () =>
+      import(
+        './components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryPlace'
+      ),
+  ),
 }
 
 const Analytics = {

--- a/packages/synapse-react-client/src/components/AccountLevelBadges/AccountLevelBadges.tsx
+++ b/packages/synapse-react-client/src/components/AccountLevelBadges/AccountLevelBadges.tsx
@@ -86,3 +86,5 @@ export function AccountLevelBadges({ userId }: AccountLevelBadgesProps) {
     </>
   )
 }
+
+export default AccountLevelBadges

--- a/packages/synapse-react-client/src/components/EntityBadgeIcons/EntityBadgeIcons.tsx
+++ b/packages/synapse-react-client/src/components/EntityBadgeIcons/EntityBadgeIcons.tsx
@@ -363,3 +363,5 @@ export const EntityBadgeIcons = (props: EntityBadgeIconsProps) => {
     </div>
   )
 }
+
+export default EntityBadgeIcons

--- a/packages/synapse-react-client/src/components/EntityIcon.tsx
+++ b/packages/synapse-react-client/src/components/EntityIcon.tsx
@@ -55,3 +55,5 @@ export function EntityTypeIcon(
     </span>
   )
 }
+
+export default EntityTypeIcon

--- a/packages/synapse-react-client/src/components/EntityUpload/EntityUploadModal.tsx
+++ b/packages/synapse-react-client/src/components/EntityUpload/EntityUploadModal.tsx
@@ -154,3 +154,5 @@ export const EntityUploadModal = forwardRef(function EntityUploadModal(
     />
   )
 })
+
+export default EntityUploadModal

--- a/packages/synapse-react-client/src/components/Evaluation/EvaluationCard.tsx
+++ b/packages/synapse-react-client/src/components/Evaluation/EvaluationCard.tsx
@@ -229,3 +229,5 @@ function EvaluationCardDropdown({
     </>
   )
 }
+
+export default EvaluationCard

--- a/packages/synapse-react-client/src/components/Evaluation/EvaluationEditorPage.tsx
+++ b/packages/synapse-react-client/src/components/Evaluation/EvaluationEditorPage.tsx
@@ -88,3 +88,5 @@ function FakeEvaluationRoundEditorList() {
 export const HelpersToTest = {
   FakeEvaluationRoundEditorList,
 }
+
+export default EvaluationEditorPage

--- a/packages/synapse-react-client/src/components/Forum/DiscussionThread.tsx
+++ b/packages/synapse-react-client/src/components/Forum/DiscussionThread.tsx
@@ -395,3 +395,5 @@ export function DiscussionThread(props: DiscussionThreadProps) {
     </div>
   )
 }
+
+export default DiscussionThread

--- a/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.tsx
+++ b/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.tsx
@@ -347,3 +347,5 @@ export function HasAccessV2(props: HasAccessProps) {
     </span>
   )
 }
+
+export default HasAccessV2

--- a/packages/synapse-react-client/src/components/HelpPopover/HelpPopover.tsx
+++ b/packages/synapse-react-client/src/components/HelpPopover/HelpPopover.tsx
@@ -46,3 +46,5 @@ export function HelpPopover({
     </>
   )
 }
+
+export default HelpPopover

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownGithub.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownGithub.tsx
@@ -66,3 +66,5 @@ function MarkdownGithub({
     </Container>
   )
 }
+
+export default MarkdownGithub

--- a/packages/synapse-react-client/src/components/OAuthClientManagement/OAuthManagement.tsx
+++ b/packages/synapse-react-client/src/components/OAuthClientManagement/OAuthManagement.tsx
@@ -275,3 +275,5 @@ export function OAuthManagement() {
     </div>
   )
 }
+
+export default OAuthManagement

--- a/packages/synapse-react-client/src/components/Skeleton/SkeletonButton.tsx
+++ b/packages/synapse-react-client/src/components/Skeleton/SkeletonButton.tsx
@@ -14,3 +14,5 @@ export function SkeletonButton({
     </Skeleton>
   )
 }
+
+export default SkeletonButton

--- a/packages/synapse-react-client/src/components/SqlDefinedTableEditor/SqlDefinedTableEditorModal.tsx
+++ b/packages/synapse-react-client/src/components/SqlDefinedTableEditor/SqlDefinedTableEditorModal.tsx
@@ -13,7 +13,7 @@ export type SqlDefinedTableEditorModalProps = {
   onUpdate: () => void
   onCancel: () => void
 }
-export default function SqlDefinedTableEditorModal(
+export function SqlDefinedTableEditorModal(
   props: SqlDefinedTableEditorModalProps,
 ) {
   const { open, entityId, onCancel, onUpdate } = props
@@ -80,3 +80,5 @@ export default function SqlDefinedTableEditorModal(
     />
   )
 }
+
+export default SqlDefinedTableEditorModal

--- a/packages/synapse-react-client/src/components/SynapseFooter/SynapseFooter.tsx
+++ b/packages/synapse-react-client/src/components/SynapseFooter/SynapseFooter.tsx
@@ -306,3 +306,5 @@ export function SynapseFooter({
     </Box>
   )
 }
+
+export default SynapseFooter

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/HomepageStyles.ts
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/HomepageStyles.ts
@@ -1,0 +1,49 @@
+import { SxProps } from '@mui/material/styles'
+
+export const darkTextColor = '#22252A'
+export const homepageBodyText: SxProps = {
+  fontSize: '24px',
+  fontWeight: 400,
+  lineHeight: '34px',
+  color: darkTextColor,
+}
+
+export const h2Sx: SxProps = {
+  fontSize: {
+    xs: '36px',
+    md: '52px',
+  },
+  fontWeight: 600,
+  lineHeight: '52px',
+  color: darkTextColor,
+}
+
+export const defaultHomepageText: SxProps = {
+  color: darkTextColor,
+  fontWeight: 600,
+}
+
+export const titleSx: SxProps = {
+  ...defaultHomepageText,
+  fontWeight: 300,
+  fontSize: {
+    xs: '48px',
+    md: '72px',
+  },
+  lineHeight: {
+    xs: '120%',
+    md: '82px',
+  },
+  color: 'white',
+}
+
+export const sidePadding: SxProps = {
+  pl: {
+    xs: '15px',
+    sm: '50px',
+  },
+  pr: {
+    xs: '15px',
+    sm: '50px',
+  },
+}

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseHomepageV2.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseHomepageV2.tsx
@@ -1,13 +1,19 @@
 import BlinkingLiveIcon from '@/assets/homepage/BlinkingLiveIcon'
 import { backgroundInlineJpeg } from '@/assets/homepage/header-splash'
-import { ReactComponent as Image1 } from '@/assets/homepage/image1.svg'
+import image1 from '@/assets/homepage/image1.svg?url'
 import SageFullLogo from '@/assets/icons/SageFullLogo'
+import {
+  defaultHomepageText,
+  h2Sx,
+  homepageBodyText,
+  sidePadding,
+  titleSx,
+} from '@/components/SynapseHomepageV2/HomepageStyles'
 import { SAGE_OFFERINGS_HELP_URL } from '@/utils/SynapseConstants'
 import {
   Box,
   Button,
   Link,
-  SxProps,
   Typography,
   useMediaQuery,
   useTheme,
@@ -30,52 +36,6 @@ export const past30DaysDownloadMetricsTable = 'syn61597084'
 export const generalStatsMetricsTable = 'syn61588123'
 export const featuredDatasetsTable = 'syn61609402'
 export const searchAutocompleteTable = 'syn61670515'
-
-export const darkTextColor = '#22252A'
-export const homepageBodyText: SxProps = {
-  fontSize: '24px',
-  fontWeight: 400,
-  lineHeight: '34px',
-  color: darkTextColor,
-}
-
-export const h2Sx: SxProps = {
-  fontSize: {
-    xs: '36px',
-    md: '52px',
-  },
-  fontWeight: 600,
-  lineHeight: '52px',
-  color: darkTextColor,
-}
-
-const defaultHomepageText: SxProps = {
-  color: darkTextColor,
-  fontWeight: 600,
-}
-const titleSx: SxProps = {
-  ...defaultHomepageText,
-  fontWeight: 300,
-  fontSize: {
-    xs: '48px',
-    md: '72px',
-  },
-  lineHeight: {
-    xs: '120%',
-    md: '82px',
-  },
-  color: 'white',
-}
-const sidePadding: SxProps = {
-  pl: {
-    xs: '15px',
-    sm: '50px',
-  },
-  pr: {
-    xs: '15px',
-    sm: '50px',
-  },
-}
 
 export type SynapseHomepageV2Props = {
   gotoPlace: (href: string) => void
@@ -274,7 +234,7 @@ export function SynapseHomepageV2({ gotoPlace }: SynapseHomepageV2Props) {
           </Box>
           {isDesktopView && (
             <Box sx={{ height: '100%', justifySelf: 'end' }}>
-              <Image1 />
+              <img src={image1} alt={''} />
             </Box>
           )}
         </Box>

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseInActionItem.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseInActionItem.tsx
@@ -1,4 +1,8 @@
 import {
+  darkTextColor,
+  homepageBodyText,
+} from '@/components/SynapseHomepageV2/HomepageStyles'
+import {
   Box,
   Chip,
   Link,
@@ -10,7 +14,6 @@ import {
 } from '@mui/material'
 import ImageFromSynapseTable from '../ImageFromSynapseTable'
 import { EastTwoTone } from '@mui/icons-material'
-import { darkTextColor, homepageBodyText } from './SynapseHomepageV2'
 import { useInView } from 'react-intersection-observer'
 import { Slide } from '@mui/material'
 

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapsePlan.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapsePlan.tsx
@@ -1,7 +1,10 @@
+import {
+  darkTextColor,
+  homepageBodyText,
+} from '@/components/SynapseHomepageV2/HomepageStyles'
 import { PropsWithChildren } from 'react'
 import { Button, Typography } from '@mui/material'
 import { Box } from '@mui/material'
-import { darkTextColor, homepageBodyText } from './SynapseHomepageV2'
 
 export type SynapsePlanProps = {
   title: string

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapsePlanContent.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapsePlanContent.tsx
@@ -1,6 +1,6 @@
 import { ReactComponent as PlanItemIcon } from '@/assets/homepage/plan-item.svg'
+import { darkTextColor } from '@/components/SynapseHomepageV2/HomepageStyles'
 import { Box, Typography } from '@mui/material'
-import { darkTextColor } from './SynapseHomepageV2'
 
 export type SynapsePlanContentProps = {
   category: string

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapsePlansPage.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapsePlansPage.tsx
@@ -1,7 +1,10 @@
+import {
+  h2Sx,
+  homepageBodyText,
+} from '@/components/SynapseHomepageV2/HomepageStyles'
 import { Box, Button, Typography } from '@mui/material'
 import { SynapsePlans } from './SynapsePlans'
 import { SynapseHomepageNavBar } from './SynapseHomepageNavBar'
-import { h2Sx, homepageBodyText } from './SynapseHomepageV2'
 
 export type SynapsePlansPageProps = {
   gotoPlace: (href: string) => void

--- a/packages/synapse-react-client/src/components/SynapseNavDrawer/SynapseNavDrawer.tsx
+++ b/packages/synapse-react-client/src/components/SynapseNavDrawer/SynapseNavDrawer.tsx
@@ -650,3 +650,5 @@ export function SynapseNavDrawer({
     </>
   )
 }
+
+export default SynapseNavDrawer

--- a/packages/synapse-react-client/src/components/SynapseTable/datasets/DatasetItemsEditor.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/datasets/DatasetItemsEditor.tsx
@@ -811,3 +811,5 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
     </div>
   )
 }
+
+export default DatasetItemsEditor

--- a/packages/synapse-react-client/src/components/dataaccess/RejectProfileValidationRequestModal.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/RejectProfileValidationRequestModal.tsx
@@ -115,3 +115,5 @@ export function RejectProfileValidationRequestModal(
     </CannedRejectionDialog>
   )
 }
+
+export default RejectProfileValidationRequestModal

--- a/packages/synapse-react-client/src/components/doi/CreateOrUpdateDoiModal.tsx
+++ b/packages/synapse-react-client/src/components/doi/CreateOrUpdateDoiModal.tsx
@@ -410,3 +410,5 @@ export function CreateOrUpdateDoiModal(props: CreateOrUpdateDoiModalProps) {
     </>
   )
 }
+
+export default CreateOrUpdateDoiModal

--- a/packages/synapse-react-client/src/components/download_list/FolderDownloadConfirmation.tsx
+++ b/packages/synapse-react-client/src/components/download_list/FolderDownloadConfirmation.tsx
@@ -59,3 +59,5 @@ export function FolderDownloadConfirmation(
     />
   )
 }
+
+export default FolderDownloadConfirmation

--- a/packages/synapse-react-client/src/components/entity/metadata/EntityModal.tsx
+++ b/packages/synapse-react-client/src/components/entity/metadata/EntityModal.tsx
@@ -265,3 +265,5 @@ export function EntityModal(props: EntityModalProps) {
     />
   )
 }
+
+export default EntityModal

--- a/packages/synapse-react-client/src/components/entity/page/CreatedByModifiedBy.tsx
+++ b/packages/synapse-react-client/src/components/entity/page/CreatedByModifiedBy.tsx
@@ -187,3 +187,5 @@ export function CreatedByModifiedBy(props: CreatedByModifiedByProps) {
     </Box>
   )
 }
+
+export default CreatedByModifiedBy

--- a/packages/synapse-react-client/src/components/trash/TrashCanList.tsx
+++ b/packages/synapse-react-client/src/components/trash/TrashCanList.tsx
@@ -257,3 +257,5 @@ export function TrashCanList() {
     </div>
   )
 }
+
+export default TrashCanList

--- a/packages/synapse-react-client/src/types/vite.d.ts
+++ b/packages/synapse-react-client/src/types/vite.d.ts
@@ -1,0 +1,1 @@
+import 'vite/client'


### PR DESCRIPTION
- Lazy-load each React component, so Vite will code-split and reduce the initial bundle size
- Remove unused React components from SWC bundle