### PR TITLE
PORTALS-3780: Fix grid creating update patches for new rows

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/utils/applyModelChange.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/applyModelChange.ts
@@ -22,10 +22,9 @@ export function applyModelChange(model: GridModel, change: ModelChange) {
   switch (change.type) {
     case 'CREATE': {
       // Convert rowData object into a CRDT vector
-      const isNewRow = Object.keys(change.rowData).length === 0
-      const rowData = isNewRow
-        ? [s.con(null)]
-        : columnNames.map(name => s.con(change.rowData[name] ?? null))
+      const rowData = columnNames.map(name =>
+        s.con(change.rowData[name] ?? null),
+      )
       // Insert a new row object at the specified index
       rowsArr?.ins(change.rowIndex, [
         s.obj({ data: s.vec(...rowData), metadata: s.obj({}) }),


### PR DESCRIPTION
For CREATE operations, check if an empty row is added. If so, don't fill the data vector with blank constants. This causes unnecessary patches.

Also, when creating or duplicating a row, create a json-joy object and add the metadata as an empty json-joy object. This will make row validation work as expected for newly created rows.