### PR TITLE
[fix] Remove `nihReporterLink` from grant card

### DIFF
--- a/apps/portals/cancercomplexity/src/config/synapseConfigs/grants.ts
+++ b/apps/portals/cancercomplexity/src/config/synapseConfigs/grants.ts
@@ -20,7 +20,6 @@ export const grantsSchema: TableToGenericCardMapping = {
     'grantNumber',
     'consortium',
     'grantType',
-    'nihReporterLink',
     'grantStartDate',
     'theme',
   ],
@@ -39,12 +38,6 @@ export const grantsCardConfiguration: CardConfiguration = {
     matchColumnName: 'grantId',
     baseURL: 'Explore/Grants/DetailsPage',
   },
-  labelLinkConfig: [
-    {
-      isMarkdown: true,
-      matchColumnName: 'nihReporterLink',
-    },
-  ],
   type: SynapseConstants.GENERIC_CARD,
   secondaryLabelLimit: 4,
   iconOptions,


### PR DESCRIPTION
We have decided to remove the NIH RePORTER links from CCKP. The links were proving to be harder to maintain than initially thought (no DOI!), so their removal will ensure a smoother user experience.

CC: @aclayton555 