### PR TITLE
PORTALS-4144

### DIFF
--- a/packages/synapse-client/src/util/synapseClientFetch.test.ts
+++ b/packages/synapse-client/src/util/synapseClientFetch.test.ts
@@ -5,6 +5,10 @@ import {
 } from './synapseClientFetch'
 import { SynapseClientError } from './SynapseClientError'
 
+// 1000ms delay plus 0-100ms jitter
+const DELAY_PLUS_MAX_JITTER = 1000 + 100
+const DELAY_CAP = 10_000 // 10s
+
 describe('synapseClientFetch', () => {
   let mockFetch = vi.spyOn(global, 'fetch')
 
@@ -57,7 +61,7 @@ describe('synapseClientFetch', () => {
 
     // Only one attempt should be made for non-retryable errors
     expect(mockFetch).toHaveBeenCalledTimes(1)
-    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER)
     expect(mockFetch).toHaveBeenCalledTimes(1)
 
     await expect(promise).rejects.toEqual(
@@ -97,15 +101,15 @@ describe('synapseClientFetch', () => {
 
     // 5 backoff errors followed by 1 success
     expect(mockFetch).toHaveBeenCalledTimes(1)
-    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER)
     expect(mockFetch).toHaveBeenCalledTimes(2)
-    await vi.advanceTimersByTimeAsync(2_000)
+    await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER * 2)
     expect(mockFetch).toHaveBeenCalledTimes(3)
-    await vi.advanceTimersByTimeAsync(4_000)
+    await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER * 4)
     expect(mockFetch).toHaveBeenCalledTimes(4)
-    await vi.advanceTimersByTimeAsync(8_000)
+    await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER * 8)
     expect(mockFetch).toHaveBeenCalledTimes(5)
-    await vi.advanceTimersByTimeAsync(10_000)
+    await vi.advanceTimersByTimeAsync(DELAY_CAP)
     expect(mockFetch).toHaveBeenCalledTimes(6)
     await expect(responsePromise).resolves.toEqual({ success: true })
   })
@@ -133,9 +137,9 @@ describe('synapseClientFetch', () => {
 
       // Maximum 3 attempts
       expect(mockFetch).toHaveBeenCalledTimes(1)
-      await vi.advanceTimersByTimeAsync(1_000)
+      await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER)
       expect(mockFetch).toHaveBeenCalledTimes(2)
-      await vi.advanceTimersByTimeAsync(2_000)
+      await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER * 2)
       expect(mockFetch).toHaveBeenCalledTimes(3)
 
       await expect(promise).rejects.toEqual(
@@ -146,17 +150,75 @@ describe('synapseClientFetch', () => {
     },
   )
 
-  it('should throw on network errors', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('Network Error'))
-
-    await expect(() =>
-      synapseClientFetch('/test-url', {
-        method: 'GET',
-      }),
-    ).rejects.toEqual(
-      new SynapseClientError(0, NETWORK_UNAVAILABLE_MESSAGE, '/test-url'),
+  it('should retry on network errors and succeed if a retry succeeds', async () => {
+    const mockSuccessResponse = new Response(
+      JSON.stringify({ success: true }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
     )
 
+    mockFetch
+      .mockRejectedValueOnce(new Error('Network Error'))
+      .mockResolvedValueOnce(mockSuccessResponse)
+
+    const responsePromise = synapseClientFetch('/test-url', { method: 'GET' })
+
     expect(mockFetch).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+
+    await expect(responsePromise).resolves.toEqual({ success: true })
+  })
+
+  it('should retry a limited number of times then throw on network errors', async () => {
+    mockFetch.mockRejectedValue(new Error('Network Error'))
+
+    const promise = synapseClientFetch('/test-url', { method: 'GET' })
+
+    promise.catch(() => {
+      // Error will be tested after timers are fired
+    })
+
+    // Maximum 3 attempts (SERVER_ERROR_MAX_RETRY = 3)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER * 2)
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+
+    await expect(promise).rejects.toEqual(
+      new SynapseClientError(0, NETWORK_UNAVAILABLE_MESSAGE, '/test-url'),
+    )
+  })
+
+  it('should share the transient error counter between server errors and network errors', async () => {
+    const mock502Response = new Response(
+      JSON.stringify({ reason: 'Bad Gateway' }),
+      { status: 502, headers: { 'Content-Type': 'application/json' } },
+    )
+
+    // 1 server error + 2 network errors = 3 transient errors total, no more retries
+    mockFetch
+      .mockResolvedValueOnce(mock502Response)
+      .mockRejectedValueOnce(new Error('Network Error'))
+      .mockRejectedValue(new Error('Network Error'))
+
+    const promise = synapseClientFetch('/test-url', { method: 'GET' })
+
+    promise.catch(() => {
+      // Error will be tested after timers are fired
+    })
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(DELAY_PLUS_MAX_JITTER * 2)
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+
+    await expect(promise).rejects.toEqual(
+      new SynapseClientError(0, NETWORK_UNAVAILABLE_MESSAGE, '/test-url'),
+    )
   })
 })

--- a/packages/synapse-client/src/util/synapseClientFetch.ts
+++ b/packages/synapse-client/src/util/synapseClientFetch.ts
@@ -7,6 +7,10 @@ const RATE_LIMIT_MAX_RETRY = 10
 const SERVER_ERROR_MAX_RETRY = 3
 export const SERVER_ERROR_RETRY_CODES = [502, 503, 504]
 
+function getRandomInt(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min) + min)
+}
+
 /**
  * Fetches data, retrying if the HTTP status code indicates that it could be retried.
  * To use it in our generated client, this function must NOT consume the response body.
@@ -16,14 +20,26 @@ export const SERVER_ERROR_RETRY_CODES = [502, 503, 504]
 export async function synapseFetchWithRetry(
   requestInfo: RequestInfo,
   options: RequestInit,
-  delayMs = 1000,
+  delayMs = 1000 + getRandomInt(0, 100),
 ): Promise<Response> {
   let rateLimitRetryCount = 0
-  let serverErrorRetryCount = 0
+  let transientErrorRetryCount = 0
 
   return promiseWithRetry(
     async () => {
-      const response = await fetch(requestInfo, options)
+      let response: Response
+      try {
+        response = await fetch(requestInfo, options)
+      } catch (err) {
+        transientErrorRetryCount++
+        if (transientErrorRetryCount < SERVER_ERROR_MAX_RETRY) {
+          throw new RetryError(
+            err instanceof Error ? err.message : 'Network error',
+            err,
+          )
+        }
+        throw err
+      }
 
       if (response.status === 429) {
         rateLimitRetryCount++
@@ -31,8 +47,8 @@ export async function synapseFetchWithRetry(
           throw new RetryError(`HTTP ${response.status}`, response)
         }
       } else if (SERVER_ERROR_RETRY_CODES.includes(response.status)) {
-        serverErrorRetryCount++
-        if (serverErrorRetryCount < SERVER_ERROR_MAX_RETRY) {
+        transientErrorRetryCount++
+        if (transientErrorRetryCount < SERVER_ERROR_MAX_RETRY) {
           throw new RetryError(`HTTP ${response.status}`, response)
         }
       }
@@ -54,12 +70,11 @@ export async function synapseFetchWithRetry(
 export const synapseClientFetch = async <TResponse>(
   requestInfo: RequestInfo,
   options: RequestInit,
-  delayMs = 1000,
 ): Promise<TResponse> => {
   const url = typeof requestInfo === 'string' ? requestInfo : requestInfo.url
   let response
   try {
-    response = await synapseFetchWithRetry(requestInfo, options, delayMs)
+    response = await synapseFetchWithRetry(requestInfo, options)
   } catch (err) {
     console.error(err)
     throw new SynapseClientError(0, NETWORK_UNAVAILABLE_MESSAGE, url)


### PR DESCRIPTION
- Retry transient network errors
- Add jitter to retry delay

Not sure if this is fixes the cause of the problem, but if the issue is that we are saturating the available connections in the container, this will hopefully alleviate the issue.