### PR TITLE
PORTALS-3800: Grid: highlight invalid cells

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -47,6 +47,7 @@ import { useDataGridWebSocket } from './useDataGridWebsocket'
 import { useGridUndoRedo } from './hooks/useGridUndoRedo'
 import { applyModelChange, ModelChange } from './utils/applyModelChange'
 import { mapOperationsToModelChanges } from './utils/mapOperationsToModelChanges'
+import { extractValidationFieldNames } from './utils/parseValidationColumns'
 
 export type SynapseGridProps = {
   query: string
@@ -321,6 +322,32 @@ const SynapseGrid = forwardRef<
                       'row-selected': selectedRowIndex === rowIndex,
                     })
                   }
+                  cellClassName={({ rowData, rowIndex, columnId }) => {
+                    const validation = (rowData as DataGridRow)
+                      .__validationResults?.allValidationMessages
+                    if (!validation) return undefined
+                    const invalidFields =
+                      extractValidationFieldNames(validation) || []
+                    if (!invalidFields.length) return undefined
+
+                    const invalidSet = new Set(
+                      invalidFields.map(f => f.toLowerCase()),
+                    )
+
+                    if (!columnId) return undefined
+
+                    const isInvalid = invalidSet.has(columnId.toLowerCase())
+                    if (!isInvalid) return undefined
+
+                    const safe = columnId.replace(/[^a-zA-Z0-9_-]/g, '-')
+                    return classNames(
+                      'cell-invalid',
+                      `cell-invalid-field-${safe}`,
+                      {
+                        'cell-row-selected': selectedRowIndex === rowIndex,
+                      },
+                    )
+                  }}
                   duplicateRow={({ rowData }: any) => ({
                     ...rowData,
                   })}

--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -48,6 +48,7 @@ import { useGridUndoRedo } from './hooks/useGridUndoRedo'
 import { applyModelChange, ModelChange } from './utils/applyModelChange'
 import { mapOperationsToModelChanges } from './utils/mapOperationsToModelChanges'
 import { extractValidationFieldNames } from './utils/parseValidationColumns'
+import { getCellClassName } from './utils/getCellClassName'
 
 export type SynapseGridProps = {
   query: string
@@ -322,32 +323,14 @@ const SynapseGrid = forwardRef<
                       'row-selected': selectedRowIndex === rowIndex,
                     })
                   }
-                  cellClassName={({ rowData, rowIndex, columnId }) => {
-                    const validation = (rowData as DataGridRow)
-                      .__validationResults?.allValidationMessages
-                    if (!validation) return undefined
-                    const invalidFields =
-                      extractValidationFieldNames(validation) || []
-                    if (!invalidFields.length) return undefined
-
-                    const invalidSet = new Set(
-                      invalidFields.map(f => f.toLowerCase()),
-                    )
-
-                    if (!columnId) return undefined
-
-                    const isInvalid = invalidSet.has(columnId.toLowerCase())
-                    if (!isInvalid) return undefined
-
-                    const safe = columnId.replace(/[^a-zA-Z0-9_-]/g, '-')
-                    return classNames(
-                      'cell-invalid',
-                      `cell-invalid-field-${safe}`,
-                      {
-                        'cell-row-selected': selectedRowIndex === rowIndex,
-                      },
-                    )
-                  }}
+                  cellClassName={({ rowData, rowIndex, columnId }) =>
+                    getCellClassName({
+                      rowData: rowData as DataGridRow,
+                      rowIndex,
+                      columnId,
+                      selectedRowIndex,
+                    })
+                  }
                   duplicateRow={({ rowData }: any) => ({
                     ...rowData,
                   })}

--- a/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.ts
@@ -1,0 +1,26 @@
+import classNames from 'classnames'
+import { extractValidationFieldNames } from './parseValidationColumns'
+import { DataGridRow } from '../DataGridTypes'
+
+export function getCellClassName(params: {
+  rowData: DataGridRow
+  rowIndex: number
+  columnId?: string
+  selectedRowIndex: number | null
+}): string | undefined {
+  const { rowData, rowIndex, columnId, selectedRowIndex } = params
+  const validationMessages = rowData.__validationResults?.allValidationMessages
+  if (!validationMessages) return undefined
+
+  const invalidFields = extractValidationFieldNames(validationMessages) || []
+  if (!invalidFields.length) return undefined
+  if (!columnId) return undefined
+
+  const invalidSet = new Set(invalidFields.map(f => f.toLowerCase()))
+  if (!invalidSet.has(columnId.toLowerCase())) return undefined
+
+  const safe = columnId.replace(/[^a-zA-Z0-9_-]/g, '-')
+  return classNames('cell-invalid', `cell-invalid-field-${safe}`, {
+    'cell-row-selected': selectedRowIndex === rowIndex,
+  })
+}

--- a/packages/synapse-react-client/src/components/DataGrid/utils/parseValidationColumns.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/parseValidationColumns.ts
@@ -1,0 +1,40 @@
+/**
+ * Extracts the column (property) names from validation message strings of the form:
+ * "#/platform: null is not a valid enum value"
+ * Returns every parsed value (no de-duplication).
+ *
+ * Example:
+ *  extractValidationFieldNames(["#/platform: null is not a valid enum value"])
+ *  -> ["platform"]
+ */
+export function extractValidationFieldNames(messages: string[]): string[] {
+  const results: string[] = []
+  const regex = /^#\/([^:]+):/
+
+  for (const raw of messages) {
+    if (typeof raw !== 'string') continue
+    const str = raw.trimStart()
+    const match = str.match(regex)
+    if (match) {
+      results.push(match[1].trim())
+    }
+  }
+  return results
+}
+
+/**
+ * Same as extractValidationFieldNames but returns unique names (order of first appearance).
+ */
+export function extractUniqueValidationFieldNames(
+  messages: string[],
+): string[] {
+  const seen = new Set<string>()
+  const ordered: string[] = []
+  for (const name of extractValidationFieldNames(messages)) {
+    if (!seen.has(name)) {
+      seen.add(name)
+      ordered.push(name)
+    }
+  }
+  return ordered
+}

--- a/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
+++ b/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
@@ -46,3 +46,7 @@
     transform: rotate(360deg);
   }
 }
+
+.cell-invalid {
+  background: #feeceb;
+}


### PR DESCRIPTION
This PR adds a visual indicator invalid cells. It adds a utility, `parseValidationColumns` to extract the column from validation messages in the form `#/column: validation message`. Then another utility `getCellClassNames` is passed to the `cellClassName` prop of `DataGrid`.