### PR TITLE
PORTALS-3848: Fix grid enum select

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/columns/AutocompleteColumn.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/AutocompleteColumn.tsx
@@ -59,7 +59,7 @@ function AutocompleteCell({
         // Update local input state to match the selected/created value
         setLocalInputState(castCellValueToString(newVal))
       }}
-      blurOnSelect={true}
+      blurOnSelect={false}
       onBlur={_event => {
         // Only update on blur if the input value differs from the current rowData
         // and no option was selected (which would have already updated via onChange)

--- a/packages/synapse-react-client/src/components/DataGrid/columns/AutocompleteColumn.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/AutocompleteColumn.tsx
@@ -60,7 +60,7 @@ function AutocompleteCell({
         setLocalInputState(castCellValueToString(newVal))
       }}
       blurOnSelect={true}
-      onBlur={event => {
+      onBlur={_event => {
         // Only update on blur if the input value differs from the current rowData
         // and no option was selected (which would have already updated via onChange)
         if (localInputState !== castCellValueToString(rowData)) {

--- a/packages/synapse-react-client/src/components/DataGrid/columns/AutocompleteColumn.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/AutocompleteColumn.tsx
@@ -56,9 +56,17 @@ function AutocompleteCell({
           // The value was selected, so explicitly set it
           setRowData(newVal)
         }
+        // Update local input state to match the selected/created value
+        setLocalInputState(castCellValueToString(newVal))
       }}
       blurOnSelect={true}
-      onBlur={() => setRowData(localInputState)}
+      onBlur={event => {
+        // Only update on blur if the input value differs from the current rowData
+        // and no option was selected (which would have already updated via onChange)
+        if (localInputState !== castCellValueToString(rowData)) {
+          setRowData(parseFreeTextGivenJsonSchemaType(localInputState, colType))
+        }
+      }}
       renderInput={params => (
         <TextField
           {...params}


### PR DESCRIPTION
Fix issue where users typing a value into an enum column and then selecting a drop-down value did not update the cell's value.