### PR TITLE
Fixes https://github.com/bridge2ai/b2ai-standards-registry/issues/373

### DIFF
--- a/packages/synapse-react-client/src/components/HeaderCard/HeaderCardV2.tsx
+++ b/packages/synapse-react-client/src/components/HeaderCard/HeaderCardV2.tsx
@@ -290,6 +290,7 @@ const HeaderCardV2 = forwardRef(function HeaderCardV2(
                 mb: 1,
                 fontSize: '2.5rem',
                 letterSpacing: '0.1em', // Add letter spacing
+                marginBottom: '0.6em',
               }}
             >
               {href ? (


### PR DESCRIPTION
Added space between title and subtitle in HeaderCardV2. This improves appearance for both Org and Standards details pages