### PR TITLE
PORTALS-3799: Grid: Indicate required columns

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -5,6 +5,7 @@ import { ComplexJSONRenderer } from '@/components/SynapseTable/SynapseTableCell/
 import { useGetSchema } from '@/synapse-queries/index'
 import getEnumeratedValues from '@/utils/jsonschema/getEnumeratedValues'
 import getSchemaForProperty from '@/utils/jsonschema/getSchemaForProperty'
+import getRequiredAttributes from '@/utils/jsonschema/getRequiredAttributes'
 import { getType } from '@/utils/jsonschema/getType'
 import Grid from '@mui/material/Grid'
 import { GridSession } from '@sage-bionetworks/synapse-client'
@@ -110,6 +111,7 @@ const SynapseGrid = forwardRef<
   function modelColsToGrid(modelSnapshot: GridModelSnapshot): Column[] {
     if (!modelSnapshot) return []
     const { columnNames, columnOrder } = modelSnapshot
+    const requiredFields = jsonSchema ? getRequiredAttributes(jsonSchema) : []
     const gridCols: Column[] = columnOrder.map((index: number) => {
       const columnName = columnNames[index]
       const enumeratedValues = jsonSchema
@@ -125,6 +127,9 @@ const SynapseGrid = forwardRef<
         return {
           ...keyColumn(columnName, checkboxColumn),
           title: columnName,
+          headerClassName: requiredFields.includes(columnName)
+            ? 'header-cell-required'
+            : 'header-cell',
         }
       }
 
@@ -132,6 +137,9 @@ const SynapseGrid = forwardRef<
         return {
           ...keyColumn(columnName, floatColumn),
           title: columnName,
+          headerClassName: requiredFields.includes(columnName)
+            ? 'header-cell-required'
+            : 'header-cell',
         }
       }
 
@@ -146,6 +154,9 @@ const SynapseGrid = forwardRef<
             }),
           ),
           title: columnName,
+          headerClassName: requiredFields.includes(columnName)
+            ? 'header-cell-required'
+            : 'header-cell',
         }
       }
       return {
@@ -155,6 +166,9 @@ const SynapseGrid = forwardRef<
           createTextColumn({ continuousUpdates: false }),
         ),
         title: columnName,
+        headerClassName: requiredFields.includes(columnName)
+          ? 'header-cell-required'
+          : 'header-cell',
       }
     })
     return gridCols

--- a/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
+++ b/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
@@ -46,3 +46,9 @@
     transform: rotate(360deg);
   }
 }
+
+.header-cell-required {
+  background-color: #395979;
+  color: white;
+  font-weight: bold;
+}

--- a/packages/synapse-react-client/src/utils/jsonschema/getRequiredAttributes.test.ts
+++ b/packages/synapse-react-client/src/utils/jsonschema/getRequiredAttributes.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import getRequiredAttributes from './getRequiredAttributes'
+
+describe('getRequiredAttributes', () => {
+  it('returns empty array for undefined/null/non-object', () => {
+    expect(getRequiredAttributes(undefined)).toEqual([])
+    expect(getRequiredAttributes(null)).toEqual([])
+    // @ts-expect-error intentional wrong type
+    expect(getRequiredAttributes(5)).toEqual([])
+  })
+
+  it('returns required fields from simple schema', () => {
+    const schema = {
+      type: 'object',
+      required: ['a', 'b'],
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'number' },
+        c: { type: 'boolean' },
+      },
+    }
+    expect(getRequiredAttributes(schema).sort()).toEqual(['a', 'b'])
+  })
+
+  it('deduplicates required fields', () => {
+    const schema = {
+      type: 'object',
+      required: ['a', 'b', 'a'],
+    }
+    expect(getRequiredAttributes(schema).sort()).toEqual(['a', 'b'])
+  })
+
+  it('handles allOf union of required', () => {
+    const schema = {
+      allOf: [
+        { required: ['a', 'b'] },
+        { required: ['b', 'c'] },
+        { properties: { d: { type: 'string' } } },
+      ],
+    }
+    expect(getRequiredAttributes(schema).sort()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('handles anyOf union of required', () => {
+    const schema = {
+      anyOf: [{ required: ['x'] }, { required: ['y', 'z'] }, { required: [] }],
+    }
+    expect(getRequiredAttributes(schema).sort()).toEqual(['x', 'y', 'z'])
+  })
+
+  it('handles oneOf union of required', () => {
+    const schema = {
+      oneOf: [
+        { required: ['m'] },
+        { required: ['n'] },
+        { required: ['m', 'o'] },
+      ],
+    }
+    expect(getRequiredAttributes(schema).sort()).toEqual(['m', 'n', 'o'])
+  })
+
+  it('traverses nested combinators', () => {
+    const schema = {
+      allOf: [
+        {
+          anyOf: [{ required: ['a'] }, { required: ['b'] }],
+        },
+        {
+          oneOf: [
+            { required: ['c'] },
+            {
+              allOf: [{ required: ['d'] }, { required: ['e', 'a'] }],
+            },
+          ],
+        },
+      ],
+    }
+    expect(getRequiredAttributes(schema).sort()).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+      'e',
+    ])
+  })
+
+  it('ignores non-array required and non-string entries', () => {
+    const schema = {
+      required: ['a', 5, null, undefined],
+      allOf: [{ required: ['b'] }, { required: [Symbol('c') as any, 'd'] }],
+    }
+    expect(getRequiredAttributes(schema).sort()).toEqual(['a', 'b', 'd'])
+  })
+
+  it('avoids infinite recursion on reused schema objects', () => {
+    const shared = { required: ['x'] }
+    const schema: any = {
+      allOf: [shared, { anyOf: [shared, { oneOf: [shared] }] }],
+    }
+    expect(getRequiredAttributes(schema)).toEqual(['x'])
+  })
+})

--- a/packages/synapse-react-client/src/utils/jsonschema/getRequiredAttributes.ts
+++ b/packages/synapse-react-client/src/utils/jsonschema/getRequiredAttributes.ts
@@ -1,5 +1,6 @@
 import isArray from 'lodash-es/isArray'
 import isObject from 'lodash-es/isObject'
+import { JSONSchema7 } from 'json-schema'
 
 /**
  * Returns a de-duplicated list of required attribute names from a JSON Schema.
@@ -9,14 +10,16 @@ import isObject from 'lodash-es/isObject'
  *  - anyOf / oneOf: union (pragmatic; intersection could be too restrictive for most UI uses)
  */
 export default function getRequiredAttributes(
-  jsonSchema: Record<string, unknown> | undefined | null,
+  jsonSchema: JSONSchema7 | Record<string, unknown> | undefined | null,
 ): string[] {
   if (!jsonSchema || !isObject(jsonSchema)) return []
 
   const collected = new Set<string>()
   const visited = new Set<object>()
 
-  function visit(schema: any) {
+  function visit(
+    schema: JSONSchema7 | Record<string, unknown> | undefined | null,
+  ) {
     if (!isObject(schema) || visited.has(schema)) return
     visited.add(schema)
 
@@ -27,7 +30,7 @@ export default function getRequiredAttributes(
     }
 
     ;['allOf', 'anyOf', 'oneOf'].forEach(key => {
-      const group = schema[key]
+      const group = (schema as any)[key]
       if (isArray(group)) {
         group.forEach(sub => visit(sub))
       }

--- a/packages/synapse-react-client/src/utils/jsonschema/getRequiredAttributes.ts
+++ b/packages/synapse-react-client/src/utils/jsonschema/getRequiredAttributes.ts
@@ -1,0 +1,39 @@
+import isArray from 'lodash-es/isArray'
+import isObject from 'lodash-es/isObject'
+
+/**
+ * Returns a de-duplicated list of required attribute names from a JSON Schema.
+ * Traverses nested combinators (allOf, anyOf, oneOf).
+ * For:
+ *  - allOf: union of required fields
+ *  - anyOf / oneOf: union (pragmatic; intersection could be too restrictive for most UI uses)
+ */
+export default function getRequiredAttributes(
+  jsonSchema: Record<string, unknown> | undefined | null,
+): string[] {
+  if (!jsonSchema || !isObject(jsonSchema)) return []
+
+  const collected = new Set<string>()
+  const visited = new Set<object>()
+
+  function visit(schema: any) {
+    if (!isObject(schema) || visited.has(schema)) return
+    visited.add(schema)
+
+    if (isArray(schema.required)) {
+      for (const r of schema.required) {
+        if (typeof r === 'string') collected.add(r)
+      }
+    }
+
+    ;['allOf', 'anyOf', 'oneOf'].forEach(key => {
+      const group = schema[key]
+      if (isArray(group)) {
+        group.forEach(sub => visit(sub))
+      }
+    })
+  }
+
+  visit(jsonSchema)
+  return Array.from(collected)
+}


### PR DESCRIPTION
This PR distinguishes required columns by giving the header cell a background color. It includes a utility to parse schemas and return required attributes. It sets `heaederClassName` of required columns. 