### PR TITLE
PORTALS-4197: filter empty arrays and single empty values in arrays, …

### DIFF
--- a/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
@@ -843,6 +843,7 @@ describe('TableRowGenericCard tests', () => {
 
       await screen.findByTestId('CardFooter')
       expect(screen.queryByText('[""]')).not.toBeInTheDocument()
+      expect(screen.queryByText(MOCKED_LABELONE)).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
@@ -140,7 +140,7 @@ const MOCKED_SUBTITLE = 'MOCKED SUBTITLE'
 const MOCKED_DESCRIPTION = 'MOCKED DESCRIPTION'
 const MOCKED_ICON = 'dataset'
 const MOCKED_LABELONE = 'MOCKED_LABELONE'
-const MOCKED_LABELTWO = 'MOCKED_LABELONE'
+const MOCKED_LABELTWO = 'MOCKED_LABELTWO'
 const MOCKED_LINK = 'MOCKED_LINK'
 const MOCKED_ID = 'MOCKED_ID'
 const MOCKED_IMAGE_FILE_HANDLE_ID = 'MOCKED_IMAGE_FILE_HANDLE_ID'
@@ -779,6 +779,70 @@ describe('TableRowGenericCard tests', () => {
       await screen.findByTestId('CardFooter')
       expect(screen.queryByText('Label One:')).not.toBeInTheDocument()
       expect(screen.getByText('Label Two:')).toBeVisible()
+    })
+  })
+
+  describe('secondary label empty-array filtering', () => {
+    test('does not render a secondary label when the value is undefined', async () => {
+      const dataWithUndefined = [...data]
+      dataWithUndefined[schema[labelOneColumnName]] =
+        undefined as unknown as string
+
+      renderComponent(
+        {
+          ...propsForNonHeaderMode,
+          genericCardSchema: {
+            ...genericCardSchema,
+            secondaryLabels: [labelOneColumnName, 'labelTwo'],
+          },
+          data: dataWithUndefined,
+        },
+        'TableEntity',
+      )
+
+      // Wait for card to render (labelTwo is present)
+      await screen.findByText(MOCKED_LABELTWO)
+      expect(screen.queryByText(MOCKED_LABELONE)).not.toBeInTheDocument()
+    })
+
+    test('does not render a secondary label when the value is an empty JSON array ("[]")', async () => {
+      const dataWithEmptyArray = [...data]
+      dataWithEmptyArray[schema[labelOneColumnName]] = '[]'
+
+      renderComponent(
+        {
+          ...propsForNonHeaderMode,
+          genericCardSchema: {
+            ...genericCardSchema,
+            secondaryLabels: [labelOneColumnName, 'labelTwo'],
+          },
+          data: dataWithEmptyArray,
+        },
+        'TableEntity',
+      )
+
+      await screen.findByTestId('CardFooter')
+      expect(screen.queryByText('[]')).not.toBeInTheDocument()
+    })
+
+    test('does not render a secondary label when the value is a JSON array containing a single empty string (\'[""]\')', async () => {
+      const dataWithEmptyStringArray = [...data]
+      dataWithEmptyStringArray[schema[labelOneColumnName]] = '[""]'
+
+      renderComponent(
+        {
+          ...propsForNonHeaderMode,
+          genericCardSchema: {
+            ...genericCardSchema,
+            secondaryLabels: [labelOneColumnName, 'labelTwo'],
+          },
+          data: dataWithEmptyStringArray,
+        },
+        'TableEntity',
+      )
+
+      await screen.findByTestId('CardFooter')
+      expect(screen.queryByText('[""]')).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
@@ -823,6 +823,7 @@ describe('TableRowGenericCard tests', () => {
 
       await screen.findByTestId('CardFooter')
       expect(screen.queryByText('[]')).not.toBeInTheDocument()
+      expect(screen.queryByText(MOCKED_LABELONE)).not.toBeInTheDocument()
     })
 
     test('does not render a secondary label when the value is a JSON array containing a single empty string (\'[""]\')', async () => {

--- a/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.tsx
@@ -429,7 +429,7 @@ export function TableRowGenericCard(props: TableRowGenericCardProps) {
     const rawValue: string | undefined = data[schema[columnName]]
     let renderedValue: React.ReactNode = rawValue
     let columnDisplayName
-    if (renderedValue) {
+    if (renderedValue && rawValue !== '[]' && rawValue !== '[""]') {
       // PORTALS-2750: special rendering of the datasetSizeInBytes (for Dataset Collections)
       if (
         isDatasetCollection(table as Entity) &&


### PR DESCRIPTION
…as we do for non _LIST column type values

Before:
<img width="1054" height="632" alt="Screenshot 2026-04-27 at 9 01 09 AM" src="https://github.com/user-attachments/assets/22d07b5d-4910-4d89-bf42-a26a983cc474" />

After:
<img width="1038" height="531" alt="Screenshot 2026-04-27 at 9 01 18 AM" src="https://github.com/user-attachments/assets/22c32b2d-1af3-46d1-a7ac-d0570251e722" />
