### PR TITLE
Got rid of `foo` on landing page

### DIFF
--- a/apps/portals/b2ai.standards/src/components/ChallengesCardDeck.tsx
+++ b/apps/portals/b2ai.standards/src/components/ChallengesCardDeck.tsx
@@ -103,7 +103,7 @@ export function ChallengesCardDeck() {
 
     const card: CardDeckCardProps = {
       title: gcOrg[ORG_TABLE_COLUMN_NAMES.NAME],
-      description: 'foo ' + gcOrg[ORG_TABLE_COLUMN_NAMES.DESCRIPTION],
+      description: gcOrg[ORG_TABLE_COLUMN_NAMES.DESCRIPTION],
       cardDeckType: 'b2ai',
       ctaButtonText: 'NOT USED IN cardDeckType = b2ai',
       ctaButtonURL: `/Explore/Organization/OrganizationDetailsPage?${


### PR DESCRIPTION
It was just there for testing and I forgot to remove it earlier