### PR TITLE
AMPALS-59: update WP rss feed URL

### DIFF
--- a/apps/portals/ampals/src/pages/HomePage.tsx
+++ b/apps/portals/ampals/src/pages/HomePage.tsx
@@ -3,7 +3,7 @@ import AMPALSHeader from '@sage-bionetworks/synapse-portal-framework/components/
 import AMPALSPublishingRequirements from '@sage-bionetworks/synapse-portal-framework/components/ampals/AMPALSPublishingRequirements'
 import HowToAccessData from '@sage-bionetworks/synapse-portal-framework/components/ampals/HowToAccessData'
 // import AMPALSExploreTheData from '@sage-bionetworks/synapse-portal-framework/components/ampals/AMPALSExploreTheData'
-import { FeaturedDataTabs } from 'synapse-react-client'
+import { FeaturedDataTabs, RssFeedCards } from 'synapse-react-client'
 // import columnAliases from '../config/columnAliases'
 import headerSvg from '../config/style/header.svg?url'
 import {
@@ -86,6 +86,22 @@ export default function HomePage() {
         />
       </SectionLayout>
       <AMPALSPublishingRequirements />
+      <SectionLayout
+        title={"What's New"}
+        centerTitle={true}
+        ContainerProps={{
+          className: 'home-spacer',
+        }}
+      >
+        <RssFeedCards
+          url=" https://salsportalnews.wpenginepowered.com"
+          itemsToShow={3}
+          allowCategories={[]}
+          // filter={{
+          //   value: "what's-new",
+          // }}
+        />
+      </SectionLayout>
       <SectionLayout
         title={'Featured Datasets'}
         centerTitle

--- a/packages/synapse-react-client/src/components/RssFeedCards/RssFeedCards.tsx
+++ b/packages/synapse-react-client/src/components/RssFeedCards/RssFeedCards.tsx
@@ -50,7 +50,7 @@ export class RssFeedCards extends Component<RssFeedCardsProps, RssState> {
       ? `/${filterType ?? 'tag'}/${filterValue.replace(' ', '-')}`
       : ''
     const allItems = `${url}${tagPath}`
-    const feedUrl = `${allItems}/feed/`
+    const feedUrl = `${allItems}/?feed=rss2`
     fetch(feedUrl)
       .then(response => response.text())
       .then(responseData => rssParser.parseString(responseData))


### PR DESCRIPTION
Fixed RSS feed URL for AMP ALS WordPress site, but still encountering a CORS error (locally anyway).
<img width="1353" height="714" alt="Screenshot 2025-09-09 at 1 19 44 PM" src="https://github.com/user-attachments/assets/46e7afd9-a1c9-4ff6-b0a5-92be01fe2411" />

Verified this URL redirects properly for other sites that use a WP RSS feed.
<img width="1354" height="803" alt="Screenshot 2025-09-09 at 1 22 41 PM" src="https://github.com/user-attachments/assets/3f4dab9a-a2a5-4704-ab30-4b3b1f4ed9bd" />
<img width="1312" height="781" alt="Screenshot 2025-09-09 at 1 25 16 PM" src="https://github.com/user-attachments/assets/d94757b8-6bec-49e1-b17a-e6b97d7c562d" />


