### PR TITLE
PORTALS-3686, PORTALS-3687

### DIFF
--- a/apps/portals/adknowledgeportal/src/pages/Contribute/Contribute-FormSubmission.tsx
+++ b/apps/portals/adknowledgeportal/src/pages/Contribute/Contribute-FormSubmission.tsx
@@ -1,8 +1,11 @@
 import { SectionLayout } from '@sage-bionetworks/synapse-portal-framework/components/SectionLayout'
 import MarkdownSynapse from 'synapse-react-client/components/Markdown/MarkdownSynapse'
 import SynapseFormWrapper from 'synapse-react-client/components/SynapseForm/SynapseFormWrapper'
+import { useGetFormPropsFromSearchParams } from 'synapse-react-client/components/SynapseForm/useGetFormPropsFromSearchParams'
 
 function ContributeHome() {
+  const propsFromParams = useGetFormPropsFromSearchParams()
+
   return (
     <SectionLayout>
       <MarkdownSynapse ownerId="syn12666371" wikiId="600034" />
@@ -14,6 +17,7 @@ function ContributeHome() {
         isWizardMode={true}
         formTitle={'Your Contribution Request'}
         formClass={'contribution-request'}
+        {...propsFromParams}
       />
     </SectionLayout>
   )

--- a/apps/portals/stopadportal/src/pages/FormSubmissionPage.tsx
+++ b/apps/portals/stopadportal/src/pages/FormSubmissionPage.tsx
@@ -1,7 +1,10 @@
 import { SectionLayout } from '@sage-bionetworks/synapse-portal-framework/components/SectionLayout'
 import SynapseFormWrapper from 'synapse-react-client/components/SynapseForm/SynapseFormWrapper'
+import { useGetFormPropsFromSearchParams } from 'synapse-react-client/components/SynapseForm/useGetFormPropsFromSearchParams'
 
 function FormSubmissionPage() {
+  const propsFromParams = useGetFormPropsFromSearchParams()
+
   return (
     <SectionLayout ContainerProps={{ maxWidth: false }}>
       <SynapseFormWrapper
@@ -11,6 +14,7 @@ function FormSubmissionPage() {
         formNavSchemaEntityId="syn20680027"
         formTitle="Your Submission"
         formClass="drug-upload-tool"
+        {...propsFromParams}
       />
     </SectionLayout>
   )

--- a/packages/synapse-react-client/src/components/SynapseForm/SynapseFormWrapper.stories.tsx
+++ b/packages/synapse-react-client/src/components/SynapseForm/SynapseFormWrapper.stories.tsx
@@ -13,20 +13,9 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Demo: Story = {
-  args: {
-    formTitle: 'Your Contribution Request',
-    formClass: 'contribution-request',
-    formSchemaEntityId: 'syn20692910',
-    fileNamePath: 'study.submission_name',
-    formUiSchemaEntityId: 'syn20692911',
-    formNavSchemaEntityId: 'syn20968007',
-    isWizardMode: true,
-  },
-}
-
 export const StopADDemo: Story = {
   args: {
+    formGroupId: '9',
     formSchemaEntityId: 'syn20680102',
     fileNamePath: 'naming.compound_name',
     formUiSchemaEntityId: 'syn20693568',

--- a/packages/synapse-react-client/src/components/SynapseForm/SynapseFormWrapper.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseForm/SynapseFormWrapper.test.tsx
@@ -10,14 +10,13 @@ import { MOCK_USER_ID } from '@/mocks/user/mock_user_profile'
 import SynapseClient from '@/synapse-client/index'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
 import { FormData, StatusEnum } from '@sage-bionetworks/synapse-types'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import cloneDeep from 'lodash-es/cloneDeep'
 import set from 'lodash-es/set'
 import SynapseForm, { IFormData } from './SynapseForm'
 import * as SynapseFormUtils from './SynapseFormUtils'
 import SynapseFormWrapper, {
   SynapseFormWrapperProps,
-  UploadToolSearchParams,
 } from './SynapseFormWrapper'
 
 vi.mock('./SynapseForm', () => {
@@ -35,9 +34,6 @@ const formNavSchemaEntityId = 'syn9988882984'
 const formDataId = 'syn9988882985'
 const formGroupId = 'syn9988882986'
 const dataFileHandleId = '43157'
-const searchParams: UploadToolSearchParams = {
-  formGroupId,
-}
 const fileNamePath = 'somescreen.somefield'
 const formTitle = 'my submission'
 const formClass = 'someFormClass'
@@ -66,10 +62,10 @@ const props: SynapseFormWrapperProps = {
   formSchemaEntityId,
   formUiSchemaEntityId,
   formNavSchemaEntityId,
-  searchParams,
   fileNamePath,
   formTitle,
   formClass,
+  formGroupId,
 }
 
 describe('SynapseFormWrapper', () => {
@@ -156,7 +152,9 @@ describe('SynapseFormWrapper', () => {
     test('should make 4 calls to getFileEntityData', async () => {
       const _props = {
         ...props,
-        ...{ searchParams: { formGroupId, formDataId, dataFileHandleId } },
+        formGroupId,
+        formDataId,
+        dataFileHandleId,
       }
 
       const getFileEntityData = vi.spyOn(SynapseFormUtils, 'getFileEntityData')
@@ -191,14 +189,10 @@ describe('SynapseFormWrapper', () => {
     test('if the form is submitted it should pull the schemas with appropriate versions', async () => {
       const _props = {
         ...props,
-        ...{
-          searchParams: {
-            formGroupId,
-            formDataId,
-            dataFileHandleId,
-            submitted: true,
-          },
-        },
+        formGroupId,
+        formDataId,
+        dataFileHandleId,
+        submitted: true,
       }
 
       const getFileEntityData = vi.spyOn(SynapseFormUtils, 'getFileEntityData')
@@ -229,7 +223,9 @@ describe('SynapseFormWrapper', () => {
     test('should pass parameters correctly', async () => {
       const _props = {
         ...props,
-        ...{ searchParams: { formGroupId, formDataId }, isWizardMode: true },
+        formGroupId,
+        formDataId,
+        isWizardMode: true,
       }
       renderComponent(_props)
 
@@ -285,7 +281,9 @@ describe('SynapseFormWrapper', () => {
 
       // Call under test -- call onSave
       const onSaveCaptor = mockSynapseForm.mock.lastCall![0].onSave
-      onSaveCaptor(formData)
+      act(() => {
+        onSaveCaptor(formData)
+      })
 
       await waitFor(() => {
         expect(create).toHaveBeenCalled()
@@ -296,7 +294,8 @@ describe('SynapseFormWrapper', () => {
     test('should UPDATE formData if there is formDataId', async () => {
       const _props = {
         ...props,
-        ...{ searchParams: { formGroupId, formDataId } },
+        formGroupId,
+        formDataId,
       }
       vi.spyOn(SynapseClient, 'uploadFile').mockResolvedValue({
         fileHandleId: '123',
@@ -318,7 +317,9 @@ describe('SynapseFormWrapper', () => {
 
       // Call under test -- call onSave
       const onSaveCaptor = mockSynapseForm.mock.lastCall![0].onSave
-      onSaveCaptor(formData)
+      act(() => {
+        onSaveCaptor(formData)
+      })
 
       await waitFor(() => {
         expect(create).not.toHaveBeenCalled()
@@ -349,7 +350,9 @@ describe('SynapseFormWrapper', () => {
 
       // Call under test -- call onSubmit
       const onSubmitCaptor = mockSynapseForm.mock.lastCall![0].onSubmit
-      onSubmitCaptor(formData)
+      act(() => {
+        onSubmitCaptor(formData)
+      })
 
       await waitFor(() => expect(submit).toHaveBeenCalled())
     })

--- a/packages/synapse-react-client/src/components/SynapseForm/SynapseFormWrapper.tsx
+++ b/packages/synapse-react-client/src/components/SynapseForm/SynapseFormWrapper.tsx
@@ -23,24 +23,21 @@ import { StatusEnum } from './types'
  * See here: https://github.com/enzymejs/enzyme/issues/1553
  */
 
-export type UploadToolSearchParams = {
-  formDataId?: string //formDataId for user data form data
-  dataFileHandleId?: string //fileHandle to get userData
-  submitted?: boolean // if the file has been submitted
-  formGroupId: string
-}
-
 export type SynapseFormWrapperProps = {
   // Provide the parent container (folder/project), that should contain a folder (named <user_id>) that this user can write to.
   formSchemaEntityId: string // Synapse file that contains the form schema.
   formUiSchemaEntityId: string // Synapse file that contains the form ui schema.
   formNavSchemaEntityId: string //Synapse file that consists screen nav schema
   token?: string // user's access token
-  searchParams?: UploadToolSearchParams
   isWizardMode?: boolean // if we are displaying the form in wizard mode
   fileNamePath: string // path in data to specify the name of saved file
   formTitle: string //for UI customization
-  formClass?: string // to support potential theaming
+  formClass?: string // to support potential theming
+
+  formDataId?: string //formDataId for user data form data
+  dataFileHandleId?: string //fileHandle to get userData
+  submitted?: boolean // if the file has been submitted
+  formGroupId: string
 }
 
 type SynapseFormWrapperState = {
@@ -72,7 +69,7 @@ class _SynapseFormWrapper extends Component<
     super(props)
     this.state = {
       isLoading: true,
-      formDataId: this.props?.searchParams?.formDataId,
+      formDataId: this.props?.formDataId,
     }
   }
 
@@ -112,15 +109,11 @@ class _SynapseFormWrapper extends Component<
     }
     try {
       let formData: Record<string, any> = {}
-      let dataFileHandleId: string | undefined
-      let submitted: boolean | undefined
+      const dataFileHandleId = this.props.dataFileHandleId
+      const submitted = this.props.submitted
       let formSchemaVersion = undefined
       let uiSchemaVersion = undefined
       let navSchemaVersion = undefined
-      const { searchParams } = this.props
-      if (searchParams) {
-        ;({ dataFileHandleId, submitted } = searchParams)
-      }
 
       //for not new form we need to get the data
       //and if it is submitted form we need to pull appropriate schema versions
@@ -230,8 +223,7 @@ class _SynapseFormWrapper extends Component<
       fileName,
       fileContentsBlob,
     )
-    const { searchParams } = this.props
-    const formGroupId = searchParams && searchParams.formGroupId
+    const formGroupId = this.props.formGroupId
     if (!formGroupId) {
       console.error('formGroupId must be defined')
       throw new Error('formGroupId must be defined')
@@ -418,10 +410,8 @@ class _SynapseFormWrapper extends Component<
                 onSubmit={(data: any) => {
                   this.submitForm(data)
                 }}
-                isSubmitted={
-                  this.props.searchParams && !!this.props.searchParams.submitted
-                }
-              ></SynapseForm>
+                isSubmitted={this.props.submitted}
+              />
             </div>
           )}
         </div>

--- a/packages/synapse-react-client/src/components/SynapseForm/useGetFormPropsFromSearchParams.ts
+++ b/packages/synapse-react-client/src/components/SynapseForm/useGetFormPropsFromSearchParams.ts
@@ -1,0 +1,13 @@
+import { useSearchParams } from 'react-router'
+
+export function useGetFormPropsFromSearchParams() {
+  const [searchParams] = useSearchParams()
+
+  const formGroupId = searchParams.get('formGroupId')!
+  const formDataId = searchParams.get('formDataId') ?? undefined
+  const dataFileHandleId = searchParams.get('dataFileHandleId') ?? undefined
+  const submittedParam = searchParams.get('submitted')
+  const submitted = Boolean(submittedParam) && submittedParam !== 'false'
+
+  return { formGroupId, formDataId, dataFileHandleId, submitted }
+}


### PR DESCRIPTION
Fix issues in SynapseForm where search params were no longer passed to the component.

We used to always inject the URLSearchParams as props to top-level portals components. This recently changed, breaking these components where these params must now be manually passed.