### PR TITLE
SWC-7549 - Curator grid sync spinner

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/DataGridWebSocket.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/DataGridWebSocket.test.ts
@@ -413,6 +413,80 @@ describe('DataGridWebSocket', () => {
 
       expect(onGridReady).toHaveBeenCalledTimes(1)
     })
+
+    it('calls onSyncEnd when clocks are synchronized', () => {
+      const onSyncEnd = vi.fn()
+      vi.spyOn(console, 'debug').mockImplementation(() => {})
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      const { mockSocket } = createDataGridWebSocket({ onSyncEnd })
+
+      mockSocket.simulateMessage([5, 1])
+
+      expect(onSyncEnd).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('sync lifecycle callbacks', () => {
+    it('calls onSyncStart when sending synchronize-clock on "connected" notification', () => {
+      const onSyncStart = vi.fn()
+      vi.spyOn(console, 'debug').mockImplementation(() => {})
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      const { mockSocket } = createDataGridWebSocket({
+        onSyncStart,
+        model: createTestModel(),
+      })
+
+      mockSocket.simulateMessage([8, 'connected'])
+
+      expect(onSyncStart).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onSyncStart when sending synchronize-clock on "new-patch" notification', () => {
+      const onSyncStart = vi.fn()
+      vi.spyOn(console, 'debug').mockImplementation(() => {})
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      const { mockSocket } = createDataGridWebSocket({
+        onSyncStart,
+        model: createTestModel(),
+      })
+
+      mockSocket.simulateMessage([8, 'new-patch'])
+
+      expect(onSyncStart).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onSyncStart after applying a server patch and flushing pending ops', () => {
+      const onSyncStart = vi.fn()
+      vi.spyOn(console, 'debug').mockImplementation(() => {})
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      const { mockSocket } = createDataGridWebSocket({
+        onSyncStart,
+        model: null,
+      })
+
+      const sourceModel = createTestModel()
+      const patchMessage = buildPatchResponseMessage(sourceModel)
+      mockSocket.simulateMessage(patchMessage)
+
+      // After applying the server patch, the client has no pending ops, so
+      // sendClockSync should fall through to sendSyncMessage and trigger onSyncStart
+      expect(onSyncStart).toHaveBeenCalled()
+    })
+
+    it('does not call onSyncStart on "new-patch" when model is null', () => {
+      const onSyncStart = vi.fn()
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.spyOn(console, 'debug').mockImplementation(() => {})
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      const { mockSocket } = createDataGridWebSocket({
+        onSyncStart,
+        model: null,
+      })
+
+      mockSocket.simulateMessage([8, 'new-patch'])
+
+      expect(onSyncStart).not.toHaveBeenCalled()
+    })
   })
 
   describe('messageHandler — notifications', () => {

--- a/packages/synapse-react-client/src/components/DataGrid/DataGridWebSocket.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/DataGridWebSocket.ts
@@ -47,6 +47,8 @@ type DataGridWebSocketConstructorArgs = {
   onModelCreate?: (model: GridModel) => void
   onReplicaConnected?: () => void
   onReplicaDisconnected?: () => void
+  onSyncStart?: () => void
+  onSyncEnd?: () => void
   maxPayloadSizeBytes?: number
   socket?: WebSocket
   model?: GridModel | null
@@ -74,6 +76,8 @@ export class DataGridWebSocket {
   private onStatusChange: (isOpen: boolean, _this: DataGridWebSocket) => void
   private onReplicaConnected: () => void
   private onReplicaDisconnected: () => void
+  private onSyncStart: () => void
+  private onSyncEnd: () => void
 
   constructor(args: DataGridWebSocketConstructorArgs) {
     const {
@@ -84,6 +88,8 @@ export class DataGridWebSocket {
       onModelCreate,
       onReplicaConnected,
       onReplicaDisconnected,
+      onSyncStart,
+      onSyncEnd,
       maxPayloadSizeBytes,
       socket,
       model,
@@ -101,6 +107,8 @@ export class DataGridWebSocket {
     this.onStatusChange = onStatusChange ?? noop
     this.onReplicaConnected = onReplicaConnected ?? noop
     this.onReplicaDisconnected = onReplicaDisconnected ?? noop
+    this.onSyncStart = onSyncStart ?? noop
+    this.onSyncEnd = onSyncEnd ?? noop
 
     // Restore existing model if provided
     if (model) {
@@ -240,6 +248,7 @@ export class DataGridWebSocket {
   private handleResponseComplete() {
     // Clocks are in sync, no further action needed
     this.onGridReady()
+    this.onSyncEnd()
     console.debug(
       'Clocks synchronized with server. Incrementing sequence number.',
     )
@@ -275,12 +284,7 @@ export class DataGridWebSocket {
         {
           const verbModel = this.verboseEncoder.encode(this.model)
           console.debug('New patch received, syncing data:', verbModel.time)
-          const msg = new JsonRxRequestComplete(
-            this.messageCounter.getNext(),
-            'synchronize-clock',
-            verbModel.time,
-          )
-          this.sendMessage(msg)
+          this.sendSyncMessage(verbModel.time)
         }
         break
 
@@ -350,6 +354,7 @@ export class DataGridWebSocket {
       'synchronize-clock',
       clock ?? [],
     )
+    this.onSyncStart()
     this.sendMessage(message)
   }
 

--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -9,13 +9,8 @@ import { SkeletonTable } from '@/components/index'
 import { useGetEntity } from '@/synapse-queries/index'
 import { getSchemaPropertiesInfo } from '@/utils/jsonschema/getSchemaPropertyInfo'
 import { SmartToyTwoTone } from '@mui/icons-material'
-import {
-  Box,
-  CircularProgress,
-  Stack,
-  Tooltip,
-  Typography,
-} from '@mui/material'
+import { Box, Stack, Tooltip, Typography } from '@mui/material'
+import { SynapseSpinner } from '../LoadingScreen/LoadingScreen'
 import Grid from '@mui/material/Grid'
 import {
   CreateGridRequest,
@@ -474,7 +469,7 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
                             mr: 'auto',
                           }}
                         >
-                          <CircularProgress size={16} />
+                          <SynapseSpinner size={16} margin="0" />
                           <Typography variant="caption" color="text.secondary">
                             {hasCompletedInitialSync ? 'Syncing…' : 'Loading…'}
                           </Typography>

--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -113,6 +113,7 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
       isConnected,
       websocketInstance,
       hasCompletedInitialSync,
+      isSyncing,
       model,
       modelSnapshot,
       connect,
@@ -464,7 +465,7 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
                       spacing={1}
                       sx={{ justifyContent: 'flex-end' }}
                     >
-                      {!hasCompletedInitialSync && (
+                      {(!hasCompletedInitialSync || isSyncing) && (
                         <Box
                           sx={{
                             display: 'flex',
@@ -475,7 +476,7 @@ const SynapseGrid = forwardRef<SynapseGridHandle, SynapseGridProps>(
                         >
                           <CircularProgress size={16} />
                           <Typography variant="caption" color="text.secondary">
-                            Syncing…
+                            {hasCompletedInitialSync ? 'Syncing…' : 'Loading…'}
                           </Typography>
                         </Box>
                       )}

--- a/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ValidationAlert.tsx
@@ -2,7 +2,6 @@ import { DataGridRow } from '../DataGridTypes'
 import {
   Box,
   Chip,
-  CircularProgress,
   Collapse,
   Divider,
   Link,
@@ -12,6 +11,7 @@ import {
   Typography,
 } from '@mui/material'
 import { Fragment, useMemo, useState } from 'react'
+import { SynapseSpinner } from '../../LoadingScreen/LoadingScreen'
 
 type ValidationError = {
   rowIndex: number
@@ -322,7 +322,7 @@ export const ValidationAlert = ({
           gap: 1,
         }}
       >
-        <CircularProgress size={14} />
+        <SynapseSpinner size={14} margin="0" />
         <Typography variant="body1" color="text.secondary">
           Loading validation errors…
         </Typography>

--- a/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.test.ts
@@ -141,6 +141,7 @@ describe('useDataGridWebSocket', () => {
     expect(result.current.isConnected).toBe(false)
     expect(result.current.websocketInstance).toBeNull()
     expect(result.current.hasCompletedInitialSync).toBe(false)
+    expect(result.current.isSyncing).toBe(false)
     expect(result.current.modelSnapshot).toBeUndefined()
     expect(result.current.presignedUrl).toBe('ws://mocked-url')
     expect(result.current.errorEstablishingWebsocketConnection).toBeNull()
@@ -466,6 +467,64 @@ describe('useDataGridWebSocket', () => {
       expect(result.current.websocketInstance).not.toBe(firstInstance)
     })
     expect(mockClearPresignedUrl).toHaveBeenCalledTimes(1)
+  })
+
+  it('should toggle isSyncing via onSyncStart/onSyncEnd callbacks', async () => {
+    const { result } = renderHook(() => useDataGridWebSocket(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.connect(42, 'sync-session')
+    })
+
+    await waitFor(() => {
+      expect(result.current.websocketInstance).not.toBeNull()
+    })
+
+    expect(result.current.isSyncing).toBe(false)
+
+    act(() => {
+      MockDataGridWebSocket.mock.lastCall![0].onSyncStart!()
+    })
+    expect(result.current.isSyncing).toBe(true)
+
+    act(() => {
+      MockDataGridWebSocket.mock.lastCall![0].onSyncEnd!()
+    })
+    expect(result.current.isSyncing).toBe(false)
+  })
+
+  it('should reset isSyncing when the websocket closes mid-sync', async () => {
+    const { result } = renderHook(() => useDataGridWebSocket(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.connect(43, 'sync-close-session')
+    })
+
+    await waitFor(() => {
+      expect(result.current.websocketInstance).not.toBeNull()
+    })
+
+    const config = MockDataGridWebSocket.mock.lastCall![0]
+
+    act(() => {
+      config.onStatusChange!(true, result.current.websocketInstance!)
+      config.onSyncStart!()
+    })
+    expect(result.current.isSyncing).toBe(true)
+
+    act(() => {
+      config.onStatusChange!(false, result.current.websocketInstance!)
+    })
+
+    // The close also triggers an auto-reconnect; wait for it to settle
+    await waitFor(() => {
+      expect(result.current.isSyncing).toBe(false)
+      expect(mockEstablishWebsocketConnection).toHaveBeenCalledTimes(2)
+    })
   })
 
   it('should disconnect the websocket on unmount without clearing the model', async () => {

--- a/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.test.ts
@@ -527,48 +527,6 @@ describe('useDataGridWebSocket', () => {
     })
   })
 
-  it('should keep isSyncing true until every in-flight clock has been acknowledged', async () => {
-    const { result } = renderHook(() => useDataGridWebSocket(), {
-      wrapper: createWrapper(),
-    })
-
-    act(() => {
-      result.current.connect(44, 'overlapping-sync-session')
-    })
-
-    await waitFor(() => {
-      expect(result.current.websocketInstance).not.toBeNull()
-    })
-
-    const config = MockDataGridWebSocket.mock.lastCall![0]
-
-    // Client sends clock #1 — round 1 starts
-    act(() => {
-      config.onSyncStart!()
-    })
-    expect(result.current.isSyncing).toBe(true)
-
-    // Before round 1 completes, client sends clock #2 (e.g. server pinged
-    // 'new-patch' while round 1 was still in flight) — round 2 starts
-    act(() => {
-      config.onSyncStart!()
-    })
-    expect(result.current.isSyncing).toBe(true)
-
-    // Server acknowledges round 1 — but round 2 is still pending, so the
-    // spinner must stay on
-    act(() => {
-      config.onSyncEnd!()
-    })
-    expect(result.current.isSyncing).toBe(true)
-
-    // Server finally acknowledges round 2 — now we are truly idle
-    act(() => {
-      config.onSyncEnd!()
-    })
-    expect(result.current.isSyncing).toBe(false)
-  })
-
   it('should disconnect the websocket on unmount without clearing the model', async () => {
     const { result, unmount } = renderHook(() => useDataGridWebSocket(), {
       wrapper: createWrapper(),

--- a/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.test.ts
@@ -527,6 +527,48 @@ describe('useDataGridWebSocket', () => {
     })
   })
 
+  it('should keep isSyncing true until every in-flight clock has been acknowledged', async () => {
+    const { result } = renderHook(() => useDataGridWebSocket(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.connect(44, 'overlapping-sync-session')
+    })
+
+    await waitFor(() => {
+      expect(result.current.websocketInstance).not.toBeNull()
+    })
+
+    const config = MockDataGridWebSocket.mock.lastCall![0]
+
+    // Client sends clock #1 — round 1 starts
+    act(() => {
+      config.onSyncStart!()
+    })
+    expect(result.current.isSyncing).toBe(true)
+
+    // Before round 1 completes, client sends clock #2 (e.g. server pinged
+    // 'new-patch' while round 1 was still in flight) — round 2 starts
+    act(() => {
+      config.onSyncStart!()
+    })
+    expect(result.current.isSyncing).toBe(true)
+
+    // Server acknowledges round 1 — but round 2 is still pending, so the
+    // spinner must stay on
+    act(() => {
+      config.onSyncEnd!()
+    })
+    expect(result.current.isSyncing).toBe(true)
+
+    // Server finally acknowledges round 2 — now we are truly idle
+    act(() => {
+      config.onSyncEnd!()
+    })
+    expect(result.current.isSyncing).toBe(false)
+  })
+
   it('should disconnect the websocket on unmount without clearing the model', async () => {
     const { result, unmount } = renderHook(() => useDataGridWebSocket(), {
       wrapper: createWrapper(),

--- a/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.ts
@@ -14,10 +14,12 @@ interface WebSocketState {
    */
   hasCompletedInitialSync: boolean
   /**
-   * True while a clock-sync round is in progress: from when the client sends a
-   * `synchronize-clock` message until the server responds with `ResponseComplete`.
+   * Number of in-flight clock-sync rounds — incremented when the client sends a
+   * `synchronize-clock` message and decremented when the server responds with
+   * `ResponseComplete`. A counter (rather than a boolean) is used because a new
+   * round can begin before the previous one is acknowledged.
    */
-  isSyncing: boolean
+  pendingSyncRounds: number
   isConnected: boolean
   isConnecting: boolean
   connectionParams: {
@@ -65,7 +67,7 @@ function websocketReducer(
         hasCompletedInitialSync: isSameConnection
           ? state.hasCompletedInitialSync
           : false,
-        isSyncing: false,
+        pendingSyncRounds: 0,
         model: isSameConnection ? state.model : null,
         isConnected: false,
         isConnecting: false,
@@ -93,7 +95,7 @@ function websocketReducer(
         ...state,
         isConnected: false,
         isConnecting: false,
-        isSyncing: false,
+        pendingSyncRounds: 0,
       }
 
     case 'GRID_READY':
@@ -105,13 +107,13 @@ function websocketReducer(
     case 'SYNC_STARTED':
       return {
         ...state,
-        isSyncing: true,
+        pendingSyncRounds: state.pendingSyncRounds + 1,
       }
 
     case 'SYNC_ENDED':
       return {
         ...state,
-        isSyncing: false,
+        pendingSyncRounds: Math.max(0, state.pendingSyncRounds - 1),
       }
 
     case 'MODEL_CREATED':
@@ -135,7 +137,7 @@ function websocketReducer(
 export const initialWebSocketState: WebSocketState = {
   model: null,
   hasCompletedInitialSync: false,
-  isSyncing: false,
+  pendingSyncRounds: 0,
   isConnected: false,
   isConnecting: false,
   connectionParams: null,
@@ -344,7 +346,7 @@ export function useDataGridWebSocket(options?: UseDataGridWebSocketOptions) {
     isConnected: state.isConnected,
     websocketInstance: state.websocketInstance,
     hasCompletedInitialSync: state.hasCompletedInitialSync,
-    isSyncing: state.isSyncing,
+    isSyncing: state.pendingSyncRounds > 0,
     model: state.model,
     modelSnapshot,
     connect,

--- a/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.ts
@@ -14,12 +14,11 @@ interface WebSocketState {
    */
   hasCompletedInitialSync: boolean
   /**
-   * Number of in-flight clock-sync rounds — incremented when the client sends a
-   * `synchronize-clock` message and decremented when the server responds with
-   * `ResponseComplete`. A counter (rather than a boolean) is used because a new
-   * round can begin before the previous one is acknowledged.
+   * True while a clock-sync exchange is in progress. Set on every outgoing
+   * `synchronize-clock` and cleared on `ResponseComplete`, which the server
+   * sends once per exchange to signal "we're synchronized" — not per request.
    */
-  pendingSyncRounds: number
+  isSyncing: boolean
   isConnected: boolean
   isConnecting: boolean
   connectionParams: {
@@ -67,7 +66,7 @@ function websocketReducer(
         hasCompletedInitialSync: isSameConnection
           ? state.hasCompletedInitialSync
           : false,
-        pendingSyncRounds: 0,
+        isSyncing: false,
         model: isSameConnection ? state.model : null,
         isConnected: false,
         isConnecting: false,
@@ -95,7 +94,7 @@ function websocketReducer(
         ...state,
         isConnected: false,
         isConnecting: false,
-        pendingSyncRounds: 0,
+        isSyncing: false,
       }
 
     case 'GRID_READY':
@@ -107,13 +106,13 @@ function websocketReducer(
     case 'SYNC_STARTED':
       return {
         ...state,
-        pendingSyncRounds: state.pendingSyncRounds + 1,
+        isSyncing: true,
       }
 
     case 'SYNC_ENDED':
       return {
         ...state,
-        pendingSyncRounds: Math.max(0, state.pendingSyncRounds - 1),
+        isSyncing: false,
       }
 
     case 'MODEL_CREATED':
@@ -137,7 +136,7 @@ function websocketReducer(
 export const initialWebSocketState: WebSocketState = {
   model: null,
   hasCompletedInitialSync: false,
-  pendingSyncRounds: 0,
+  isSyncing: false,
   isConnected: false,
   isConnecting: false,
   connectionParams: null,
@@ -346,7 +345,7 @@ export function useDataGridWebSocket(options?: UseDataGridWebSocketOptions) {
     isConnected: state.isConnected,
     websocketInstance: state.websocketInstance,
     hasCompletedInitialSync: state.hasCompletedInitialSync,
-    isSyncing: state.pendingSyncRounds > 0,
+    isSyncing: state.isSyncing,
     model: state.model,
     modelSnapshot,
     connect,

--- a/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.ts
@@ -13,6 +13,11 @@ interface WebSocketState {
    * Corresponds to the `GRID_READY` action.
    */
   hasCompletedInitialSync: boolean
+  /**
+   * True while a clock-sync round is in progress: from when the client sends a
+   * `synchronize-clock` message until the server responds with `ResponseComplete`.
+   */
+  isSyncing: boolean
   isConnected: boolean
   isConnecting: boolean
   connectionParams: {
@@ -34,6 +39,8 @@ type WebSocketAction =
   | { type: 'CONNECTION_OPENED' }
   | { type: 'CONNECTION_CLOSED' }
   | { type: 'GRID_READY' }
+  | { type: 'SYNC_STARTED' }
+  | { type: 'SYNC_ENDED' }
   | { type: 'MODEL_CREATED'; payload: GridModel }
   | { type: 'CONNECTION_ERROR'; payload: unknown }
 
@@ -58,6 +65,7 @@ function websocketReducer(
         hasCompletedInitialSync: isSameConnection
           ? state.hasCompletedInitialSync
           : false,
+        isSyncing: false,
         model: isSameConnection ? state.model : null,
         isConnected: false,
         isConnecting: false,
@@ -85,12 +93,25 @@ function websocketReducer(
         ...state,
         isConnected: false,
         isConnecting: false,
+        isSyncing: false,
       }
 
     case 'GRID_READY':
       return {
         ...state,
         hasCompletedInitialSync: true,
+      }
+
+    case 'SYNC_STARTED':
+      return {
+        ...state,
+        isSyncing: true,
+      }
+
+    case 'SYNC_ENDED':
+      return {
+        ...state,
+        isSyncing: false,
       }
 
     case 'MODEL_CREATED':
@@ -114,6 +135,7 @@ function websocketReducer(
 export const initialWebSocketState: WebSocketState = {
   model: null,
   hasCompletedInitialSync: false,
+  isSyncing: false,
   isConnected: false,
   isConnecting: false,
   connectionParams: null,
@@ -176,6 +198,8 @@ export function useDataGridWebSocket(options?: UseDataGridWebSocketOptions) {
       onModelCreate: handleModelCreate,
       onReplicaConnected: options?.onReplicaConnected,
       onReplicaDisconnected: options?.onReplicaDisconnected,
+      onSyncStart: () => dispatch({ type: 'SYNC_STARTED' }),
+      onSyncEnd: () => dispatch({ type: 'SYNC_ENDED' }),
     }),
     [
       handleModelCreate,
@@ -320,6 +344,7 @@ export function useDataGridWebSocket(options?: UseDataGridWebSocketOptions) {
     isConnected: state.isConnected,
     websocketInstance: state.websocketInstance,
     hasCompletedInitialSync: state.hasCompletedInitialSync,
+    isSyncing: state.isSyncing,
     model: state.model,
     modelSnapshot,
     connect,

--- a/packages/synapse-react-client/src/synapse-queries/grid/useEstablishWebsocketConnection.ts
+++ b/packages/synapse-react-client/src/synapse-queries/grid/useEstablishWebsocketConnection.ts
@@ -13,6 +13,8 @@ interface EstablishWebsocketParams {
     onModelCreate?: (model: GridModel) => void
     onReplicaConnected?: () => void
     onReplicaDisconnected?: () => void
+    onSyncStart?: () => void
+    onSyncEnd?: () => void
     model?: GridModel | null
   }
 }


### PR DESCRIPTION
SWC-7770 introduced a loading spinner while the client receives the initial grid data. This PR expands on that by showing a sync spinner any time the client and server sync clocks. Among other things, this gives a visual clue that agentic changes are being applied outside of the current view.