### PR TITLE
PORTALS-3702: Portals FileEntity Page: Cleanup Properties and Provenance Node Click

### DIFF
--- a/apps/synapse-portal-framework/src/components/RedirectDialog.tsx
+++ b/apps/synapse-portal-framework/src/components/RedirectDialog.tsx
@@ -173,13 +173,7 @@ const RedirectDialog = (props: RedirectDialogProps) => {
   }
 
   // Show loading state while fetching entity for FileEntity redirect
-  if (
-    redirectUrl &&
-    entityId &&
-    isLoading &&
-    isFeatureFlagEnabled &&
-    location.pathname !== '/FileEntity'
-  ) {
+  if (redirectUrl && entityId && isLoading && isFeatureFlagEnabled) {
     return (
       <Dialog
         open={true}

--- a/apps/synapse-portal-framework/src/components/RedirectDialog.tsx
+++ b/apps/synapse-portal-framework/src/components/RedirectDialog.tsx
@@ -13,7 +13,7 @@ import {
 } from 'synapse-react-client/synapse-queries'
 import { isFileEntity } from 'synapse-react-client'
 import { FeatureFlagEnum } from '@sage-bionetworks/synapse-types'
-import { useNavigate } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 import { SynapseSpinner } from 'synapse-react-client/components/LoadingScreen/LoadingScreen'
 
 export type RedirectDialogProps = {
@@ -92,6 +92,7 @@ const RedirectDialog = (props: RedirectDialogProps) => {
   const { entityId, versionNumber } =
     parseSynIdFromRedirectUrl(redirectUrl) ?? {}
   const { data: entity, isLoading } = useGetEntity(entityId)
+  const location = useLocation()
 
   const isRedirectTargetFileEntity = entity ? isFileEntity(entity) : false
 
@@ -106,9 +107,15 @@ const RedirectDialog = (props: RedirectDialogProps) => {
       !isLoading &&
       isFeatureFlagEnabled
     ) {
+      const currentUrl = `${location.pathname}${location.search}`
       const internalUrl = `/FileEntity?entityId=${entityId}${
         versionNumber ? `&version=${versionNumber}` : ''
       }`
+
+      if (currentUrl === internalUrl) {
+        return
+      }
+
       navigate(internalUrl)
       onCancelRedirect()
     }
@@ -121,6 +128,8 @@ const RedirectDialog = (props: RedirectDialogProps) => {
     navigate,
     onCancelRedirect,
     isLoading,
+    location.pathname,
+    location.search,
   ])
 
   useEffect(() => {
@@ -164,7 +173,13 @@ const RedirectDialog = (props: RedirectDialogProps) => {
   }
 
   // Show loading state while fetching entity for FileEntity redirect
-  if (redirectUrl && entityId && isLoading && isFeatureFlagEnabled) {
+  if (
+    redirectUrl &&
+    entityId &&
+    isLoading &&
+    isFeatureFlagEnabled &&
+    location.pathname !== '/FileEntity'
+  ) {
     return (
       <Dialog
         open={true}

--- a/apps/synapse-portal-framework/src/pages/FileEntityPage/SynapseFileEntityPageProperties.tsx
+++ b/apps/synapse-portal-framework/src/pages/FileEntityPage/SynapseFileEntityPageProperties.tsx
@@ -23,16 +23,28 @@ type FilePropertyValueProps = {
   storageLocationName?: string
 }
 
-const FilePropertyValue: React.FC<FilePropertyValueProps> = ({
+type FilePropertyRowProps = {
+  keyName: string
+  label: string
+  fileEntity: FileEntity
+  fileHandle: EntityBundle['fileHandles'][number] | undefined
+  storageLocationName?: string
+}
+
+const FilePropertyRow: React.FC<FilePropertyRowProps> = ({
+  keyName,
+  label,
   fileEntity,
   fileHandle,
-  keyName,
   storageLocationName,
 }) => {
+  let content: React.ReactNode = null
+
   switch (keyName) {
     case 'id':
     case 'parentId':
-      return (
+      if (!fileEntity[keyName]) return null
+      content = (
         <>
           {fileEntity[keyName]}{' '}
           <CopyToClipboardIcon
@@ -41,37 +53,60 @@ const FilePropertyValue: React.FC<FilePropertyValueProps> = ({
           />
         </>
       )
+      break
     case 'createdBy':
-      return (
+      if (!fileEntity.createdBy) return null
+      content = (
         <>
           <UserBadge userId={fileEntity.createdBy} /> on{' '}
           {formatDate(dayjs(fileEntity.createdOn))}
         </>
       )
+      break
     case 'modifiedBy':
-      return (
+      if (!fileEntity.modifiedBy) return null
+      content = (
         <>
           <UserBadge userId={fileEntity.modifiedBy} /> on{' '}
           {formatDate(dayjs(fileEntity.modifiedOn))}
         </>
       )
+      break
     case 'contentMd5':
-      return (
+      if (!fileHandle?.contentMd5) return null
+      content = (
         <>
-          {fileHandle?.contentMd5}{' '}
+          {fileHandle.contentMd5}{' '}
           <CopyToClipboardIcon
-            value={fileHandle?.contentMd5 ?? ''}
+            value={fileHandle.contentMd5}
             sx={{ marginTop: '-4px' }}
           />
         </>
       )
+      break
     case 'storageLocationId':
-      return <>{storageLocationName}</>
+      if (!storageLocationName) return null
+      content = storageLocationName
+      break
     case 'contentSize':
-      return <>{calculateFriendlyFileSize(fileHandle?.contentSize)}</>
+      if (!fileHandle?.contentSize) return null
+      content = calculateFriendlyFileSize(fileHandle.contentSize)
+      break
     default:
-      return <>{fileEntity[keyName] as React.ReactNode}</>
+      if (!fileEntity[keyName]) return null
+      content = fileEntity[keyName] as React.ReactNode
   }
+
+  return (
+    <tr key={keyName}>
+      <td style={{ width: '256px' }}>
+        <Box sx={{ fontSize: '14px', lineHeight: '20px', color: '#333' }}>
+          {label}
+        </Box>
+      </td>
+      <td>{content}</td>
+    </tr>
+  )
 }
 
 const SynapseFileEntityPageProperties = ({
@@ -115,28 +150,15 @@ const SynapseFileEntityPageProperties = ({
     <StyledTableContainer sx={{ width: '100%' }}>
       <table style={{ width: '100%' }}>
         <tbody>
-          {selectedKeys?.map(({ key, label }) => (
-            <tr key={key}>
-              <td style={{ width: '256px' }}>
-                <Box
-                  style={{
-                    fontSize: '14px',
-                    lineHeight: '20px',
-                    color: '#333',
-                  }}
-                >
-                  {label}
-                </Box>
-              </td>
-              <td>
-                <FilePropertyValue
-                  keyName={key}
-                  fileEntity={fileEntity}
-                  fileHandle={fileHandle}
-                  storageLocationName={fileLocationName}
-                />
-              </td>
-            </tr>
+          {selectedKeys.map(({ key, label }) => (
+            <FilePropertyRow
+              key={key}
+              keyName={key}
+              label={label}
+              fileEntity={fileEntity}
+              fileHandle={fileHandle}
+              storageLocationName={fileLocationName}
+            />
           ))}
         </tbody>
       </table>

--- a/apps/synapse-portal-framework/src/pages/FileEntityPage/SynapseFileEntityPageProperties.tsx
+++ b/apps/synapse-portal-framework/src/pages/FileEntityPage/SynapseFileEntityPageProperties.tsx
@@ -16,13 +16,6 @@ type SynapseFileEntityPagePropertiesProps = {
   versionNumber: number | undefined
 }
 
-type FilePropertyValueProps = {
-  fileEntity: FileEntity
-  fileHandle: EntityBundle['fileHandles'][number] | undefined
-  keyName: string
-  storageLocationName?: string
-}
-
 type FilePropertyRowProps = {
   keyName: string
   label: string


### PR DESCRIPTION
- When a property has no value, do not show the property row.

Before:
<img width="500" height="500" alt="Screenshot 2025-07-24 at 1 38 34 PM" src="https://github.com/user-attachments/assets/7ba988f4-350c-49c9-bbae-044f99b9a93f" />

After:
<img width="500" height="500" alt="Screenshot 2025-07-24 at 1 39 05 PM" src="https://github.com/user-attachments/assets/ab9632d7-045f-48aa-91e7-902480759178" />


- Recognize when we are already on the FileEntity page. Since the provenance graph is displayed there, clicking a node should trigger the default redirect behavior to the appropriate Synapse page.
