### PR TITLE
Remove unnecessary overrides 

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,15 +47,8 @@
   },
   "pnpm": {
     "overrides": {
-      "word-wrap": "^1.2.4",
-      "semver": "^7.5.4",
       "@types/react": "19.1.8",
-      "@types/react-dom": "19.1.6",
-      "goober": "2.1.9",
-      "react-hot-toast": "2.2.0",
-      "postcss": "^8.4.31",
-      "elliptic": "^6.6.1",
-      "cross-spawn": "^7.0.5"
+      "@types/react-dom": "19.1.6"
     }
   },
   "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"

--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -92,7 +92,7 @@
     "raf": "^3.4.1",
     "react-datetime": "^3.3.1",
     "react-error-boundary": "^3.1.4",
-    "react-hot-toast": "2.2.0",
+    "react-hot-toast": "^2.5.2",
     "react-inspector": "^6.0.2",
     "react-intersection-observer": "^9.16.0",
     "react-mailchimp-subscribe": "^2.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,15 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  word-wrap: ^1.2.4
-  semver: ^7.5.4
   '@types/react': 19.1.8
   '@types/react-dom': 19.1.6
-  goober: 2.1.9
-  react-hot-toast: 2.2.0
-  postcss: ^8.4.31
-  elliptic: ^6.6.1
-  cross-spawn: ^7.0.5
 
 importers:
 
@@ -1631,8 +1624,8 @@ importers:
         specifier: ^3.1.4
         version: 3.1.4(react@19.1.0)
       react-hot-toast:
-        specifier: 2.2.0
-        version: 2.2.0(csstype@3.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^2.5.2
+        version: 2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-inspector:
         specifier: ^6.0.2
         version: 6.0.2(react@19.1.0)
@@ -7286,8 +7279,8 @@ packages:
     resolution: {integrity: sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==}
     hasBin: true
 
-  goober@2.1.9:
-    resolution: {integrity: sha512-PAtnJbrWtHbfpJUIveG5PJIB6Mc9Kd0gimu9wZwPyA+wQUSeOeA4x4Ug16lyaaUUKZ/G6QEH1xunKOuXP1F4Vw==}
+  goober@2.1.16:
+    resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
     peerDependencies:
       csstype: ^3.0.10
 
@@ -8266,6 +8259,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
@@ -9025,14 +9022,14 @@ packages:
     engines: {node: '>=8'}
     peerDependencies:
       browserslist: '>=4'
-      postcss: ^8.4.31
+      postcss: '>=8'
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: ^8.4.31
+      postcss: '>=8.0.9'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -9050,7 +9047,7 @@ packages:
     engines: {node: '>= 12'}
     peerDependencies:
       browserslist: '>= 4'
-      postcss: ^8.4.31
+      postcss: '>= 8'
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
@@ -9223,8 +9220,8 @@ packages:
     peerDependencies:
       react: '>=16.13.1'
 
-  react-hot-toast@2.2.0:
-    resolution: {integrity: sha512-248rXw13uhf/6TNDVzagX+y7R8J183rp7MwUMNkcrBRyHj/jWOggfXTGlM8zAOuh701WyVW+eUaWG2LeSufX9g==}
+  react-hot-toast@2.5.2:
+    resolution: {integrity: sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==}
     engines: {node: '>=10'}
     peerDependencies:
       react: '>=16'
@@ -9670,6 +9667,15 @@ packages:
 
   selectn@1.3.0:
     resolution: {integrity: sha512-mid0kbUHd1kZ2hMYIMTqPMJ4xpLiaGnpXqkiMuwSBH9GiS0jkE8wGjlMG9D6ICZ4Nj8iln75wn3oCZQf9Gudpw==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
@@ -10332,7 +10338,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.31
+      postcss: ^8.4.12
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -10945,6 +10951,9 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
@@ -11540,7 +11549,7 @@ snapshots:
       debug: 4.4.0(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 7.7.1
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -11560,7 +11569,7 @@ snapshots:
       debug: 4.4.1
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 7.7.2
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -11586,7 +11595,7 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.24.5
       lru-cache: 5.1.1
-      semver: 7.7.1
+      semver: 6.3.1
 
   '@babel/helper-globals@7.28.0': {}
 
@@ -12554,7 +12563,7 @@ snapshots:
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
-      semver: 7.7.1
+      semver: 7.5.4
       source-map: 0.6.1
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -12573,7 +12582,7 @@ snapshots:
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
-      semver: 7.7.1
+      semver: 7.5.4
       source-map: 0.6.1
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -13474,7 +13483,7 @@ snapshots:
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.10
-      semver: 7.7.1
+      semver: 7.5.4
     optionalDependencies:
       '@types/node': 20.17.41
     optional: true
@@ -13488,7 +13497,7 @@ snapshots:
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.10
-      semver: 7.7.1
+      semver: 7.5.4
     optionalDependencies:
       '@types/node': 20.19.7
 
@@ -16847,7 +16856,7 @@ snapshots:
       object.values: 1.2.1
       prop-types: 15.8.1
       resolve: 2.0.0-next.5
-      semver: 7.7.1
+      semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
@@ -17503,7 +17512,7 @@ snapshots:
       through2: 2.0.5
       xtend: 4.0.2
 
-  goober@2.1.9(csstype@3.1.3):
+  goober@2.1.16(csstype@3.1.3):
     dependencies:
       csstype: 3.1.3
 
@@ -17954,7 +17963,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.2
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -18809,6 +18818,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lru-cache@7.18.3: {}
 
@@ -20032,13 +20045,12 @@ snapshots:
       '@babel/runtime': 7.27.6
       react: 19.1.0
 
-  react-hot-toast@2.2.0(csstype@3.1.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-hot-toast@2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      goober: 2.1.9(csstype@3.1.3)
+      csstype: 3.1.3
+      goober: 2.1.16(csstype@3.1.3)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-    transitivePeerDependencies:
-      - csstype
 
   react-inspector@6.0.2(react@19.1.0):
     dependencies:
@@ -20613,6 +20625,12 @@ snapshots:
       brackets2dots: 1.1.0
       curry2: 1.0.3
       dotsplit.js: 1.1.0
+
+  semver@6.3.1: {}
+
+  semver@7.5.4:
+    dependencies:
+      lru-cache: 6.0.0
 
   semver@7.7.1: {}
 
@@ -22199,6 +22217,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yaml@1.10.2: {}
 


### PR DESCRIPTION
- Upgrade `react-hot-toast`. Verified https://github.com/timolins/react-hot-toast/issues/170 (issue with `goober`) does not reproduce
- Remove remaining `overrides` that were added to address security alerts. Verified (via `pnpm why`) that we did not regress to dependency versions with known vulnerabilities after removing each override (`word-wrap`, `semver`, `postcss`, `elliptic`, `cross-spawn`)

Depends on #2083 