### PR TITLE
SWC-7770: Curator grid validation message enhancements

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/DataGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/DataGrid.tsx
@@ -36,10 +36,6 @@ type DataGridProps = {
   lastSelection: SelectionWithId | null
   handleChange: (newValue: DataGridRow[], operations: Operation[]) => void
   handleSelectionChange: (opts: { selection: SelectionWithId | null }) => void
-  onSelectedRowChange?: (
-    rowIndex: number | null,
-    row: DataGridRow | null,
-  ) => void
   remoteSelections?: readonly RemoteSelection[]
 }
 
@@ -60,7 +56,6 @@ export default function DataGrid(props: DataGridProps) {
     lastSelection,
     handleChange,
     handleSelectionChange,
-    onSelectedRowChange,
     remoteSelections,
   } = props
 
@@ -212,15 +207,9 @@ export default function DataGrid(props: DataGridProps) {
   // Wrap onActiveCellChange in useCallback
   const handleActiveCellChange = useCallback(
     ({ cell }: { cell: { row: number; col: number } | null }) => {
-      if (cell) {
-        setSelectedRowIndex(cell.row)
-        onSelectedRowChange?.(cell.row, rowValues[cell.row])
-      } else {
-        setSelectedRowIndex(null)
-        onSelectedRowChange?.(null, null)
-      }
+      setSelectedRowIndex(cell ? cell.row : null)
     },
-    [onSelectedRowChange, rowValues],
+    [],
   )
 
   // Wrapper ref for the grid container

--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -324,18 +324,9 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
       [applyAndCommitChanges, model, replicaId],
     )
 
-    // Track selected row index for validation display
-    const selectedRowIndexRef = useRef<number | null>(null)
-    const [, forceUpdate] = useState({})
-
-    const handleSelectedRowChange = useCallback(
-      (rowIndex: number | null, _row: DataGridRow | null) => {
-        // Only update when a real row is selected — don't clear on blur/click-away
-        // so the ValidationAlert stays open while the user interacts with it.
-        if (rowIndex !== null) {
-          selectedRowIndexRef.current = rowIndex
-          forceUpdate({})
-        }
+    const handleNavigateToCell = useCallback(
+      (rowIndex: number, colIndex: number) => {
+        gridRef.current?.setActiveCell({ col: colIndex, row: rowIndex })
       },
       [],
     )
@@ -453,6 +444,14 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
               {hasSufficientData && (
                 <>
                   <Grid size={12}>
+                    <ValidationAlert
+                      rowValues={rowValues}
+                      columnNames={modelSnapshot?.columnNames ?? []}
+                      columnOrder={modelSnapshot?.columnOrder ?? []}
+                      onNavigateToCell={handleNavigateToCell}
+                    />
+                  </Grid>
+                  <Grid size={12}>
                     <Stack
                       direction={'row'}
                       spacing={1}
@@ -509,14 +508,7 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
                       lastSelection={lastSelection}
                       handleChange={handleChange}
                       handleSelectionChange={handleSelectionChange}
-                      onSelectedRowChange={handleSelectedRowChange}
                       remoteSelections={remoteSelections}
-                    />
-                  </Grid>
-                  <Grid size={12}>
-                    <ValidationAlert
-                      selectedRowIndex={selectedRowIndexRef.current}
-                      rowValues={rowValues}
                     />
                   </Grid>
                 </>

--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -455,7 +455,7 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
                       columnNames={modelSnapshot?.columnNames ?? []}
                       columnOrder={modelSnapshot?.columnOrder ?? []}
                       onNavigateToCell={handleNavigateToCell}
-                      isSyncing={!hasCompletedInitialSync}
+                      isLoading={!hasCompletedInitialSync}
                     />
                   </Grid>
                   <Grid size={12}>

--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -9,7 +9,13 @@ import { SkeletonTable } from '@/components/index'
 import { useGetEntity } from '@/synapse-queries/index'
 import { getSchemaPropertiesInfo } from '@/utils/jsonschema/getSchemaPropertyInfo'
 import { SmartToyTwoTone } from '@mui/icons-material'
-import { Stack, Tooltip } from '@mui/material'
+import {
+  Box,
+  CircularProgress,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material'
 import Grid from '@mui/material/Grid'
 import {
   CreateGridRequest,
@@ -449,6 +455,7 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
                       columnNames={modelSnapshot?.columnNames ?? []}
                       columnOrder={modelSnapshot?.columnOrder ?? []}
                       onNavigateToCell={handleNavigateToCell}
+                      isSyncing={!hasCompletedInitialSync}
                     />
                   </Grid>
                   <Grid size={12}>
@@ -457,6 +464,21 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
                       spacing={1}
                       sx={{ justifyContent: 'flex-end' }}
                     >
+                      {!hasCompletedInitialSync && (
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1,
+                            mr: 'auto',
+                          }}
+                        >
+                          <CircularProgress size={16} />
+                          <Typography variant="caption" color="text.secondary">
+                            Syncing…
+                          </Typography>
+                        </Box>
+                      )}
                       {undoUI}
                       {redoUI}
                       <GridMenuButton

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
@@ -37,10 +37,10 @@ describe('ValidationAlert', () => {
     expect(screen.getByText('No validation errors')).toBeInTheDocument()
   })
 
-  it('shows syncing message when isSyncing is true', () => {
+  it('shows syncing message when isLoading is true', () => {
     const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
     render(
-      <ValidationAlert {...defaultProps} rowValues={rowValues} isSyncing />,
+      <ValidationAlert {...defaultProps} rowValues={rowValues} isLoading />,
     )
     expect(screen.getByText('Syncing validation errors…')).toBeInTheDocument()
     expect(screen.queryByText('Validation errors')).not.toBeInTheDocument()

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
@@ -16,6 +16,13 @@ function makeInvalidRow(cellErrors: Record<string, string[]>): DataGridRow {
   } as unknown as DataGridRow
 }
 
+function makePendingRow(cellErrors: Record<string, string[]>): DataGridRow {
+  return {
+    __validationStatus: 'pending',
+    __cellValidationResults: new Map(Object.entries(cellErrors)),
+  } as unknown as DataGridRow
+}
+
 describe('ValidationAlert', () => {
   it('shows a no-errors message when there are no invalid rows', () => {
     const rowValues: DataGridRow[] = [
@@ -253,19 +260,40 @@ describe('ValidationAlert', () => {
     expect(screen.getByText('3')).toBeInTheDocument()
   })
 
-  it('ignores rows with valid or pending status', () => {
-    const cellMap = new Map([['platform', ['cannot be empty']]])
+  it('ignores rows with valid status', () => {
     const rowValues: DataGridRow[] = [
       {
         __validationStatus: 'valid',
-        __cellValidationResults: cellMap,
-      } as unknown as DataGridRow,
-      {
-        __validationStatus: 'pending',
-        __cellValidationResults: cellMap,
+        __cellValidationResults: new Map([['platform', ['cannot be empty']]]),
       } as unknown as DataGridRow,
     ]
     render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
     expect(screen.getByText('No validation errors')).toBeInTheDocument()
+  })
+
+  describe('pending rows', () => {
+    it('includes pending rows with prior errors in the error list', () => {
+      const rowValues = [makePendingRow({ platform: ['cannot be empty'] })]
+      render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+      expect(screen.getByText('Validation errors')).toBeInTheDocument()
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+
+    it('shows no-errors message for pending rows without prior errors', () => {
+      const rowValues: DataGridRow[] = [
+        { __validationStatus: 'pending' } as unknown as DataGridRow,
+      ]
+      render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+      expect(screen.getByText('No validation errors')).toBeInTheDocument()
+    })
+
+    it('counts both confirmed and pending errors in the total badge', () => {
+      const rowValues = [
+        makeInvalidRow({ platform: ['cannot be empty'] }),
+        makePendingRow({ disease: ['invalid value'] }),
+      ]
+      render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+      expect(screen.getByText('2')).toBeInTheDocument()
+    })
   })
 })

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
@@ -1,62 +1,147 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { ValidationAlert } from './ValidationAlert'
 import { DataGridRow } from '../DataGridTypes'
 
+const defaultProps = {
+  columnNames: ['patientId', 'platform', 'disease'],
+  columnOrder: [0, 1, 2],
+  onNavigateToCell: vi.fn(),
+}
+
+function makeInvalidRow(cellErrors: Record<string, string[]>): DataGridRow {
+  return {
+    __validationStatus: 'invalid',
+    __cellValidationResults: new Map(Object.entries(cellErrors)),
+  } as unknown as DataGridRow
+}
+
 describe('ValidationAlert', () => {
-  it('returns null when selectedRowIndex is null', () => {
-    const { container } = render(
-      <ValidationAlert selectedRowIndex={null} rowValues={[]} />,
-    )
-    expect(container.firstChild).toBeNull()
-  })
-
-  it('returns null when selected row does not exist', () => {
-    const { container } = render(
-      <ValidationAlert selectedRowIndex={5} rowValues={[]} />,
-    )
-    expect(container.firstChild).toBeNull()
-  })
-
-  it('returns null when row has no validation messages', () => {
+  it('returns null when there are no invalid rows', () => {
     const rowValues: DataGridRow[] = [
-      { id: '1', col1: 'value1' } as DataGridRow,
+      { __validationStatus: 'valid' } as unknown as DataGridRow,
     ]
     const { container } = render(
-      <ValidationAlert selectedRowIndex={0} rowValues={rowValues} />,
+      <ValidationAlert {...defaultProps} rowValues={rowValues} />,
     )
     expect(container.firstChild).toBeNull()
   })
 
-  it('returns null when validation messages array is empty', () => {
+  it('returns null when rowValues is empty', () => {
+    const { container } = render(
+      <ValidationAlert {...defaultProps} rowValues={[]} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows the correct error count badge', () => {
+    const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
+    render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+    expect(screen.getByText('Validation errors')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('shows first error preview when collapsed', () => {
+    const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
+    render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+    // Column name and message are rendered as separate spans
+    expect(screen.getAllByText('platform')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('cannot be empty')[0]).toBeInTheDocument()
+  })
+
+  it('shows expand link when collapsed and collapse link when expanded', async () => {
+    const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
+    render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+
+    expect(screen.getByText('Expand')).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Expand'))
+    expect(screen.getByText('Collapse')).toBeInTheDocument()
+  })
+
+  it('shows full error list when expanded', async () => {
+    const rowValues = [
+      makeInvalidRow({
+        platform: ['cannot be empty'],
+        disease: ['invalid value'],
+      }),
+    ]
+    render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+
+    await userEvent.click(screen.getByText('Expand'))
+    expect(screen.getAllByText('platform').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('cannot be empty').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('disease').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('invalid value').length).toBeGreaterThan(0)
+  })
+
+  it('calls onNavigateToCell with correct rowIndex and colDisplayIndex when error is clicked', async () => {
+    const onNavigateToCell = vi.fn()
+    // columnOrder [0,1,2] means: col 0=patientId, col 1=platform, col 2=disease
+    const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
+    render(
+      <ValidationAlert
+        {...defaultProps}
+        rowValues={rowValues}
+        onNavigateToCell={onNavigateToCell}
+      />,
+    )
+
+    await userEvent.click(screen.getByText('Expand'))
+    // The error link button's accessible name contains both column name and message
+    await userEvent.click(
+      screen.getByRole('button', { name: /platform.*cannot be empty/i }),
+    )
+    // 'platform' is at columnOrder index 1 (columnNames[1] === 'platform')
+    expect(onNavigateToCell).toHaveBeenCalledWith(0, 1)
+  })
+
+  it('navigates to col 0 for row-level (_row) errors', async () => {
+    const onNavigateToCell = vi.fn()
+    const rowValues = [
+      makeInvalidRow({ _row: ['required key [platform] not found'] }),
+    ]
+    render(
+      <ValidationAlert
+        {...defaultProps}
+        rowValues={rowValues}
+        onNavigateToCell={onNavigateToCell}
+      />,
+    )
+
+    await userEvent.click(screen.getByText('Expand'))
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /required key \[platform\] not found/i,
+      }),
+    )
+    expect(onNavigateToCell).toHaveBeenCalledWith(0, 0)
+  })
+
+  it('aggregates errors across multiple invalid rows', () => {
+    const rowValues = [
+      makeInvalidRow({ platform: ['cannot be empty'] }),
+      makeInvalidRow({ disease: ['invalid value'], patientId: ['too long'] }),
+    ]
+    render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+    // 1 + 2 = 3 total errors
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('ignores rows with valid or pending status', () => {
+    const cellMap = new Map([['platform', ['cannot be empty']]])
     const rowValues: DataGridRow[] = [
       {
-        id: '1',
-        col1: 'value1',
-        __validationResults: { allValidationMessages: [] },
+        __validationStatus: 'valid',
+        __cellValidationResults: cellMap,
+      } as unknown as DataGridRow,
+      {
+        __validationStatus: 'pending',
+        __cellValidationResults: cellMap,
       } as unknown as DataGridRow,
     ]
     const { container } = render(
-      <ValidationAlert selectedRowIndex={0} rowValues={rowValues} />,
+      <ValidationAlert {...defaultProps} rowValues={rowValues} />,
     )
     expect(container.firstChild).toBeNull()
-  })
-
-  it('renders alert with validation messages', () => {
-    const rowValues: DataGridRow[] = [
-      {
-        id: '1',
-        col1: 'value1',
-        __validationResults: {
-          allValidationMessages: ['Error 1', 'Error 2'],
-        },
-      } as unknown as DataGridRow,
-    ]
-    render(<ValidationAlert selectedRowIndex={0} rowValues={rowValues} />)
-
-    expect(
-      screen.getByText('Validation Messages For Selected Row:'),
-    ).toBeInTheDocument()
-    expect(screen.getByText('Error 1')).toBeInTheDocument()
-    expect(screen.getByText('Error 2')).toBeInTheDocument()
   })
 })

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
@@ -42,7 +42,7 @@ describe('ValidationAlert', () => {
     render(
       <ValidationAlert {...defaultProps} rowValues={rowValues} isLoading />,
     )
-    expect(screen.getByText('Syncing validation errors…')).toBeInTheDocument()
+    expect(screen.getByText('Loading validation errors…')).toBeInTheDocument()
     expect(screen.queryByText('Validation errors')).not.toBeInTheDocument()
   })
 
@@ -56,9 +56,11 @@ describe('ValidationAlert', () => {
   it('shows first error preview when collapsed', () => {
     const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
     render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
-    // Column name and message are rendered as separate spans
+    // Column name is a standalone span; message is combined with separator and row suffix
     expect(screen.getAllByText('platform')[0]).toBeInTheDocument()
-    expect(screen.getAllByText('cannot be empty')[0]).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /cannot be empty/i }),
+    ).toBeInTheDocument()
   })
 
   it('shows expand link when collapsed and collapse link when expanded', async () => {
@@ -92,9 +94,13 @@ describe('ValidationAlert', () => {
 
       await userEvent.click(screen.getByText('Expand'))
       expect(screen.getAllByText('platform').length).toBeGreaterThan(0)
-      expect(screen.getAllByText('cannot be empty').length).toBeGreaterThan(0)
+      expect(
+        screen.getByRole('button', { name: /cannot be empty/i }),
+      ).toBeInTheDocument()
       expect(screen.getAllByText('disease').length).toBeGreaterThan(0)
-      expect(screen.getAllByText('invalid value').length).toBeGreaterThan(0)
+      expect(
+        screen.getByRole('button', { name: /invalid value/i }),
+      ).toBeInTheDocument()
     })
 
     it('calls onNavigateToCell with correct rowIndex and colDisplayIndex', async () => {

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
@@ -58,63 +58,193 @@ describe('ValidationAlert', () => {
     expect(screen.getByText('Collapse')).toBeInTheDocument()
   })
 
-  it('shows full error list when expanded', async () => {
-    const rowValues = [
-      makeInvalidRow({
-        platform: ['cannot be empty'],
-        disease: ['invalid value'],
-      }),
-    ]
+  it('renders three tabs when expanded', async () => {
+    const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
     render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
 
     await userEvent.click(screen.getByText('Expand'))
-    expect(screen.getAllByText('platform').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('cannot be empty').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('disease').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('invalid value').length).toBeGreaterThan(0)
+    expect(screen.getByRole('tab', { name: 'By row' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'By column' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'By message' })).toBeInTheDocument()
   })
 
-  it('calls onNavigateToCell with correct rowIndex and colDisplayIndex when error is clicked', async () => {
-    const onNavigateToCell = vi.fn()
-    // columnOrder [0,1,2] means: col 0=patientId, col 1=platform, col 2=disease
-    const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
-    render(
-      <ValidationAlert
-        {...defaultProps}
-        rowValues={rowValues}
-        onNavigateToCell={onNavigateToCell}
-      />,
-    )
+  describe('By row tab (default)', () => {
+    it('shows a flat list of all errors', async () => {
+      const rowValues = [
+        makeInvalidRow({
+          platform: ['cannot be empty'],
+          disease: ['invalid value'],
+        }),
+      ]
+      render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
 
-    await userEvent.click(screen.getByText('Expand'))
-    // The error link button's accessible name contains both column name and message
-    await userEvent.click(
-      screen.getByRole('button', { name: /platform.*cannot be empty/i }),
-    )
-    // 'platform' is at columnOrder index 1 (columnNames[1] === 'platform')
-    expect(onNavigateToCell).toHaveBeenCalledWith(0, 1)
+      await userEvent.click(screen.getByText('Expand'))
+      expect(screen.getAllByText('platform').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('cannot be empty').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('disease').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('invalid value').length).toBeGreaterThan(0)
+    })
+
+    it('calls onNavigateToCell with correct rowIndex and colDisplayIndex', async () => {
+      const onNavigateToCell = vi.fn()
+      const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
+      render(
+        <ValidationAlert
+          {...defaultProps}
+          rowValues={rowValues}
+          onNavigateToCell={onNavigateToCell}
+        />,
+      )
+
+      await userEvent.click(screen.getByText('Expand'))
+      // The error link's accessible name contains both column name and message
+      await userEvent.click(
+        screen.getByRole('button', { name: /platform.*cannot be empty/i }),
+      )
+      // 'platform' is at columnOrder index 1 (columnNames[1] === 'platform')
+      expect(onNavigateToCell).toHaveBeenCalledWith(0, 1)
+    })
+
+    it('navigates to col 0 for row-level (_row) errors', async () => {
+      const onNavigateToCell = vi.fn()
+      const rowValues = [
+        makeInvalidRow({ _row: ['required key [platform] not found'] }),
+      ]
+      render(
+        <ValidationAlert
+          {...defaultProps}
+          rowValues={rowValues}
+          onNavigateToCell={onNavigateToCell}
+        />,
+      )
+
+      await userEvent.click(screen.getByText('Expand'))
+      await userEvent.click(
+        screen.getByRole('button', {
+          name: /required key \[platform\] not found/i,
+        }),
+      )
+      expect(onNavigateToCell).toHaveBeenCalledWith(0, 0)
+    })
   })
 
-  it('navigates to col 0 for row-level (_row) errors', async () => {
-    const onNavigateToCell = vi.fn()
-    const rowValues = [
-      makeInvalidRow({ _row: ['required key [platform] not found'] }),
-    ]
-    render(
-      <ValidationAlert
-        {...defaultProps}
-        rowValues={rowValues}
-        onNavigateToCell={onNavigateToCell}
-      />,
-    )
+  describe('By column tab', () => {
+    it('groups errors under column section headers with counts', async () => {
+      // 2 platform errors, 1 disease error
+      const rowValues = [
+        makeInvalidRow({ platform: ['cannot be empty'] }),
+        makeInvalidRow({ platform: ['cannot be empty'] }),
+        makeInvalidRow({ disease: ['invalid value'] }),
+      ]
+      render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
 
-    await userEvent.click(screen.getByText('Expand'))
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: /required key \[platform\] not found/i,
-      }),
-    )
-    expect(onNavigateToCell).toHaveBeenCalledWith(0, 0)
+      await userEvent.click(screen.getByText('Expand'))
+      await userEvent.click(screen.getByRole('tab', { name: 'By column' }))
+
+      expect(screen.getAllByText('platform').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('disease').length).toBeGreaterThan(0)
+      // platform section chip shows count 2
+      expect(screen.getAllByText('2').length).toBeGreaterThan(0)
+    })
+
+    it('shows message text and row number links within each column section', async () => {
+      const rowValues = [
+        makeInvalidRow({ platform: ['cannot be empty'] }),
+        makeInvalidRow({ platform: ['cannot be empty'] }),
+      ]
+      render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+
+      await userEvent.click(screen.getByText('Expand'))
+      await userEvent.click(screen.getByRole('tab', { name: 'By column' }))
+
+      expect(screen.getAllByText('cannot be empty').length).toBeGreaterThan(0)
+      // First row shows "Row 1"; subsequent rows in the same group show just the number
+      expect(screen.getByRole('button', { name: 'Row 1' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument()
+    })
+
+    it('calls onNavigateToCell when a row number link is clicked', async () => {
+      const onNavigateToCell = vi.fn()
+      const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
+      render(
+        <ValidationAlert
+          {...defaultProps}
+          rowValues={rowValues}
+          onNavigateToCell={onNavigateToCell}
+        />,
+      )
+
+      await userEvent.click(screen.getByText('Expand'))
+      await userEvent.click(screen.getByRole('tab', { name: 'By column' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Row 1' }))
+
+      expect(onNavigateToCell).toHaveBeenCalledWith(0, 1)
+    })
+
+    it('shows row-level errors under "Row-level" section header', async () => {
+      const rowValues = [
+        makeInvalidRow({ _row: ['required key [x] not found'] }),
+      ]
+      render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+
+      await userEvent.click(screen.getByText('Expand'))
+      await userEvent.click(screen.getByRole('tab', { name: 'By column' }))
+
+      expect(screen.getByText('Row-level')).toBeInTheDocument()
+    })
+  })
+
+  describe('By message tab', () => {
+    it('groups errors under message section headers with counts', async () => {
+      const rowValues = [
+        makeInvalidRow({ platform: ['cannot be empty'] }),
+        makeInvalidRow({ disease: ['cannot be empty'] }),
+        makeInvalidRow({ patientId: ['too long'] }),
+      ]
+      render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+
+      await userEvent.click(screen.getByText('Expand'))
+      await userEvent.click(screen.getByRole('tab', { name: 'By message' }))
+
+      // 'cannot be empty' applies to 2 errors — count badge shows 2
+      expect(screen.getAllByText('cannot be empty').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('2').length).toBeGreaterThan(0)
+    })
+
+    it('shows column names and row number links within each message section', async () => {
+      const rowValues = [
+        makeInvalidRow({ platform: ['cannot be empty'] }),
+        makeInvalidRow({ disease: ['cannot be empty'] }),
+      ]
+      render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+
+      await userEvent.click(screen.getByText('Expand'))
+      await userEvent.click(screen.getByRole('tab', { name: 'By message' }))
+
+      expect(screen.getAllByText('platform').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('disease').length).toBeGreaterThan(0)
+      expect(screen.getByRole('button', { name: 'Row 1' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Row 2' })).toBeInTheDocument()
+    })
+
+    it('calls onNavigateToCell when a row number link is clicked', async () => {
+      const onNavigateToCell = vi.fn()
+      const rowValues = [makeInvalidRow({ disease: ['invalid value'] })]
+      render(
+        <ValidationAlert
+          {...defaultProps}
+          rowValues={rowValues}
+          onNavigateToCell={onNavigateToCell}
+        />,
+      )
+
+      await userEvent.click(screen.getByText('Expand'))
+      await userEvent.click(screen.getByRole('tab', { name: 'By message' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Row 1' }))
+
+      // 'disease' is at columnOrder index 2
+      expect(onNavigateToCell).toHaveBeenCalledWith(0, 2)
+    })
   })
 
   it('aggregates errors across multiple invalid rows', () => {

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
@@ -17,21 +17,17 @@ function makeInvalidRow(cellErrors: Record<string, string[]>): DataGridRow {
 }
 
 describe('ValidationAlert', () => {
-  it('returns null when there are no invalid rows', () => {
+  it('shows a no-errors message when there are no invalid rows', () => {
     const rowValues: DataGridRow[] = [
       { __validationStatus: 'valid' } as unknown as DataGridRow,
     ]
-    const { container } = render(
-      <ValidationAlert {...defaultProps} rowValues={rowValues} />,
-    )
-    expect(container.firstChild).toBeNull()
+    render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+    expect(screen.getByText('No validation errors')).toBeInTheDocument()
   })
 
-  it('returns null when rowValues is empty', () => {
-    const { container } = render(
-      <ValidationAlert {...defaultProps} rowValues={[]} />,
-    )
-    expect(container.firstChild).toBeNull()
+  it('shows a no-errors message when rowValues is empty', () => {
+    render(<ValidationAlert {...defaultProps} rowValues={[]} />)
+    expect(screen.getByText('No validation errors')).toBeInTheDocument()
   })
 
   it('shows the correct error count badge', () => {
@@ -269,9 +265,7 @@ describe('ValidationAlert', () => {
         __cellValidationResults: cellMap,
       } as unknown as DataGridRow,
     ]
-    const { container } = render(
-      <ValidationAlert {...defaultProps} rowValues={rowValues} />,
-    )
-    expect(container.firstChild).toBeNull()
+    render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)
+    expect(screen.getByText('No validation errors')).toBeInTheDocument()
   })
 })

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.test.tsx
@@ -37,6 +37,15 @@ describe('ValidationAlert', () => {
     expect(screen.getByText('No validation errors')).toBeInTheDocument()
   })
 
+  it('shows syncing message when isSyncing is true', () => {
+    const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
+    render(
+      <ValidationAlert {...defaultProps} rowValues={rowValues} isSyncing />,
+    )
+    expect(screen.getByText('Syncing validation errors…')).toBeInTheDocument()
+    expect(screen.queryByText('Validation errors')).not.toBeInTheDocument()
+  })
+
   it('shows the correct error count badge', () => {
     const rowValues = [makeInvalidRow({ platform: ['cannot be empty'] })]
     render(<ValidationAlert {...defaultProps} rowValues={rowValues} />)

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -1,5 +1,14 @@
 import { DataGridRow } from '../DataGridTypes'
-import { Box, Chip, Collapse, Link, Tab, Tabs, Typography } from '@mui/material'
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Collapse,
+  Link,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material'
 import { Fragment, useEffect, useMemo, useState } from 'react'
 
 type ValidationError = {
@@ -16,6 +25,7 @@ type ValidationAlertProps = {
   columnNames: string[]
   columnOrder: number[]
   onNavigateToCell: (rowIndex: number, colIndex: number) => void
+  isSyncing?: boolean
 }
 
 function getColDisplayIndex(
@@ -119,6 +129,7 @@ export const ValidationAlert = ({
   columnNames,
   columnOrder,
   onNavigateToCell,
+  isSyncing = false,
 }: ValidationAlertProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const [groupBy, setGroupBy] = useState<GroupBy>('row')
@@ -169,6 +180,31 @@ export const ValidationAlert = ({
   }, [allErrors.length])
 
   const firstError = allErrors[0]
+
+  if (isSyncing) {
+    return (
+      <Box
+        sx={{
+          border: '1px solid',
+          borderColor: 'divider',
+          borderLeft: '4px solid',
+          borderLeftColor: 'divider',
+          borderRadius: 1,
+          mb: 1,
+          px: 2,
+          py: 1,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
+        <CircularProgress size={14} />
+        <Typography variant="body2" color="text.secondary">
+          Syncing validation errors…
+        </Typography>
+      </Box>
+    )
+  }
 
   if (allErrors.length === 0) {
     return (

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -324,7 +324,7 @@ export const ValidationAlert = ({
       >
         <CircularProgress size={14} />
         <Typography variant="body1" color="text.secondary">
-          Syncing validation errors…
+          Loading validation errors…
         </Typography>
       </Box>
     )

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -65,8 +65,10 @@ function ErrorText({
   if (columnName === '_row') {
     return (
       <>
-        {message}
-        {rowSuffix}
+        <Box component="span" sx={{ fontWeight: 'normal' }}>
+          {message}
+          {rowSuffix}
+        </Box>
       </>
     )
   }
@@ -75,9 +77,11 @@ function ErrorText({
       <Box component="span" sx={{ fontWeight: 'bold' }}>
         {columnName}
       </Box>
-      {' — '}
-      {message}
-      {rowSuffix}
+      <Box component="span" sx={{ fontWeight: 'normal' }}>
+        {' — '}
+        {message}
+        {rowSuffix}
+      </Box>
     </>
   )
 }
@@ -370,7 +374,7 @@ export const ValidationAlert = ({
           component="button"
           variant="body1"
           onClick={() => setIsExpanded(p => !p)}
-          sx={{ cursor: 'pointer', flexShrink: 0 }}
+          sx={{ cursor: 'pointer', flexShrink: 0, fontWeight: 'normal' }}
         >
           {shouldExpand ? 'Collapse' : 'Expand'}
         </Link>

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -1,12 +1,14 @@
 import { DataGridRow } from '../DataGridTypes'
-import { Box, Chip, Collapse, Link, Typography } from '@mui/material'
-import { useEffect, useMemo, useState } from 'react'
+import { Box, Chip, Collapse, Link, Tab, Tabs, Typography } from '@mui/material'
+import { Fragment, useEffect, useMemo, useState } from 'react'
 
 type ValidationError = {
   rowIndex: number
   columnName: string
   message: string
 }
+
+type GroupBy = 'row' | 'column' | 'message'
 
 type ValidationAlertProps = {
   rowValues: DataGridRow[]
@@ -21,6 +23,11 @@ function getColDisplayIndex(
   columnOrder: number[],
 ): number {
   return columnOrder.findIndex(i => columnNames[i] === colName)
+}
+
+/** Column name for display — '_row' becomes 'Row-level'. */
+function colLabel(colName: string): string {
+  return colName === '_row' ? 'Row-level' : colName
 }
 
 /** Renders a column name + message pair with distinct styles. */
@@ -60,6 +67,51 @@ function ErrorText({
   )
 }
 
+const rowLinkSx = {
+  textDecoration: 'none',
+  cursor: 'pointer',
+  '&:hover': { textDecoration: 'underline' },
+} as const
+
+/** Renders a list of row number links. The first shows "Row N"; subsequent
+ *  items show only the number, separated by a middle dot. */
+function RowLinks({
+  rows,
+  navCol,
+  onNavigateToCell,
+}: {
+  rows: number[]
+  navCol: number
+  onNavigateToCell: (rowIndex: number, colIndex: number) => void
+}) {
+  return (
+    <>
+      {rows.map((rowIndex, j) => (
+        <Fragment key={rowIndex}>
+          {j > 0 && (
+            <Box
+              component="span"
+              aria-hidden
+              sx={{ color: 'text.disabled', userSelect: 'none' }}
+            >
+              ·
+            </Box>
+          )}
+          <Link
+            component="button"
+            variant="caption"
+            color="text.secondary"
+            onClick={() => onNavigateToCell(rowIndex, navCol)}
+            sx={rowLinkSx}
+          >
+            {j === 0 ? `Row ${rowIndex + 1}` : rowIndex + 1}
+          </Link>
+        </Fragment>
+      ))}
+    </>
+  )
+}
+
 export const ValidationAlert = ({
   rowValues,
   columnNames,
@@ -67,6 +119,7 @@ export const ValidationAlert = ({
   onNavigateToCell,
 }: ValidationAlertProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
+  const [groupBy, setGroupBy] = useState<GroupBy>('row')
 
   const allErrors = useMemo((): ValidationError[] => {
     const errors: ValidationError[] = []
@@ -80,6 +133,30 @@ export const ValidationAlert = ({
     })
     return errors
   }, [rowValues])
+
+  // columnName → messageText → rowIndex[]
+  const byColumn = useMemo(() => {
+    const groups = new Map<string, Map<string, number[]>>()
+    allErrors.forEach(({ rowIndex, columnName, message }) => {
+      if (!groups.has(columnName)) groups.set(columnName, new Map())
+      const colGroup = groups.get(columnName)!
+      if (!colGroup.has(message)) colGroup.set(message, [])
+      colGroup.get(message)!.push(rowIndex)
+    })
+    return groups
+  }, [allErrors])
+
+  // messageText → columnName → rowIndex[]
+  const byMessage = useMemo(() => {
+    const groups = new Map<string, Map<string, number[]>>()
+    allErrors.forEach(({ rowIndex, columnName, message }) => {
+      if (!groups.has(message)) groups.set(message, new Map())
+      const msgGroup = groups.get(message)!
+      if (!msgGroup.has(columnName)) msgGroup.set(columnName, [])
+      msgGroup.get(columnName)!.push(rowIndex)
+    })
+    return groups
+  }, [allErrors])
 
   useEffect(() => {
     if (allErrors.length === 0) setIsExpanded(false)
@@ -100,6 +177,7 @@ export const ValidationAlert = ({
         mb: 1,
       }}
     >
+      {/* Header */}
       <Box
         sx={{
           display: 'flex',
@@ -131,48 +209,185 @@ export const ValidationAlert = ({
           </Typography>
         )}
       </Box>
+
+      {/* Expanded panel */}
       <Collapse in={isExpanded}>
-        <Box
-          component="ul"
+        <Tabs
+          value={groupBy}
+          onChange={(_, v: GroupBy) => setGroupBy(v)}
+          textColor="inherit"
           sx={{
-            m: 0,
             px: 2,
-            pb: 1,
-            listStyle: 'none',
-            maxHeight: 200,
-            overflowY: 'auto',
+            minHeight: 36,
+            borderTop: '1px solid',
+            borderColor: 'divider',
           }}
+          TabIndicatorProps={{ style: { height: 2 } }}
         >
-          {allErrors.map((error, i) => {
-            const colIdx = getColDisplayIndex(
-              error.columnName,
-              columnNames,
-              columnOrder,
-            )
-            const navCol = colIdx >= 0 ? colIdx : 0
-            return (
-              <Box component="li" key={i} sx={{ py: 0.25 }}>
-                <Link
-                  component="button"
-                  variant="body2"
-                  color="text.secondary"
-                  onClick={() => onNavigateToCell(error.rowIndex, navCol)}
-                  sx={{
-                    textAlign: 'left',
-                    cursor: 'pointer',
-                    textDecoration: 'none',
-                    '&:hover': { textDecoration: 'underline' },
-                  }}
-                >
-                  <ErrorText
-                    columnName={error.columnName}
-                    message={error.message}
-                    rowIndex={error.rowIndex}
-                  />
-                </Link>
-              </Box>
-            )
-          })}
+          <Tab
+            label="By row"
+            value="row"
+            sx={{ minHeight: 36, py: 0.5, fontSize: '0.75rem' }}
+          />
+          <Tab
+            label="By column"
+            value="column"
+            sx={{ minHeight: 36, py: 0.5, fontSize: '0.75rem' }}
+          />
+          <Tab
+            label="By message"
+            value="message"
+            sx={{ minHeight: 36, py: 0.5, fontSize: '0.75rem' }}
+          />
+        </Tabs>
+
+        <Box sx={{ px: 2, py: 1, maxHeight: 200, overflowY: 'auto' }}>
+          {/* ── By row ─────────────────────────────────────────── */}
+          {groupBy === 'row' && (
+            <Box component="ul" sx={{ m: 0, p: 0, listStyle: 'none' }}>
+              {allErrors.map((error, i) => {
+                const navCol = Math.max(
+                  0,
+                  getColDisplayIndex(
+                    error.columnName,
+                    columnNames,
+                    columnOrder,
+                  ),
+                )
+                return (
+                  <Box component="li" key={i} sx={{ py: 0.25 }}>
+                    <Link
+                      component="button"
+                      variant="body2"
+                      color="text.secondary"
+                      onClick={() => onNavigateToCell(error.rowIndex, navCol)}
+                      sx={{ textAlign: 'left', ...rowLinkSx }}
+                    >
+                      <ErrorText
+                        columnName={error.columnName}
+                        message={error.message}
+                        rowIndex={error.rowIndex}
+                      />
+                    </Link>
+                  </Box>
+                )
+              })}
+            </Box>
+          )}
+
+          {/* ── By column ──────────────────────────────────────── */}
+          {groupBy === 'column' &&
+            Array.from(byColumn.entries()).map(([colName, messages]) => {
+              const totalCount = Array.from(messages.values()).reduce(
+                (sum, rows) => sum + rows.length,
+                0,
+              )
+              const navCol = Math.max(
+                0,
+                getColDisplayIndex(colName, columnNames, columnOrder),
+              )
+              return (
+                <Box key={colName} sx={{ mb: 1 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      mb: 0.25,
+                    }}
+                  >
+                    <Typography variant="body2" fontWeight="bold">
+                      {colLabel(colName)}
+                    </Typography>
+                    <Chip label={totalCount} color="error" size="small" />
+                  </Box>
+                  {Array.from(messages.entries()).map(([msg, rows]) => (
+                    <Box
+                      key={msg}
+                      sx={{
+                        pl: 2,
+                        display: 'flex',
+                        alignItems: 'baseline',
+                        flexWrap: 'wrap',
+                        gap: 0.5,
+                        py: 0.25,
+                      }}
+                    >
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{ mr: 0.5 }}
+                      >
+                        {msg}
+                      </Typography>
+                      <RowLinks
+                        rows={rows}
+                        navCol={navCol}
+                        onNavigateToCell={onNavigateToCell}
+                      />
+                    </Box>
+                  ))}
+                </Box>
+              )
+            })}
+
+          {/* ── By message ─────────────────────────────────────── */}
+          {groupBy === 'message' &&
+            Array.from(byMessage.entries()).map(([msg, columns]) => {
+              const totalCount = Array.from(columns.values()).reduce(
+                (sum, rows) => sum + rows.length,
+                0,
+              )
+              return (
+                <Box key={msg} sx={{ mb: 1 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      mb: 0.25,
+                    }}
+                  >
+                    <Typography variant="body2" fontWeight="bold">
+                      {msg}
+                    </Typography>
+                    <Chip label={totalCount} color="error" size="small" />
+                  </Box>
+                  {Array.from(columns.entries()).map(([colName, rows]) => {
+                    const navCol = Math.max(
+                      0,
+                      getColDisplayIndex(colName, columnNames, columnOrder),
+                    )
+                    return (
+                      <Box
+                        key={colName}
+                        sx={{
+                          pl: 2,
+                          display: 'flex',
+                          alignItems: 'baseline',
+                          flexWrap: 'wrap',
+                          gap: 0.5,
+                          py: 0.25,
+                        }}
+                      >
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{ mr: 0.5, fontStyle: 'italic' }}
+                        >
+                          {colLabel(colName)}
+                        </Typography>
+                        <RowLinks
+                          rows={rows}
+                          navCol={navCol}
+                          onNavigateToCell={onNavigateToCell}
+                        />
+                      </Box>
+                    )
+                  })}
+                </Box>
+              )
+            })}
         </Box>
       </Collapse>
     </Box>

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -25,7 +25,7 @@ type ValidationAlertProps = {
   columnNames: string[]
   columnOrder: number[]
   onNavigateToCell: (rowIndex: number, colIndex: number) => void
-  isSyncing?: boolean
+  isLoading?: boolean
 }
 
 function getColDisplayIndex(
@@ -129,7 +129,7 @@ export const ValidationAlert = ({
   columnNames,
   columnOrder,
   onNavigateToCell,
-  isSyncing = false,
+  isLoading = false,
 }: ValidationAlertProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const [groupBy, setGroupBy] = useState<GroupBy>('row')
@@ -181,7 +181,7 @@ export const ValidationAlert = ({
 
   const firstError = allErrors[0]
 
-  if (isSyncing) {
+  if (isLoading) {
     return (
       <Box
         sx={{

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -51,11 +51,7 @@ function ErrorText({
   message: string
   rowIndex: number
 }) {
-  const rowSuffix = (
-    <Box component="span" sx={{ color: 'text.secondary', ml: 0.5 }}>
-      (Row {rowIndex + 1})
-    </Box>
-  )
+  const rowSuffix = ` (Row ${rowIndex + 1})`
   if (columnName === '_row') {
     return (
       <>
@@ -69,9 +65,7 @@ function ErrorText({
       <Box component="span" sx={{ fontWeight: 'bold' }}>
         {columnName}
       </Box>
-      <Box component="span" sx={{ mx: 0.5 }}>
-        —
-      </Box>
+      {' — '}
       {message}
       {rowSuffix}
     </>

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -99,7 +99,7 @@ const bannerBaseSx = {
   mb: 1,
 } as const
 
-const tabSx = { minHeight: 36, py: 0.5, fontSize: '0.75rem' } as const
+const tabSx = { minHeight: 36, py: 0.5 } as const
 
 const groupSectionHeaderSx = {
   display: 'flex',
@@ -144,7 +144,7 @@ function RowLinks({
           )}
           <Link
             component="button"
-            variant="caption"
+            variant="body1"
             color="text.secondary"
             onClick={() => onNavigateToCell(rowIndex, navCol)}
             sx={{ ...rowLinkSx, opacity: pending ? 0.5 : 1 }}

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -1,41 +1,180 @@
-import FullWidthAlert from '../../FullWidthAlert/FullWidthAlert'
 import { DataGridRow } from '../DataGridTypes'
+import { Box, Chip, Collapse, Link, Typography } from '@mui/material'
+import { useEffect, useMemo, useState } from 'react'
+
+type ValidationError = {
+  rowIndex: number
+  columnName: string
+  message: string
+}
 
 type ValidationAlertProps = {
-  selectedRowIndex: number | null
   rowValues: DataGridRow[]
+  columnNames: string[]
+  columnOrder: number[]
+  onNavigateToCell: (rowIndex: number, colIndex: number) => void
+}
+
+function getColDisplayIndex(
+  colName: string,
+  columnNames: string[],
+  columnOrder: number[],
+): number {
+  return columnOrder.findIndex(i => columnNames[i] === colName)
+}
+
+/** Renders a column name + message pair with distinct styles. */
+function ErrorText({
+  columnName,
+  message,
+  rowIndex,
+}: {
+  columnName: string
+  message: string
+  rowIndex: number
+}) {
+  const rowSuffix = (
+    <Box component="span" sx={{ color: 'text.secondary', ml: 0.5 }}>
+      (Row {rowIndex + 1})
+    </Box>
+  )
+  if (columnName === '_row') {
+    return (
+      <>
+        {message}
+        {rowSuffix}
+      </>
+    )
+  }
+  return (
+    <>
+      <Box component="span" sx={{ fontWeight: 'bold' }}>
+        {columnName}
+      </Box>
+      <Box component="span" sx={{ mx: 0.5 }}>
+        —
+      </Box>
+      {message}
+      {rowSuffix}
+    </>
+  )
 }
 
 export const ValidationAlert = ({
-  selectedRowIndex,
   rowValues,
+  columnNames,
+  columnOrder,
+  onNavigateToCell,
 }: ValidationAlertProps) => {
-  if (selectedRowIndex === null) return null
+  const [isExpanded, setIsExpanded] = useState(false)
 
-  const selectedRow = rowValues[selectedRowIndex]
-  if (!selectedRow) return null
+  const allErrors = useMemo((): ValidationError[] => {
+    const errors: ValidationError[] = []
+    rowValues.forEach((row, rowIndex) => {
+      if (row.__validationStatus !== 'invalid') return
+      row.__cellValidationResults?.forEach((messages, columnName) => {
+        messages.forEach(message =>
+          errors.push({ rowIndex, columnName, message }),
+        )
+      })
+    })
+    return errors
+  }, [rowValues])
 
-  const validationMessages =
-    selectedRow.__validationResults?.allValidationMessages
-  if (!Array.isArray(validationMessages) || validationMessages.length === 0) {
-    return null
-  }
+  useEffect(() => {
+    if (allErrors.length === 0) setIsExpanded(false)
+  }, [allErrors.length])
+
+  if (allErrors.length === 0) return null
+
+  const firstError = allErrors[0]
 
   return (
-    <FullWidthAlert
-      variant="warning"
-      title="Validation Messages For Selected Row:"
-      isGlobal={false}
-      description={
-        <ul>
-          {validationMessages.map((msg: string) => (
-            <li key={msg}>{msg}</li>
-          ))}
-        </ul>
-      }
+    <Box
       sx={{
-        marginTop: '12px',
+        border: '1px solid',
+        borderColor: 'error.main',
+        borderLeft: '4px solid',
+        borderLeftColor: 'error.main',
+        borderRadius: 1,
+        mb: 1,
       }}
-    />
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          px: 2,
+          py: 1,
+          gap: 1,
+        }}
+      >
+        <Typography variant="body2" fontWeight="bold">
+          Validation errors
+        </Typography>
+        <Chip label={allErrors.length} color="error" size="small" />
+        <Link
+          component="button"
+          variant="body2"
+          onClick={() => setIsExpanded(p => !p)}
+          sx={{ cursor: 'pointer', flexShrink: 0 }}
+        >
+          {isExpanded ? 'Collapse' : 'Expand'}
+        </Link>
+        {!isExpanded && (
+          <Typography variant="body2" color="text.secondary" noWrap>
+            <ErrorText
+              columnName={firstError.columnName}
+              message={firstError.message}
+              rowIndex={firstError.rowIndex}
+            />
+          </Typography>
+        )}
+      </Box>
+      <Collapse in={isExpanded}>
+        <Box
+          component="ul"
+          sx={{
+            m: 0,
+            px: 2,
+            pb: 1,
+            listStyle: 'none',
+            maxHeight: 200,
+            overflowY: 'auto',
+          }}
+        >
+          {allErrors.map((error, i) => {
+            const colIdx = getColDisplayIndex(
+              error.columnName,
+              columnNames,
+              columnOrder,
+            )
+            const navCol = colIdx >= 0 ? colIdx : 0
+            return (
+              <Box component="li" key={i} sx={{ py: 0.25 }}>
+                <Link
+                  component="button"
+                  variant="body2"
+                  color="text.secondary"
+                  onClick={() => onNavigateToCell(error.rowIndex, navCol)}
+                  sx={{
+                    textAlign: 'left',
+                    cursor: 'pointer',
+                    textDecoration: 'none',
+                    '&:hover': { textDecoration: 'underline' },
+                  }}
+                >
+                  <ErrorText
+                    columnName={error.columnName}
+                    message={error.message}
+                    rowIndex={error.rowIndex}
+                  />
+                </Link>
+              </Box>
+            )
+          })}
+        </Box>
+      </Collapse>
+    </Box>
   )
 }

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -200,13 +200,32 @@ export const ValidationAlert = ({
           {isExpanded ? 'Collapse' : 'Expand'}
         </Link>
         {!isExpanded && (
-          <Typography variant="body2" color="text.secondary" noWrap>
+          <Link
+            component="button"
+            variant="body2"
+            color="text.secondary"
+            onClick={() =>
+              onNavigateToCell(
+                firstError.rowIndex,
+                Math.max(
+                  0,
+                  getColDisplayIndex(
+                    firstError.columnName,
+                    columnNames,
+                    columnOrder,
+                  ),
+                ),
+              )
+            }
+            noWrap
+            sx={{ textAlign: 'left', ...rowLinkSx }}
+          >
             <ErrorText
               columnName={firstError.columnName}
               message={firstError.message}
               rowIndex={firstError.rowIndex}
             />
-          </Typography>
+          </Link>
         )}
       </Box>
 

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -18,6 +18,8 @@ type ValidationError = {
   pending: boolean
 }
 
+type RowEntry = { rowIndex: number; pending: boolean }
+
 type GroupBy = 'row' | 'column' | 'message'
 
 type ValidationAlertProps = {
@@ -26,6 +28,12 @@ type ValidationAlertProps = {
   columnOrder: number[]
   onNavigateToCell: (rowIndex: number, colIndex: number) => void
   isLoading?: boolean
+}
+
+type NavProps = {
+  columnNames: string[]
+  columnOrder: number[]
+  onNavigateToCell: (rowIndex: number, colIndex: number) => void
 }
 
 function getColDisplayIndex(
@@ -78,6 +86,31 @@ const rowLinkSx = {
   '&:hover': { textDecoration: 'underline' },
 } as const
 
+const bannerBaseSx = {
+  border: '1px solid',
+  borderLeft: '4px solid',
+  borderRadius: 1,
+  mb: 1,
+} as const
+
+const tabSx = { minHeight: 36, py: 0.5, fontSize: '0.75rem' } as const
+
+const groupSectionHeaderSx = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 0.5,
+  mb: 0.25,
+} as const
+
+const groupSectionItemSx = {
+  pl: 2,
+  display: 'flex',
+  alignItems: 'baseline',
+  flexWrap: 'wrap',
+  gap: 0.5,
+  py: 0.25,
+} as const
+
 /** Renders a list of row number links. The first shows "Row N"; subsequent
  *  items show only the number, separated by a middle dot.
  *  Pending entries are dimmed to signal unconfirmed validation state. */
@@ -86,7 +119,7 @@ function RowLinks({
   navCol,
   onNavigateToCell,
 }: {
-  rows: { rowIndex: number; pending: boolean }[]
+  rows: RowEntry[]
   navCol: number
   onNavigateToCell: (rowIndex: number, colIndex: number) => void
 }) {
@@ -118,6 +151,104 @@ function RowLinks({
   )
 }
 
+function ByColumnTab({
+  groups,
+  columnNames,
+  columnOrder,
+  onNavigateToCell,
+}: NavProps & { groups: Map<string, Map<string, RowEntry[]>> }) {
+  return (
+    <>
+      {Array.from(groups.entries()).map(([colName, messages]) => {
+        const totalCount = Array.from(messages.values()).reduce(
+          (sum, rows) => sum + rows.length,
+          0,
+        )
+        const navCol = Math.max(
+          0,
+          getColDisplayIndex(colName, columnNames, columnOrder),
+        )
+        return (
+          <Box key={colName} sx={{ mb: 1 }}>
+            <Box sx={groupSectionHeaderSx}>
+              <Typography variant="body2" fontWeight="bold">
+                {colLabel(colName)}
+              </Typography>
+              <Chip label={totalCount} color="error" size="small" />
+            </Box>
+            {Array.from(messages.entries()).map(([msg, rows]) => (
+              <Box key={msg} sx={groupSectionItemSx}>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ mr: 0.5 }}
+                >
+                  {msg}
+                </Typography>
+                <RowLinks
+                  rows={rows}
+                  navCol={navCol}
+                  onNavigateToCell={onNavigateToCell}
+                />
+              </Box>
+            ))}
+          </Box>
+        )
+      })}
+    </>
+  )
+}
+
+function ByMessageTab({
+  groups,
+  columnNames,
+  columnOrder,
+  onNavigateToCell,
+}: NavProps & { groups: Map<string, Map<string, RowEntry[]>> }) {
+  return (
+    <>
+      {Array.from(groups.entries()).map(([msg, columns]) => {
+        const totalCount = Array.from(columns.values()).reduce(
+          (sum, rows) => sum + rows.length,
+          0,
+        )
+        return (
+          <Box key={msg} sx={{ mb: 1 }}>
+            <Box sx={groupSectionHeaderSx}>
+              <Typography variant="body2" fontWeight="bold">
+                {msg}
+              </Typography>
+              <Chip label={totalCount} color="error" size="small" />
+            </Box>
+            {Array.from(columns.entries()).map(([colName, rows]) => {
+              const navCol = Math.max(
+                0,
+                getColDisplayIndex(colName, columnNames, columnOrder),
+              )
+              return (
+                <Box key={colName} sx={groupSectionItemSx}>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mr: 0.5, fontStyle: 'italic' }}
+                  >
+                    {colLabel(colName)}
+                  </Typography>
+                  <RowLinks
+                    rows={rows}
+                    navCol={navCol}
+                    onNavigateToCell={onNavigateToCell}
+                  />
+                </Box>
+              )
+            })}
+          </Box>
+        )
+      })}
+    </>
+  )
+}
+
 export const ValidationAlert = ({
   rowValues,
   columnNames,
@@ -142,8 +273,6 @@ export const ValidationAlert = ({
     })
     return errors
   }, [rowValues])
-
-  type RowEntry = { rowIndex: number; pending: boolean }
 
   // columnName → messageText → RowEntry[]
   const byColumn = useMemo(() => {
@@ -177,12 +306,9 @@ export const ValidationAlert = ({
     return (
       <Box
         sx={{
-          border: '1px solid',
+          ...bannerBaseSx,
           borderColor: 'divider',
-          borderLeft: '4px solid',
           borderLeftColor: 'divider',
-          borderRadius: 1,
-          mb: 1,
           px: 2,
           py: 1,
           display: 'flex',
@@ -202,12 +328,9 @@ export const ValidationAlert = ({
     return (
       <Box
         sx={{
-          border: '1px solid',
+          ...bannerBaseSx,
           borderColor: 'success.main',
-          borderLeft: '4px solid',
           borderLeftColor: 'success.main',
-          borderRadius: 1,
-          mb: 1,
           px: 2,
           py: 1,
         }}
@@ -222,12 +345,9 @@ export const ValidationAlert = ({
   return (
     <Box
       sx={{
-        border: '1px solid',
+        ...bannerBaseSx,
         borderColor: 'error.main',
-        borderLeft: '4px solid',
         borderLeftColor: 'error.main',
-        borderRadius: 1,
-        mb: 1,
       }}
     >
       {/* Header */}
@@ -240,7 +360,7 @@ export const ValidationAlert = ({
           gap: 1,
         }}
       >
-        <Typography variant="body2" fontWeight="bold">
+        <Typography variant="body1" fontWeight="bold">
           Validation errors
         </Typography>
         <Chip label={allErrors.length} color="error" size="small" />
@@ -300,21 +420,9 @@ export const ValidationAlert = ({
           }}
           TabIndicatorProps={{ style: { height: 2 } }}
         >
-          <Tab
-            label="By row"
-            value="row"
-            sx={{ minHeight: 36, py: 0.5, fontSize: '0.75rem' }}
-          />
-          <Tab
-            label="By column"
-            value="column"
-            sx={{ minHeight: 36, py: 0.5, fontSize: '0.75rem' }}
-          />
-          <Tab
-            label="By message"
-            value="message"
-            sx={{ minHeight: 36, py: 0.5, fontSize: '0.75rem' }}
-          />
+          <Tab label="By row" value="row" sx={tabSx} />
+          <Tab label="By column" value="column" sx={tabSx} />
+          <Tab label="By message" value="message" sx={tabSx} />
         </Tabs>
 
         <Box sx={{ px: 2, py: 1, maxHeight: 200, overflowY: 'auto' }}>
@@ -356,118 +464,24 @@ export const ValidationAlert = ({
           )}
 
           {/* ── By column ──────────────────────────────────────── */}
-          {groupBy === 'column' &&
-            Array.from(byColumn.entries()).map(([colName, messages]) => {
-              const totalCount = Array.from(messages.values()).reduce(
-                (sum, rows) => sum + rows.length,
-                0,
-              )
-              const navCol = Math.max(
-                0,
-                getColDisplayIndex(colName, columnNames, columnOrder),
-              )
-              return (
-                <Box key={colName} sx={{ mb: 1 }}>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 0.5,
-                      mb: 0.25,
-                    }}
-                  >
-                    <Typography variant="body2" fontWeight="bold">
-                      {colLabel(colName)}
-                    </Typography>
-                    <Chip label={totalCount} color="error" size="small" />
-                  </Box>
-                  {Array.from(messages.entries()).map(([msg, rows]) => (
-                    <Box
-                      key={msg}
-                      sx={{
-                        pl: 2,
-                        display: 'flex',
-                        alignItems: 'baseline',
-                        flexWrap: 'wrap',
-                        gap: 0.5,
-                        py: 0.25,
-                      }}
-                    >
-                      <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{ mr: 0.5 }}
-                      >
-                        {msg}
-                      </Typography>
-                      <RowLinks
-                        rows={rows}
-                        navCol={navCol}
-                        onNavigateToCell={onNavigateToCell}
-                      />
-                    </Box>
-                  ))}
-                </Box>
-              )
-            })}
+          {groupBy === 'column' && (
+            <ByColumnTab
+              groups={byColumn}
+              columnNames={columnNames}
+              columnOrder={columnOrder}
+              onNavigateToCell={onNavigateToCell}
+            />
+          )}
 
           {/* ── By message ─────────────────────────────────────── */}
-          {groupBy === 'message' &&
-            Array.from(byMessage.entries()).map(([msg, columns]) => {
-              const totalCount = Array.from(columns.values()).reduce(
-                (sum, rows) => sum + rows.length,
-                0,
-              )
-              return (
-                <Box key={msg} sx={{ mb: 1 }}>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 0.5,
-                      mb: 0.25,
-                    }}
-                  >
-                    <Typography variant="body2" fontWeight="bold">
-                      {msg}
-                    </Typography>
-                    <Chip label={totalCount} color="error" size="small" />
-                  </Box>
-                  {Array.from(columns.entries()).map(([colName, rows]) => {
-                    const navCol = Math.max(
-                      0,
-                      getColDisplayIndex(colName, columnNames, columnOrder),
-                    )
-                    return (
-                      <Box
-                        key={colName}
-                        sx={{
-                          pl: 2,
-                          display: 'flex',
-                          alignItems: 'baseline',
-                          flexWrap: 'wrap',
-                          gap: 0.5,
-                          py: 0.25,
-                        }}
-                      >
-                        <Typography
-                          variant="body2"
-                          color="text.secondary"
-                          sx={{ mr: 0.5, fontStyle: 'italic' }}
-                        >
-                          {colLabel(colName)}
-                        </Typography>
-                        <RowLinks
-                          rows={rows}
-                          navCol={navCol}
-                          onNavigateToCell={onNavigateToCell}
-                        />
-                      </Box>
-                    )
-                  })}
-                </Box>
-              )
-            })}
+          {groupBy === 'message' && (
+            <ByMessageTab
+              groups={byMessage}
+              columnNames={columnNames}
+              columnOrder={columnOrder}
+              onNavigateToCell={onNavigateToCell}
+            />
+          )}
         </Box>
       </Collapse>
     </Box>

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -162,9 +162,28 @@ export const ValidationAlert = ({
     if (allErrors.length === 0) setIsExpanded(false)
   }, [allErrors.length])
 
-  if (allErrors.length === 0) return null
-
   const firstError = allErrors[0]
+
+  if (allErrors.length === 0) {
+    return (
+      <Box
+        sx={{
+          border: '1px solid',
+          borderColor: 'success.main',
+          borderLeft: '4px solid',
+          borderLeftColor: 'success.main',
+          borderRadius: 1,
+          mb: 1,
+          px: 2,
+          py: 1,
+        }}
+      >
+        <Typography variant="body2" color="success.main">
+          No validation errors
+        </Typography>
+      </Box>
+    )
+  }
 
   return (
     <Box

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -9,7 +9,7 @@ import {
   Tabs,
   Typography,
 } from '@mui/material'
-import { Fragment, useEffect, useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 
 type ValidationError = {
   rowIndex: number
@@ -175,9 +175,7 @@ export const ValidationAlert = ({
     return groups
   }, [allErrors])
 
-  useEffect(() => {
-    if (allErrors.length === 0) setIsExpanded(false)
-  }, [allErrors.length])
+  const shouldExpand = isExpanded && allErrors.length > 0
 
   const firstError = allErrors[0]
 
@@ -258,9 +256,9 @@ export const ValidationAlert = ({
           onClick={() => setIsExpanded(p => !p)}
           sx={{ cursor: 'pointer', flexShrink: 0 }}
         >
-          {isExpanded ? 'Collapse' : 'Expand'}
+          {shouldExpand ? 'Collapse' : 'Expand'}
         </Link>
-        {!isExpanded && (
+        {!shouldExpand && (
           <Link
             component="button"
             variant="body2"
@@ -295,7 +293,7 @@ export const ValidationAlert = ({
       </Box>
 
       {/* Expanded panel */}
-      <Collapse in={isExpanded}>
+      <Collapse in={shouldExpand}>
         <Tabs
           value={groupBy}
           onChange={(_, v: GroupBy) => setGroupBy(v)}

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -171,7 +171,7 @@ function ByColumnTab({
         return (
           <Box key={colName} sx={{ mb: 1 }}>
             <Box sx={groupSectionHeaderSx}>
-              <Typography variant="body2" fontWeight="bold">
+              <Typography variant="body1" fontWeight="bold">
                 {colLabel(colName)}
               </Typography>
               <Chip label={totalCount} color="error" size="small" />
@@ -179,7 +179,7 @@ function ByColumnTab({
             {Array.from(messages.entries()).map(([msg, rows]) => (
               <Box key={msg} sx={groupSectionItemSx}>
                 <Typography
-                  variant="body2"
+                  variant="body1"
                   color="text.secondary"
                   sx={{ mr: 0.5 }}
                 >
@@ -215,7 +215,7 @@ function ByMessageTab({
         return (
           <Box key={msg} sx={{ mb: 1 }}>
             <Box sx={groupSectionHeaderSx}>
-              <Typography variant="body2" fontWeight="bold">
+              <Typography variant="body1" fontWeight="bold">
                 {msg}
               </Typography>
               <Chip label={totalCount} color="error" size="small" />
@@ -228,7 +228,7 @@ function ByMessageTab({
               return (
                 <Box key={colName} sx={groupSectionItemSx}>
                   <Typography
-                    variant="body2"
+                    variant="body1"
                     color="text.secondary"
                     sx={{ mr: 0.5, fontStyle: 'italic' }}
                   >
@@ -310,14 +310,14 @@ export const ValidationAlert = ({
           borderColor: 'divider',
           borderLeftColor: 'divider',
           px: 2,
-          py: 1,
+          py: 2,
           display: 'flex',
           alignItems: 'center',
           gap: 1,
         }}
       >
         <CircularProgress size={14} />
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body1" color="text.secondary">
           Syncing validation errors…
         </Typography>
       </Box>
@@ -332,10 +332,10 @@ export const ValidationAlert = ({
           borderColor: 'success.main',
           borderLeftColor: 'success.main',
           px: 2,
-          py: 1,
+          py: 2,
         }}
       >
-        <Typography variant="body2" color="success.main">
+        <Typography variant="body1" color="success.main">
           No validation errors
         </Typography>
       </Box>
@@ -356,7 +356,7 @@ export const ValidationAlert = ({
           display: 'flex',
           alignItems: 'center',
           px: 2,
-          py: 1,
+          py: 2,
           gap: 1,
         }}
       >
@@ -366,7 +366,7 @@ export const ValidationAlert = ({
         <Chip label={allErrors.length} color="error" size="small" />
         <Link
           component="button"
-          variant="body2"
+          variant="body1"
           onClick={() => setIsExpanded(p => !p)}
           sx={{ cursor: 'pointer', flexShrink: 0 }}
         >
@@ -375,7 +375,7 @@ export const ValidationAlert = ({
         {!shouldExpand && (
           <Link
             component="button"
-            variant="body2"
+            variant="body1"
             color="text.secondary"
             onClick={() =>
               onNavigateToCell(
@@ -393,6 +393,7 @@ export const ValidationAlert = ({
             noWrap
             sx={{
               textAlign: 'left',
+              ml: 'auto',
               ...rowLinkSx,
               opacity: firstError.pending ? 0.5 : 1,
             }}
@@ -442,7 +443,7 @@ export const ValidationAlert = ({
                   <Box component="li" key={i} sx={{ py: 0.25 }}>
                     <Link
                       component="button"
-                      variant="body2"
+                      variant="body1"
                       color="text.secondary"
                       onClick={() => onNavigateToCell(error.rowIndex, navCol)}
                       sx={{

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -4,7 +4,9 @@ import {
   Chip,
   CircularProgress,
   Collapse,
+  Divider,
   Link,
+  Stack,
   Tab,
   Tabs,
   Typography,
@@ -158,7 +160,7 @@ function ByColumnTab({
   onNavigateToCell,
 }: NavProps & { groups: Map<string, Map<string, RowEntry[]>> }) {
   return (
-    <>
+    <Stack divider={<Divider />} spacing={1}>
       {Array.from(groups.entries()).map(([colName, messages]) => {
         const totalCount = Array.from(messages.values()).reduce(
           (sum, rows) => sum + rows.length,
@@ -169,7 +171,7 @@ function ByColumnTab({
           getColDisplayIndex(colName, columnNames, columnOrder),
         )
         return (
-          <Box key={colName} sx={{ mb: 1 }}>
+          <Box key={colName}>
             <Box sx={groupSectionHeaderSx}>
               <Typography variant="body1" fontWeight="bold">
                 {colLabel(colName)}
@@ -195,7 +197,7 @@ function ByColumnTab({
           </Box>
         )
       })}
-    </>
+    </Stack>
   )
 }
 
@@ -206,14 +208,14 @@ function ByMessageTab({
   onNavigateToCell,
 }: NavProps & { groups: Map<string, Map<string, RowEntry[]>> }) {
   return (
-    <>
+    <Stack divider={<Divider />} spacing={1}>
       {Array.from(groups.entries()).map(([msg, columns]) => {
         const totalCount = Array.from(columns.values()).reduce(
           (sum, rows) => sum + rows.length,
           0,
         )
         return (
-          <Box key={msg} sx={{ mb: 1 }}>
+          <Box key={msg}>
             <Box sx={groupSectionHeaderSx}>
               <Typography variant="body1" fontWeight="bold">
                 {msg}
@@ -245,7 +247,7 @@ function ByMessageTab({
           </Box>
         )
       })}
-    </>
+    </Stack>
   )
 }
 
@@ -429,7 +431,7 @@ export const ValidationAlert = ({
         <Box sx={{ px: 2, py: 1, maxHeight: 200, overflowY: 'auto' }}>
           {/* ── By row ─────────────────────────────────────────── */}
           {groupBy === 'row' && (
-            <Box component="ul" sx={{ m: 0, p: 0, listStyle: 'none' }}>
+            <Stack divider={<Divider />}>
               {allErrors.map((error, i) => {
                 const navCol = Math.max(
                   0,
@@ -440,28 +442,28 @@ export const ValidationAlert = ({
                   ),
                 )
                 return (
-                  <Box component="li" key={i} sx={{ py: 0.25 }}>
-                    <Link
-                      component="button"
-                      variant="body1"
-                      color="text.secondary"
-                      onClick={() => onNavigateToCell(error.rowIndex, navCol)}
-                      sx={{
-                        textAlign: 'left',
-                        ...rowLinkSx,
-                        opacity: error.pending ? 0.5 : 1,
-                      }}
-                    >
-                      <ErrorText
-                        columnName={error.columnName}
-                        message={error.message}
-                        rowIndex={error.rowIndex}
-                      />
-                    </Link>
-                  </Box>
+                  <Link
+                    key={i}
+                    component="button"
+                    variant="body1"
+                    color="text.secondary"
+                    onClick={() => onNavigateToCell(error.rowIndex, navCol)}
+                    sx={{
+                      textAlign: 'left',
+                      py: 0.5,
+                      ...rowLinkSx,
+                      opacity: error.pending ? 0.5 : 1,
+                    }}
+                  >
+                    <ErrorText
+                      columnName={error.columnName}
+                      message={error.message}
+                      rowIndex={error.rowIndex}
+                    />
+                  </Link>
                 )
               })}
-            </Box>
+            </Stack>
           )}
 
           {/* ── By column ──────────────────────────────────────── */}

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -6,6 +6,7 @@ type ValidationError = {
   rowIndex: number
   columnName: string
   message: string
+  pending: boolean
 }
 
 type GroupBy = 'row' | 'column' | 'message'
@@ -74,19 +75,20 @@ const rowLinkSx = {
 } as const
 
 /** Renders a list of row number links. The first shows "Row N"; subsequent
- *  items show only the number, separated by a middle dot. */
+ *  items show only the number, separated by a middle dot.
+ *  Pending entries are dimmed to signal unconfirmed validation state. */
 function RowLinks({
   rows,
   navCol,
   onNavigateToCell,
 }: {
-  rows: number[]
+  rows: { rowIndex: number; pending: boolean }[]
   navCol: number
   onNavigateToCell: (rowIndex: number, colIndex: number) => void
 }) {
   return (
     <>
-      {rows.map((rowIndex, j) => (
+      {rows.map(({ rowIndex, pending }, j) => (
         <Fragment key={rowIndex}>
           {j > 0 && (
             <Box
@@ -102,7 +104,7 @@ function RowLinks({
             variant="caption"
             color="text.secondary"
             onClick={() => onNavigateToCell(rowIndex, navCol)}
-            sx={rowLinkSx}
+            sx={{ ...rowLinkSx, opacity: pending ? 0.5 : 1 }}
           >
             {j === 0 ? `Row ${rowIndex + 1}` : rowIndex + 1}
           </Link>
@@ -124,36 +126,40 @@ export const ValidationAlert = ({
   const allErrors = useMemo((): ValidationError[] => {
     const errors: ValidationError[] = []
     rowValues.forEach((row, rowIndex) => {
-      if (row.__validationStatus !== 'invalid') return
+      const status = row.__validationStatus
+      if (status !== 'invalid' && status !== 'pending') return
+      const pending = status === 'pending'
       row.__cellValidationResults?.forEach((messages, columnName) => {
         messages.forEach(message =>
-          errors.push({ rowIndex, columnName, message }),
+          errors.push({ rowIndex, columnName, message, pending }),
         )
       })
     })
     return errors
   }, [rowValues])
 
-  // columnName → messageText → rowIndex[]
+  type RowEntry = { rowIndex: number; pending: boolean }
+
+  // columnName → messageText → RowEntry[]
   const byColumn = useMemo(() => {
-    const groups = new Map<string, Map<string, number[]>>()
-    allErrors.forEach(({ rowIndex, columnName, message }) => {
+    const groups = new Map<string, Map<string, RowEntry[]>>()
+    allErrors.forEach(({ rowIndex, columnName, message, pending }) => {
       if (!groups.has(columnName)) groups.set(columnName, new Map())
       const colGroup = groups.get(columnName)!
       if (!colGroup.has(message)) colGroup.set(message, [])
-      colGroup.get(message)!.push(rowIndex)
+      colGroup.get(message)!.push({ rowIndex, pending })
     })
     return groups
   }, [allErrors])
 
-  // messageText → columnName → rowIndex[]
+  // messageText → columnName → RowEntry[]
   const byMessage = useMemo(() => {
-    const groups = new Map<string, Map<string, number[]>>()
-    allErrors.forEach(({ rowIndex, columnName, message }) => {
+    const groups = new Map<string, Map<string, RowEntry[]>>()
+    allErrors.forEach(({ rowIndex, columnName, message, pending }) => {
       if (!groups.has(message)) groups.set(message, new Map())
       const msgGroup = groups.get(message)!
       if (!msgGroup.has(columnName)) msgGroup.set(columnName, [])
-      msgGroup.get(columnName)!.push(rowIndex)
+      msgGroup.get(columnName)!.push({ rowIndex, pending })
     })
     return groups
   }, [allErrors])
@@ -237,7 +243,11 @@ export const ValidationAlert = ({
               )
             }
             noWrap
-            sx={{ textAlign: 'left', ...rowLinkSx }}
+            sx={{
+              textAlign: 'left',
+              ...rowLinkSx,
+              opacity: firstError.pending ? 0.5 : 1,
+            }}
           >
             <ErrorText
               columnName={firstError.columnName}
@@ -299,7 +309,11 @@ export const ValidationAlert = ({
                       variant="body2"
                       color="text.secondary"
                       onClick={() => onNavigateToCell(error.rowIndex, navCol)}
-                      sx={{ textAlign: 'left', ...rowLinkSx }}
+                      sx={{
+                        textAlign: 'left',
+                        ...rowLinkSx,
+                        opacity: error.pending ? 0.5 : 1,
+                      }}
                     >
                       <ErrorText
                         columnName={error.columnName}

--- a/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.test.ts
@@ -7,9 +7,13 @@ import { Column } from '@sage-bionetworks/react-datasheet-grid'
 describe('getCellClassName', () => {
   const createMockRowData = (
     validationResults?: Map<string, string[]>,
+    validationStatus: DataGridRow['__validationStatus'] = validationResults
+      ? 'invalid'
+      : undefined,
   ): DataGridRow =>
     ({
       __cellValidationResults: validationResults,
+      __validationStatus: validationStatus,
     } as DataGridRow)
 
   const createMockColumns = (): Column[] => [
@@ -167,6 +171,42 @@ describe('getCellClassName', () => {
     })
 
     expect(result).toBe('cell-invalid')
+  })
+
+  it('adds cell-unknown class when row is pending and cell had a prior error', () => {
+    const validationResults = new Map([['col1', ['Error message']]])
+    const result = getCellClassName({
+      rowData: createMockRowData(validationResults, 'pending'),
+      rowIndex: 0,
+      columnId: 'col1',
+      selectedRowIndex: null,
+    })
+
+    expect(result).toBe('cell-unknown')
+  })
+
+  it('does not add cell-invalid or cell-unknown when row is pending but cell had no prior error', () => {
+    const validationResults = new Map([['col2', ['Error message']]])
+    const result = getCellClassName({
+      rowData: createMockRowData(validationResults, 'pending'),
+      rowIndex: 0,
+      columnId: 'col1',
+      selectedRowIndex: null,
+    })
+
+    expect(result).toBeUndefined()
+  })
+
+  it('does not add cell-invalid or cell-unknown for a valid row', () => {
+    const validationResults = new Map([['col1', ['Error message']]])
+    const result = getCellClassName({
+      rowData: createMockRowData(validationResults, 'valid'),
+      rowIndex: 0,
+      columnId: 'col1',
+      selectedRowIndex: null,
+    })
+
+    expect(result).toBeUndefined()
   })
 
   describe('lastSelection functionality', () => {
@@ -376,6 +416,7 @@ describe('getCellClassName', () => {
     it('combines cell-row-selected, cell-invalid, and cell-changed--other-user when all three apply', () => {
       const validationResults = new Map([['c0', ['Required field']]])
       const rowData: DataGridRow = {
+        __validationStatus: 'invalid',
         __cellValidationResults: validationResults,
         __cellChangeInfo: {
           c0: { category: 'other-user', tooltipText: 'Changed by Alice' },

--- a/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/getCellClassName.ts
@@ -25,8 +25,11 @@ export function getCellClassName(params: {
 
   const isSelected = selectedRowIndex === rowIndex
   const cellValidationResults = rowData.__cellValidationResults
-  const isInvalid =
-    cellValidationResults && columnId && cellValidationResults.has(columnId)
+  const validationStatus = rowData.__validationStatus
+  const hasCellError =
+    cellValidationResults != null &&
+    columnId != null &&
+    cellValidationResults.has(columnId)
 
   const classList: string[] = []
 
@@ -49,8 +52,15 @@ export function getCellClassName(params: {
     }
   }
 
-  if (isInvalid) {
-    classList.push('cell-invalid')
+  if (hasCellError) {
+    // Confirmed invalid — full red cell background
+    if (validationStatus === 'invalid') {
+      classList.push('cell-invalid')
+    }
+    // Pending revalidation — yellow cell background to signal the prior error is unconfirmed
+    if (validationStatus === 'pending') {
+      classList.push('cell-unknown')
+    }
   }
 
   // ── Cell change indicator ─────────────────────────────────────────────────

--- a/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
+++ b/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
@@ -127,6 +127,8 @@ $remote-selection-colors: #1677ff, #52c41a, #fa8c16, #eb2f96, #13c2c2, #9254de,
   }
 
   &.cell-unknown {
+    background: $color-unknown;
+
     &.dsg-cell-sticky-left {
       @include data-cell-only {
         background: $color-unknown;


### PR DESCRIPTION
- Display the Validation Message banner at all times on top of the grid.
- Display total number of validation errors.
- Scroll through all messages by row, column, or message.
- Link to the invalid cell.
- Hide validation messages during initial grid sync

Collapsed
<img width="1056" height="122" alt="collapsed" src="https://github.com/user-attachments/assets/31631ee9-cf4b-40b4-8e4d-d71f41f14add" />

</br>
Expanded
<img width="1055" height="363" alt="expanded" src="https://github.com/user-attachments/assets/562bd10f-eadd-4624-a8ad-046bdae4e118" />

</br>
No errors
<img width="1052" height="118" alt="clean" src="https://github.com/user-attachments/assets/f3f1200f-cb7c-41c3-8517-a9ad9d335cff" />

</br>
Sync
<img width="777" height="112" alt="sync" src="https://github.com/user-attachments/assets/35671a5c-be6f-49d0-99f6-60ad8eb0065c" />

