### PR TITLE
SWC-7384

### DIFF
--- a/apps/SageAccountWeb/package.json
+++ b/apps/SageAccountWeb/package.json
@@ -16,6 +16,7 @@
     "@sage-bionetworks/synapse-portal-framework": "workspace:*",
     "@sage-bionetworks/synapse-types": "workspace:*",
     "@tanstack/react-query": "5.22.2",
+    "dayjs": "^1.11.13",
     "katex": "^0.16.22",
     "lodash-es": "^4.17.21",
     "plotly.js-basic-dist": "^2.35.3",
@@ -66,6 +67,7 @@
     "vite": "^6.3.5",
     "vite-config": "workspace:*",
     "vitest": "^3.2.2",
+    "vitest-when": "^0.6.1",
     "whatwg-fetch": "^3.6.20"
   },
   "scripts": {

--- a/apps/SageAccountWeb/src/hooks/useMaybeForceEnable2FA.test.ts
+++ b/apps/SageAccountWeb/src/hooks/useMaybeForceEnable2FA.test.ts
@@ -1,4 +1,7 @@
+import usePathBefore2FARedirect from '@/hooks/usePathBefore2FARedirect'
+import { useSkipMfaPrompt } from '@/hooks/useSkipMfaPrompt'
 import { renderHook, waitFor } from '@testing-library/react'
+import { useGetCurrentUserProfile } from 'synapse-react-client/synapse-queries/index'
 import {
   ApplicationSessionContextType,
   useApplicationSessionContext,
@@ -33,6 +36,15 @@ vi.mock('react-router', () => {
   }
 })
 
+vi.mock('@/hooks/useSkipMfaPrompt')
+vi.mock('@/hooks/usePathBefore2FARedirect')
+
+const mockUseSkipMfaPrompt = vi.mocked(useSkipMfaPrompt)
+mockUseSkipMfaPrompt.mockReturnValue({
+  hasSkippedRecently: false,
+  skip: vi.fn(),
+})
+
 const mockApplicationSessionContext: ApplicationSessionContextType = {
   hasInitializedSession: true,
   refreshSession: vi.fn(),
@@ -57,6 +69,13 @@ vi.mocked(useNavigate).mockReturnValue(mockNavigate)
 vi.mocked(useLocation).mockReturnValue(mockLocation)
 const mockFeatureFlagValue = true
 vi.mocked(useGetFeatureFlag).mockReturnValue(mockFeatureFlagValue)
+const mockSetPathBefore2FARedirect = vi.fn()
+vi.mocked(usePathBefore2FARedirect).mockReturnValue({
+  value: undefined,
+  set: mockSetPathBefore2FARedirect,
+  remove: vi.fn(),
+  fetch: vi.fn(),
+})
 
 describe('useMaybeForceEnable2FA', () => {
   beforeEach(() => {
@@ -72,6 +91,7 @@ describe('useMaybeForceEnable2FA', () => {
     await waitFor(() => {
       expect(hook.result.current.mayForceEnable2FA).toBe(false)
       expect(mockNavigate).not.toHaveBeenCalled()
+      expect(mockSetPathBefore2FARedirect).not.toHaveBeenCalled()
     })
   })
   it('does not redirect when user is not logged in', async () => {
@@ -85,6 +105,7 @@ describe('useMaybeForceEnable2FA', () => {
     await waitFor(() => {
       expect(hook.result.current.mayForceEnable2FA).toBe(true)
       expect(mockNavigate).not.toHaveBeenCalled()
+      expect(mockSetPathBefore2FARedirect).not.toHaveBeenCalled()
     })
   })
   it('redirects to 2faRequired when user has not enabled 2FA', async () => {
@@ -99,6 +120,7 @@ describe('useMaybeForceEnable2FA', () => {
     await waitFor(() => {
       expect(hook.result.current.mayForceEnable2FA).toBe(true)
       expect(mockNavigate).toHaveBeenCalledWith('/authenticated/2faRequired')
+      expect(mockSetPathBefore2FARedirect).toHaveBeenLastCalledWith('/')
     })
   })
 
@@ -120,6 +142,7 @@ describe('useMaybeForceEnable2FA', () => {
       expect(mockNavigate).not.toHaveBeenCalledWith(
         '/authenticated/2faRequired',
       )
+      expect(mockSetPathBefore2FARedirect).not.toHaveBeenCalled()
     })
   })
   it('does not redirect to 2faRequired if user is already on 2fa enroll page', async () => {
@@ -140,6 +163,7 @@ describe('useMaybeForceEnable2FA', () => {
       expect(mockNavigate).not.toHaveBeenCalledWith(
         '/authenticated/2faRequired',
       )
+      expect(mockSetPathBefore2FARedirect).not.toHaveBeenCalled()
     })
   })
   it('does not redirect to 2faRequired if user is signing the terms of use', async () => {
@@ -160,6 +184,7 @@ describe('useMaybeForceEnable2FA', () => {
       expect(mockNavigate).not.toHaveBeenCalledWith(
         '/authenticated/2faRequired',
       )
+      expect(mockSetPathBefore2FARedirect).not.toHaveBeenCalled()
     })
   })
   it('does not redirect to 2faRequired if user is signing updated terms of use', async () => {
@@ -179,6 +204,85 @@ describe('useMaybeForceEnable2FA', () => {
       expect(hook.result.current.mayForceEnable2FA).toBe(true)
       expect(mockNavigate).not.toHaveBeenCalledWith(
         '/authenticated/2faRequired',
+      )
+      expect(mockSetPathBefore2FARedirect).not.toHaveBeenCalled()
+    })
+  })
+
+  it('does not redirect to 2faRequired if the user has skipped recently and MFA is not required', async () => {
+    vi.mocked(useGetFeatureFlag).mockReturnValue(false)
+    vi.mocked(useSkipMfaPrompt).mockReturnValue({
+      hasSkippedRecently: true,
+      skip: vi.fn(),
+    })
+    vi.mocked(useLocation).mockReturnValue({
+      ...mockLocation,
+      pathname: '/',
+    })
+    mockUseApplicationSessionContext.mockReturnValue({
+      ...mockApplicationSessionContext,
+      twoFactorStatus: {
+        status: 'DISABLED',
+      },
+    })
+
+    const hook = renderHook(() => useMaybeForceEnable2FA())
+    await waitFor(() => {
+      expect(hook.result.current.mayForceEnable2FA).toBe(false)
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        '/authenticated/2faRequired',
+      )
+      expect(mockSetPathBefore2FARedirect).not.toHaveBeenCalled()
+    })
+  })
+
+  it('redirect to 2faRequired if the user has skipped recently and MFA is required', async () => {
+    vi.mocked(useGetFeatureFlag).mockReturnValue(true) // Feature flag is on, so user cannot skip
+    vi.mocked(useSkipMfaPrompt).mockReturnValue({
+      hasSkippedRecently: true,
+      skip: vi.fn(),
+    })
+    vi.mocked(useLocation).mockReturnValue({
+      ...mockLocation,
+      pathname: '/',
+    })
+    mockUseApplicationSessionContext.mockReturnValue({
+      ...mockApplicationSessionContext,
+      twoFactorStatus: {
+        status: 'DISABLED',
+      },
+    })
+
+    const hook = renderHook(() => useMaybeForceEnable2FA())
+    await waitFor(() => {
+      expect(hook.result.current.mayForceEnable2FA).toBe(true)
+      expect(mockNavigate).toHaveBeenCalledWith('/authenticated/2faRequired')
+      expect(mockSetPathBefore2FARedirect).toHaveBeenLastCalledWith('/')
+    })
+  })
+
+  it('sets the redirect path to the current path before redirecting to 2faRequired', async () => {
+    // Simulate e.g. the account created workflow
+    const accountCreatedPath = '/authenticated/accountCreated'
+    vi.mocked(useLocation).mockReturnValue({
+      ...mockLocation,
+      pathname: accountCreatedPath,
+    })
+    vi.mocked(useGetFeatureFlag).mockReturnValue(true)
+    mockUseApplicationSessionContext.mockReturnValue({
+      ...mockApplicationSessionContext,
+      twoFactorStatus: {
+        status: 'DISABLED',
+      },
+    })
+
+    const hook = renderHook(() => useMaybeForceEnable2FA())
+    await waitFor(() => {
+      expect(hook.result.current.mayForceEnable2FA).toBe(true)
+      expect(mockNavigate).toHaveBeenCalledWith('/authenticated/2faRequired')
+      // Verify that the user will be redirected back to the account created path after 2FA enrollment
+      expect(mockSetPathBefore2FARedirect).toHaveBeenLastCalledWith(
+        accountCreatedPath,
       )
     })
   })

--- a/apps/SageAccountWeb/src/hooks/usePathBefore2FARedirect.ts
+++ b/apps/SageAccountWeb/src/hooks/usePathBefore2FARedirect.ts
@@ -1,0 +1,8 @@
+import { PATH_BEFORE_2FA_REDIRECT_LOCALSTORAGE_KEY } from '@/utils/StorageKeys'
+import { useLocalStorageValue } from '@react-hookz/web'
+
+function usePathBefore2FARedirect() {
+  return useLocalStorageValue<string>(PATH_BEFORE_2FA_REDIRECT_LOCALSTORAGE_KEY)
+}
+
+export default usePathBefore2FARedirect

--- a/apps/SageAccountWeb/src/hooks/useSkipMfaPrompt.test.ts
+++ b/apps/SageAccountWeb/src/hooks/useSkipMfaPrompt.test.ts
@@ -1,0 +1,252 @@
+import { renderHook, act } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import dayjs, { Dayjs } from 'dayjs'
+import { when } from 'vitest-when'
+import { useSkipMfaPrompt } from './useSkipMfaPrompt'
+import { useLocalStorageValue } from '@react-hookz/web'
+
+vi.mock('@react-hookz/web', () => ({
+  useLocalStorageValue: vi.fn(),
+}))
+
+vi.mock('dayjs', async importOriginal => {
+  return {
+    ...(await importOriginal()),
+    default: vi.fn(() => ({
+      subtract: vi.fn().mockReturnThis(),
+      isAfter: vi.fn(),
+    })),
+  }
+})
+
+const mockUseLocalStorageValue = vi.mocked(useLocalStorageValue)
+const mockDayjs = vi.mocked(dayjs)
+
+describe('useSkipMfaPrompt', () => {
+  const mockAccountId = '123'
+  const mockSetTimestamp = vi.fn()
+  const mockUseLocalStorageValueReturn = {
+    value: null,
+    set: mockSetTimestamp,
+    remove: vi.fn(),
+    fetch: vi.fn(),
+  }
+  // The dayjs mock for the current time should always return a consistent instance
+  const mockDayjsInstanceForCurrentTime = {
+    subtract: vi.fn().mockReturnThis(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Mock console.error to suppress error logs in tests
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    when(mockDayjs)
+      .calledWith() // No arguments for the current time
+      .thenReturn(mockDayjsInstanceForCurrentTime as unknown as Dayjs)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('hasSkippedRecently', () => {
+    it('should return false when no timestamp is stored', () => {
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: null,
+      })
+
+      const { result } = renderHook(() => useSkipMfaPrompt(mockAccountId))
+
+      expect(result.current.hasSkippedRecently).toBe(false)
+    })
+
+    it('should return false when timestamp is empty string', () => {
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: '',
+      })
+
+      const { result } = renderHook(() => useSkipMfaPrompt(mockAccountId))
+
+      expect(result.current.hasSkippedRecently).toBe(false)
+    })
+
+    it('should return true when timestamp is less than 12 hours old', () => {
+      const mockTimestamp = '2023-12-01T10:00:00.000Z'
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: mockTimestamp,
+      })
+
+      const mockDayjsInstanceForStoredTimestamp = {
+        isAfter: vi.fn().mockReturnValue(true),
+      }
+
+      when(mockDayjs)
+        .calledWith(mockTimestamp)
+        .thenReturn(mockDayjsInstanceForStoredTimestamp as unknown as Dayjs)
+
+      const { result } = renderHook(() => useSkipMfaPrompt(mockAccountId))
+
+      expect(result.current.hasSkippedRecently).toBe(true)
+    })
+
+    it('should return false when timestamp is more than 12 hours old', () => {
+      const mockTimestamp = '2023-12-01T01:00:00.000Z'
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: mockTimestamp,
+      })
+
+      // Mock dayjs to return that the timestamp is before 12 hours ago
+      const mockDayjsInstanceForStoredTimestamp = {
+        isAfter: vi.fn().mockReturnValue(false),
+      }
+
+      when(mockDayjs)
+        .calledWith(mockTimestamp)
+        .thenReturn(mockDayjsInstanceForStoredTimestamp as unknown as Dayjs)
+
+      const { result } = renderHook(() => useSkipMfaPrompt())
+
+      expect(result.current.hasSkippedRecently).toBe(false)
+    })
+
+    it('should return false when dayjs throws an error', () => {
+      const mockTimestamp = 'invalid-timestamp'
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: mockTimestamp,
+      })
+
+      // Mock dayjs to throw an error
+      when(mockDayjs)
+        .calledWith(mockTimestamp)
+        .thenThrow(new Error('Invalid date'))
+
+      const { result } = renderHook(() => useSkipMfaPrompt())
+
+      expect(result.current.hasSkippedRecently).toBe(false)
+      expect(console.error).toHaveBeenCalledWith(
+        'Error thrown computing timestamp',
+        mockTimestamp,
+        expect.any(Error),
+      )
+    })
+  })
+
+  describe('skip function', () => {
+    beforeEach(() => {
+      // Mock Date.now() to return a consistent timestamp
+      vi.spyOn(Date.prototype, 'toISOString').mockReturnValue(
+        '2023-12-01T12:00:00.000Z',
+      )
+    })
+
+    it('should set current timestamp when skip is called', () => {
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: null,
+      })
+
+      const { result } = renderHook(() => useSkipMfaPrompt(mockAccountId))
+
+      act(() => {
+        result.current.skip()
+      })
+
+      expect(mockSetTimestamp).toHaveBeenCalledWith('2023-12-01T12:00:00.000Z')
+    })
+
+    it('should maintain the same skip function reference across renders', () => {
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: null,
+      })
+
+      const { result, rerender } = renderHook(() => useSkipMfaPrompt())
+      const firstSkipRef = result.current.skip
+
+      rerender()
+      const secondSkipRef = result.current.skip
+
+      expect(firstSkipRef).toBe(secondSkipRef)
+    })
+  })
+
+  describe('return value memoization', () => {
+    it('should return the same object reference when values have not changed', () => {
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: null,
+      })
+
+      const { result, rerender } = renderHook(() => useSkipMfaPrompt())
+      const firstResult = result.current
+
+      rerender()
+      const secondResult = result.current
+
+      expect(firstResult).toBe(secondResult)
+    })
+
+    it('should return a new object reference when hasSkippedRecently changes', () => {
+      // Start with no timestamp
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: null,
+      })
+
+      const { result, rerender } = renderHook(() => useSkipMfaPrompt())
+      const firstResult = result.current
+
+      // Change to have a recent timestamp
+      const mockTimestamp = '2023-12-01T10:00:00.000Z'
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: mockTimestamp,
+      })
+
+      const mockDayjsInstanceForStoredTimestamp = {
+        isAfter: vi.fn().mockReturnValue(true),
+      }
+
+      when(mockDayjs)
+        .calledWith(mockTimestamp)
+        .thenReturn(mockDayjsInstanceForStoredTimestamp as unknown as Dayjs)
+
+      rerender()
+      const secondResult = result.current
+
+      expect(firstResult).not.toBe(secondResult)
+      expect(firstResult.hasSkippedRecently).toBe(false)
+      expect(secondResult.hasSkippedRecently).toBe(true)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle null timestamp in isTimestampLessThan12HoursOld', () => {
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: null,
+      })
+
+      const { result } = renderHook(() => useSkipMfaPrompt(mockAccountId))
+
+      expect(result.current.hasSkippedRecently).toBe(false)
+    })
+
+    it('should handle undefined timestamp', () => {
+      mockUseLocalStorageValue.mockReturnValue({
+        ...mockUseLocalStorageValueReturn,
+        value: undefined,
+      })
+
+      const { result } = renderHook(() => useSkipMfaPrompt(mockAccountId))
+
+      expect(result.current.hasSkippedRecently).toBe(false)
+    })
+  })
+})

--- a/apps/SageAccountWeb/src/hooks/useSkipMfaPrompt.ts
+++ b/apps/SageAccountWeb/src/hooks/useSkipMfaPrompt.ts
@@ -1,0 +1,44 @@
+import { SKIPPED_2FA_REQUIREMENT_TIMESTAMP_LOCALSTORAGE_KEY } from '@/utils/StorageKeys'
+import { useLocalStorageValue } from '@react-hookz/web'
+import dayjs from 'dayjs'
+import { useCallback, useMemo } from 'react'
+
+function isTimestampLessThan12HoursOld(timestamp: string | null): boolean {
+  try {
+    const twelveHoursAgo = dayjs().subtract(12, 'hours')
+    return timestamp !== null && dayjs(timestamp).isAfter(twelveHoursAgo)
+  } catch (error) {
+    console.error('Error thrown computing timestamp', timestamp, error)
+    return false
+  }
+}
+
+/**
+ * Hook to determine if the user has skipped the 2FA prompt recently, and provides a callback to invoke when the user
+ * skips MFA.
+ *
+ * This is temporary code that can be deleted once 2FA is required for all users.
+ * @param accountId
+ */
+export function useSkipMfaPrompt() {
+  const { value: lastSkippedTimestamp, set: setTimestamp } =
+    useLocalStorageValue<string>(
+      SKIPPED_2FA_REQUIREMENT_TIMESTAMP_LOCALSTORAGE_KEY,
+    )
+  const hasSkipped2faPromptInLast12Hours =
+    !!lastSkippedTimestamp &&
+    isTimestampLessThan12HoursOld(lastSkippedTimestamp)
+
+  const skip = useCallback(() => {
+    const currentTimestamp = new Date().toISOString()
+    setTimestamp(currentTimestamp)
+  }, [setTimestamp])
+
+  return useMemo(
+    () => ({
+      hasSkippedRecently: hasSkipped2faPromptInLast12Hours,
+      skip,
+    }),
+    [hasSkipped2faPromptInLast12Hours, skip],
+  )
+}

--- a/apps/SageAccountWeb/src/pages/MfaRequiredPage.test.tsx
+++ b/apps/SageAccountWeb/src/pages/MfaRequiredPage.test.tsx
@@ -1,0 +1,46 @@
+import { FeatureFlagEnum } from '@sage-bionetworks/synapse-types'
+import { render, screen } from '@testing-library/react'
+import MfaRequiredPage from './MfaRequiredPage'
+import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/featureflags/useGetFeatureFlag'
+import { when } from 'vitest-when'
+
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+}))
+vi.mock('synapse-react-client/synapse-queries/featureflags/useGetFeatureFlag')
+
+describe('MFA Required Page', () => {
+  const mockUseGetFeatureFlag = vi.mocked(useGetFeatureFlag)
+
+  function renderComponent() {
+    render(<MfaRequiredPage />)
+  }
+  test('UI explains that MFA is required', () => {
+    when(mockUseGetFeatureFlag)
+      .calledWith(FeatureFlagEnum.MFA_REQUIRED)
+      .thenReturn(true)
+    renderComponent()
+
+    screen.getByText('Two Factor Authentication (2FA) is now required')
+    screen.getByRole('button', { name: 'Activate 2FA to Continue' })
+
+    // No skip button (check can be removed when skip functionality is removed)
+    expect(
+      screen.queryByRole('button', { name: 'Skip for now' }),
+    ).not.toBeInTheDocument()
+  })
+
+  test('UI explains that MFA will be required soon', () => {
+    when(mockUseGetFeatureFlag)
+      .calledWith(FeatureFlagEnum.MFA_REQUIRED)
+      .thenReturn(false)
+
+    renderComponent()
+
+    screen.getByText(
+      'Two Factor Authentication (2FA) will be required starting July 1, 2025',
+    )
+    screen.getByRole('button', { name: 'Activate 2FA to Continue' })
+    screen.getByRole('button', { name: 'Skip for now' })
+  })
+})

--- a/apps/SageAccountWeb/src/pages/MfaRequiredPage.tsx
+++ b/apps/SageAccountWeb/src/pages/MfaRequiredPage.tsx
@@ -1,12 +1,42 @@
-import { Box, Button, Link, Paper, Typography } from '@mui/material'
-import { StyledOuterContainer } from '../components/StyledComponents.js'
 import mfaRequiredImageURL from '@/assets/2FAHeroImage.svg?url'
+import usePathBefore2FARedirect from '@/hooks/usePathBefore2FARedirect'
+import { useSkipMfaPrompt } from '@/hooks/useSkipMfaPrompt'
+import { Box, Button, Link, Paper, Typography } from '@mui/material'
+import { FeatureFlagEnum } from '@sage-bionetworks/synapse-types'
 import { useNavigate } from 'react-router'
+import { StyledOuterContainer } from '../components/StyledComponents.js'
+import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/featureflags/useGetFeatureFlag'
 
-export type mfaRequiredPageProps = {}
+const MFA_SOON_REQUIRED_TITLE =
+  'Two Factor Authentication (2FA) will be required starting July 1, 2025'
+const MFA_SOON_REQUIRED_DESCRIPTION =
+  'To enhance account security, two-factor authentication (2FA) will soon be mandatory for all users. This extra layer ' +
+  'of protection helps keep your data safe by requiring both your password and a verification code sent to your device.'
 
-function MfaRequiredPage(props: mfaRequiredPageProps) {
+const MFA_REQUIRED_TITLE = 'Two Factor Authentication (2FA) is now required'
+const MFA_REQUIRED_DESCRIPTION =
+  'To enhance account security, two-factor authentication (2FA) is mandatory for all users. This extra layer ' +
+  'of protection helps keep your data safe by requiring both your password and a verification code sent to your device.'
+
+function MfaRequiredPage() {
+  const isMfaRequired = useGetFeatureFlag(FeatureFlagEnum.MFA_REQUIRED)
   const navigate = useNavigate()
+
+  // START TEMPORARY CODE: This code can be removed once MFA is required for all users.
+  const { skip: skipMfaPrompt } = useSkipMfaPrompt()
+  const { value: pathBefore2faRedirect, remove: clearPathBefore2faRedirect } =
+    usePathBefore2FARedirect()
+  function onSkip() {
+    // 1. Set the last skipped 2FA prompt timestamp to the current time, so we don't immediately redirect them back here.
+    skipMfaPrompt()
+
+    // 2. Redirect them to the last page they were on before being redirected to enroll in 2FA.
+    const redirectToAfterSkip =
+      pathBefore2faRedirect || '/authenticated/myaccount'
+    clearPathBefore2faRedirect()
+    navigate(redirectToAfterSkip)
+  }
+  // END TEMPORARY CODE
 
   return (
     <StyledOuterContainer>
@@ -44,13 +74,12 @@ function MfaRequiredPage(props: mfaRequiredPageProps) {
             variant="headline3"
             sx={{ marginTop: '20px', marginBottom: '20px' }}
           >
-            Two Factor Authentication (2FA) is now required
+            {isMfaRequired ? MFA_REQUIRED_TITLE : MFA_SOON_REQUIRED_TITLE}
           </Typography>
           <Typography variant="body1" sx={{ marginBottom: '20px' }}>
-            To enhance account security, two-factor authentication (2FA) is now
-            mandatory for all users. This extra layer of protection helps keep
-            your data safe by requiring both your password and a verification
-            code sent to your device.
+            {isMfaRequired
+              ? MFA_REQUIRED_DESCRIPTION
+              : MFA_SOON_REQUIRED_DESCRIPTION}
           </Typography>
           <Link
             target={'_blank'}
@@ -64,13 +93,39 @@ function MfaRequiredPage(props: mfaRequiredPageProps) {
           <Box
             sx={{
               display: 'flex',
+              gap: 2,
               justifyContent: {
                 xs: 'center',
                 md: 'flex-end',
               },
+              flexWrap: {
+                xs: 'wrap',
+                md: 'nowrap',
+              },
+              mt: {
+                xs: '30px',
+                md: '0px',
+              },
+
               alignItems: 'center',
             }}
           >
+            {!isMfaRequired && (
+              <Button
+                variant={'outlined'}
+                size="large"
+                sx={{
+                  width: {
+                    xs: '100%',
+                    md: 'unset',
+                  },
+                  display: 'block',
+                }}
+                onClick={onSkip}
+              >
+                Skip for now
+              </Button>
+            )}
             <Button
               variant="contained"
               size="large"
@@ -78,10 +133,6 @@ function MfaRequiredPage(props: mfaRequiredPageProps) {
                 width: {
                   xs: '100%',
                   md: 'unset',
-                },
-                mt: {
-                  xs: '30px',
-                  md: '0px',
                 },
                 display: 'block',
               }}

--- a/apps/SageAccountWeb/src/pages/TwoFactorAuthBackupCodesPage.tsx
+++ b/apps/SageAccountWeb/src/pages/TwoFactorAuthBackupCodesPage.tsx
@@ -1,3 +1,4 @@
+import usePathBefore2FARedirect from '@/hooks/usePathBefore2FARedirect'
 import { useLocation, useNavigate } from 'react-router'
 import TwoFactorBackupCodes from 'synapse-react-client/components/Authentication/TwoFactorBackupCodes'
 
@@ -10,10 +11,23 @@ function TwoFactorAuthBackupCodesPage() {
   const navigate = useNavigate()
   const { search } = useLocation()
   const warn = new URLSearchParams(search).get('warn')
+
+  const { value: pathBefore2faRedirect, remove: clearPathBefore2faRedirect } =
+    usePathBefore2FARedirect()
+
   return (
     <TwoFactorBackupCodes
       showReplaceOldCodesWarning={warn !== 'false'}
-      onClose={() => navigate('/authenticated/myaccount')}
+      onClose={() => {
+        // This is the last step in 2FA enrollment. Once the user is done, take them to the page they were on before being
+        // redirected to start 2FA enrollment.
+        // If the user was not originally redirected (e.g. the user voluntarily regenerated backup codes), redirect to the
+        // account settings page.
+        const redirectToAfterComplete =
+          pathBefore2faRedirect || '/authenticated/myaccount'
+        clearPathBefore2faRedirect()
+        navigate(redirectToAfterComplete)
+      }}
     />
   )
 }

--- a/apps/SageAccountWeb/src/utils/StorageKeys.ts
+++ b/apps/SageAccountWeb/src/utils/StorageKeys.ts
@@ -1,0 +1,8 @@
+/**
+ * Keys used for browser storage that are only used in this application.
+ */
+export const SKIPPED_2FA_REQUIREMENT_TIMESTAMP_LOCALSTORAGE_KEY =
+  'org.sagebionetworks.web.client.skipped_2fa_requirement_timestamp'
+
+export const PATH_BEFORE_2FA_REDIRECT_LOCALSTORAGE_KEY =
+  'org.sagebionetworks.web.client.path_before_2fa_redirect'

--- a/packages/synapse-react-client/src/mocks/msw/handlers/featureFlagHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/featureFlagHandlers.ts
@@ -20,7 +20,7 @@ export function getFeatureFlagsOverride(
   },
 ) {
   const { portalOrigin, overrides } = options
-  return http.get(`${portalOrigin}Portal/featureflags`, () => {
+  return http.get(`${portalOrigin}/Portal/featureflags`, () => {
     return HttpResponse.json(
       { ...MOCK_FEATURE_FLAGS_VALUE, ...overrides },
       { status: 200 },

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -5313,7 +5313,7 @@ export function getPortalFileHandleServletUrl(
  */
 export const getFeatureFlags = () => {
   return doGet<FeatureFlags>(
-    `Portal/featureflags`,
+    `/Portal/featureflags`,
     undefined,
     BackendDestinationEnum.PORTAL_ENDPOINT,
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.22.2
         version: 5.22.2(react@18.3.1)
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       katex:
         specifier: ^0.16.22
         version: 0.16.22
@@ -265,6 +268,9 @@ importers:
       vitest:
         specifier: ^3.2.2
         version: 3.2.2(@types/debug@4.1.12)(@types/node@20.17.41)(@vitest/ui@3.2.2)(jsdom@21.1.2)(msw@2.10.2(@types/node@20.17.41)(typescript@5.8.3))(sass@1.87.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
+      vitest-when:
+        specifier: ^0.6.1
+        version: 0.6.1(@vitest/expect@3.2.2)(vitest@3.2.2)
       whatwg-fetch:
         specifier: ^3.6.20
         version: 3.6.20
@@ -10574,6 +10580,15 @@ packages:
 
   vitest-when@0.6.0:
     resolution: {integrity: sha512-t6RbY1ZYj7ndrlvVPUSbt+SCQkBTET8nyvCqXsaTzGFuRHjoA0qFMmu5qGcJjn/8s9RCjB7od5TOKHezpHE2ow==}
+    peerDependencies:
+      '@vitest/expect': '>=0.31.0 <4'
+      vitest: '>=0.31.0 <4'
+    peerDependenciesMeta:
+      '@vitest/expect':
+        optional: true
+
+  vitest-when@0.6.1:
+    resolution: {integrity: sha512-KLMQaRuMBBpc6xQeDsYi69ypBBU4p9hUq388xq/b/d0xL6+6f9PmOxMs1K1iofqV3Kl8JWV9ym8S/V1oIN6wzg==}
     peerDependencies:
       '@vitest/expect': '>=0.31.0 <4'
       vitest: '>=0.31.0 <4'
@@ -21448,6 +21463,13 @@ snapshots:
     dependencies:
       pretty-format: 29.7.0
       vitest: 3.2.2(@types/debug@4.1.12)(@types/node@20.17.41)(@vitest/ui@3.2.2)(jsdom@26.1.0)(msw@2.10.2(@types/node@20.17.41)(typescript@5.8.3))(sass@1.87.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
+    optionalDependencies:
+      '@vitest/expect': 3.2.2
+
+  vitest-when@0.6.1(@vitest/expect@3.2.2)(vitest@3.2.2):
+    dependencies:
+      pretty-format: 29.7.0
+      vitest: 3.2.2(@types/debug@4.1.12)(@types/node@20.17.41)(@vitest/ui@3.2.2)(jsdom@21.1.2)(msw@2.10.2(@types/node@20.17.41)(typescript@5.8.3))(sass@1.87.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
     optionalDependencies:
       '@vitest/expect': 3.2.2
 


### PR DESCRIPTION
- Add UI to inform users MFA is required soon, with "skip" functionality
- When MFA_REQUIRED feature flag is enabled, "skip" functionality will be hidden
- Fix bad feature flag API path in synapse-react-client


Before MFA_REQUIRED is enabled: 

![image](https://github.com/user-attachments/assets/b279cd70-5a4a-4221-912d-6dc902f79f7f)

Once enabled:

![image](https://github.com/user-attachments/assets/683df633-3632-48d7-930e-be793de1b1d7)
