### PR TITLE
SWC 7500 - show cell selection when grid is not focused

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -178,7 +178,6 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
     const handleSelectionChange = useCallback(
       (opts: { selection: SelectionWithId | null }) => {
         const { selection } = opts
-
         if (selection != null) {
           setLastSelection(selection)
 
@@ -348,25 +347,13 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
                         })
                       }
                       cellClassName={({ rowData, rowIndex, columnId }) => {
-                        const baseCellClassName = getCellClassName({
+                        return getCellClassName({
                           rowData: rowData as DataGridRow,
                           rowIndex,
                           columnId,
                           selectedRowIndex,
-                        })
-
-                        // Add selection styling based on lastSelection
-                        const isInSelection =
-                          lastSelection &&
-                          rowIndex >= lastSelection.min.row &&
-                          rowIndex <= lastSelection.max.row &&
-                          colValues.findIndex(col => col.id === columnId) >=
-                            lastSelection.min.col &&
-                          colValues.findIndex(col => col.id === columnId) <=
-                            lastSelection.max.col
-
-                        return classNames(baseCellClassName, {
-                          'cell-selected': isInSelection,
+                          lastSelection,
+                          colValues,
                         })
                       }}
                       duplicateRow={({ rowData }: any) => ({

--- a/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { getCellClassName } from './getCellClassName'
 import { DataGridRow } from '../DataGridTypes'
+import { SelectionWithId } from 'react-datasheet-grid/dist/types'
+import { Column } from 'react-datasheet-grid'
 
 describe('getCellClassName', () => {
   const createMockRowData = (
@@ -9,6 +11,23 @@ describe('getCellClassName', () => {
     ({
       __cellValidationResults: validationResults,
     } as DataGridRow)
+
+  const createMockColumns = (): Column[] => [
+    { id: 'col1' } as Column,
+    { id: 'col2' } as Column,
+    { id: 'col3' } as Column,
+  ]
+
+  const createMockSelection = (
+    minRow: number,
+    maxRow: number,
+    minCol: number,
+    maxCol: number,
+  ): SelectionWithId =>
+    ({
+      min: { row: minRow, col: minCol },
+      max: { row: maxRow, col: maxCol },
+    } as SelectionWithId)
 
   it('returns undefined when no classes should be applied', () => {
     const result = getCellClassName({
@@ -148,5 +167,138 @@ describe('getCellClassName', () => {
     })
 
     expect(result).toBe('cell-invalid')
+  })
+
+  describe('lastSelection functionality', () => {
+    it('adds cell-selected class when cell is within selection bounds', () => {
+      const result = getCellClassName({
+        rowData: createMockRowData(),
+        rowIndex: 1,
+        columnId: 'col2',
+        selectedRowIndex: null,
+        lastSelection: createMockSelection(0, 2, 1, 2),
+        colValues: createMockColumns(),
+      })
+
+      expect(result).toBe('cell-selected')
+    })
+
+    it('does not add cell-selected class when cell is outside row selection bounds', () => {
+      const result = getCellClassName({
+        rowData: createMockRowData(),
+        rowIndex: 3,
+        columnId: 'col2',
+        selectedRowIndex: null,
+        lastSelection: createMockSelection(0, 2, 1, 2),
+        colValues: createMockColumns(),
+      })
+
+      expect(result).toBeUndefined()
+    })
+
+    it('does not add cell-selected class when cell is outside column selection bounds', () => {
+      const result = getCellClassName({
+        rowData: createMockRowData(),
+        rowIndex: 1,
+        columnId: 'col1',
+        selectedRowIndex: null,
+        lastSelection: createMockSelection(0, 2, 1, 2),
+        colValues: createMockColumns(),
+      })
+
+      expect(result).toBeUndefined()
+    })
+
+    it('does not add cell-selected class when lastSelection is null', () => {
+      const result = getCellClassName({
+        rowData: createMockRowData(),
+        rowIndex: 1,
+        columnId: 'col2',
+        selectedRowIndex: null,
+        lastSelection: null,
+        colValues: createMockColumns(),
+      })
+
+      expect(result).toBeUndefined()
+    })
+
+    it('does not add cell-selected class when columnId is undefined', () => {
+      const result = getCellClassName({
+        rowData: createMockRowData(),
+        rowIndex: 1,
+        columnId: undefined,
+        selectedRowIndex: null,
+        lastSelection: createMockSelection(0, 2, 1, 2),
+        colValues: createMockColumns(),
+      })
+
+      expect(result).toBeUndefined()
+    })
+
+    it('does not add cell-selected class when colValues is undefined', () => {
+      const result = getCellClassName({
+        rowData: createMockRowData(),
+        rowIndex: 1,
+        columnId: 'col2',
+        selectedRowIndex: null,
+        lastSelection: createMockSelection(0, 2, 1, 2),
+        colValues: undefined,
+      })
+
+      expect(result).toBeUndefined()
+    })
+
+    it('handles single cell selection', () => {
+      const result = getCellClassName({
+        rowData: createMockRowData(),
+        rowIndex: 1,
+        columnId: 'col2',
+        selectedRowIndex: null,
+        lastSelection: createMockSelection(1, 1, 1, 1),
+        colValues: createMockColumns(),
+      })
+
+      expect(result).toBe('cell-selected')
+    })
+
+    it('combines all three classes when applicable', () => {
+      const validationResults = new Map([['col2', ['Error']]])
+      const result = getCellClassName({
+        rowData: createMockRowData(validationResults),
+        rowIndex: 1,
+        columnId: 'col2',
+        selectedRowIndex: 1,
+        lastSelection: createMockSelection(0, 2, 1, 2),
+        colValues: createMockColumns(),
+      })
+
+      expect(result).toBe('cell-row-selected cell-invalid cell-selected')
+    })
+
+    it('handles column not found in colValues', () => {
+      const result = getCellClassName({
+        rowData: createMockRowData(),
+        rowIndex: 1,
+        columnId: 'nonexistent',
+        selectedRowIndex: null,
+        lastSelection: createMockSelection(0, 2, 1, 2),
+        colValues: createMockColumns(),
+      })
+
+      expect(result).toBeUndefined()
+    })
+
+    it('handles edge case where cell is at selection boundary', () => {
+      const result = getCellClassName({
+        rowData: createMockRowData(),
+        rowIndex: 2,
+        columnId: 'col3',
+        selectedRowIndex: null,
+        lastSelection: createMockSelection(0, 2, 1, 2),
+        colValues: createMockColumns(),
+      })
+
+      expect(result).toBe('cell-selected')
+    })
   })
 })

--- a/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.ts
@@ -1,13 +1,24 @@
 import classNames from 'classnames'
 import { DataGridRow } from '../DataGridTypes'
+import { SelectionWithId } from 'react-datasheet-grid/dist/types'
+import { Column } from 'react-datasheet-grid'
 
 export function getCellClassName(params: {
   rowData: DataGridRow
   rowIndex: number
   columnId?: string
   selectedRowIndex: number | null
+  lastSelection?: SelectionWithId | null
+  colValues?: Column[]
 }): string | undefined {
-  const { rowData, rowIndex, columnId, selectedRowIndex } = params
+  const {
+    rowData,
+    rowIndex,
+    columnId,
+    selectedRowIndex,
+    lastSelection,
+    colValues,
+  } = params
 
   const isSelected = selectedRowIndex === rowIndex
   const cellValidationResults = rowData.__cellValidationResults
@@ -20,6 +31,20 @@ export function getCellClassName(params: {
   if (cellValidationResults && columnId) {
     if (cellValidationResults.has(columnId)) {
       classList.push('cell-invalid')
+    }
+  }
+
+  // Add selection styling based on lastSelection
+  if (lastSelection && columnId && colValues) {
+    const isInSelection =
+      rowIndex >= lastSelection.min.row &&
+      rowIndex <= lastSelection.max.row &&
+      colValues.findIndex(col => col.id === columnId) >=
+        lastSelection.min.col &&
+      colValues.findIndex(col => col.id === columnId) <= lastSelection.max.col
+
+    if (isInSelection) {
+      classList.push('cell-selected')
     }
   }
 

--- a/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
+++ b/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
@@ -64,3 +64,13 @@
 .multi-value-cell-large {
   min-height: 80px;
 }
+
+.cell-selected {
+  background-color: rgba(25, 118, 210, 0.08);
+  border: 1px solid rgba(25, 118, 210, 0.5);
+}
+
+.dsg-container:not(:focus-within) .cell-selected {
+  background-color: rgba(25, 118, 210, 0.04);
+  border: 1px solid rgba(25, 118, 210, 0.3);
+}


### PR DESCRIPTION
Store the selected cells in state and add CSS to keep them highlighted when the grid loses focus. This allows the users to see which cells are highlighted when interacting with the chatbot.
<img width="1858" height="1172" alt="image" src="https://github.com/user-attachments/assets/3f8d27f8-b9cc-4f65-9b89-33f32b23b807" />
