### PR TITLE
SWC-7601: ACL editor should handle multiple resource access objects with the same principals

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementAclEditor/AccessRequirementAclEditor.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementAclEditor/AccessRequirementAclEditor.tsx
@@ -9,12 +9,14 @@ import { PermissionLevel } from '@/utils/PermissionLevelToAccessType'
 import { Alert, Box, Stack, Typography } from '@mui/material'
 import { SynapseClientError } from '@sage-bionetworks/synapse-client/util/SynapseClientError'
 import { ACCESS_TYPE, AccessControlList } from '@sage-bionetworks/synapse-types'
+import { consolidateResourceAccessList } from '@/utils/functions/AccessControlListUtils'
 import { isEqual } from 'lodash-es'
 import {
   ForwardedRef,
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useState,
 } from 'react'
 import { AclEditor } from '../AclEditor/AclEditor'
@@ -70,6 +72,11 @@ export const AccessRequirementAclEditor = forwardRef(
         staleTime: Infinity,
       })
 
+    const originalResourceAccess = useMemo(
+      () => consolidateResourceAccessList(originalAcl?.resourceAccess ?? []),
+      [originalAcl],
+    )
+
     const {
       resourceAccessList,
       setResourceAccessList,
@@ -86,9 +93,14 @@ export const AccessRequirementAclEditor = forwardRef(
     useEffect(() => {
       if (originalAcl) {
         resetDirtyState()
-        setResourceAccessList(originalAcl.resourceAccess)
+        setResourceAccessList(originalResourceAccess)
       }
-    }, [originalAcl, setResourceAccessList])
+    }, [
+      originalAcl,
+      originalResourceAccess,
+      resetDirtyState,
+      setResourceAccessList,
+    ])
 
     const { mutate: deleteAcl } = useDeleteAccessRequirementACL({
       onSuccess: () => onMutationSuccess(),
@@ -121,7 +133,7 @@ export const AccessRequirementAclEditor = forwardRef(
             const aclIsUnchanged =
               (originalAcl === null && updatedAcl == null) ||
               // ignore properties that will change when the ACL is saved (etag, modifiedOn)
-              (isEqual(originalAcl?.resourceAccess, resourceAccessList) &&
+              (isEqual(originalResourceAccess, resourceAccessList) &&
                 originalAcl?.id === updatedAcl?.id)
 
             if (aclIsUnchanged) {

--- a/packages/synapse-react-client/src/components/AccessRequirementAclEditor/AccessRequirementAclEditor.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementAclEditor/AccessRequirementAclEditor.tsx
@@ -72,7 +72,7 @@ export const AccessRequirementAclEditor = forwardRef(
         staleTime: Infinity,
       })
 
-    const originalResourceAccess = useMemo(
+    const consolidatedOriginalResourceAccess = useMemo(
       () => consolidateResourceAccessList(originalAcl?.resourceAccess ?? []),
       [originalAcl],
     )
@@ -93,11 +93,11 @@ export const AccessRequirementAclEditor = forwardRef(
     useEffect(() => {
       if (originalAcl) {
         resetDirtyState()
-        setResourceAccessList(originalResourceAccess)
+        setResourceAccessList(consolidatedOriginalResourceAccess)
       }
     }, [
       originalAcl,
-      originalResourceAccess,
+      consolidatedOriginalResourceAccess,
       resetDirtyState,
       setResourceAccessList,
     ])
@@ -133,7 +133,10 @@ export const AccessRequirementAclEditor = forwardRef(
             const aclIsUnchanged =
               (originalAcl === null && updatedAcl == null) ||
               // ignore properties that will change when the ACL is saved (etag, modifiedOn)
-              (isEqual(originalResourceAccess, resourceAccessList) &&
+              (isEqual(
+                consolidatedOriginalResourceAccess,
+                resourceAccessList,
+              ) &&
                 originalAcl?.id === updatedAcl?.id)
 
             if (aclIsUnchanged) {

--- a/packages/synapse-react-client/src/components/EntityAclEditor/EntityAclEditor.stories.tsx
+++ b/packages/synapse-react-client/src/components/EntityAclEditor/EntityAclEditor.stories.tsx
@@ -11,6 +11,11 @@ import { Meta, StoryObj } from '@storybook/react-vite'
 import EntityAclEditorModal, {
   EntityAclEditorModalProps,
 } from './EntityAclEditorModal'
+import { ACCESS_TYPE } from '@sage-bionetworks/synapse-types'
+import { MOCK_USER_ID } from '@/mocks/user/mock_user_profile'
+import { getEntityBundleHandler } from '@/mocks/msw/handlers/entityHandlers'
+import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
+import { getHandlers } from '@/mocks/msw/handlers'
 
 const meta: Meta<EntityAclEditorModalProps> = {
   title: 'Synapse/Entity ACL Editor',
@@ -31,6 +36,43 @@ export const Project: Story = {
   },
 }
 
+export const DuplicatePrincipal: Story = {
+  args: {
+    entityId: mockProject.id,
+  },
+  parameters: {
+    stack: 'mock',
+    msw: {
+      handlers: [
+        getEntityBundleHandler(MOCK_REPO_ORIGIN, {
+          ...mockProject.bundle,
+          benefactorAcl: {
+            id: mockProject.id,
+            etag: 'test-etag',
+            resourceAccess: [
+              {
+                principalId: MOCK_USER_ID,
+                accessType: [
+                  ACCESS_TYPE.READ,
+                  ACCESS_TYPE.DOWNLOAD,
+                  ACCESS_TYPE.CREATE,
+                  ACCESS_TYPE.UPDATE,
+                  ACCESS_TYPE.DELETE,
+                  ACCESS_TYPE.CHANGE_PERMISSIONS,
+                  ACCESS_TYPE.CHANGE_SETTINGS,
+                  ACCESS_TYPE.MODERATE,
+                ],
+              },
+
+              { principalId: MOCK_USER_ID, accessType: [ACCESS_TYPE.READ] },
+            ],
+          },
+        }),
+        ...getHandlers(MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
+}
 export const ReadOnly: Story = {
   args: {
     entityId: mockFileEntityCurrentUserCannotEdit.id,

--- a/packages/synapse-react-client/src/components/EntityAclEditor/EntityAclEditor.stories.tsx
+++ b/packages/synapse-react-client/src/components/EntityAclEditor/EntityAclEditor.stories.tsx
@@ -48,7 +48,6 @@ export const DuplicatePrincipal: Story = {
           ...mockProject.bundle,
           benefactorAcl: {
             id: mockProject.id,
-            etag: 'test-etag',
             resourceAccess: [
               {
                 principalId: MOCK_USER_ID,

--- a/packages/synapse-react-client/src/components/EntityAclEditor/EntityAclEditor.tsx
+++ b/packages/synapse-react-client/src/components/EntityAclEditor/EntityAclEditor.tsx
@@ -178,7 +178,7 @@ const EntityAclEditor = forwardRef(function EntityAclEditor(
     },
   )
 
-  const originalResourceAccess = useMemo(
+  const consolidatedOriginalResourceAccess = useMemo(
     () =>
       consolidateResourceAccessList(entityBundle.benefactorAcl.resourceAccess),
     [entityBundle.benefactorAcl.resourceAccess],
@@ -203,15 +203,21 @@ const EntityAclEditor = forwardRef(function EntityAclEditor(
     updateResourceAccessItem,
     removeResourceAccessItem,
     resetDirtyState,
-  } = useUpdateAcl({ initialResourceAccessList: originalResourceAccess })
+  } = useUpdateAcl({
+    initialResourceAccessList: consolidatedOriginalResourceAccess,
+  })
 
-  // If `originalResourceAccess` changes, reset state
+  // If `consolidatedOriginalResourceAccess` changes, reset state
   useEffect(() => {
-    if (originalResourceAccess) {
+    if (consolidatedOriginalResourceAccess) {
       resetDirtyState()
-      setResourceAccessList([...originalResourceAccess])
+      setResourceAccessList([...consolidatedOriginalResourceAccess])
     }
-  }, [originalResourceAccess, resetDirtyState, setResourceAccessList])
+  }, [
+    consolidatedOriginalResourceAccess,
+    resetDirtyState,
+    setResourceAccessList,
+  ])
 
   // If `originalIsInherited` changes, reset state
   useEffect(() => {
@@ -223,7 +229,7 @@ const EntityAclEditor = forwardRef(function EntityAclEditor(
   useEffect(() => {
     if (originalIsInherited == updatedIsInherited) {
       // The user reverted to the original state (regardless of inherited or not)
-      setResourceAccessList(originalResourceAccess)
+      setResourceAccessList(consolidatedOriginalResourceAccess)
     } else if (updatedIsInherited) {
       // The user toggled to inherited, update the resource access list to match the parent
       setResourceAccessList(parentResourceAccess)
@@ -233,7 +239,7 @@ const EntityAclEditor = forwardRef(function EntityAclEditor(
     resetDirtyState()
   }, [
     originalIsInherited,
-    originalResourceAccess,
+    consolidatedOriginalResourceAccess,
     parentResourceAccess,
     resetDirtyState,
     setResourceAccessList,
@@ -252,7 +258,7 @@ const EntityAclEditor = forwardRef(function EntityAclEditor(
   } = useNotifyNewACLUsers({
     subject: getSubject(entityBundle.entity.name || ''),
     body: getBody(ownProfile, entityId),
-    initialResourceAccessList: originalResourceAccess,
+    initialResourceAccessList: consolidatedOriginalResourceAccess,
     newResourceAccessList: updatedResourceAccessList,
   })
 
@@ -285,12 +291,12 @@ const EntityAclEditor = forwardRef(function EntityAclEditor(
     return (
       originalIsInherited != updatedIsInherited ||
       !resourceAccessListIsEqual(
-        originalResourceAccess,
+        consolidatedOriginalResourceAccess,
         updatedResourceAccessList,
       )
     )
   }, [
-    originalResourceAccess,
+    consolidatedOriginalResourceAccess,
     originalIsInherited,
     updatedIsInherited,
     updatedResourceAccessList,

--- a/packages/synapse-react-client/src/components/EntityAclEditor/EntityAclEditor.tsx
+++ b/packages/synapse-react-client/src/components/EntityAclEditor/EntityAclEditor.tsx
@@ -9,6 +9,7 @@ import {
 import { useGetRealmPrincipals } from '@/synapse-queries/realm/useRealmPrincipals'
 import { BackendDestinationEnum, getEndpoint } from '@/utils/functions'
 import {
+  consolidateResourceAccessList,
   isEntityPublic,
   resourceAccessListIsEqual,
 } from '@/utils/functions/AccessControlListUtils'
@@ -177,7 +178,12 @@ const EntityAclEditor = forwardRef(function EntityAclEditor(
     },
   )
 
-  const originalResourceAccess = entityBundle.benefactorAcl.resourceAccess
+  const originalResourceAccess = useMemo(
+    () =>
+      consolidateResourceAccessList(entityBundle.benefactorAcl.resourceAccess),
+    [entityBundle.benefactorAcl.resourceAccess],
+  )
+
   const parentResourceAccess = useMemo(
     () => parentAcl?.resourceAccess ?? [],
     [parentAcl],

--- a/packages/synapse-react-client/src/components/OAuthClientAclEditor/OAuthClientAclEditor.tsx
+++ b/packages/synapse-react-client/src/components/OAuthClientAclEditor/OAuthClientAclEditor.tsx
@@ -63,7 +63,7 @@ export const OAuthClientAclEditor = forwardRef(function OAuthClientAclEditor(
       staleTime: Infinity,
     })
 
-  const originalResourceAccess = useMemo(
+  const consolidatedOriginalResourceAccess = useMemo(
     () =>
       consolidateResourceAccessList(
         convertResourceAccessSetToSRC(originalAcl?.resourceAccess),
@@ -87,11 +87,11 @@ export const OAuthClientAclEditor = forwardRef(function OAuthClientAclEditor(
   useEffect(() => {
     if (originalAcl) {
       resetDirtyState()
-      setResourceAccessList(originalResourceAccess)
+      setResourceAccessList(consolidatedOriginalResourceAccess)
     }
   }, [
     originalAcl,
-    originalResourceAccess,
+    consolidatedOriginalResourceAccess,
     resetDirtyState,
     setResourceAccessList,
   ])
@@ -111,7 +111,7 @@ export const OAuthClientAclEditor = forwardRef(function OAuthClientAclEditor(
           const aclIsUnchanged =
             (originalAcl === null && updatedAcl == null) ||
             // ignore properties that will change when the ACL is saved (etag, modifiedOn)
-            (isEqual(originalResourceAccess, resourceAccessList) &&
+            (isEqual(consolidatedOriginalResourceAccess, resourceAccessList) &&
               originalAcl?.id === updatedAcl?.id)
 
           if (aclIsUnchanged) {
@@ -126,7 +126,7 @@ export const OAuthClientAclEditor = forwardRef(function OAuthClientAclEditor(
     [
       clientId,
       originalAcl,
-      originalResourceAccess,
+      consolidatedOriginalResourceAccess,
       resourceAccessList,
       onSaveComplete,
       updateAcl,

--- a/packages/synapse-react-client/src/components/OAuthClientAclEditor/OAuthClientAclEditor.tsx
+++ b/packages/synapse-react-client/src/components/OAuthClientAclEditor/OAuthClientAclEditor.tsx
@@ -8,21 +8,23 @@ import {
 } from '@/utils/PermissionLevelToAccessType'
 import { Alert, Stack } from '@mui/material'
 import { SynapseClientError } from '@sage-bionetworks/synapse-client/util/SynapseClientError'
+import {
+  consolidateResourceAccessList,
+  convertResourceAccessSetToSRC,
+  updateACLWithSRCResourceAccessList,
+} from '@/utils/functions/AccessControlListUtils'
 import { isEqual } from 'lodash-es'
 import {
   ForwardedRef,
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useState,
 } from 'react'
 import { AclEditor } from '../AclEditor/AclEditor'
 import useUpdateAcl from '../AclEditor/useUpdateAcl'
 import { AccessControlList } from '@sage-bionetworks/synapse-client'
-import {
-  convertResourceAccessSetToSRC,
-  updateACLWithSRCResourceAccessList,
-} from '@/utils/functions/AccessControlListUtils'
 
 const availablePermissionLevels: PermissionLevel[] = [
   'CAN_ADMINISTER_OAUTH_CLIENT',
@@ -61,6 +63,14 @@ export const OAuthClientAclEditor = forwardRef(function OAuthClientAclEditor(
       staleTime: Infinity,
     })
 
+  const originalResourceAccess = useMemo(
+    () =>
+      consolidateResourceAccessList(
+        convertResourceAccessSetToSRC(originalAcl?.resourceAccess),
+      ),
+    [originalAcl],
+  )
+
   const {
     resourceAccessList,
     setResourceAccessList,
@@ -77,11 +87,14 @@ export const OAuthClientAclEditor = forwardRef(function OAuthClientAclEditor(
   useEffect(() => {
     if (originalAcl) {
       resetDirtyState()
-      setResourceAccessList(
-        convertResourceAccessSetToSRC(originalAcl.resourceAccess),
-      )
+      setResourceAccessList(originalResourceAccess)
     }
-  }, [originalAcl, setResourceAccessList])
+  }, [
+    originalAcl,
+    originalResourceAccess,
+    resetDirtyState,
+    setResourceAccessList,
+  ])
 
   const { mutate: updateAcl } = useUpdateOAuthClientACL({
     onSuccess: () => onMutationSuccess(),
@@ -98,7 +111,7 @@ export const OAuthClientAclEditor = forwardRef(function OAuthClientAclEditor(
           const aclIsUnchanged =
             (originalAcl === null && updatedAcl == null) ||
             // ignore properties that will change when the ACL is saved (etag, modifiedOn)
-            (isEqual(originalAcl?.resourceAccess, resourceAccessList) &&
+            (isEqual(originalResourceAccess, resourceAccessList) &&
               originalAcl?.id === updatedAcl?.id)
 
           if (aclIsUnchanged) {
@@ -110,7 +123,14 @@ export const OAuthClientAclEditor = forwardRef(function OAuthClientAclEditor(
         },
       }
     },
-    [clientId, originalAcl, resourceAccessList, onSaveComplete, updateAcl],
+    [
+      clientId,
+      originalAcl,
+      originalResourceAccess,
+      resourceAccessList,
+      onSaveComplete,
+      updateAcl,
+    ],
   )
 
   return (

--- a/packages/synapse-react-client/src/components/PortalAclEditor/PortalAclEditor.tsx
+++ b/packages/synapse-react-client/src/components/PortalAclEditor/PortalAclEditor.tsx
@@ -5,21 +5,23 @@ import {
 } from '@/utils/PermissionLevelToAccessType'
 import { Alert, Stack } from '@mui/material'
 import { SynapseClientError } from '@sage-bionetworks/synapse-client/util/SynapseClientError'
+import {
+  consolidateResourceAccessList,
+  convertResourceAccessSetToSRC,
+  updateACLWithSRCResourceAccessList,
+} from '@/utils/functions/AccessControlListUtils'
 import { isEqual } from 'lodash-es'
 import {
   ForwardedRef,
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useState,
 } from 'react'
 import { AclEditor } from '../AclEditor/AclEditor'
 import useUpdateAcl from '../AclEditor/useUpdateAcl'
 import { AccessControlList } from '@sage-bionetworks/synapse-client'
-import {
-  convertResourceAccessSetToSRC,
-  updateACLWithSRCResourceAccessList,
-} from '@/utils/functions/AccessControlListUtils'
 
 const availablePermissionLevels: PermissionLevel[] = ['CAN_ADMINISTER_PORTAL']
 
@@ -56,6 +58,14 @@ export const PortalAclEditor = forwardRef(function PortalAclEditor(
       staleTime: Infinity,
     })
 
+  const originalResourceAccess = useMemo(
+    () =>
+      consolidateResourceAccessList(
+        convertResourceAccessSetToSRC(originalAcl?.resourceAccess),
+      ),
+    [originalAcl],
+  )
+
   const {
     resourceAccessList,
     setResourceAccessList,
@@ -72,11 +82,14 @@ export const PortalAclEditor = forwardRef(function PortalAclEditor(
   useEffect(() => {
     if (originalAcl) {
       resetDirtyState()
-      setResourceAccessList(
-        convertResourceAccessSetToSRC(originalAcl.resourceAccess),
-      )
+      setResourceAccessList(originalResourceAccess)
     }
-  }, [originalAcl, setResourceAccessList, resetDirtyState])
+  }, [
+    originalAcl,
+    originalResourceAccess,
+    resetDirtyState,
+    setResourceAccessList,
+  ])
 
   const { mutate: updateAcl } = useUpdatePortalACL({
     onSuccess: () => onMutationSuccess(),
@@ -93,7 +106,7 @@ export const PortalAclEditor = forwardRef(function PortalAclEditor(
           const aclIsUnchanged =
             (originalAcl === null && updatedAcl == null) ||
             // ignore properties that will change when the ACL is saved (etag, modifiedOn)
-            (isEqual(originalAcl?.resourceAccess, resourceAccessList) &&
+            (isEqual(originalResourceAccess, resourceAccessList) &&
               originalAcl?.id === updatedAcl?.id)
 
           if (aclIsUnchanged) {
@@ -105,7 +118,14 @@ export const PortalAclEditor = forwardRef(function PortalAclEditor(
         },
       }
     },
-    [portalId, originalAcl, resourceAccessList, onSaveComplete, updateAcl],
+    [
+      portalId,
+      originalAcl,
+      originalResourceAccess,
+      resourceAccessList,
+      onSaveComplete,
+      updateAcl,
+    ],
   )
 
   return (

--- a/packages/synapse-react-client/src/components/PortalAclEditor/PortalAclEditor.tsx
+++ b/packages/synapse-react-client/src/components/PortalAclEditor/PortalAclEditor.tsx
@@ -58,7 +58,7 @@ export const PortalAclEditor = forwardRef(function PortalAclEditor(
       staleTime: Infinity,
     })
 
-  const originalResourceAccess = useMemo(
+  const consolidatedOriginalResourceAccess = useMemo(
     () =>
       consolidateResourceAccessList(
         convertResourceAccessSetToSRC(originalAcl?.resourceAccess),
@@ -82,11 +82,11 @@ export const PortalAclEditor = forwardRef(function PortalAclEditor(
   useEffect(() => {
     if (originalAcl) {
       resetDirtyState()
-      setResourceAccessList(originalResourceAccess)
+      setResourceAccessList(consolidatedOriginalResourceAccess)
     }
   }, [
     originalAcl,
-    originalResourceAccess,
+    consolidatedOriginalResourceAccess,
     resetDirtyState,
     setResourceAccessList,
   ])
@@ -106,7 +106,7 @@ export const PortalAclEditor = forwardRef(function PortalAclEditor(
           const aclIsUnchanged =
             (originalAcl === null && updatedAcl == null) ||
             // ignore properties that will change when the ACL is saved (etag, modifiedOn)
-            (isEqual(originalResourceAccess, resourceAccessList) &&
+            (isEqual(consolidatedOriginalResourceAccess, resourceAccessList) &&
               originalAcl?.id === updatedAcl?.id)
 
           if (aclIsUnchanged) {
@@ -121,7 +121,7 @@ export const PortalAclEditor = forwardRef(function PortalAclEditor(
     [
       portalId,
       originalAcl,
-      originalResourceAccess,
+      consolidatedOriginalResourceAccess,
       resourceAccessList,
       onSaveComplete,
       updateAcl,

--- a/packages/synapse-react-client/src/utils/functions/AccessControlListUtils.test.ts
+++ b/packages/synapse-react-client/src/utils/functions/AccessControlListUtils.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@/mocks/realm/mockRealmPrincipal'
 import { ACCESS_TYPE, ResourceAccess } from '@sage-bionetworks/synapse-types'
 import {
+  consolidateResourceAccessList,
   isEntityPublic,
   resourceAccessListIsEqual,
 } from './AccessControlListUtils'
@@ -259,6 +260,49 @@ describe('AccessControlListUtils', () => {
       })
 
       expect(result).toBe(false)
+    })
+  })
+
+  describe('consolidateResourceAccessList', () => {
+    it('returns the same number of entries when there are no duplicates', () => {
+      const list: ResourceAccess[] = [
+        { principalId: 1, accessType: [ACCESS_TYPE.READ] },
+        { principalId: 2, accessType: [ACCESS_TYPE.DOWNLOAD] },
+      ]
+
+      expect(consolidateResourceAccessList(list)).toHaveLength(2)
+    })
+
+    it('unions accessType arrays for duplicate principalId entries', () => {
+      const list: ResourceAccess[] = [
+        {
+          principalId: 1,
+          accessType: [ACCESS_TYPE.READ, ACCESS_TYPE.DOWNLOAD],
+        },
+        {
+          principalId: 1,
+          accessType: [ACCESS_TYPE.UPDATE, ACCESS_TYPE.DELETE],
+        },
+        { principalId: 2, accessType: [ACCESS_TYPE.READ] },
+      ]
+
+      const result = consolidateResourceAccessList(list)
+      expect(result).toHaveLength(2)
+
+      const entry = result.find(item => item.principalId === 1)
+      expect(entry?.accessType).toHaveLength(4)
+      expect(entry?.accessType).toEqual(
+        expect.arrayContaining([
+          ACCESS_TYPE.READ,
+          ACCESS_TYPE.DOWNLOAD,
+          ACCESS_TYPE.UPDATE,
+          ACCESS_TYPE.DELETE,
+        ]),
+      )
+    })
+
+    it('returns an empty list for empty input', () => {
+      expect(consolidateResourceAccessList([])).toEqual([])
     })
   })
 })

--- a/packages/synapse-react-client/src/utils/functions/AccessControlListUtils.test.ts
+++ b/packages/synapse-react-client/src/utils/functions/AccessControlListUtils.test.ts
@@ -299,6 +299,10 @@ describe('AccessControlListUtils', () => {
           ACCESS_TYPE.DELETE,
         ]),
       )
+
+      // Verify that the non-duplicate entry is unchanged
+      const entry2 = result.find(item => item.principalId === 2)
+      expect(entry2?.accessType).toEqual([ACCESS_TYPE.READ])
     })
 
     it('returns an empty list for empty input', () => {

--- a/packages/synapse-react-client/src/utils/functions/AccessControlListUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/AccessControlListUtils.ts
@@ -87,3 +87,26 @@ export function isEntityPublic(
     publicPrincipalIds.includes(String(ra.principalId)),
   )
 }
+
+/**
+ * Consolidate access types for duplicate entries for the same principal into a single entry with the union of all access types.
+ */
+export function consolidateResourceAccessList(
+  list: ResourceAccess[],
+): ResourceAccess[] {
+  const permissionsMap = new Map<number, Set<ACCESS_TYPE>>()
+  for (const item of list) {
+    const permissions = permissionsMap.get(item.principalId)
+
+    if (permissions) {
+      item.accessType.forEach(type => permissions.add(type))
+    } else {
+      permissionsMap.set(item.principalId, new Set(item.accessType))
+    }
+  }
+
+  return Array.from(permissionsMap, ([principalId, accessTypeSet]) => ({
+    principalId,
+    accessType: Array.from(accessTypeSet),
+  }))
+}


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/issues?jql=project%20IN%20(SWC%2C%20PORTALS)%20AND%20status%20%3D%20%22Ready%20for%20Team%22%20AND%20assignee%20%3D%20empty%20ORDER%20BY%20created%20DESC&selectedIssue=SWC-7601

Issue: Backend can return multiple resourceAccess entries with the same principalId but different access types but only the last entry would be used, meaning users could be shown the wrong permission level.

Create a utility function that unions accessType arrays for entries sharing the same principalId.

Before:
<img width="2992" height="1669" alt="image" src="https://github.com/user-attachments/assets/0aa54b3f-465b-46a6-a546-8f26f0e053d9" />

After:
<img width="1512" height="982" alt="Screenshot 2026-04-24 at 2 31 35 PM" src="https://github.com/user-attachments/assets/1fc1b9ac-a498-4206-9c67-d58a44a5ab0c" />



