### PR TITLE
SWC-7503 - Fix grid selection and chatbot

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.test.ts
@@ -272,7 +272,7 @@ describe('getCellClassName', () => {
         colValues: createMockColumns(),
       })
 
-      expect(result).toBe('cell-row-selected cell-invalid cell-selected')
+      expect(result).toBe('cell-row-selected cell-selected cell-invalid')
     })
 
     it('handles column not found in colValues', () => {

--- a/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.ts
@@ -48,10 +48,6 @@ export function getCellClassName(params: {
 
   if (isInvalid) {
     classList.push('cell-invalid')
-    // Add combined class for specific styling when both selected and invalid
-    if (isInSelection) {
-      classList.push('cell-selected-invalid')
-    }
   }
 
   return classList.length ? classNames(classList) : undefined

--- a/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
+++ b/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
@@ -66,16 +66,9 @@
 }
 
 .cell-selected {
-  background-color: rgba(25, 118, 210, 0.08);
   border: 1px solid rgba(25, 118, 210, 0.5);
 }
 
-.cell-selected-invalid {
-  border: 2px solid red !important;
-  background-color: rgba(255, 0, 0, 0.1) !important;
-}
-
 .dsg-container:not(:focus-within) .cell-selected {
-  background-color: rgba(25, 118, 210, 0.04);
   border: 1px solid rgba(25, 118, 210, 0.3);
 }


### PR DESCRIPTION
The grid's single and multiple selection and validation CSS was not playing nicely with the chatbot window. This simplifies the grid cell's CSS largely by removing background color for selected cells. Also adds styling for selected when the grid is not focused. 