### PR TITLE
SWC-7792

### DIFF
--- a/packages/synapse-react-client/src/components/styled/HoverPopover.module.scss
+++ b/packages/synapse-react-client/src/components/styled/HoverPopover.module.scss
@@ -1,5 +1,6 @@
 .triggerWrapper {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
 }
 
 .paper {

--- a/packages/synapse-react-client/src/components/styled/HoverPopover.tsx
+++ b/packages/synapse-react-client/src/components/styled/HoverPopover.tsx
@@ -120,13 +120,14 @@ export function HoverPopover({
         disableAutoFocus
         disableEnforceFocus
         disableScrollLock
+        sx={{ pointerEvents: 'none' }}
         slotProps={{
           backdrop: { sx: { pointerEvents: 'none' } },
           paper: {
             onMouseEnter: cancelClose,
             onMouseLeave: scheduleClose,
             className: styles.paper,
-            sx: { maxWidth, minWidth },
+            sx: { maxWidth, minWidth, pointerEvents: 'auto' },
           },
         }}
       >


### PR DESCRIPTION
Icon alignment — .triggerWrapper changed from inline-block to inline-flex + align-items: center so the wrapper collapses to the icon's actual height instead of expanding with line-height.

Flicker while hovering trigger — Added sx={{ pointerEvents: 'none' }} to the Modal root (with pointerEvents: auto restored on the paper) so the full-viewport Modal overlay doesn't intercept mouse events from the trigger element beneath it.