### PR TITLE
Quick style pass of the Data Grid buttons & chat

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/MergeGridWithSourceTableButton.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/MergeGridWithSourceTableButton.tsx
@@ -1,6 +1,6 @@
+import GridMenuButton from '@/components/DataGrid/components/GridMenuButton/GridMenuButton'
 import useMergeGridWithSource from '@/components/DataGrid/useMergeGridWithSource'
 import { displayToast } from '@/components/index'
-import { Button } from '@mui/material'
 import {
   EntityUpdateResults,
   instanceOfEntityUpdateResults,
@@ -28,15 +28,15 @@ export default function MergeGridWithSourceTableButton(
   })
 
   return (
-    <Button
+    <GridMenuButton
       loading={isPending}
       onClick={() => {
         mergeGridWithSource({ gridSessionId, sourceEntityId })
       }}
       variant="contained"
     >
-      Update table with changes
-    </Button>
+      Apply changes
+    </GridMenuButton>
   )
 }
 

--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -1,3 +1,4 @@
+import GridMenuButton from '@/components/DataGrid/components/GridMenuButton/GridMenuButton'
 import MergeGridWithSourceTableButton from '@/components/DataGrid/MergeGridWithSourceTableButton'
 import computeReplicaSelectionModel from '@/components/DataGrid/utils/computeReplicaSelectionModel'
 import modelRowsToGrid from '@/components/DataGrid/utils/modelRowsToGrid'
@@ -54,8 +55,9 @@ import {
 } from './utils/DataGridUtils'
 import { getCellClassName } from './utils/getCellClassName'
 import { mapOperationsToModelChanges } from './utils/mapOperationsToModelChanges'
-import { Button } from '@mui/material'
+import { Stack } from '@mui/material'
 import GridAgentChat from '../SynapseChat/GridAgentChat'
+import { SmartToyTwoTone } from '@mui/icons-material'
 
 export type SynapseGridProps = {
   showDebugInfo?: boolean
@@ -360,92 +362,107 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
 
               {/* Grid */}
               {isGridReady && (
-                <Grid size={12}>
-                  {undoUI}
-                  {redoUI}
-                  <Button onClick={() => setChatOpen(true)}>Open chat</Button>
-                  <GridAgentChat
-                    open={chatOpen}
-                    onClose={() => setChatOpen(false)}
-                    gridSessionId={session.sessionId!}
-                    usersReplicaId={replicaId!}
-                    chatbotName="Grid Assistant"
-                  />
-
-                  <DataSheetGrid
-                    ref={gridRef}
-                    value={rowValues}
-                    columns={colValues}
-                    rowKey={GRID_ROW_REACT_KEY_PROPERTY}
-                    rowClassName={({ rowData, rowIndex }) =>
-                      classNames({
-                        'row-valid':
-                          rowData.__validationResults?.isValid === true,
-                        'row-invalid':
-                          rowData.__validationResults?.isValid === false,
-                        'row-unknown':
-                          !!jsonSchema &&
-                          rowData.__validationResults?.isValid == undefined,
-                        'row-selected': selectedRowIndex === rowIndex,
-                      })
-                    }
-                    cellClassName={({ rowData, rowIndex, columnId }) =>
-                      getCellClassName({
-                        rowData: rowData as DataGridRow,
-                        rowIndex,
-                        columnId,
-                        selectedRowIndex,
-                      })
-                    }
-                    duplicateRow={({ rowData }: any) => ({
-                      ...rowData,
-                    })}
-                    onChange={handleChange}
-                    onActiveCellChange={({ cell }) => {
-                      if (cell) {
-                        setSelectedRowIndex(cell.row)
-                      }
-                    }}
-                    onSelectionChange={handleSelectionChange}
-                  />
-                  {/* Show validation messages for selected row */}
-                  {selectedRowIndex !== null &&
-                    rowValues[selectedRowIndex] &&
-                    Array.isArray(
-                      rowValues[selectedRowIndex].__validationResults
-                        ?.allValidationMessages,
-                    ) &&
-                    rowValues[selectedRowIndex].__validationResults
-                      ?.allValidationMessages.length > 0 && (
-                      <FullWidthAlert
-                        variant="warning"
-                        title="Validation Messages For Selected Row:"
-                        isGlobal={false}
-                        description={
-                          <ul>
-                            {rowValues[
-                              selectedRowIndex
-                            ].__validationResults.allValidationMessages.map(
-                              (msg: string) => (
-                                <li key={msg}>{msg}</li>
-                              ),
-                            )}
-                          </ul>
-                        }
-                        sx={{
-                          marginTop: '12px',
-                        }}
+                <>
+                  <Grid size={12}>
+                    <Stack
+                      direction={'row'}
+                      spacing={1}
+                      sx={{ justifyContent: 'flex-end' }}
+                    >
+                      {undoUI}
+                      {redoUI}
+                      <GridMenuButton
+                        variant={'outlined'}
+                        onClick={() => setChatOpen(true)}
+                        startIcon={<SmartToyTwoTone />}
+                      >
+                        Open chat
+                      </GridMenuButton>
+                      <GridAgentChat
+                        open={chatOpen}
+                        onClose={() => setChatOpen(false)}
+                        gridSessionId={session.sessionId!}
+                        usersReplicaId={replicaId!}
+                        chatbotName="Grid Assistant"
                       />
-                    )}
-                </Grid>
-              )}
-              {isGridReady && session.sourceEntityId && (
-                <Grid container size={12} sx={{ justifyContent: 'flex-end' }}>
-                  <MergeGridWithSourceTableButton
-                    sourceEntityId={session.sourceEntityId}
-                    gridSessionId={session.sessionId!}
-                  />
-                </Grid>
+                      {session.sourceEntityId && (
+                        <MergeGridWithSourceTableButton
+                          sourceEntityId={session.sourceEntityId}
+                          gridSessionId={session.sessionId!}
+                        />
+                      )}
+                    </Stack>
+                  </Grid>
+                  <Grid size={12}>
+                    <DataSheetGrid
+                      ref={gridRef}
+                      value={rowValues}
+                      columns={colValues}
+                      rowKey={GRID_ROW_REACT_KEY_PROPERTY}
+                      rowClassName={({ rowData, rowIndex }) =>
+                        classNames({
+                          'row-valid':
+                            rowData.__validationResults?.isValid === true,
+                          'row-invalid':
+                            rowData.__validationResults?.isValid === false,
+                          'row-unknown':
+                            !!jsonSchema &&
+                            rowData.__validationResults?.isValid == undefined,
+                          'row-selected': selectedRowIndex === rowIndex,
+                        })
+                      }
+                      cellClassName={({ rowData, rowIndex, columnId }) =>
+                        getCellClassName({
+                          rowData: rowData as DataGridRow,
+                          rowIndex,
+                          columnId,
+                          selectedRowIndex,
+                        })
+                      }
+                      duplicateRow={({ rowData }: any) => ({
+                        ...rowData,
+                      })}
+                      onChange={handleChange}
+                      onActiveCellChange={({ cell }) => {
+                        if (cell) {
+                          setSelectedRowIndex(cell.row)
+                        }
+                      }}
+                      onSelectionChange={handleSelectionChange}
+                    />
+                  </Grid>
+                  <Grid size={12}>
+                    {/* Show validation messages for selected row */}
+                    {selectedRowIndex !== null &&
+                      rowValues[selectedRowIndex] &&
+                      Array.isArray(
+                        rowValues[selectedRowIndex].__validationResults
+                          ?.allValidationMessages,
+                      ) &&
+                      rowValues[selectedRowIndex].__validationResults
+                        ?.allValidationMessages.length > 0 && (
+                        <FullWidthAlert
+                          variant="warning"
+                          title="Validation Messages For Selected Row:"
+                          isGlobal={false}
+                          description={
+                            <ul>
+                              {rowValues[
+                                selectedRowIndex
+                              ].__validationResults.allValidationMessages.map(
+                                (msg: string) => (
+                                  <li key={msg}>{msg}</li>
+                                ),
+                              )}
+                            </ul>
+                          }
+                          sx={{
+                            marginTop: '12px',
+                          }}
+                        />
+                      )}
+                  </Grid>
+                </>
               )}
               {/* Debug Model Snapshot */}
               {showDebugInfo && (

--- a/packages/synapse-react-client/src/components/DataGrid/components/GridMenuButton/GridMenuButton.module.scss
+++ b/packages/synapse-react-client/src/components/DataGrid/components/GridMenuButton/GridMenuButton.module.scss
@@ -1,0 +1,17 @@
+@use '../../../../style/abstracts/variables' as SRC;
+@use 'sass:map';
+
+.button:global(.MuiButton-root) {
+  height: 36px;
+  font-size: 16px;
+  font-weight: 400;
+  white-space: nowrap;
+
+  &:global(.MuiButton-outlined:not(.Mui-disabled)) {
+    color: map.get(SRC.$colors, 'gray-900');
+    border: 1px solid map.get(SRC.$colors, 'gray-300');
+    :global(.MuiButton-icon) {
+      color: map.get(SRC.$colors, 'gray-700');
+    }
+  }
+}

--- a/packages/synapse-react-client/src/components/DataGrid/components/GridMenuButton/GridMenuButton.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/GridMenuButton/GridMenuButton.tsx
@@ -1,0 +1,6 @@
+import Button, { ButtonProps } from '@mui/material/Button'
+import styles from './GridMenuButton.module.scss'
+
+export default function GridMenuButton(props: ButtonProps) {
+  return <Button {...props} className={styles.button} />
+}

--- a/packages/synapse-react-client/src/components/DataGrid/hooks/useGridUndoRedo.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/hooks/useGridUndoRedo.tsx
@@ -1,8 +1,9 @@
-import { DataGridRow, Operation } from '../DataGridTypes'
-import { useCallback, useEffect, useState } from 'react'
-import { ModelChange } from '../utils/applyModelChange'
-import { Button, Menu, MenuItem } from '@mui/material'
+import GridMenuButton from '@/components/DataGrid/components/GridMenuButton/GridMenuButton'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
+import { Menu, MenuItem } from '@mui/material'
+import { useCallback, useEffect, useState } from 'react'
+import { DataGridRow, Operation } from '../DataGridTypes'
+import { ModelChange } from '../utils/applyModelChange'
 import { convertActionToModelChange } from '../utils/convertActionToModelChange'
 import { useStack } from './useStack'
 
@@ -222,7 +223,8 @@ export function useGridUndoRedo(
 
   const undoUI = (
     <>
-      <Button
+      <GridMenuButton
+        variant={'outlined'}
         aria-controls={undoOpen ? 'undo-menu' : undefined}
         aria-haspopup="true"
         onClick={handleUndoClick}
@@ -230,7 +232,7 @@ export function useGridUndoRedo(
         endIcon={<KeyboardArrowDownIcon />}
       >
         Undo {undoPreview && `(${undoPreview.totalActions})`}
-      </Button>
+      </GridMenuButton>
       <Menu
         id="undo-menu"
         anchorEl={undoAnchorEl}
@@ -250,7 +252,8 @@ export function useGridUndoRedo(
 
   const redoUI = (
     <>
-      <Button
+      <GridMenuButton
+        variant={'outlined'}
         aria-controls={redoOpen ? 'redo-menu' : undefined}
         aria-haspopup="true"
         onClick={handleRedoClick}
@@ -258,7 +261,7 @@ export function useGridUndoRedo(
         endIcon={<KeyboardArrowDownIcon />}
       >
         Redo {redoPreview && `(${redoPreview.totalActions})`}
-      </Button>
+      </GridMenuButton>
       <Menu
         id="redo-menu"
         anchorEl={redoAnchorEl}

--- a/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.tsx
@@ -397,7 +397,14 @@ export function SynapseChat({
       >
         <Box
           component="form"
-          sx={{ pb: '10px', position: 'sticky' }}
+          sx={{
+            pt: '8px',
+            mt: '5px',
+            pb: '10px',
+            position: 'sticky',
+            borderTop: '1px solid',
+            borderColor: 'grey.400',
+          }}
           onSubmit={handleSendMessage}
         >
           <TextField

--- a/packages/synapse-react-client/src/style/components/_markdown.scss
+++ b/packages/synapse-react-client/src/style/components/_markdown.scss
@@ -70,8 +70,9 @@
   list-style-type: decimal;
   padding-left: 15px;
 }
-.markdown ol li {
-  padding-top: 5px;
+.markdown ol li,
+.markdown ul li {
+  margin-top: 5px;
 }
 .markdown ul {
   list-style-type: square;
@@ -80,8 +81,10 @@
     content: none;
   }
 }
-.markdown ul li {
-  padding-top: 5px;
+
+.markdown ol + p,
+.markdown ul + p {
+  margin-top: 10px;
 }
 .markdown strong {
   font-weight: bold;


### PR DESCRIPTION
- Create new button component to match designs and apply to all buttons used in grid
- Improve spacing in markdown (agent commonly follows paragraphs with lists, so those should look good)
- Improve spacing in SynapseChat

<img width="2197" height="608" alt="image" src="https://github.com/user-attachments/assets/259414ea-01cf-4802-8e71-53e088e79c29" />
