### PR TITLE
PORTALS-3669 - Custom access column for ALS portal

### DIFF
--- a/apps/portals/ampals/package.json
+++ b/apps/portals/ampals/package.json
@@ -7,6 +7,7 @@
     "@mui/material": "^7.1.1",
     "@sage-bionetworks/synapse-portal-framework": "workspace:*",
     "@sage-bionetworks/synapse-types": "workspace:*",
+    "@tanstack/react-table": "^8.21.3",
     "katex": "^0.16.22",
     "pluralize": "^8.0.0",
     "react": "^19.1.0",

--- a/apps/portals/ampals/src/components/AmpAlsAccessColumn.tsx
+++ b/apps/portals/ampals/src/components/AmpAlsAccessColumn.tsx
@@ -1,0 +1,78 @@
+import { Row } from '@sage-bionetworks/synapse-types/src/Table/QueryResult'
+import { CellContext, ColumnDef } from '@tanstack/react-table'
+import AccessIcon, {
+  RestrictionUiType,
+} from 'synapse-react-client/components/HasAccess/AccessIcon'
+import HasAccessV2 from 'synapse-react-client/components/HasAccess/HasAccessV2'
+import IconSvg from 'synapse-react-client/components/IconSvg'
+import { getColumnIndex } from 'synapse-react-client/utils/functions'
+
+type SourceValue = 'Synapse' | 'GEO' | 'Critical Path Institute' | null
+
+const ID_COLUMN_NAME = 'id'
+const SOURCE_COLUMN_NAME = 'source'
+const URL_COLUMN_NAME = 'url'
+
+function AccessBySource(props: {
+  source: SourceValue
+  id: string
+  url?: string
+}) {
+  const { source, id, url } = props
+
+  switch (source) {
+    case 'GEO':
+      return <AccessIcon restrictionUiType={RestrictionUiType.Accessible} />
+    case 'Critical Path Institute':
+      return (
+        <a href={url} target="_blank">
+          <IconSvg icon="linkOff" wrap={false} />
+        </a>
+      )
+    case 'Synapse':
+    default:
+      return <HasAccessV2 entityId={id} showButtonText={false} />
+  }
+}
+
+/**
+ * Given the (tanstack react) Table CellContext, return an access column that changes based on the value of the 'source' column.
+ */
+function AmpAlsAccessColumnCell<TValue = unknown>(
+  props: CellContext<Row, TValue>,
+) {
+  const { row, table } = props
+
+  const selectColumns = table.options.meta?.rowSet?.headers ?? []
+
+  const idColumnIndex = getColumnIndex(ID_COLUMN_NAME, selectColumns)
+  const sourceColumnIndex = getColumnIndex(SOURCE_COLUMN_NAME, selectColumns)
+  const urlColumnIndex = getColumnIndex(URL_COLUMN_NAME, selectColumns)
+
+  if (
+    idColumnIndex == null ||
+    sourceColumnIndex == null ||
+    urlColumnIndex == null
+  ) {
+    console.warn("AmpAlsAccessColumn: 'id', 'source' or 'url' column not found")
+    return null
+  }
+
+  const id = row.original.values[idColumnIndex]!
+  const sourceValue = row.original.values[sourceColumnIndex] as SourceValue
+  const url = row.original.values[urlColumnIndex] ?? undefined
+
+  return <AccessBySource source={sourceValue} id={id} url={url} />
+}
+
+const ampAlsAccessColumn: ColumnDef<Row, any> = {
+  id: 'ampAlsAccess',
+  cell: AmpAlsAccessColumnCell,
+  enableResizing: false,
+  maxSize: 50,
+  meta: {
+    textAlign: 'center',
+  },
+}
+
+export default ampAlsAccessColumn

--- a/apps/portals/ampals/src/config/synapseConfigs/datasets.tsx
+++ b/apps/portals/ampals/src/config/synapseConfigs/datasets.tsx
@@ -1,3 +1,4 @@
+import ampAlsAccessColumn from '@/components/AmpAlsAccessColumn'
 import type {
   CardConfiguration,
   LabelLinkConfig,
@@ -27,7 +28,8 @@ export const datasetQueryWrapperPlotNavProps: QueryWrapperPlotNavProps = {
   columnAliases,
   tableConfiguration: {
     columnLinks: datasetColumnLinks,
-    showAccessColumn: true,
+    showAccessColumn: false, // use custom access column instead
+    customColumns: [ampAlsAccessColumn],
   },
   defaultShowSearchBox: true,
   facetsToPlot: ['program', 'project', 'datasetType', 'assay'],

--- a/apps/portals/ampals/src/types.d.ts
+++ b/apps/portals/ampals/src/types.d.ts
@@ -11,3 +11,5 @@ interface ImportMeta {
 
 // Import MUI type augmentations from 'synapse-react-client' so we can use custom property values defined for our MUI theme
 import 'synapse-react-client/ThemeTypes'
+
+import 'synapse-react-client/types/tanstack-table-augmentation'

--- a/packages/synapse-react-client/src/components/HasAccess/AccessIcon.tsx
+++ b/packages/synapse-react-client/src/components/HasAccess/AccessIcon.tsx
@@ -1,0 +1,70 @@
+import { Theme, useTheme } from '@mui/material'
+import IconSvg, { IconName } from '../IconSvg/IconSvg'
+
+export enum RestrictionUiType {
+  Accessible = 'Accessible',
+  AccessibleWithTerms = 'AccessibleWithTerms',
+  AccessBlockedByRestriction = 'AccessBlockedByRestriction',
+  AccessBlockedByACL = 'AccessBlockedByACL',
+  AccessBlockedToAnonymous = 'AccessBlockedToAnonymous',
+  AccessibleExternalFileHandle = 'AccessibleExternalFileHandle',
+}
+
+const iconConfiguration: Record<
+  RestrictionUiType,
+  { icon: IconName; color: (theme: Theme) => string; tooltipText: string }
+> = {
+  [RestrictionUiType.AccessBlockedToAnonymous]: {
+    icon: 'accessClosed',
+    color: theme => theme.palette.warning.main,
+    tooltipText: 'You must sign in to access this item.',
+  },
+  [RestrictionUiType.AccessBlockedByRestriction]: {
+    icon: 'accessClosed',
+    color: theme => theme.palette.warning.main,
+    tooltipText: 'You must request access to this restricted item.',
+  },
+  [RestrictionUiType.AccessBlockedByACL]: {
+    icon: 'accessClosed',
+    color: theme => theme.palette.warning.main,
+    tooltipText: 'You do not have download access for this item.',
+  },
+  [RestrictionUiType.AccessibleWithTerms]: {
+    icon: 'accessOpen',
+    color: theme => theme.palette.success.main,
+    tooltipText: 'View Terms',
+  },
+  [RestrictionUiType.Accessible]: {
+    icon: 'accessOpen',
+    color: theme => theme.palette.success.main,
+    tooltipText: '',
+  },
+  [RestrictionUiType.AccessibleExternalFileHandle]: {
+    icon: 'linkOff',
+    color: theme => theme.palette.grey[700],
+    tooltipText: 'Access may be controlled by an external system.',
+  },
+}
+
+function AccessIcon(props: { restrictionUiType: RestrictionUiType }) {
+  const { restrictionUiType } = props
+  const theme = useTheme()
+  if (restrictionUiType) {
+    const configuration = iconConfiguration[restrictionUiType]
+    return (
+      <IconSvg
+        icon={configuration.icon}
+        label={configuration.tooltipText}
+        sx={{
+          color: configuration.color(theme),
+          height: '16px',
+          verticalAlign: 'text-top',
+        }}
+      />
+    )
+  }
+  // nothing is rendered until downloadType is determined
+  return <></>
+}
+
+export default AccessIcon

--- a/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.tsx
+++ b/packages/synapse-react-client/src/components/HasAccess/HasAccessV2.tsx
@@ -6,7 +6,7 @@ import {
 import { SynapseClientError, useSynapseContext } from '@/utils'
 import { BackendDestinationEnum, getEndpoint } from '@/utils/functions'
 import { SRC_SIGN_IN_CLASS } from '@/utils/SynapseConstants'
-import { Box, Button, Theme, useTheme } from '@mui/material'
+import { Box, Button } from '@mui/material'
 import {
   AccessRequirement,
   EntityBundle,
@@ -18,12 +18,12 @@ import { useCallback, useMemo, useState } from 'react'
 import AccessRequirementList, {
   checkHasUnsupportedRequirement,
 } from '../AccessRequirementList/AccessRequirementList'
-import IconSvg, { IconName } from '../IconSvg/IconSvg'
 import {
   implementsExternalFileHandleInterface,
   isFileEntity,
 } from '@/utils/types/IsType'
 import { UseQueryOptions } from '@tanstack/react-query'
+import AccessIcon, { RestrictionUiType } from './AccessIcon'
 
 export type HasAccessProps = {
   onHide?: () => void
@@ -42,72 +42,6 @@ export type HasAccessProps = {
 }
 
 const buttonSx = { p: '0px', minWidth: 'unset' }
-
-export enum RestrictionUiType {
-  Accessible = 'Accessible',
-  AccessibleWithTerms = 'AccessibleWithTerms',
-  AccessBlockedByRestriction = 'AccessBlockedByRestriction',
-  AccessBlockedByACL = 'AccessBlockedByACL',
-  AccessBlockedToAnonymous = 'AccessBlockedToAnonymous',
-  AccessibleExternalFileHandle = 'AccessibleExternalFileHandle',
-}
-
-const iconConfiguration: Record<
-  RestrictionUiType,
-  { icon: IconName; color: (theme: Theme) => string; tooltipText: string }
-> = {
-  [RestrictionUiType.AccessBlockedToAnonymous]: {
-    icon: 'accessClosed',
-    color: theme => theme.palette.warning.main,
-    tooltipText: 'You must sign in to access this item.',
-  },
-  [RestrictionUiType.AccessBlockedByRestriction]: {
-    icon: 'accessClosed',
-    color: theme => theme.palette.warning.main,
-    tooltipText: 'You must request access to this restricted item.',
-  },
-  [RestrictionUiType.AccessBlockedByACL]: {
-    icon: 'accessClosed',
-    color: theme => theme.palette.warning.main,
-    tooltipText: 'You do not have download access for this item.',
-  },
-  [RestrictionUiType.AccessibleWithTerms]: {
-    icon: 'accessOpen',
-    color: theme => theme.palette.success.main,
-    tooltipText: 'View Terms',
-  },
-  [RestrictionUiType.Accessible]: {
-    icon: 'accessOpen',
-    color: theme => theme.palette.success.main,
-    tooltipText: '',
-  },
-  [RestrictionUiType.AccessibleExternalFileHandle]: {
-    icon: 'linkOff',
-    color: theme => theme.palette.grey[700],
-    tooltipText: 'Access may be controlled by an external system.',
-  },
-}
-
-function AccessIcon(props: { restrictionUiType: RestrictionUiType }) {
-  const { restrictionUiType } = props
-  const theme = useTheme()
-  if (restrictionUiType) {
-    const configuration = iconConfiguration[restrictionUiType]
-    return (
-      <IconSvg
-        icon={configuration.icon}
-        label={configuration.tooltipText}
-        sx={{
-          color: configuration.color(theme),
-          height: '16px',
-          verticalAlign: 'text-top',
-        }}
-      />
-    )
-  }
-  // nothing is rendered until downloadType is determined
-  return <></>
-}
 
 /**
  * Determines whether an Entity is accessible for download, or if it is blocked by the ACL or unmet Access Requirements.

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
@@ -8,6 +8,7 @@ import {
 } from '@sage-bionetworks/synapse-types'
 import {
   Cell,
+  ColumnDef,
   createColumnHelper,
   getCoreRowModel,
   useReactTable,
@@ -38,6 +39,8 @@ import {
 import { usePrefetchResourcesInTable } from './usePrefetchTableData'
 import { useTableSort } from './useTableSort'
 
+const DEFAULT_CUSTOM_COLUMNS: ColumnDef<Row, any>[] = []
+
 export type SynapseTableConfiguration = Pick<
   SynapseTableProps,
   | 'showAccessColumn'
@@ -48,6 +51,7 @@ export type SynapseTableConfiguration = Pick<
   | 'showDirectDownloadColumn'
   | 'hideAddToDownloadListColumn'
   | 'columnLinks'
+  | 'customColumns'
 >
 
 export type SynapseTableProps = {
@@ -55,7 +59,8 @@ export type SynapseTableProps = {
   rowSet: RowSet
   /** Whether a new page of data is being loaded */
   isLoadingNewPage: boolean
-
+  /** Custom columns to render in the table */
+  customColumns?: ColumnDef<Row, any>[]
   /** If true and entity is a view or dataset, renders a column that represents if the caller has permission to download the entity represented by the row */
   showAccessColumn?: boolean
   /**
@@ -87,6 +92,7 @@ export function SynapseTable(props: SynapseTableProps) {
   const {
     rowSet,
     isLoadingNewPage,
+    customColumns = DEFAULT_CUSTOM_COLUMNS,
     showAccessColumn,
     showExternalAccessIcon,
     showAccessColumnHeader,
@@ -156,6 +162,7 @@ export function SynapseTable(props: SynapseTableProps) {
 
   const columns = useMemo(
     () => [
+      ...customColumns,
       rowSelectionColumn,
       addToDownloadListColumn,
       directDownloadColumn,
@@ -174,7 +181,7 @@ export function SynapseTable(props: SynapseTableProps) {
         })
       }) ?? []),
     ],
-    [selectColumns, showAccessColumn],
+    [customColumns, selectColumns, showAccessColumn, showAccessColumnHeader],
   )
 
   const prependColumnVisibility: VisibilityState = useMemo(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,9 @@ importers:
       '@sage-bionetworks/synapse-types':
         specifier: workspace:*
         version: link:../../../packages/synapse-types
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       katex:
         specifier: ^0.16.22
         version: 0.16.22
@@ -11546,7 +11549,7 @@ snapshots:
       '@babel/traverse': 7.27.1
       '@babel/types': 7.27.1
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.7.1
@@ -11762,7 +11765,7 @@ snapshots:
       '@babel/parser': 7.27.2
       '@babel/template': 7.27.2
       '@babel/types': 7.27.1
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -14918,7 +14921,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.2(@types/debug@4.1.12)(@types/node@20.17.41)(@vitest/ui@3.2.4)(jsdom@26.1.0)(msw@2.10.2(@types/node@20.17.41)(typescript@5.8.3))(sass@1.87.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
+      vitest: 3.2.2(@types/debug@4.1.12)(@types/node@20.17.41)(@vitest/ui@3.2.4)(jsdom@21.1.2)(msw@2.10.2(@types/node@20.17.41)(typescript@5.8.3))(sass@1.87.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15032,7 +15035,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.2(@types/debug@4.1.12)(@types/node@20.17.41)(@vitest/ui@3.2.4)(jsdom@26.1.0)(msw@2.10.2(@types/node@20.17.41)(typescript@5.8.3))(sass@1.87.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
+      vitest: 3.2.2(@types/debug@4.1.12)(@types/node@20.17.41)(@vitest/ui@3.2.4)(jsdom@21.1.2)(msw@2.10.2(@types/node@20.17.41)(typescript@5.8.3))(sass@1.87.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -15158,7 +15161,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16304,10 +16307,6 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
-  debug@4.4.0:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -16712,7 +16711,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.4):
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       esbuild: 0.25.4
     transitivePeerDependencies:
       - supports-color
@@ -17642,7 +17641,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17658,7 +17657,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
PORTALS-3669

- Add ability to supply custom columns to SynapseTable
- Create custom access column for ALS portal datasets based on dataset source

<img width="850" height="628" alt="image" src="https://github.com/user-attachments/assets/e3e32b15-04d1-474e-ab33-1612968fc11f" />
