### PR TITLE
Grid: create row with metadata object

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -184,7 +184,9 @@ const SynapseGrid = forwardRef<
           const dataArray = columnNames.map(columnName =>
             s.con(rowData[columnName] ?? ''),
           )
-          rowsArr?.ins(i, [{ data: s.vec(...dataArray) }])
+          rowsArr?.ins(i, [
+            s.obj({ data: s.vec(...dataArray), metadata: s.obj({}) }),
+          ])
         }
       }
 


### PR DESCRIPTION
when creating or duplicating a row, create a json-joy object and add the metadata as an empty json-joy object. This will make row validation work as expected for newly created rows.