### PR TITLE
[Challenge Portal] Add more labels to the challenge cards

### DIFF
--- a/apps/portals/challenges/src/config/synapseConfig/allChallenges.ts
+++ b/apps/portals/challenges/src/config/synapseConfig/allChallenges.ts
@@ -9,11 +9,11 @@ import { allChallengesSql } from '../resources'
 const allChallengesSchema: TableToGenericCardMapping = {
   type: SynapseConstants.CHALLENGE,
   title: 'title',
-  subTitle: 'organizingCommunity',
+  subTitle: 'platform',
   description: 'description',
   secondaryLabels: [
     'metadataCompletenessTier',
-    'platform',
+    'organizingCommunity',
     'keywords',
     'incentive',
     'inputDataType',

--- a/apps/portals/challenges/src/config/synapseConfig/allChallenges.ts
+++ b/apps/portals/challenges/src/config/synapseConfig/allChallenges.ts
@@ -16,8 +16,14 @@ const allChallengesSchema: TableToGenericCardMapping = {
     'platform',
     'keywords',
     'incentive',
-    'submissionType',
     'inputDataType',
+    'dataFormat',
+    'evaluationMetric',
+    'submissionType',
+    'dataAccessType',
+    'dataLicense',
+    'submissionLicense',
+    'contactEmail',
   ],
   titleAreaDetails: (schema, data) => {
     const status = data[schema['status']]


### PR DESCRIPTION
Currently, our challenge cards highlight a "Metadata Completeness Tier" but there's not enough context on the cards to justify the score. This is especially confusing when comparing challenges with similar missingness, for example:

<img width="1422" height="1114" alt="Screenshot 2026-04-24 at 15 43 22" src="https://github.com/user-attachments/assets/5ee4b681-c563-478a-9439-54981a3b260f" />

To fix this, I propose showing more metadata fields on the card to justify the tier rating:

<img width="1149" height="1270" alt="Screenshot 2026-04-24 at 15 35 35" src="https://github.com/user-attachments/assets/8bf8186d-d811-4244-b0fd-ac13fa216723" />


---

I have also reordered the labels so that the "journey" of the labels goes from "does this challenge matter/relate to me?" -> "Can I do this challenge?" -> "the fine print"