### PR TITLE
PORTALS-3657: NF Data Portal: Text wrapping issue in study card secondary labels

### DIFF
--- a/packages/synapse-react-client/src/components/row_renderers/utils/CardFooter.tsx
+++ b/packages/synapse-react-client/src/components/row_renderers/utils/CardFooter.tsx
@@ -144,7 +144,12 @@ class CardFooter extends Component<CardFooterProps, State> {
         className={`SRC-cardMetadata ${this.props.className ?? ''}`}
       >
         {cardTopContent}
-        <table>
+        <table
+          style={{
+            width: '100%',
+            wordBreak: 'break-word',
+          }}
+        >
           <tbody>
             {this.renderRows(valuesFiltered, limit, isDesktop)}
             {hasMoreValuesThanLimit && (

--- a/packages/synapse-react-client/src/style/components/_cards.scss
+++ b/packages/synapse-react-client/src/style/components/_cards.scss
@@ -240,6 +240,7 @@ $text-color-lighter: #898989;
     }
     &.hasIcon {
       padding-left: 15%;
+      padding-right: 15%;
     }
     .row {
       margin: 5px !important;


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/PORTALS-3657?atlOrigin=eyJpIjoiOWVjMWUyZDNkYTU3NDIzMWJjMWZkODc2Zjk3YjIyMmYiLCJwIjoiaiJ9

Before:
<img width="1285" alt="Screenshot 2025-06-18 at 5 24 36 PM" src="https://github.com/user-attachments/assets/8257a102-5823-4078-8edb-d7e6e616f784" />


After:
<img width="876" alt="Screenshot 2025-06-27 at 10 56 32 AM" src="https://github.com/user-attachments/assets/db433b63-30f6-4239-b696-283416bf2bb0" />
