### PR TITLE
[Challenge Portal] Minor updates to sections in Details Page

### DIFF
--- a/apps/portals/challenges/src/pages/ChallengeDetailsPageTabContent/InstructionsTab.tsx
+++ b/apps/portals/challenges/src/pages/ChallengeDetailsPageTabContent/InstructionsTab.tsx
@@ -13,11 +13,9 @@ function InstructionsTab() {
           ),
         },
         {
-          id: 'Eligibility Rules',
-          title: 'Eligibility Rules',
-          element: (
-            <MarkdownSynapseFromColumnData columnName={'EligibilityRules'} />
-          ),
+          id: 'Eligibility',
+          title: 'Eligibility',
+          element: <MarkdownSynapseFromColumnData columnName={'Eligibility'} />,
         },
         // {
         //   id: 'Conduct Rules',
@@ -27,12 +25,10 @@ function InstructionsTab() {
         //   ),
         // },
         {
-          id: 'Data Conditions For Use',
-          title: 'Data Conditions For Use',
+          id: 'Challenge Rules',
+          title: 'Challenge Rules',
           element: (
-            <MarkdownSynapseFromColumnData
-              columnName={'DataConditionsForUse'}
-            />
+            <MarkdownSynapseFromColumnData columnName={'ChallengeRules'} />
           ),
         },
       ]}

--- a/apps/portals/challenges/src/pages/ChallengeDetailsPageTabContent/InstructionsTab.tsx
+++ b/apps/portals/challenges/src/pages/ChallengeDetailsPageTabContent/InstructionsTab.tsx
@@ -19,13 +19,13 @@ function InstructionsTab() {
             <MarkdownSynapseFromColumnData columnName={'EligibilityRules'} />
           ),
         },
-        {
-          id: 'Conduct Rules',
-          title: 'Conduct Rules',
-          element: (
-            <MarkdownSynapseFromColumnData columnName={'ConductRules'} />
-          ),
-        },
+        // {
+        //   id: 'Conduct Rules',
+        //   title: 'Conduct Rules',
+        //   element: (
+        //     <MarkdownSynapseFromColumnData columnName={'ConductRules'} />
+        //   ),
+        // },
         {
           id: 'Data Conditions For Use',
           title: 'Data Conditions For Use',

--- a/apps/portals/challenges/src/pages/ChallengeDetailsPageTabContent/OverviewTab.tsx
+++ b/apps/portals/challenges/src/pages/ChallengeDetailsPageTabContent/OverviewTab.tsx
@@ -15,11 +15,11 @@ function OverviewTab() {
           title: 'Overview',
           element: <MarkdownSynapseFromColumnData columnName={'id'} />,
         },
-        {
-          id: 'Objective',
-          title: 'Objective',
-          element: <MarkdownSynapseFromColumnData columnName={'Objective'} />,
-        },
+        // {
+        //   id: 'Objective',
+        //   title: 'Objective',
+        //   element: <MarkdownSynapseFromColumnData columnName={'Objective'} />,
+        // },
         {
           id: 'Description',
           title: 'Description',
@@ -55,71 +55,71 @@ function OverviewTab() {
             />
           ),
         },
-        {
-          id: 'Contributors',
-          title: 'Contributors',
-          element: (
-            <DetailsPageContextConsumer columnName={'Contributors'}>
-              {({ value }) => (
-                <CardContainerLogic
-                  sql={`SELECT * FROM ${value}`}
-                  limit={6}
-                  cardConfiguration={{
-                    type: SynapseConstants.MEDIUM_USER_CARD,
-                  }}
-                />
-              )}
-            </DetailsPageContextConsumer>
-          ),
-        },
-        {
-          id: 'ContributorsDescription',
-          element: (
-            <MarkdownSynapseFromColumnData
-              columnName={'ContributorsDescription'}
-            />
-          ),
-        },
-        {
-          id: 'Sponsors',
-          title: 'Sponsors',
-          element: (
-            <DetailsPageContextConsumer columnName={'Sponsors'}>
-              {({ value }) => (
-                <CardContainerLogic
-                  sql={`SELECT * FROM ${value}`}
-                  limit={6}
-                  cardConfiguration={{
-                    type: SynapseConstants.MEDIUM_USER_CARD,
-                  }}
-                />
-              )}
-            </DetailsPageContextConsumer>
-          ),
-        },
-        {
-          id: 'Support',
-          title: 'Support',
-          element: (
-            <DetailsPageContextConsumer columnName={'Support'}>
-              {({ value }) => {
-                // TODO: Generalize sql transform to apply falsy check everywhere
-                if (value) {
-                  return (
-                    <CardContainerLogic
-                      sql={`SELECT * FROM ${value}`}
-                      limit={6}
-                      cardConfiguration={{
-                        type: SynapseConstants.MEDIUM_USER_CARD,
-                      }}
-                    />
-                  )
-                }
-                return <NoContentAvailable />
-              }}
-            </DetailsPageContextConsumer>
-          ),
-        },
+        // {
+        //   id: 'Contributors',
+        //   title: 'Contributors',
+        //   element: (
+        //     <DetailsPageContextConsumer columnName={'Contributors'}>
+        //       {({ value }) => (
+        //         <CardContainerLogic
+        //           sql={`SELECT * FROM ${value}`}
+        //           limit={6}
+        //           cardConfiguration={{
+        //             type: SynapseConstants.MEDIUM_USER_CARD,
+        //           }}
+        //         />
+        //       )}
+        //     </DetailsPageContextConsumer>
+        //   ),
+        // },
+        // {
+        //   id: 'ContributorsDescription',
+        //   element: (
+        //     <MarkdownSynapseFromColumnData
+        //       columnName={'ContributorsDescription'}
+        //     />
+        //   ),
+        // },
+        // {
+        //   id: 'Sponsors',
+        //   title: 'Sponsors',
+        //   element: (
+        //     <DetailsPageContextConsumer columnName={'Sponsors'}>
+        //       {({ value }) => (
+        //         <CardContainerLogic
+        //           sql={`SELECT * FROM ${value}`}
+        //           limit={6}
+        //           cardConfiguration={{
+        //             type: SynapseConstants.MEDIUM_USER_CARD,
+        //           }}
+        //         />
+        //       )}
+        //     </DetailsPageContextConsumer>
+        //   ),
+        // },
+        // {
+        //   id: 'Support',
+        //   title: 'Support',
+        //   element: (
+        //     <DetailsPageContextConsumer columnName={'Support'}>
+        //       {({ value }) => {
+        //         // TODO: Generalize sql transform to apply falsy check everywhere
+        //         if (value) {
+        //           return (
+        //             <CardContainerLogic
+        //               sql={`SELECT * FROM ${value}`}
+        //               limit={6}
+        //               cardConfiguration={{
+        //                 type: SynapseConstants.MEDIUM_USER_CARD,
+        //               }}
+        //             />
+        //           )
+        //         }
+        //         return <NoContentAvailable />
+        //       }}
+        //     </DetailsPageContextConsumer>
+        //   ),
+        // },
         {
           id: 'Participants',
           title: 'Participants',

--- a/apps/portals/challenges/src/pages/ChallengeDetailsPageTabContent/OverviewTab.tsx
+++ b/apps/portals/challenges/src/pages/ChallengeDetailsPageTabContent/OverviewTab.tsx
@@ -3,7 +3,7 @@ import { DetailsPageContent } from '@sage-bionetworks/synapse-portal-framework/c
 import { DetailsPageContextConsumer } from '@sage-bionetworks/synapse-portal-framework/components/DetailsPage/DetailsPageContext'
 import { MarkdownSynapseFromColumnData } from '@sage-bionetworks/synapse-portal-framework/components/DetailsPage/markdown/MarkdownSynapseFromColumnData'
 import CardContainerLogic from 'synapse-react-client/components/CardContainerLogic/index'
-import NoContentAvailable from 'synapse-react-client/components/SynapseTable/NoContentAvailable'
+// import NoContentAvailable from 'synapse-react-client/components/SynapseTable/NoContentAvailable'
 import * as SynapseConstants from 'synapse-react-client/utils/SynapseConstants'
 
 function OverviewTab() {


### PR DESCRIPTION
As we begin launching challenges on the Challenges Portal, I've received a couple feedback from organizers that certain sections seem unnecessary. I've temporarily hidden these sections for now, just in case we need to restore them in the future.

## Changelog
* temporarily hide unused sections based on organizer feedback
* generalize section titles within the Instructions tab
* 

## Preview

**Updated Overview tab**
<img width="942" height="696" alt="Screenshot 2026-04-16 at 09 35 38" src="https://github.com/user-attachments/assets/963eaa08-724a-42f3-9be2-aa39283d1ffd" />

**Updated Instructions tab**
<img width="945" height="680" alt="Screenshot 2026-04-16 at 09 35 46" src="https://github.com/user-attachments/assets/560f75b8-7c5d-4f4d-ac5c-a9734fc5bc41" />
