### PR TITLE
Minor data grid demo story improvements

### DIFF
--- a/apps/SageAccountWeb/.env.localhost
+++ b/apps/SageAccountWeb/.env.localhost
@@ -1,0 +1,3 @@
+VITE_SYNAPSE_REPO_ENDPOINT=http://localhost:8080/services-repository-develop-SNAPSHOT
+VITE_SYNAPSE_PORTAL_ENDPOINT=http://localhost:8888
+

--- a/packages/synapse-react-client/.storybook/preview.tsx
+++ b/packages/synapse-react-client/.storybook/preview.tsx
@@ -172,6 +172,7 @@ const preview: Preview = {
           { value: 'staging', title: 'Staging' },
           { value: 'development', title: 'Development' },
           { value: 'mock', title: 'Mocked Data' },
+          { value: 'local', title: 'Local Instance of Synapse' },
         ],
       },
     },

--- a/packages/synapse-react-client/src/components/DataGrid/DataGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/DataGrid.tsx
@@ -1,3 +1,4 @@
+import { ComplexJSONRenderer } from '@/components/SynapseTable/SynapseTableCell/JSON/ComplexJSONRenderer'
 import { useCallback, useRef, useEffect, useMemo, useState } from 'react'
 import {
   DataSheetGrid,
@@ -42,10 +43,10 @@ const DataGrid = () => {
     getModel,
   } = useDataGridWebSocket()
   useEffect(() => {
-    if (presignedUrl) {
-      createWebsocket(presignedUrl)
+    if (replicaId && presignedUrl) {
+      createWebsocket(replicaId, presignedUrl)
     }
-  }, [presignedUrl, createWebsocket])
+  }, [replicaId, presignedUrl, createWebsocket])
 
   const connectionStatus = isConnected ? 'Connected' : 'Disconnected'
 
@@ -441,14 +442,17 @@ const DataGrid = () => {
           margin: '10px 0',
           padding: '10px',
           border: '1px solid #ccc',
-          maxHeight: '200px',
+          maxHeight: '400px',
           overflowY: 'auto',
         }}
       >
         <h3>Model snapshot</h3>
-        <p>
-          {modelSnapshot ? JSON.stringify(modelSnapshot) : 'No model available'}
-        </p>
+
+        {modelSnapshot ? (
+          <ComplexJSONRenderer value={modelSnapshot} />
+        ) : (
+          'No model available'
+        )}
       </div>
     </div>
   )

--- a/packages/synapse-react-client/src/components/DataGrid/DataGridWebSocket.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/DataGridWebSocket.ts
@@ -5,6 +5,7 @@ import noop from 'lodash-es/noop'
 import { JsonCrdtVerboseLogicalTimestamp } from 'json-joy/lib/json-crdt/codec/structural/verbose/types'
 
 type DataGridWebSocketConstructorArgs = {
+  replicaId: number
   url: string
   onGridReady?: () => void
   onStatusChange?: (isOpen: boolean, instance: DataGridWebSocket) => void
@@ -25,7 +26,8 @@ export class DataGridWebSocket {
     noop
 
   constructor(args: DataGridWebSocketConstructorArgs) {
-    const { url, onGridReady, onStatusChange, onModelChange } = args
+    const { replicaId, url, onGridReady, onStatusChange, onModelChange } = args
+    this.replicaId = replicaId
     this.socket = new WebSocket(url)
 
     this.socket.onopen = () => {

--- a/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.ts
@@ -10,9 +10,10 @@ export function useDataGridWebSocket() {
 
   const { modelRef, modelSnapshot, getModel, setModel } = useCRDTState()
 
-  const createWebsocket = useCallback((url: string) => {
+  const createWebsocket = useCallback((replicaId: number, url: string) => {
     if (url && !websocketInstance) {
       const webSocketHandler = new DataGridWebSocket({
+        replicaId: replicaId,
         url,
         onGridReady: () => {
           setIsGridReady(true)

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/JSON/ComplexJSONRenderer.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/JSON/ComplexJSONRenderer.tsx
@@ -27,13 +27,18 @@ export function ComplexJSONRenderer(props: ComplexJSONRendererProps) {
     <>
       <Typography
         variant={'smallText1'}
-        sx={{ py: 0.5, color: 'grey.600', fontStyle: 'italic' }}
+        sx={{
+          py: 0.5,
+          color: 'grey.600',
+          fontStyle: 'italic',
+          cursor: 'pointer',
+        }}
+        onClick={() => setExpandAll(v => !v)}
       >
         {expandAll ? 'Collapse' : 'Expand'} all
         <ExpandCollapseButton
           className="ExpandableTableData__expandButton"
           isExpanded={expandAll}
-          onClick={() => setExpandAll(v => !v)}
         />
       </Typography>
       <Box sx={{ pl: '2px' }}>

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/JSON/__snapshots__/JSONTableCellRenderer.test.tsx.snap
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableCell/JSON/__snapshots__/JSONTableCellRenderer.test.tsx.snap
@@ -263,7 +263,7 @@ exports[`JSONTableCellRenderer > handles Object of primitives case 1`] = `
 exports[`JSONTableCellRenderer > handles complex array case 1`] = `
 <div>
   <span
-    class="MuiTypography-root MuiTypography-smallText1 css-1iri0n7-MuiTypography-root"
+    class="MuiTypography-root MuiTypography-smallText1 css-rrx1sp-MuiTypography-root"
   >
     Expand
      all
@@ -348,7 +348,7 @@ exports[`JSONTableCellRenderer > handles complex array case 1`] = `
 exports[`JSONTableCellRenderer > handles complex object case 1`] = `
 <div>
   <span
-    class="MuiTypography-root MuiTypography-smallText1 css-1iri0n7-MuiTypography-root"
+    class="MuiTypography-root MuiTypography-smallText1 css-rrx1sp-MuiTypography-root"
   >
     Expand
      all

--- a/packages/synapse-react-client/src/utils/functions/getEndpoint.ts
+++ b/packages/synapse-react-client/src/utils/functions/getEndpoint.ts
@@ -55,7 +55,12 @@ export const getEndpoint = (endpoint: BackendDestinationEnum): string => {
   return REPO
 }
 
-export type SynapseStack = 'production' | 'staging' | 'development' | 'mock'
+export type SynapseStack =
+  | 'production'
+  | 'staging'
+  | 'development'
+  | 'mock'
+  | 'local'
 
 export const MOCK_REPO_ORIGIN =
   'https://mock-repo.sagebase.org' satisfies string
@@ -77,5 +82,9 @@ export const STACK_MAP: Record<SynapseStack, EndpointObject> = {
   mock: {
     REPO: MOCK_REPO_ORIGIN,
     PORTAL: MOCK_PORTAL_ORIGIN,
+  },
+  local: {
+    REPO: 'http://localhost:8080/services-repository-develop-SNAPSHOT',
+    PORTAL: 'http://localhost:8888/',
   },
 }


### PR DESCRIPTION
- Use replicaId from server
- Use ComplexJSONRenderer to display model snapshot
- Update ComplexJSONRenderer so 'expand'/'collapse' text is also interactive
- Add config options to Storybook to use localhost as a Synapse backend.