### PR TITLE
SWC-7756 part 2 - display concurrent user selections

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/DataGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/DataGrid.tsx
@@ -23,6 +23,7 @@ import {
   calculateDefaultColumnWidth,
   HeaderOptions,
 } from './utils/calculateColumnWidth'
+import type { RemoteSelection } from './hooks/useRemoteSelections'
 
 type DataGridProps = {
   gridRef: React.RefObject<DataSheetGridRef | null>
@@ -39,6 +40,7 @@ type DataGridProps = {
     rowIndex: number | null,
     row: DataGridRow | null,
   ) => void
+  remoteSelections?: readonly RemoteSelection[]
 }
 
 /**
@@ -59,6 +61,7 @@ export default function DataGrid(props: DataGridProps) {
     handleChange,
     handleSelectionChange,
     onSelectedRowChange,
+    remoteSelections,
   } = props
 
   // Move columnWidths state into DataGrid
@@ -192,9 +195,10 @@ export default function DataGrid(props: DataGridProps) {
         selectedRowIndex,
         lastSelection,
         colValues,
+        remoteSelections,
       })
     },
-    [selectedRowIndex, lastSelection, colValues],
+    [selectedRowIndex, lastSelection, colValues, remoteSelections],
   )
 
   // Wrap duplicateRow in useCallback

--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -38,6 +38,7 @@ import { removeNoOpOperations } from './utils/DataGridUtils'
 import { mapOperationsToModelChanges } from './utils/mapOperationsToModelChanges'
 import { useGetCurrentUserBundle } from '@/synapse-queries'
 import { useListGridReplicas } from '@/synapse-queries/grid/useGridSession'
+import { useRemoteSelections } from './hooks/useRemoteSelections'
 import CertificationRequirement from '@/components/AccessRequirementList/RequirementItem/CertificationRequirement'
 import { ValidationAlert } from './components/ValidationAlert'
 
@@ -180,6 +181,13 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
     }, [jsonSchema])
 
     const connectionStatus = isConnected ? 'Connected' : 'Disconnected'
+
+    const remoteSelections = useRemoteSelections(
+      modelSnapshot,
+      model,
+      replicas,
+      replicaId,
+    )
 
     // Transform the model view rows and columns to DataSheetGrid format
     const rowValues = useMemo(
@@ -478,6 +486,7 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
                       handleChange={handleChange}
                       handleSelectionChange={handleSelectionChange}
                       onSelectedRowChange={handleSelectedRowChange}
+                      remoteSelections={remoteSelections}
                     />
                   </Grid>
                   <Grid size={12}>

--- a/packages/synapse-react-client/src/components/DataGrid/hooks/useRemoteSelections.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/hooks/useRemoteSelections.ts
@@ -1,5 +1,9 @@
 import { useMemo } from 'react'
-import type { GridModel, ReplicaSelectionModel } from '../DataGridTypes'
+import type {
+  GridModel,
+  GridModelSnapshot,
+  ReplicaSelectionModel,
+} from '../DataGridTypes'
 import type { GridReplicaInfo } from '@sage-bionetworks/synapse-client'
 import {
   replicaSelectionToGridSelection,

--- a/packages/synapse-react-client/src/components/DataGrid/hooks/useRemoteSelections.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/hooks/useRemoteSelections.ts
@@ -19,7 +19,7 @@ export interface RemoteSelection {
  * `snapshot.selection[replicaId]`, so no extra API calls are needed.
  */
 export function useRemoteSelections(
-  modelSnapshot: ReturnType<GridModel['api']['getSnapshot']> | null | undefined,
+  modelSnapshot: GridModelSnapshot | null | undefined,
   model: GridModel | null | undefined,
   replicas: GridReplicaInfo[],
   localReplicaId: number | null,

--- a/packages/synapse-react-client/src/components/DataGrid/hooks/useRemoteSelections.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/hooks/useRemoteSelections.ts
@@ -1,0 +1,63 @@
+import { useMemo } from 'react'
+import type { GridModel, ReplicaSelectionModel } from '../DataGridTypes'
+import type { GridReplicaInfo } from '@sage-bionetworks/synapse-client'
+import {
+  replicaSelectionToGridSelection,
+  type GridSelectionRange,
+} from '../utils/replicaSelectionToGridSelection'
+
+export interface RemoteSelection {
+  replicaId: number
+  range: GridSelectionRange
+  /** 0-7 color index, derived from replicaId for a stable per-session color. */
+  colorIndex: number
+}
+
+/**
+ * Derives remote replica selection ranges from the CRDT model's selection map.
+ * The server mirrors each replica's selection into the model under
+ * `snapshot.selection[replicaId]`, so no extra API calls are needed.
+ */
+export function useRemoteSelections(
+  modelSnapshot: ReturnType<GridModel['api']['getSnapshot']> | null | undefined,
+  model: GridModel | null | undefined,
+  replicas: GridReplicaInfo[],
+  localReplicaId: number | null,
+): RemoteSelection[] {
+  return useMemo(() => {
+    if (!modelSnapshot || !model) return []
+
+    const selectionMap = modelSnapshot.selection as Record<
+      string,
+      ReplicaSelectionModel
+    >
+    if (!selectionMap) return []
+
+    const results: RemoteSelection[] = []
+
+    for (const replica of replicas) {
+      const rid = replica.replicaId
+      if (rid == null || rid === localReplicaId) continue
+      if (!replica.isConnected) continue
+      if (replica.replicaType === 'SERVICE') continue
+
+      const selectionModel = selectionMap[String(rid)]
+      if (!selectionModel) continue
+
+      try {
+        const range = replicaSelectionToGridSelection(selectionModel, model)
+        if (range) {
+          results.push({
+            replicaId: rid,
+            range,
+            colorIndex: rid % 8,
+          })
+        }
+      } catch {
+        // Ignore stale/malformed selection data for a replica
+      }
+    }
+
+    return results
+  }, [modelSnapshot, model, replicas, localReplicaId])
+}

--- a/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.ts
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import { DataGridRow } from '../DataGridTypes'
 import { SelectionWithId } from '@sage-bionetworks/react-datasheet-grid'
 import { Column } from '@sage-bionetworks/react-datasheet-grid'
+import type { RemoteSelection } from '../hooks/useRemoteSelections'
 
 export function getCellClassName(params: {
   rowData: DataGridRow
@@ -10,6 +11,8 @@ export function getCellClassName(params: {
   selectedRowIndex: number | null
   lastSelection?: SelectionWithId | null
   colValues?: Column[]
+  /** Remote replica selection ranges to visualise as tinted backgrounds. */
+  remoteSelections?: readonly RemoteSelection[]
 }): string | undefined {
   const {
     rowData,
@@ -18,6 +21,7 @@ export function getCellClassName(params: {
     selectedRowIndex,
     lastSelection,
     colValues,
+    remoteSelections,
   } = params
 
   const isSelected = selectedRowIndex === rowIndex
@@ -48,6 +52,18 @@ export function getCellClassName(params: {
 
   if (isInvalid) {
     classList.push('cell-invalid')
+  }
+
+  // ── Remote selection tint ─────────────────────────────────────────────────
+  if (remoteSelections && columnId) {
+    for (const remote of remoteSelections) {
+      const { minRow, maxRow, columnNames } = remote.range
+      if (rowIndex < minRow || rowIndex > maxRow) continue
+      if (columnNames !== undefined && !columnNames.has(columnId)) continue
+      classList.push('cell-remote-selected')
+      classList.push(`cell-remote-selected--color-${remote.colorIndex}`)
+      break // apply the first matching remote selection only
+    }
   }
 
   return classList.length ? classNames(classList) : undefined

--- a/packages/synapse-react-client/src/components/DataGrid/utils/replicaSelectionToGridSelection.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/replicaSelectionToGridSelection.test.ts
@@ -1,0 +1,216 @@
+import {
+  GridModel,
+  ReplicaSelectionModel,
+} from '@/components/DataGrid/DataGridTypes'
+import computeReplicaSelectionModel from '@/components/DataGrid/utils/computeReplicaSelectionModel'
+import createTestModel from '@/components/DataGrid/utils/createTestModel'
+import { replicaSelectionToGridSelection } from '@/components/DataGrid/utils/replicaSelectionToGridSelection'
+import { SelectionWithId } from '@sage-bionetworks/react-datasheet-grid'
+
+/**
+ * NOTE: createTestModel uses json-joy's `s.vec(s.con(''))` for columnNames,
+ * which inserts a schema-default '' element at index 0.  After pushing c0…c2,
+ * the snapshot snapshot.columnNames = ['', 'c0', 'c1', 'c2'] and
+ * snapshot.columnOrder = [0, 1, 2].  Therefore the resolved column name for
+ * colIdx N is columnNames[N], i.e.:
+ *   colIdx 0 → ''
+ *   colIdx 1 → 'c0'
+ *   colIdx 2 → 'c1'
+ */
+
+describe('replicaSelectionToGridSelection', () => {
+  const sid = 456
+  const nRow = 4
+  const nCol = 3
+  let model: GridModel
+
+  beforeEach(() => {
+    model = createTestModel(nRow, nCol, sid)
+  })
+
+  // ── null / empty inputs ───────────────────────────────────────────────────
+
+  it('returns null when selection is null', () => {
+    expect(replicaSelectionToGridSelection(null, model)).toBeNull()
+  })
+
+  it('returns null when selection is undefined', () => {
+    expect(
+      replicaSelectionToGridSelection(
+        undefined as unknown as ReplicaSelectionModel,
+        model,
+      ),
+    ).toBeNull()
+  })
+
+  it('returns null when the model has no rows', () => {
+    const emptyModel = createTestModel(0, nCol, sid)
+    const selection: ReplicaSelectionModel = {
+      rowSelectAll: true,
+      columnSelectAll: true,
+    }
+    expect(replicaSelectionToGridSelection(selection, emptyModel)).toBeNull()
+  })
+
+  it('returns null when rowSelectAll is false and rowSelection is empty', () => {
+    const selection: ReplicaSelectionModel = {
+      rowSelection: [],
+      columnSelectAll: true,
+    }
+    expect(replicaSelectionToGridSelection(selection, model)).toBeNull()
+  })
+
+  it('returns null when columnSelectAll is false and columnSelection is empty', () => {
+    const selection: ReplicaSelectionModel = {
+      rowSelectAll: true,
+      columnSelection: [],
+    }
+    expect(replicaSelectionToGridSelection(selection, model)).toBeNull()
+  })
+
+  it('returns null when rowSelection contains IDs not present in the model', () => {
+    const selection: ReplicaSelectionModel = {
+      rowSelection: [{ rep: 9999, seq: 9999 }],
+      columnSelectAll: true,
+    }
+    expect(replicaSelectionToGridSelection(selection, model)).toBeNull()
+  })
+
+  it('returns null when columnSelection contains IDs not present in the model', () => {
+    const selection: ReplicaSelectionModel = {
+      rowSelectAll: true,
+      columnSelection: [{ rep: 9999, seq: 9999 }],
+    }
+    expect(replicaSelectionToGridSelection(selection, model)).toBeNull()
+  })
+
+  // ── rowSelectAll + columnSelectAll ────────────────────────────────────────
+
+  it('returns full range with undefined columnNames when both selectAll flags are set', () => {
+    const selection: ReplicaSelectionModel = {
+      rowSelectAll: true,
+      columnSelectAll: true,
+    }
+    const result = replicaSelectionToGridSelection(selection, model)
+    expect(result).not.toBeNull()
+    expect(result!.minRow).toBe(0)
+    expect(result!.maxRow).toBe(nRow - 1)
+    expect(result!.columnNames).toBeUndefined()
+  })
+
+  // ── rowSelectAll + specific columns ───────────────────────────────────────
+
+  it('covers all rows and resolves specific column names when rowSelectAll is true', () => {
+    // Selects columns at grid indices 0 and 1
+    const dsSelection: SelectionWithId = {
+      min: { col: 0, row: 0, colId: 'c0' },
+      max: { col: 1, row: nRow - 1, colId: 'c1' },
+    }
+    const replicaModel = computeReplicaSelectionModel(dsSelection, model)
+    expect(replicaModel.rowSelectAll).toBe(true)
+
+    const result = replicaSelectionToGridSelection(replicaModel, model)
+    expect(result).not.toBeNull()
+    expect(result!.minRow).toBe(0)
+    expect(result!.maxRow).toBe(nRow - 1)
+    // colIdx 0 → '' (vec schema default), colIdx 1 → 'c0'
+    expect(result!.columnNames).toEqual(new Set(['', 'c0']))
+  })
+
+  it('covers all rows and resolves a single column name when rowSelectAll is true', () => {
+    const dsSelection: SelectionWithId = {
+      min: { col: 2, row: 0, colId: 'c2' },
+      max: { col: 2, row: nRow - 1, colId: 'c2' },
+    }
+    const replicaModel = computeReplicaSelectionModel(dsSelection, model)
+    expect(replicaModel.rowSelectAll).toBe(true)
+
+    const result = replicaSelectionToGridSelection(replicaModel, model)
+    expect(result).not.toBeNull()
+    expect(result!.minRow).toBe(0)
+    expect(result!.maxRow).toBe(nRow - 1)
+    // colIdx 2 → 'c1'
+    expect(result!.columnNames).toEqual(new Set(['c1']))
+  })
+
+  // ── specific rows + columnSelectAll ───────────────────────────────────────
+
+  it('covers all columns (undefined columnNames) and resolves specific row range when columnSelectAll is true', () => {
+    const dsSelection: SelectionWithId = {
+      min: { col: 0, row: 1, colId: 'c0' },
+      max: { col: nCol - 1, row: 2, colId: `c${nCol - 1}` },
+    }
+    const replicaModel = computeReplicaSelectionModel(dsSelection, model)
+    expect(replicaModel.columnSelectAll).toBe(true)
+
+    const result = replicaSelectionToGridSelection(replicaModel, model)
+    expect(result).not.toBeNull()
+    expect(result!.minRow).toBe(1)
+    expect(result!.maxRow).toBe(2)
+    expect(result!.columnNames).toBeUndefined()
+  })
+
+  // ── specific rows + specific columns ──────────────────────────────────────
+
+  it('correctly maps a single cell selection back to its grid coordinates', () => {
+    const dsSelection: SelectionWithId = {
+      min: { col: 1, row: 2, colId: 'c1' },
+      max: { col: 1, row: 2, colId: 'c1' },
+    }
+    const replicaModel = computeReplicaSelectionModel(dsSelection, model)
+
+    const result = replicaSelectionToGridSelection(replicaModel, model)
+    expect(result).not.toBeNull()
+    expect(result!.minRow).toBe(2)
+    expect(result!.maxRow).toBe(2)
+    // colIdx 1 → 'c0'
+    expect(result!.columnNames).toEqual(new Set(['c0']))
+  })
+
+  it('correctly maps a multi-row, multi-column selection back to its grid coordinates', () => {
+    const dsSelection: SelectionWithId = {
+      min: { col: 0, row: 1, colId: 'c0' },
+      max: { col: 1, row: 3, colId: 'c1' },
+    }
+    const replicaModel = computeReplicaSelectionModel(dsSelection, model)
+
+    const result = replicaSelectionToGridSelection(replicaModel, model)
+    expect(result).not.toBeNull()
+    expect(result!.minRow).toBe(1)
+    expect(result!.maxRow).toBe(3)
+    // colIdx 0 → '', colIdx 1 → 'c0'
+    expect(result!.columnNames).toEqual(new Set(['', 'c0']))
+  })
+
+  it('derives minRow and maxRow from the minimum and maximum matched row indices', () => {
+    // Select rows 0 and 3 (non-contiguous range from CRDT perspective — the function
+    // returns min/max, not an exact set of rows)
+    const dsSelection: SelectionWithId = {
+      min: { col: 2, row: 0, colId: 'c2' },
+      max: { col: 2, row: 3, colId: 'c2' },
+    }
+    const replicaModel = computeReplicaSelectionModel(dsSelection, model)
+
+    const result = replicaSelectionToGridSelection(replicaModel, model)
+    expect(result).not.toBeNull()
+    expect(result!.minRow).toBe(0)
+    expect(result!.maxRow).toBe(3)
+    // colIdx 2 → 'c1'
+    expect(result!.columnNames).toEqual(new Set(['c1']))
+  })
+
+  it('returns a single-row range for a first-row selection', () => {
+    const dsSelection: SelectionWithId = {
+      min: { col: 0, row: 0, colId: 'c0' },
+      max: { col: 0, row: 0, colId: 'c0' },
+    }
+    const replicaModel = computeReplicaSelectionModel(dsSelection, model)
+
+    const result = replicaSelectionToGridSelection(replicaModel, model)
+    expect(result).not.toBeNull()
+    expect(result!.minRow).toBe(0)
+    expect(result!.maxRow).toBe(0)
+    // colIdx 0 → ''
+    expect(result!.columnNames).toEqual(new Set(['']))
+  })
+})

--- a/packages/synapse-react-client/src/components/DataGrid/utils/replicaSelectionToGridSelection.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/replicaSelectionToGridSelection.test.ts
@@ -35,12 +35,7 @@ describe('replicaSelectionToGridSelection', () => {
   })
 
   it('returns null when selection is undefined', () => {
-    expect(
-      replicaSelectionToGridSelection(
-        undefined as unknown as ReplicaSelectionModel,
-        model,
-      ),
-    ).toBeNull()
+    expect(replicaSelectionToGridSelection(undefined, model)).toBeNull()
   })
 
   it('returns null when the model has no rows', () => {

--- a/packages/synapse-react-client/src/components/DataGrid/utils/replicaSelectionToGridSelection.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/replicaSelectionToGridSelection.ts
@@ -40,7 +40,7 @@ function crdtIdsToIndices(
  * This is the inverse of getCrdtIdsForArrayRange in computeReplicaSelectionModel.
  */
 export function replicaSelectionToGridSelection(
-  selection: ReplicaSelectionModel,
+  selection: ReplicaSelectionModel | null | undefined,
   model: GridModel,
 ): GridSelectionRange | null {
   if (!selection) return null

--- a/packages/synapse-react-client/src/components/DataGrid/utils/replicaSelectionToGridSelection.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/replicaSelectionToGridSelection.ts
@@ -1,0 +1,85 @@
+import type { GridModel, ReplicaSelectionModel, CrdtId } from '../DataGridTypes'
+
+export interface GridSelectionRange {
+  minRow: number
+  maxRow: number
+  /** undefined means all columns are selected */
+  columnNames: Set<string> | undefined
+}
+
+/**
+ * Convert a flat array of CrdtIds to a Set of array indices by walking the
+ * arr node's chunks.
+ */
+function crdtIdsToIndices(
+  arrApi: ReturnType<GridModel['api']['arr']>,
+  ids: CrdtId[],
+): Set<number> {
+  const result = new Set<number>()
+  if (ids.length === 0) return result
+
+  // Build a lookup set for O(1) membership test
+  const lookup = new Set(ids.map(id => `${id.rep}:${id.seq}`))
+
+  let idx = 0
+  for (const chunk of arrApi.node.chunks()) {
+    if (chunk.del) continue
+    for (let offset = 0; offset < chunk.span; offset++) {
+      const key = `${chunk.id.sid}:${chunk.id.time + offset}`
+      if (lookup.has(key)) result.add(idx + offset)
+    }
+    idx += chunk.span
+  }
+  return result
+}
+
+/**
+ * Converts a stored ReplicaSelectionModel (CRDT-stable IDs) back into a
+ * plain grid selection range that can be used for cell class computation.
+ *
+ * This is the inverse of getCrdtIdsForArrayRange in computeReplicaSelectionModel.
+ */
+export function replicaSelectionToGridSelection(
+  selection: ReplicaSelectionModel,
+  model: GridModel,
+): GridSelectionRange | null {
+  if (!selection) return null
+
+  const snapshot = model.api.getSnapshot()
+  const numRows = snapshot.rows.length
+  const numCols = snapshot.columnNames.length
+
+  if (numRows < 1 || numCols < 1) return null
+
+  // ── Row range ────────────────────────────────────────────────────────────
+  let minRow = 0
+  let maxRow = numRows - 1
+
+  if (!selection.rowSelectAll) {
+    const rowIds = selection.rowSelection
+    if (!rowIds || rowIds.length === 0) return null
+
+    const rowIndexSet = crdtIdsToIndices(model.api.arr(['rows']), rowIds)
+    if (rowIndexSet.size === 0) return null
+    minRow = [...rowIndexSet].reduce((a, b) => Math.min(a, b))
+    maxRow = [...rowIndexSet].reduce((a, b) => Math.max(a, b))
+  }
+
+  // ── Column range ─────────────────────────────────────────────────────────
+  let columnNames: Set<string> | undefined = undefined // undefined = all columns
+
+  if (!selection.columnSelectAll) {
+    const colIds = selection.columnSelection
+    if (!colIds || colIds.length === 0) return null
+
+    const colIndexSet = crdtIdsToIndices(model.api.arr(['columnOrder']), colIds)
+    if (colIndexSet.size === 0) return null
+    columnNames = new Set(
+      [...colIndexSet]
+        .map(colIdx => snapshot.columnNames[snapshot.columnOrder[colIdx]])
+        .filter((name): name is string => name !== undefined),
+    )
+  }
+
+  return { minRow, maxRow, columnNames }
+}

--- a/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
+++ b/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
@@ -9,6 +9,10 @@ $color-spinner: #e6c200;
 $color-text-primary: #353a3f; // grey-900
 $color-text-disabled: #71767f; // gray-700
 
+// Remote selection palette (8 colors, semi-transparent tints)
+$remote-selection-colors: #1677ff, #52c41a, #fa8c16, #eb2f96, #13c2c2, #9254de,
+  #f5222d, #faad14;
+
 // Input styles
 .dsg-input {
   font-size: inherit;
@@ -221,5 +225,17 @@ body.col-resizing {
   .dsg-container,
   .dsg-container * {
     cursor: col-resize;
+  }
+}
+
+// ── Remote selection tints ─────────────────────────────────────────────────
+// Cells within another connected replica's selection are tinted with one of
+// 8 stable colors (replicaId % 8).
+@each $color in $remote-selection-colors {
+  $i: index($remote-selection-colors, $color) - 1;
+
+  .dsg-cell.cell-remote-selected--color-#{$i} {
+    background-color: rgba($color, 0.12) !important;
+    box-shadow: inset 0 0 0 1px rgba($color, 0.4);
   }
 }


### PR DESCRIPTION
Tints cells covered by another connected replica's active selection with a semi-transparent color (replicaId % 8 for a stable per-session hue), providing real-time awareness of where other users are working.

- replicaSelectionToGridSelection: converts stored CRDT-stable IDs back to a plain GridSelectionRange (row min/max + optional column set)
- useRemoteSelections: derives RemoteSelection entries from snapshot.selection[replicaId] for all connected non-SERVICE non-local replicas; no extra API calls needed
- getCellClassName / DataGrid / SynapseGrid: thread remoteSelections through so each cell can render cell-remote-selected--color-{i}
- _data-grid-extra.scss: 8-color palette and per-index tint rules