### PR TITLE
PORTALS-3907: Storybook Build Error Share This Page

### DIFF
--- a/packages/synapse-react-client/src/components/ShareThisPage/ShareThisPage.module.scss
+++ b/packages/synapse-react-client/src/components/ShareThisPage/ShareThisPage.module.scss
@@ -1,4 +1,4 @@
-@use 'synapse-react-client/style/abstracts/variables' as SrcVariables;
+@use '../../style/abstracts/variables' as SrcVariables;
 @use 'sass:map';
 
 .dialogPaper:global(.MuiDialog-root) {


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/PORTALS-3907?atlOrigin=eyJpIjoiYjkyNGNlYWM0ZjEyNDhiMThmZGUzMTkwODFiMTMwMTciLCJwIjoiaiJ9


Updated ShareThisPage's module.scss file to use relative import for _variable similar to GridMenuButton component's module.scss. I don't think we have a storybook alias to import it the way I originally did. Hopefully this fixes the issue.