### PR TITLE
switch to pluto and add terra

### DIFF
--- a/apps/portals/nf/src/config/resources.ts
+++ b/apps/portals/nf/src/config/resources.ts
@@ -30,7 +30,6 @@ export const topProjectsSql =
 
 export const enabledAnalysisPlatforms: ExternalAnalysisPlatform[] = [
   'cavatica',
-  'plutodev',
-  // 'pluto',
-  // 'terra',
+  'pluto',
+  'terra',
 ]


### PR DESCRIPTION
This pull request updates the list of enabled analysis platforms in the `resources.ts` configuration file. The change re-enables both `pluto` and `terra` platforms for use, while removing the development-only `plutodev` entry.

Configuration updates:

* Replaced `plutodev` with `pluto` and added `terra` to the `enabledAnalysisPlatforms` array in `resources.ts`, making these platforms available for analysis.