### PR TITLE
SWC-7441 grid support primitive json types

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -21,6 +21,8 @@ import {
   createTextColumn,
   DataSheetGrid,
   keyColumn,
+  checkboxColumn,
+  floatColumn,
 } from 'react-datasheet-grid'
 import 'react-datasheet-grid/dist/style.css'
 import '../../style/components/_data-grid-extra.scss'
@@ -142,6 +144,23 @@ const SynapseGrid = forwardRef<
             item => item.value,
           )
         : null
+      const colType = jsonSchema
+        ? getSchemaForProperty(jsonSchema, columnName).type
+        : null
+
+      if (colType === 'boolean') {
+        return {
+          ...keyColumn(columnName, checkboxColumn),
+          title: columnName,
+        }
+      }
+
+      if (colType === 'number' || colType === 'integer') {
+        return {
+          ...keyColumn(columnName, floatColumn),
+          title: columnName,
+        }
+      }
 
       if (enumeratedValues && enumeratedValues.length > 0) {
         // Use autocomplete column for columns with enumerated values


### PR DESCRIPTION
The current grid implementation casts every cell as a string, which causes validation issues for columns with non-string types. This PR parses the schema to get a type for each column and chooses the corresponding column. It uses a checkbox for boolean values, float input for integers and floats, and text for strings and properties that do not define type.