### PR TITLE
PORTALS-3697

### DIFF
--- a/packages/synapse-react-client/src/style/components/_cards.scss
+++ b/packages/synapse-react-client/src/style/components/_cards.scss
@@ -153,11 +153,17 @@ $text-color-lighter: #898989;
   }
 
   .SRC-cardThumbnail {
-    display: inline-block;
+    @media (max-width: map.get(SRC.$breakpoints, 'medium')) {
+      display: none;
+    }
+    @media (min-width: map.get(SRC.$breakpoints, 'medium')) {
+      max-width: 215px;
+      display: inline-block;
+    }
     vertical-align: top;
     margin-top: auto;
     margin-bottom: auto;
-    max-width: 215px;
+
     img {
       margin: auto;
       display: block;
@@ -174,8 +180,15 @@ $text-color-lighter: #898989;
     }
   }
   .SRC-imageThumbnail {
-    display: inline-block;
-    width: 25%;
+    @media (max-width: map.get(SRC.$breakpoints, 'medium')) {
+      width: 0%;
+      display: none;
+    }
+    @media (min-width: map.get(SRC.$breakpoints, 'medium')) {
+      width: 25%;
+      display: inline-block;
+    }
+
     vertical-align: top;
     padding-right: 15px;
     max-width: 215px;
@@ -238,9 +251,12 @@ $text-color-lighter: #898989;
     > * {
       margin-left: 15px;
     }
+
     &.hasIcon {
-      padding-left: 15%;
-      padding-right: 15%;
+      @media (min-width: map.get(SRC.$breakpoints, 'medium')) {
+        padding-left: 15%;
+        padding-right: 15%;
+      }
     }
     .row {
       margin: 5px !important;


### PR DESCRIPTION
Use old style css media queries to hide icon on mobile (as well as adjust padding):

<img width="415" height="581" alt="Screenshot 2025-07-17 at 6 21 56 PM" src="https://github.com/user-attachments/assets/d87b1f99-a4f5-40b1-b762-c9dcf93c8bf8" />
