### PR TITLE
PORTALS-4158: ADKP Homepage Redesign:  Add new Search place

### DIFF
--- a/apps/portals/adknowledgeportal/src/config/searchConfig.tsx
+++ b/apps/portals/adknowledgeportal/src/config/searchConfig.tsx
@@ -1,11 +1,49 @@
 import { PortalSearchTabConfig } from '@sage-bionetworks/synapse-portal-framework/components/PortalSearch/PortalSearchTabs'
 import { studiesQueryWrapperPlotNavProps } from '@/config/synapseConfigs/studies'
+// import { projectsQueryWrapperPlotNavProps } from '@/config/synapseConfigs/projects'
+// import { publicationsQueryWrapperPlotNavProps } from '@/config/synapseConfigs/publications'
+// import { peopleQueryWrapperPlotNavProps } from '@/config/synapseConfigs/people'
+// import { experimentalToolsQueryWrapperPlotNavProps } from '@/config/synapseConfigs/experimental_tools'
+// import { computationalToolsQueryWrapperPlotNavProps } from '@/config/synapseConfigs/computational_tools'
+// import { targetEnablingResourcesQueryWrapperPlotNavProps } from '@/config/synapseConfigs/target_enabling_resources'
 
 export const searchPageTabs = [
   {
     title: 'Studies',
     path: 'Studies',
   },
+  // {
+  //   title: 'Projects',
+  //   path: 'Projects',
+  // },
+  // {
+  //   title: 'Publications',
+  //   path: 'Publications',
+  // },
+  // {
+  //   title: 'People',
+  //   path: 'People',
+  // },
+  // {
+  //   title: 'Experimental Tools',
+  //   path: 'ExperimentalTools',
+  // },
+  // {
+  //   title: 'Computational Tools',
+  //   path: 'ComputationalTools',
+  // },
+  // {
+  //   title: 'Target Enabling Resources',
+  //   path: 'TargetEnablingResources',
+  // },
 ] as const satisfies PortalSearchTabConfig[]
 
-export const portalSearchPageConfigs = [studiesQueryWrapperPlotNavProps]
+export const portalSearchPageConfigs = [
+  studiesQueryWrapperPlotNavProps,
+  // projectsQueryWrapperPlotNavProps,
+  // publicationsQueryWrapperPlotNavProps,
+  // peopleQueryWrapperPlotNavProps,
+  // experimentalToolsQueryWrapperPlotNavProps,
+  // computationalToolsQueryWrapperPlotNavProps,
+  // targetEnablingResourcesQueryWrapperPlotNavProps,
+]

--- a/apps/portals/adknowledgeportal/src/config/searchConfig.tsx
+++ b/apps/portals/adknowledgeportal/src/config/searchConfig.tsx
@@ -1,49 +1,11 @@
 import { PortalSearchTabConfig } from '@sage-bionetworks/synapse-portal-framework/components/PortalSearch/PortalSearchTabs'
 import { studiesQueryWrapperPlotNavProps } from '@/config/synapseConfigs/studies'
-import { projectsQueryWrapperPlotNavProps } from '@/config/synapseConfigs/projects'
-import { publicationsQueryWrapperPlotNavProps } from '@/config/synapseConfigs/publications'
-import { peopleQueryWrapperPlotNavProps } from '@/config/synapseConfigs/people'
-import { experimentalToolsQueryWrapperPlotNavProps } from '@/config/synapseConfigs/experimental_tools'
-import { computationalToolsQueryWrapperPlotNavProps } from '@/config/synapseConfigs/computational_tools'
-import { targetEnablingResourcesQueryWrapperPlotNavProps } from '@/config/synapseConfigs/target_enabling_resources'
 
 export const searchPageTabs = [
   {
     title: 'Studies',
     path: 'Studies',
   },
-  {
-    title: 'Projects',
-    path: 'Projects',
-  },
-  {
-    title: 'Publications',
-    path: 'Publications',
-  },
-  {
-    title: 'People',
-    path: 'People',
-  },
-  {
-    title: 'Experimental Tools',
-    path: 'ExperimentalTools',
-  },
-  {
-    title: 'Computational Tools',
-    path: 'ComputationalTools',
-  },
-  {
-    title: 'Target Enabling Resources',
-    path: 'TargetEnablingResources',
-  },
 ] as const satisfies PortalSearchTabConfig[]
 
-export const portalSearchPageConfigs = [
-  studiesQueryWrapperPlotNavProps,
-  projectsQueryWrapperPlotNavProps,
-  publicationsQueryWrapperPlotNavProps,
-  peopleQueryWrapperPlotNavProps,
-  experimentalToolsQueryWrapperPlotNavProps,
-  computationalToolsQueryWrapperPlotNavProps,
-  targetEnablingResourcesQueryWrapperPlotNavProps,
-]
+export const portalSearchPageConfigs = [studiesQueryWrapperPlotNavProps]


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/PORTALS-4158

/Search route already exists, just needed some cleanup.

Only studies tables seemed to have FTS enabled:
<img width="1512" height="982" alt="Screenshot 2026-04-15 at 2 22 10 PM" src="https://github.com/user-attachments/assets/24714ecb-6f38-4cac-84eb-f05069ad6029" />



