### PR TITLE
add pluto to NF

### DIFF
--- a/apps/portals/nf/src/config/resources.ts
+++ b/apps/portals/nf/src/config/resources.ts
@@ -30,5 +30,6 @@ export const topProjectsSql =
 
 export const enabledAnalysisPlatforms: ExternalAnalysisPlatform[] = [
   'cavatica',
+  'pluto',
   // 'terra',
 ]


### PR DESCRIPTION
Blocked until Pluto DRS manifest support (and Synapse link, and other requirements).  But this is the result in the UX:

<img width="891" alt="Screenshot 2025-07-09 at 12 14 31 PM" src="https://github.com/user-attachments/assets/66c2e854-5275-4430-adce-83e1163a9de6" />

<img width="902" alt="Screenshot 2025-07-09 at 12 14 37 PM" src="https://github.com/user-attachments/assets/230314bd-c8f9-48d3-8f6d-4ad1dde0d36e" />

<img width="905" alt="Screenshot 2025-07-09 at 12 14 45 PM" src="https://github.com/user-attachments/assets/bac033c2-504a-47ea-a29c-b036930da8e1" />
