### PR TITLE
Update StorybookComponentWrapper to allow requiring login

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.stories.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.stories.tsx
@@ -12,6 +12,7 @@ const meta = {
   component: SynapseGrid,
   parameters: {
     stack: 'staging',
+    requireLogin: true,
   },
   argTypes: {
     query: {


### PR DESCRIPTION
This should improve the experience of using stories that require authentication -- you now know that you are logged in before you interact with a story that requires it!