### PR TITLE
SWC-7803 - Revert task linking behavior

### DIFF
--- a/packages/synapse-react-client/src/features/entity/metadata-task/CLAUDE.md
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/CLAUDE.md
@@ -22,7 +22,8 @@ Data curation task management for Synapse. Enables two user types to collaborate
 - **`hooks/`** — Data fetching and state management
   - `useMetadataTaskTable` — TanStack Table instance with columns and data fetching
   - `useGetOrCreateGridSessionForSource` — Gets or creates a grid session for a task's data source
-  - `useGridSessionForCurationTask` — Higher-level hook combining task data + grid session
+  - `useGridSessionForCurationTask_legacy` — Used by `MetadataTaskTableActionCell` to get or create a grid session owned by the calling user. Does not link the session to the task or check assignee. Deprecated long-term (enables a data-loss scenario when multiple users create parallel sessions) but currently the only path used, since task-linked sessions caused unexpected assignee-gating behavior for users
+  - `useGridSessionForCurationTask` — Task-linked variant that tracks session ownership vs. task assignee. Not currently wired into the UI; retained for when task linking is revisited
 - **`utils/`** — Helper functions
   - `getGridSourceIdForTask` — Determines the entity ID to open for editing
   - `getLatestGridSessionForSource` — Finds the most recent grid session for a data source
@@ -31,11 +32,12 @@ Data curation task management for Synapse. Enables two user types to collaborate
 
 ## Key Pattern: Grid Session Lifecycle
 
-1. User opens a task → `useGridSessionForCurationTask` is called
-2. Hook checks if a grid session exists for this task's data source
-3. If missing → `useGetOrCreateGridSessionForSource` creates one
-4. Grid session ID is used to open the editing context (usually opens SWC)
-5. Subsequent tasks from the same source reuse the grid session
+1. User opens a task → `useGridSessionForCurationTask_legacy` is called
+2. `useGetOrCreateGridSessionForSource` returns an existing session for the data source or creates one owned by the calling user
+3. Grid session ID is used to open the editing context (usually opens SWC)
+4. Subsequent tasks from the same source reuse the grid session
+
+The action cell only gates the **Open Curator** button on READ access to the source entity — no assignee check, no feature-flag branches, no warning dialogs. Task assignee is informational only.
 
 ## Testing
 

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/MetadataTaskTableActionCell.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/MetadataTaskTableActionCell.test.tsx
@@ -5,8 +5,6 @@ import {
   MOCK_CURATION_TASK_ID,
 } from '@/mocks/curation/mockCurationTask'
 import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
-import { useGetFeatureFlag } from '@/synapse-queries/index'
-import { useGetIsPrincipalIdUserOrMemberOfTeam } from '@/synapse-queries/team/useTeamMembers'
 import { getLinkToGridSession } from '@/utils/functions/getSynapseWebClientLink'
 import {
   CurationTask,
@@ -19,18 +17,10 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach } from 'vitest'
-import useGridSessionForCurationTask, {
-  UseGridSessionForCurationTaskResult,
-} from '../hooks/useGridSessionForCurationTask'
 import MetadataTaskTableActionCell, {
-  NO_TASK_ASSIGNEE_WARNING_DIALOG_TITLE,
   OPEN_CURATOR_ERROR_TITLE,
   OPEN_CURATOR_UNAUTHORIZED_ERROR_MESSAGE,
 } from './MetadataTaskTableActionCell'
-
-vi.mock('../hooks/useGridSessionForCurationTask', () => ({
-  default: vi.fn(),
-}))
 
 vi.mock('../hooks/useGridSessionForCurationTask_legacy', () => ({
   default: vi.fn(),
@@ -42,67 +32,16 @@ vi.mock('@/utils/functions/getSynapseWebClientLink', () => ({
 
 vi.mock('@/components/ToastMessage/ToastMessage')
 
-vi.mock('@/synapse-queries/user/useUserBundle', () => ({
-  useGetCurrentUserProfile: vi.fn().mockReturnValue({
-    data: { ownerId: 'user123' },
-  }),
-}))
-
-vi.mock('@/synapse-queries/featureflags/useGetFeatureFlag', () => ({
-  useGetFeatureFlag: vi.fn().mockReturnValue({
-    data: true,
-  }),
-}))
-
-vi.mock('@/synapse-queries/team/useTeamMembers', () => ({
-  useGetIsPrincipalIdUserOrMemberOfTeam: vi.fn().mockReturnValue({
-    data: true,
-  }),
-}))
-
 vi.mock('@/synapse-queries/entity/useEntity', () => ({
   useGetEntityPermissions: vi.fn(),
 }))
 
-vi.mock('@/components/UserOrTeamBadge', () => ({
-  UserOrTeamBadge: ({ principalId }: { principalId: string }) => (
-    <span data-testid="user-or-team-badge" data-principal-id={principalId} />
-  ),
-}))
-
 const mockDisplayToast = vi.mocked(displayToast)
-const mockUseGridSessionForCurationTask = vi.mocked(
-  useGridSessionForCurationTask,
-)
 const mockUseGridSessionForCurationTaskLegacy = vi.mocked(
   useGridSessionForCurationTask_legacy,
 )
 const mockGetLinkToGridSession = vi.mocked(getLinkToGridSession)
-
-const mockUseGetFeatureFlag = vi.mocked(useGetFeatureFlag)
 const mockUseGetEntityPermissions = vi.mocked(useGetEntityPermissions)
-const mockUseGetIsPrincipalIdUserOrMemberOfTeam = vi.mocked(
-  useGetIsPrincipalIdUserOrMemberOfTeam,
-)
-
-type UseGridForTaskMutationResult = UseMutationResult<
-  UseGridSessionForCurationTaskResult,
-  SynapseClientError,
-  TaskBundle
->
-
-const mockUseGridForTaskMutateAsync =
-  vi.fn<UseGridForTaskMutationResult['mutateAsync']>()
-
-const createUseGridForTaskMutationResult = (
-  overrides: Partial<UseGridForTaskMutationResult> = {},
-): UseGridForTaskMutationResult =>
-  ({
-    mutateAsync: mockUseGridForTaskMutateAsync,
-    isPending: false,
-    data: undefined,
-    ...overrides,
-  } as Partial<UseGridForTaskMutationResult> as UseGridForTaskMutationResult)
 
 type UseGridForTaskLegacyMutationResult = UseMutationResult<
   GridSession,
@@ -153,13 +92,6 @@ const renderComponent = (
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockUseGridForTaskMutateAsync.mockResolvedValue({
-    gridSession: { sessionId: 'session-123' },
-    gridSessionOwnerMatchesTaskAssignee: true,
-  })
-  mockUseGridSessionForCurationTask.mockReturnValue(
-    createUseGridForTaskMutationResult(),
-  )
   mockUseGridForTaskLegacyMutateAsync.mockResolvedValue({
     sessionId: 'session-123',
   })
@@ -168,10 +100,6 @@ beforeEach(() => {
     createUseGridForTaskLegacyMutationResult(),
   )
   mockUseGetEntityPermissions.mockReturnValue(createPermissionsQueryResult())
-  mockUseGetFeatureFlag.mockReturnValue(true)
-  mockUseGetIsPrincipalIdUserOrMemberOfTeam.mockReturnValue({
-    data: true,
-  } as any)
   mockGetLinkToGridSession.mockReturnValue('mock-grid-url')
 })
 
@@ -203,55 +131,9 @@ describe('MetadataTaskTableActionCell', () => {
     expect(screen.getByRole('button', { name: /open curator/i })).toBeDisabled()
   })
 
-  it('disables the Open Curator button when user is not assigned', () => {
-    mockUseGetEntityPermissions.mockReturnValue(
-      createPermissionsQueryResult({
-        data: { canView: true } as UserEntityPermissions,
-      }),
-    )
-    mockUseGetIsPrincipalIdUserOrMemberOfTeam.mockReturnValue({
-      data: false,
-    } as any)
-
-    renderComponent({ canEdit: false })
-
-    expect(screen.getByRole('button', { name: /open curator/i })).toBeDisabled()
-  })
-
-  it('enables the Open Curator button when user is not assigned if CURATOR_DISABLE_OPEN_FOR_UNASSIGNED_TASKS is false', () => {
-    mockUseGetFeatureFlag.mockReturnValue(false)
-    mockUseGetEntityPermissions.mockReturnValue(
-      createPermissionsQueryResult({
-        data: { canView: true } as UserEntityPermissions,
-      }),
-    )
-    mockUseGetIsPrincipalIdUserOrMemberOfTeam.mockReturnValue({
-      data: false,
-    } as any)
-
-    renderComponent({ canEdit: false })
-
-    expect(screen.getByRole('button', { name: /open curator/i })).toBeEnabled()
-  })
-
-  it('enables the Open Curator button when canEdit=false but user is assigned to task', () => {
-    mockUseGetEntityPermissions.mockReturnValue(
-      createPermissionsQueryResult({
-        data: { canView: true } as UserEntityPermissions,
-      }),
-    )
-    mockUseGetIsPrincipalIdUserOrMemberOfTeam.mockReturnValue({
-      data: true,
-    } as any)
-
-    renderComponent({ canEdit: false })
-
-    expect(screen.getByRole('button', { name: /open curator/i })).toBeEnabled()
-  })
-
   it('disables the Open Curator button while opening the grid session', () => {
-    mockUseGridSessionForCurationTask.mockReturnValue(
-      createUseGridForTaskMutationResult({ isPending: true }),
+    mockUseGridSessionForCurationTaskLegacy.mockReturnValue(
+      createUseGridForTaskLegacyMutationResult({ isPending: true }),
     )
 
     renderComponent()
@@ -270,8 +152,9 @@ describe('MetadataTaskTableActionCell', () => {
     await userEvent.click(screen.getByRole('button', { name: /open curator/i }))
 
     await waitFor(() => {
-      expect(mockUseGridForTaskMutateAsync).toHaveBeenCalledWith(mockTaskBundle)
-      expect(mockUseGridForTaskLegacyMutateAsync).not.toHaveBeenCalled()
+      expect(mockUseGridForTaskLegacyMutateAsync).toHaveBeenCalledWith({
+        curationTask: mockTaskBundle.task,
+      })
       expect(mockGetLinkToGridSession).toHaveBeenCalledWith(
         'session-123',
         MOCK_CURATION_TASK_ID,
@@ -291,7 +174,9 @@ describe('MetadataTaskTableActionCell', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => {})
     const errorMessage = 'Failed to open grid session'
-    mockUseGridForTaskMutateAsync.mockRejectedValue(new Error(errorMessage))
+    mockUseGridForTaskLegacyMutateAsync.mockRejectedValue(
+      new Error(errorMessage),
+    )
 
     renderComponent()
 
@@ -314,206 +199,37 @@ describe('MetadataTaskTableActionCell', () => {
     consoleErrorSpy.mockRestore()
   })
 
-  describe('no-assignee warning', () => {
-    beforeEach(() => {
-      // This flow is only supported when CURATOR_DISABLE_OPEN_FOR_UNASSIGNED_TASKS is false
-      mockUseGetFeatureFlag.mockReturnValue(false)
-    })
-    const taskBundleWithNoAssignee: TaskBundle = {
-      ...mockTaskBundle,
-      task: { ...mockTaskBundle.task!, assigneePrincipalId: undefined },
-    }
+  it('shows an unauthorized error toast when the user has no access to the session', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    mockUseGridForTaskLegacyMutateAsync.mockRejectedValue(
+      new SynapseClientError(
+        403,
+        'Forbidden',
+        expect.getState().currentTestName!,
+      ),
+    )
+    const windowOpenSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue(null as unknown as Window)
 
-    it('shows a warning dialog when task has no assignee', async () => {
-      renderComponent({ taskBundle: taskBundleWithNoAssignee })
+    renderComponent()
 
-      await userEvent.click(
-        screen.getByRole('button', { name: /open curator/i }),
-      )
+    await userEvent.click(screen.getByRole('button', { name: /open curator/i }))
 
-      await screen.findByRole('heading', {
-        name: NO_TASK_ASSIGNEE_WARNING_DIALOG_TITLE,
-      })
-      expect(mockUseGridForTaskLegacyMutateAsync).not.toHaveBeenCalled()
-      expect(mockUseGridForTaskMutateAsync).not.toHaveBeenCalled()
-    })
-
-    it('cancelling the no-assignee dialog closes it without opening a session', async () => {
-      renderComponent({ taskBundle: taskBundleWithNoAssignee })
-
-      await userEvent.click(
-        screen.getByRole('button', { name: /open curator/i }),
-      )
-      await screen.findByRole('heading', {
-        name: NO_TASK_ASSIGNEE_WARNING_DIALOG_TITLE,
-      })
-
-      await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
-
-      await waitFor(() =>
-        expect(
-          screen.queryByRole('heading', {
-            name: NO_TASK_ASSIGNEE_WARNING_DIALOG_TITLE,
-          }),
-        ).not.toBeInTheDocument(),
-      )
-      expect(mockUseGridForTaskLegacyMutateAsync).not.toHaveBeenCalled()
-      expect(mockUseGridForTaskMutateAsync).not.toHaveBeenCalled()
-    })
-
-    it('confirming the no-assignee dialog proceeds to open the session', async () => {
-      const windowOpenSpy = vi
-        .spyOn(window, 'open')
-        .mockReturnValue(null as unknown as Window)
-
-      renderComponent({ taskBundle: taskBundleWithNoAssignee })
-
-      await userEvent.click(
-        screen.getByRole('button', { name: /open curator/i }),
-      )
-      await screen.findByRole('heading', {
-        name: NO_TASK_ASSIGNEE_WARNING_DIALOG_TITLE,
-      })
-
-      await userEvent.click(screen.getByRole('button', { name: /proceed/i }))
-
-      await waitFor(() => {
-        expect(mockUseGridForTaskLegacyMutateAsync).toHaveBeenCalled()
-        expect(mockUseGridForTaskMutateAsync).not.toHaveBeenCalled()
-        expect(windowOpenSpy).toHaveBeenCalled()
-      })
-
-      windowOpenSpy.mockRestore()
-    })
-  })
-
-  describe('session access control', () => {
-    it('shows an error toast and does not open window when user has no access to session', async () => {
-      mockUseGridForTaskMutateAsync.mockRejectedValue(
-        new SynapseClientError(
-          403,
-          'Forbidden',
-          expect.getState().currentTestName!,
-        ),
-      )
-      const windowOpenSpy = vi
-        .spyOn(window, 'open')
-        .mockReturnValue(null as unknown as Window)
-
-      renderComponent()
-
-      await userEvent.click(
-        screen.getByRole('button', { name: /open curator/i }),
-      )
-
-      await waitFor(() => {
-        expect(mockDisplayToast).toHaveBeenCalledWith(
-          expect.stringContaining(OPEN_CURATOR_UNAUTHORIZED_ERROR_MESSAGE),
-          'danger',
-          {
-            title: OPEN_CURATOR_ERROR_TITLE,
-          },
-        )
-        expect(windowOpenSpy).not.toHaveBeenCalled()
-      })
-
-      windowOpenSpy.mockRestore()
-    })
-
-    it('shows assignee-mismatch dialog when session owner differs from assignee', async () => {
-      const sessionData: UseGridSessionForCurationTaskResult = {
-        gridSession: {
-          sessionId: 'session-123',
-          ownerPrincipalId: 'ownerPrincipal',
+    await waitFor(() => {
+      expect(mockDisplayToast).toHaveBeenCalledWith(
+        expect.stringContaining(OPEN_CURATOR_UNAUTHORIZED_ERROR_MESSAGE),
+        'danger',
+        {
+          title: OPEN_CURATOR_ERROR_TITLE,
         },
-        gridSessionOwnerMatchesTaskAssignee: false,
-      }
-      mockUseGridForTaskMutateAsync.mockResolvedValue(sessionData)
-      mockUseGridSessionForCurationTask.mockReturnValue(
-        createUseGridForTaskMutationResult({ data: sessionData }),
-      )
-
-      renderComponent()
-
-      await userEvent.click(
-        screen.getByRole('button', { name: /open curator/i }),
-      )
-
-      await screen.findByText(/task assignee changed/i)
-    })
-
-    it('cancelling the assignee-mismatch dialog closes it without opening a window', async () => {
-      const sessionData: UseGridSessionForCurationTaskResult = {
-        gridSession: {
-          sessionId: 'session-123',
-          ownerPrincipalId: 'ownerPrincipal',
-        },
-        gridSessionOwnerMatchesTaskAssignee: false,
-      }
-      mockUseGridForTaskMutateAsync.mockResolvedValue(sessionData)
-      mockUseGridSessionForCurationTask.mockReturnValue(
-        createUseGridForTaskMutationResult({ data: sessionData }),
-      )
-      const windowOpenSpy = vi
-        .spyOn(window, 'open')
-        .mockReturnValue(null as unknown as Window)
-
-      renderComponent()
-
-      await userEvent.click(
-        screen.getByRole('button', { name: /open curator/i }),
-      )
-      await screen.findByText(/task assignee changed/i)
-
-      await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
-
-      await waitFor(() =>
-        expect(
-          screen.queryByText(/task assignee changed/i),
-        ).not.toBeInTheDocument(),
       )
       expect(windowOpenSpy).not.toHaveBeenCalled()
-
-      windowOpenSpy.mockRestore()
     })
 
-    it('confirming the assignee-mismatch dialog opens the session', async () => {
-      const sessionData: UseGridSessionForCurationTaskResult = {
-        gridSession: {
-          sessionId: 'session-123',
-          ownerPrincipalId: 'ownerPrincipal',
-        },
-        gridSessionOwnerMatchesTaskAssignee: false,
-      }
-      mockUseGridForTaskMutateAsync.mockResolvedValue(sessionData)
-      mockUseGridSessionForCurationTask.mockReturnValue(
-        createUseGridForTaskMutationResult({ data: sessionData }),
-      )
-      mockGetLinkToGridSession.mockReturnValue('https://example.org/grid')
-      const windowOpenSpy = vi
-        .spyOn(window, 'open')
-        .mockReturnValue(null as unknown as Window)
-
-      renderComponent()
-
-      await userEvent.click(
-        screen.getByRole('button', { name: /open curator/i }),
-      )
-      await screen.findByText(/task assignee changed/i)
-
-      await userEvent.click(
-        screen.getByRole('button', { name: /open curator/i }),
-      )
-
-      await waitFor(() => {
-        expect(windowOpenSpy).toHaveBeenCalledWith(
-          'https://example.org/grid',
-          '_blank',
-          'noopener',
-        )
-      })
-
-      windowOpenSpy.mockRestore()
-    })
+    consoleErrorSpy.mockRestore()
+    windowOpenSpy.mockRestore()
   })
 })

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/MetadataTaskTableActionCell.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/MetadataTaskTableActionCell.tsx
@@ -1,26 +1,16 @@
-import { ConfirmationDialog } from '@/components/ConfirmationDialog'
 import { displayToast } from '@/components/ToastMessage/ToastMessage'
-import { UserOrTeamBadge } from '@/components/UserOrTeamBadge'
 import useGridSessionForCurationTask_legacy from '@/features/entity/metadata-task/hooks/useGridSessionForCurationTask_legacy'
-import {
-  useGetCurrentUserProfile,
-  useGetFeatureFlag,
-  useGetIsPrincipalIdUserOrMemberOfTeam,
-} from '@/synapse-queries'
 import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
 import { getLinkToGridSession } from '@/utils/functions/getSynapseWebClientLink'
 import { StickyNote2Outlined } from '@mui/icons-material'
-import { Button, Tooltip, Typography } from '@mui/material'
+import { Button, Tooltip } from '@mui/material'
 import {
   GridSession,
   SynapseClientError,
   TaskBundle,
 } from '@sage-bionetworks/synapse-client'
-import { FeatureFlagEnum } from '@sage-bionetworks/synapse-types'
-import { useCallback, useState } from 'react'
-import useGridSessionForCurationTask from '../hooks/useGridSessionForCurationTask'
+import { useCallback } from 'react'
 import { getGridSourceIdForTask } from '../utils/getGridSourceIdForTask'
-import taskHasAssignee from '../utils/taskHasAssignee'
 
 export const OPEN_CURATOR_ERROR_TITLE =
   'An error occurred while trying to open Curator'
@@ -43,44 +33,13 @@ export default function MetadataTaskTableActionCell(props: {
   taskBundle: TaskBundle
   canEdit: boolean
 }) {
-  const { taskBundle, canEdit } = props
+  const { taskBundle } = props
   const curationTask = taskBundle.task!
-
-  // If false, allows opening a grid session for an unassigned task, even if it can lead to data loss,
-  // because blocking this behavior prevents important use cases such as data contributors creating a
-  // grid session before a task is assigned
-  const disableLegacyUnassignedTaskBehavior = useGetFeatureFlag(
-    FeatureFlagEnum.CURATOR_DISABLE_OPEN_FOR_UNASSIGNED_TASKS,
-  )
-
-  const [showOpenWithNoAssigneeWarning, setShowOpenWithNoAssigneeWarning] =
-    useState(false)
-  const [
-    showGridSessionAssigneeMismatchDialog,
-    setShowGridSessionAssigneeMismatchDialog,
-  ] = useState(false)
-
-  const { data: currentUser } = useGetCurrentUserProfile()
-
-  const { data: isUserAssignedToTask } = useGetIsPrincipalIdUserOrMemberOfTeam(
-    currentUser?.ownerId!,
-    curationTask.assigneePrincipalId!,
-    { enabled: !!currentUser?.ownerId && !!curationTask.assigneePrincipalId },
-  )
-
-  const {
-    data: gridSessionInfoForCurationTask,
-    mutateAsync: getGridSessionForTask,
-    isPending: getOrCreateGridSessionIsPending,
-  } = useGridSessionForCurationTask()
 
   const {
     mutateAsync: getOrCreateLegacyGridSessionForUnassignedTask,
-    isPending: getOrCreateLegacyGridSessionIsPending,
+    isPending: openGridIsPending,
   } = useGridSessionForCurationTask_legacy()
-
-  const openGridIsPending =
-    getOrCreateGridSessionIsPending || getOrCreateLegacyGridSessionIsPending
 
   const gridSourceEntityId = getGridSourceIdForTask(curationTask)
   const {
@@ -89,174 +48,47 @@ export default function MetadataTaskTableActionCell(props: {
   } = useGetEntityPermissions(gridSourceEntityId)
 
   const isLoading = isLoadingEntityPermissions
-  const hasAssignee = taskHasAssignee(curationTask)
-  const isAssignedToTask = canEdit || isUserAssignedToTask || !hasAssignee
 
-  const hasPermission =
-    sourceEntityPermissions?.canView &&
-    (isAssignedToTask || !disableLegacyUnassignedTaskBehavior)
+  const hasPermission = sourceEntityPermissions?.canView
 
   const isOpenDataGridDisabled =
     openGridIsPending || isLoading || !hasPermission
   const toolTipTitle = hasPermission
     ? 'Open Curator to edit metadata'
-    : !isAssignedToTask && disableLegacyUnassignedTaskBehavior
-    ? 'You must be assigned to this task to open it'
     : sourceEntityPermissions?.canView
     ? 'You must have READ access to ' +
       gridSourceEntityId +
       ' to view the Working Copy'
     : 'You do not have permission to view the Working Copy'
 
-  const openNewOrExistingCuratorSession = useCallback(
-    async (
-      /**
-       * If unassigned, use legacy grid session retrieval behavior where grid sessions are not linked to the task
-       * This can lead to data loss because different users create multiple grid sessions that overwrite each other
-       */
-      legacyIgnoreLinkedGridSession = false,
-    ) => {
-      let gridSession: GridSession
-      try {
-        if (
-          legacyIgnoreLinkedGridSession &&
-          !disableLegacyUnassignedTaskBehavior
-        ) {
-          gridSession = await getOrCreateLegacyGridSessionForUnassignedTask({
-            curationTask,
-          })
-        } else {
-          const getSessionResult = await getGridSessionForTask(taskBundle)
-          gridSession = getSessionResult.gridSession
-
-          if (!getSessionResult.gridSessionOwnerMatchesTaskAssignee) {
-            // The user has access, but the assignee does not match the grid session owner.
-            // Show a warning before allowing the user to proceed.
-            setShowGridSessionAssigneeMismatchDialog(true)
-            return
-          }
-        }
-        openGridSessionInNewWindow(gridSession.sessionId!, curationTask.taskId!)
-      } catch (error) {
-        if (error instanceof SynapseClientError && error.status === 403) {
-          console.error(error)
-          displayToast(OPEN_CURATOR_UNAUTHORIZED_ERROR_MESSAGE, 'danger', {
-            title: OPEN_CURATOR_ERROR_TITLE,
-          })
-        } else {
-          console.error('Error opening Curator for curation task', error)
-          displayToast(error.message, 'danger', {
-            title: OPEN_CURATOR_ERROR_TITLE,
-          })
-        }
+  const openNewOrExistingCuratorSession = useCallback(async () => {
+    let gridSession: GridSession
+    try {
+      gridSession = await getOrCreateLegacyGridSessionForUnassignedTask({
+        curationTask,
+      })
+      openGridSessionInNewWindow(gridSession.sessionId!, curationTask.taskId!)
+    } catch (error) {
+      if (error instanceof SynapseClientError && error.status === 403) {
+        console.error(error)
+        displayToast(OPEN_CURATOR_UNAUTHORIZED_ERROR_MESSAGE, 'danger', {
+          title: OPEN_CURATOR_ERROR_TITLE,
+        })
+      } else {
+        console.error('Error opening Curator for curation task', error)
+        displayToast(error.message, 'danger', {
+          title: OPEN_CURATOR_ERROR_TITLE,
+        })
       }
-    },
-    [
-      curationTask,
-      getGridSessionForTask,
-      getOrCreateLegacyGridSessionForUnassignedTask,
-      taskBundle,
-    ],
-  )
+    }
+  }, [curationTask, getOrCreateLegacyGridSessionForUnassignedTask])
 
   const handleClickOpenCurator = useCallback(() => {
-    if (!hasAssignee) {
-      setShowOpenWithNoAssigneeWarning(true)
-    } else {
-      void openNewOrExistingCuratorSession()
-    }
-  }, [openNewOrExistingCuratorSession, hasAssignee])
-
-  // Dialog to warn a user before opening a curation task without an assignee. Intended to discourage creating
-  // grid sessions for unassigned tasks without completely blocking data contributors from doing so
-  const openWithNoAssigneeWarningDialog = (
-    <ConfirmationDialog
-      open={showOpenWithNoAssigneeWarning}
-      title={NO_TASK_ASSIGNEE_WARNING_DIALOG_TITLE}
-      content={
-        <>
-          <Typography variant="body1" gutterBottom>
-            This task is currently unassigned. A Curator session created using
-            an unassigned task will be private to your account. If the task is
-            assigned later, a new Curator session will be created and you may be
-            unable to recover any unsaved changes.
-          </Typography>
-          <Typography variant="body1">
-            Do you want to proceed and open Curator using this unassigned task?
-          </Typography>
-        </>
-      }
-      confirmButtonProps={{ children: 'Proceed' }}
-      onConfirm={() => {
-        // If unassigned, use legacy grid session retrieval behavior where grid sessions are not linked to the task
-        // This can lead to data loss because different users create multiple grid sessions that overwrite each other
-        void openNewOrExistingCuratorSession(true)
-        setShowOpenWithNoAssigneeWarning(false)
-      }}
-      onCancel={() => {
-        setShowOpenWithNoAssigneeWarning(false)
-      }}
-    />
-  )
-
-  const assigneeMismatchWarningDialog = (
-    <ConfirmationDialog
-      open={showGridSessionAssigneeMismatchDialog}
-      title={'Task assignee changed'}
-      content={
-        <>
-          <p>
-            The existing Curator session for the task was created with a
-            different owner{' '}
-            <span style={{ whiteSpace: 'nowrap' }}>
-              (
-              {gridSessionInfoForCurationTask?.gridSession.ownerPrincipalId && (
-                <UserOrTeamBadge
-                  principalId={
-                    gridSessionInfoForCurationTask.gridSession.ownerPrincipalId
-                  }
-                />
-              )}
-              )
-            </span>{' '}
-            than the current assignee{' '}
-            <span style={{ whiteSpace: 'nowrap' }}>
-              (
-              {curationTask.assigneePrincipalId ? (
-                <UserOrTeamBadge
-                  principalId={curationTask.assigneePrincipalId}
-                />
-              ) : (
-                'None'
-              )}
-              )
-            </span>
-            . Collaborators may not have access to this session.
-          </p>
-          <p>Are you sure you want to open Curator?</p>
-        </>
-      }
-      confirmButtonProps={{ children: 'Open Curator' }}
-      onConfirm={() => {
-        if (gridSessionInfoForCurationTask?.gridSession) {
-          openGridSessionInNewWindow(
-            gridSessionInfoForCurationTask.gridSession.sessionId!,
-            curationTask.taskId!,
-          )
-
-          setShowGridSessionAssigneeMismatchDialog(false)
-        }
-      }}
-      onCancel={() => {
-        setShowGridSessionAssigneeMismatchDialog(false)
-      }}
-    />
-  )
+    void openNewOrExistingCuratorSession()
+  }, [openNewOrExistingCuratorSession])
 
   return (
     <>
-      {openWithNoAssigneeWarningDialog}
-      {assigneeMismatchWarningDialog}
       <Tooltip title={toolTipTitle}>
         <span>
           <Button


### PR DESCRIPTION
 'Open Curator' always opens a current user-owned session for the task's source (legacy behavior)