### PR TITLE
PORTALS-3746: Flaky test in synapse-react-client

### DIFF
--- a/packages/synapse-react-client/src/components/EntityCitation/EntityCitation.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityCitation/EntityCitation.test.tsx
@@ -222,7 +222,11 @@ describe('EntityCitation tests', () => {
       name: /Citation options/i,
     })
 
-    await screen.findByText(content => content.includes('version=1'))
+    await waitFor(() =>
+      expect(
+        screen.getByText(content => content.includes('version=1')),
+      ).toBeInTheDocument(),
+    )
   })
 
   it('Versionless Entity DOI', async () => {


### PR DESCRIPTION
<img width="676" height="66" alt="Screenshot 2025-08-21 at 2 30 47 PM" src="https://github.com/user-attachments/assets/40930eaf-8de7-44b3-8bf4-91eb70b371af" />

Was originally using findByText but the test was flaky because the citation loads asynchronously + text might be split across multiple elements. Using waitFor + getByText seems to fix it. It might be because findByText is for if the text is fully contained in a single DOM element but in our case the citation text might be split across multiple nested elements.