### PR TITLE
Update B2AI Standards Explorer Homepage example search terms

### DIFF
--- a/apps/synapse-portal-framework/src/components/b2ai.standards/StandardsHeader.tsx
+++ b/apps/synapse-portal-framework/src/components/b2ai.standards/StandardsHeader.tsx
@@ -12,12 +12,11 @@ export type StandardsHeaderProps = {
 const StandardsHeader = (props: StandardsHeaderProps) => {
   const searchPlaceholder = 'Search for a biomedical data standard'
   const searchExampleTerms = [
-    'Ophthalmic imaging',
+    'Imaging',
     'Integration',
     'Acquisition',
     'File formats',
     'Ontologies',
-    'Retinal fundus images',
     'Machine learning platform',
     'Datasheets',
   ]


### PR DESCRIPTION
Addressing https://github.com/bridge2ai/b2ai-standards-registry/issues/395

`Ophthalmic imaging` and `Retinal fundus images` were producing no results, so replacing them with `Imaging`