### PR TITLE
SWC-7430: Fix grid row insertion

### DIFF
--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -67,7 +67,7 @@
     "dompurify": "^3.2.5",
     "immutable": "4.1.0",
     "jotai": "^2.12.4",
-    "json-joy": "17.40.0",
+    "json-joy": "^17.49.1",
     "json-rules-engine": "^4.1.0",
     "jsonpath": "^1.1.1",
     "katex": "^0.16.22",

--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -1,5 +1,5 @@
 import { ComplexJSONRenderer } from '@/components/SynapseTable/SynapseTableCell/JSON/ComplexJSONRenderer'
-import { konst } from 'json-joy/lib/json-crdt-patch'
+import { s } from 'json-joy/lib/json-crdt-patch'
 import throttle from 'lodash-es/throttle'
 import {
   forwardRef,
@@ -142,21 +142,19 @@ const SynapseGrid = forwardRef<
   // Function to apply grid changes to a model
   function gridToModel(gridRows: DataGridRow[], model: GridModel): GridModel {
     if (!model) return model
-    const rowsArr = model.api.node.get('rows')
     const { columnNames: mcnUpdate } = model.api.getSnapshot()
 
     // Apply row changes
     // Update existing rows and add new ones
     for (let i = 0; i < gridRows.length; i++) {
       const editedRow = gridRows[i]
-      const rowObj = rowsArr.get(i)
-      const rowVec = rowObj.get('data')
+      const rowVec = model.api.vec(['rows', String(i), 'data'])
 
       // Update each cell in the row
       Object.entries(editedRow).forEach(([key, value]) => {
         const columnIndex = mcnUpdate.indexOf(key)
         if (!isNaN(columnIndex)) {
-          rowVec.set([[columnIndex, konst(value)]])
+          rowVec?.set([[columnIndex, s.con(value)]])
         }
       })
     }
@@ -200,12 +198,14 @@ const SynapseGrid = forwardRef<
 
   const handleChange = (newValue: DataGridRow[], operations: Operation[]) => {
     for (const operation of operations) {
-      const rowsArr = modelRef.current?.api.arr(['rows'])
+      const model = getModel()!
+      const rowsArr = model.api.arr(['rows'])
       if (operation.type === 'CREATE') {
         // Add new rows to the model iterating fromRowIndex to toRowIndex
         // and adding rows to the model via the api
         for (let i = operation.fromRowIndex; i < operation.toRowIndex; i++) {
-          rowsArr?.ins(i, [modelRef.current?.api.builder.vec()])
+          const rowArr = model.api.arr(['rows'])
+          rowArr.ins(i, [{ data: s.vec(s.con('')), metadata: {} }])
         }
 
         newValue

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1549,8 +1549,8 @@ importers:
         specifier: ^2.12.4
         version: 2.12.4(@types/react@19.1.8)(react@19.1.0)
       json-joy:
-        specifier: 17.40.0
-        version: 17.40.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)(tslib@2.8.1)
+        specifier: ^17.49.1
+        version: 17.49.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)(tslib@2.8.1)
       json-rules-engine:
         specifier: ^4.1.0
         version: 4.1.0
@@ -8024,8 +8024,8 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
-  json-joy@17.40.0:
-    resolution: {integrity: sha512-wO6sz5+Rzp9aIcz/WqGpSgEsWQ1/eH/nsheP2Asl2G/532wLb+VvLEb8+05GoQPlx3YKGoNYENjyJgslVB6mQg==}
+  json-joy@17.49.1:
+    resolution: {integrity: sha512-S/fEfAYxzOr8CoBg915bMkPQpY7mwgMxPNloKbEnnzMg3o9dkQmu7NWGqwROIkq28N82LNMUkL1FfFB9dwdlRA==}
     engines: {node: '>=10.0'}
     hasBin: true
     peerDependencies:
@@ -18543,7 +18543,7 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
-  json-joy@17.40.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)(tslib@2.8.1):
+  json-joy@17.49.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)(tslib@2.8.1):
     dependencies:
       '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
       '@jsonjoy.com/json-expression': 1.1.0(tslib@2.8.1)
@@ -19186,7 +19186,7 @@ snapshots:
 
   nano-css@5.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.4
       css-tree: 1.1.3
       csstype: 3.1.3
       fastest-stable-stringify: 2.0.2


### PR DESCRIPTION
This PR updates json-joy to the latest version to fix an issue where querying a arr node returned the error `NOT_ARR`. It makes a few compatibility updates with the updated API.

It also fixes the insertion and editing of grid data by properly querying the new nested data structure.