### PR TITLE
PORTALS-3880-follow-up

### DIFF
--- a/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.tsx
@@ -497,7 +497,7 @@ export function TableRowGenericCard(props: TableRowGenericCardProps) {
               defaultCitationFormat={defaultCitationFormat}
             />
           )}
-          {includeShareButton && (
+          {includeShareButton && isHeader && (
             <ShareThisPage {...sharePageLinkButtonProps} />
           )}
         </>


### PR DESCRIPTION
Share button should only appear on nf study details pages not cards.

<img width="1348" height="416" alt="Screenshot 2025-10-23 at 3 00 46 PM" src="https://github.com/user-attachments/assets/6645bfa7-15d8-4f65-9fa6-124638bea9f9" />
<img width="1081" height="399" alt="Screenshot 2025-10-23 at 3 00 38 PM" src="https://github.com/user-attachments/assets/deb50d23-d23d-4acd-9a4b-df02fdf626e4" />
