### PR TITLE
SWC-7405 - Fix unrecoverable query error

### DIFF
--- a/packages/synapse-react-client/src/utils/functions/SqlFunctions.ts
+++ b/packages/synapse-react-client/src/utils/functions/SqlFunctions.ts
@@ -158,11 +158,11 @@ export const parseEntityIdFromSqlStatement = (sql: string): string => {
 
 export const parseEntityIdAndVersionFromSqlStatement = (
   sql: string,
-): { entityId: string; versionNumber?: number } | null => {
+): { entityId?: string; versionNumber?: number } => {
   const regex = /from\s+(syn\d+)(?:\.(\d+))?/i
   const matches = regex.exec(sql)
   if (!matches) {
-    return null
+    return { entityId: undefined, versionNumber: undefined }
   }
   return {
     entityId: matches[1],

--- a/packages/synapse-react-client/src/utils/functions/sqlFunctions.test.ts
+++ b/packages/synapse-react-client/src/utils/functions/sqlFunctions.test.ts
@@ -48,7 +48,7 @@ describe('parseEntityIdAndVersionFromSqlStatement', () => {
     })
     expect(
       parseEntityIdAndVersionFromSqlStatement('SELECT * from somethingweird'),
-    ).toEqual(null)
+    ).toEqual({ entityId: undefined, versionNumber: undefined })
     expect(
       parseEntityIdAndVersionFromSqlStatement('SELECT * from     syn12345'),
     ).toEqual({

--- a/packages/synapse-react-client/src/utils/hooks/useImmutableTableQuery/useImmutableTableQuery.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useImmutableTableQuery/useImmutableTableQuery.ts
@@ -258,7 +258,7 @@ export default function useImmutableTableQuery(
 
   const { entityId, versionNumber } = useMemo(
     () =>
-      parseEntityIdAndVersionFromSqlStatement(currentQueryRequest.query.sql)!,
+      parseEntityIdAndVersionFromSqlStatement(currentQueryRequest.query.sql),
     [currentQueryRequest.query.sql],
   )
 


### PR DESCRIPTION
Fix issue where an unrecoverable error was thrown when the synID could not be parsed in a SQL statement