### PR TITLE
PORTALS-3705: Portals FileEntity Page: Make Entire View FileEntity on Synapse.org component clickable

### DIFF
--- a/apps/synapse-portal-framework/src/pages/FileEntityPage/FileEntityPage.tsx
+++ b/apps/synapse-portal-framework/src/pages/FileEntityPage/FileEntityPage.tsx
@@ -110,6 +110,7 @@ function FileEntityPage() {
         sx={{
           '& .SRC-boldText': {
             fontSize: '36px !important',
+            marginTop: '0',
           },
           '& .SRC-portalCardMain': {
             alignItems: 'center',

--- a/apps/synapse-portal-framework/src/pages/FileEntityPage/SynapseFileEntityLinkCard.tsx
+++ b/apps/synapse-portal-framework/src/pages/FileEntityPage/SynapseFileEntityLinkCard.tsx
@@ -13,39 +13,47 @@ const SynapseFileEntityLinkCard = ({
   const synapseUrl = getSynapseEntityUrl(synId, version)
 
   return (
-    <Card
+    <Link
+      href={synapseUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="View this file on Synapse.org"
       sx={{
-        display: 'flex',
-        gap: '20px',
-        alignItems: 'center',
-        padding: '30px',
+        display: 'block',
+        textDecoration: 'none !important',
       }}
     >
-      <SynapseIconLogo />
-      <Stack>
-        <Typography
-          variant="headline3"
-          sx={{ color: 'grey.800', fontSize: '16px', marginBottom: '10px' }}
-        >
-          View this file on Synapse.org
-        </Typography>
-        <Typography variant="smallText1" sx={{ color: 'grey.700' }}>
-          Synapse empowers biomedical researchers with tools for open science
-          and collaboration.
-        </Typography>
-      </Stack>
-      <Link
-        href={synapseUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="View on Synapse.org"
-        sx={{ marginLeft: 'auto' }}
+      <Card
+        sx={{
+          display: 'flex',
+          gap: '20px',
+          alignItems: 'center',
+          padding: '30px',
+        }}
       >
+        <SynapseIconLogo />
+        <Stack>
+          <Typography
+            variant="headline3"
+            sx={{ color: 'grey.800', fontSize: '16px', marginBottom: '10px' }}
+          >
+            View this file on Synapse.org
+          </Typography>
+          <Typography variant="smallText1" sx={{ color: 'grey.700' }}>
+            Synapse empowers biomedical researchers with tools for open science
+            and collaboration.
+          </Typography>
+        </Stack>
         <OpenInNewIcon
-          sx={{ color: '#878E95', width: '32px', height: '32px' }}
+          sx={{
+            color: '#878E95',
+            width: '32px',
+            height: '32px',
+            marginLeft: 'auto',
+          }}
         />
-      </Link>
-    </Card>
+      </Card>
+    </Link>
   )
 }
 


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/PORTALS-3705

1) Entire SynapseFileEntityLinkCard component is now a clickable link
2) Reduced margins for file name in header of file entity pages as per Adam's request

Before: 
<img width="300" height="144" alt="Screenshot 2025-07-25 at 12 43 43 PM" src="https://github.com/user-attachments/assets/380e8e42-1115-4e50-a777-8a472903063e" />

After:
<img width="300" height="140" alt="Screenshot 2025-07-25 at 12 43 39 PM" src="https://github.com/user-attachments/assets/7dfd7b67-2e65-4179-81de-bc43d06c93d6" />
