### PR TITLE
PORTALS-4199

### DIFF
--- a/apps/SageAccountWeb/src/pages/RegisterAccount1.tsx
+++ b/apps/SageAccountWeb/src/pages/RegisterAccount1.tsx
@@ -14,7 +14,6 @@ import {
 } from '@mui/material'
 import {
   AliasType,
-  FeatureFlagEnum,
   isMembershipInvtnSignedToken,
 } from '@sage-bionetworks/synapse-types'
 import { SyntheticEvent, useEffect, useMemo, useState } from 'react'
@@ -40,8 +39,10 @@ import LastLoginInfo, {
 import RegisterPageLogoutPrompt from 'synapse-react-client/components/RegisterPageLogoutPrompt/RegisterPageLogoutPrompt'
 import IconSvg from 'synapse-react-client/components/IconSvg/IconSvg'
 import { generateCsrfToken } from 'synapse-react-client/utils/functions/generateCsrfToken'
-import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/featureflags/useGetFeatureFlag'
-import { hasArcusProvider } from 'synapse-react-client/utils/functions/RealmUtils'
+import {
+  hasArcusProvider,
+  hasSageBionetworksProvider,
+} from 'synapse-react-client/utils/functions/RealmUtils'
 
 export enum Pages {
   CHOOSE_REGISTRATION,
@@ -53,10 +54,10 @@ export enum Pages {
 function BackButtonForPage(props: {
   page: Pages
   setPage: (page: Pages) => void
-  isArcusApp: boolean
+  isSingleIdp: boolean
 }) {
-  const { page, setPage, isArcusApp } = props
-  if (isArcusApp) {
+  const { page, setPage, isSingleIdp } = props
+  if (isSingleIdp) {
     return <></>
   }
   switch (page) {
@@ -99,9 +100,7 @@ const RegisterAccount1 = (): React.ReactNode => {
     friendlyName: sourceAppName,
     defaultRealm,
   } = useSourceApp()
-  const showSageBionetworksIdp = useGetFeatureFlag(
-    FeatureFlagEnum.SAGE_BIONETWORKS_IDP,
-  )
+  const isSageBionetworksApp = hasSageBionetworksProvider(defaultRealm)
   const isArcusApp = hasArcusProvider(defaultRealm)
   const [page, setPage] = useState(Pages.CHOOSE_REGISTRATION)
   const [membershipInvitationEmail, setMembershipInvitationEmail] =
@@ -111,7 +110,7 @@ const RegisterAccount1 = (): React.ReactNode => {
   const { search } = useLocation()
   const queryParams = useMemo(() => new URLSearchParams(search), [search])
   const emailFromParams = queryParams.get('email')
-
+  const isSingleIdp = isArcusApp || isSageBionetworksApp
   // If we have an email param, initialize the email address with the param
   useEffect(() => {
     if (emailFromParams) {
@@ -124,11 +123,21 @@ const RegisterAccount1 = (): React.ReactNode => {
 
   // If this is the Arcus app, skip the "choose registration" page and go straight to OAuth registration
   useEffect(() => {
-    if (isArcusApp) {
+    if (isSingleIdp) {
       setPage(Pages.OAUTH_REGISTRATION)
-      setOAuthRegistrationProvider(SynapseConstants.OAUTH2_PROVIDERS.ARCUS)
+      let provider: string
+      if (isArcusApp) {
+        provider = SynapseConstants.OAUTH2_PROVIDERS.ARCUS
+      } else if (isSageBionetworksApp) {
+        provider = SynapseConstants.OAUTH2_PROVIDERS.SAGE_BIONETWORKS
+      } else {
+        // This should never happen
+        console.error('No valid identity provider found for this app')
+        provider = SynapseConstants.OAUTH2_PROVIDERS.GOOGLE
+      }
+      setOAuthRegistrationProvider(provider)
     }
-  }, [isArcusApp])
+  }, [isSingleIdp, isArcusApp, isSageBionetworksApp])
 
   // If we have a MembershipInvtnSignedToken, initialize the email address with the membership invitation invitee email.
   useEffect(() => {
@@ -255,7 +264,7 @@ const RegisterAccount1 = (): React.ReactNode => {
                 <BackButtonForPage
                   page={page}
                   setPage={setPage}
-                  isArcusApp={isArcusApp}
+                  isSingleIdp={isSingleIdp}
                 />
                 <Box
                   sx={{
@@ -298,21 +307,6 @@ const RegisterAccount1 = (): React.ReactNode => {
                         >
                           Create account with your email
                         </Button>
-                        {showSageBionetworksIdp && (
-                          <Button
-                            onClick={() => {
-                              setOAuthRegistrationProvider(
-                                SynapseConstants.OAUTH2_PROVIDERS
-                                  .SAGE_BIONETWORKS,
-                              )
-                              setPage(Pages.OAUTH_REGISTRATION)
-                            }}
-                            sx={chooseButtonSx}
-                            variant="outlined"
-                          >
-                            Create account with Sage Bionetworks (Realm)
-                          </Button>
-                        )}
                       </div>
                       {lastLoginInfo && (
                         <Box

--- a/packages/synapse-react-client/src/components/Authentication/AuthenticationMethodSelection.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/AuthenticationMethodSelection.tsx
@@ -12,10 +12,11 @@ import {
 import { Box } from '@mui/material'
 import { MouseEvent } from 'react'
 import LoginMethodButton from './LoginMethodButton'
-import { useGetFeatureFlag } from '@/synapse-queries/featureflags/useGetFeatureFlag'
-import { FeatureFlagEnum } from '@sage-bionetworks/synapse-types'
 import { Realm } from '@sage-bionetworks/synapse-client'
-import { hasArcusProvider } from '@/utils/functions/RealmUtils'
+import {
+  hasArcusProvider,
+  hasSageBionetworksProvider,
+} from '@/utils/functions/RealmUtils'
 
 type AuthenticationMethodSelectionProps = {
   ssoRedirectUrl?: string
@@ -45,10 +46,10 @@ export default function AuthenticationMethodSelection(
   } = props
 
   const showArcusSSOButtonOnly = hasArcusProvider(realm)
-  const showSageBionetworksIdp = useGetFeatureFlag(
-    FeatureFlagEnum.SAGE_BIONETWORKS_IDP,
-  )
+  const showSageBionetworksSSOButtonOnly = hasSageBionetworksProvider(realm)
 
+  const isSingleIdpOnly =
+    showArcusSSOButtonOnly || showSageBionetworksSSOButtonOnly
   const stateWithCSRF: OAuth2State = { ...state, csrfToken }
 
   function onSSOSignIn(event: MouseEvent<HTMLButtonElement>, provider: string) {
@@ -72,7 +73,7 @@ export default function AuthenticationMethodSelection(
 
   return (
     <Box>
-      {!showArcusSSOButtonOnly && (
+      {!isSingleIdpOnly && (
         <>
           <LoginMethodButton
             loginMethod={LOGIN_METHOD_OAUTH2_GOOGLE}
@@ -93,14 +94,6 @@ export default function AuthenticationMethodSelection(
             iconName="email"
             onClick={onSelectUsernameAndPassword}
           />
-          {showSageBionetworksIdp && (
-            <LoginMethodButton
-              loginMethod={LOGIN_METHOD_OAUTH2_SAGE_BIONETWORKS}
-              onClick={event => {
-                onSSOSignIn(event, OAUTH2_PROVIDERS.SAGE_BIONETWORKS)
-              }}
-            />
-          )}
         </>
       )}
       {showArcusSSOButtonOnly && (
@@ -109,6 +102,14 @@ export default function AuthenticationMethodSelection(
           // iconName="arcusbio"
           onClick={event => {
             onSSOSignIn(event, OAUTH2_PROVIDERS.ARCUS)
+          }}
+        />
+      )}
+      {showSageBionetworksSSOButtonOnly && (
+        <LoginMethodButton
+          loginMethod={LOGIN_METHOD_OAUTH2_SAGE_BIONETWORKS}
+          onClick={event => {
+            onSSOSignIn(event, OAUTH2_PROVIDERS.SAGE_BIONETWORKS)
           }}
         />
       )}

--- a/packages/synapse-react-client/src/utils/functions/RealmUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/RealmUtils.ts
@@ -8,10 +8,24 @@ import {
  * Check if a realm has the ARCUS_BIOSCIENCES identity provider
  */
 export function hasArcusProvider(realm?: Realm): boolean {
+  return hasProvider(realm, OAuthIdentityProviderProviderEnum.ARCUS_BIOSCIENCES)
+}
+
+/**
+ * Check if a realm has the SAGE_BIONETWORKS identity provider
+ */
+export function hasSageBionetworksProvider(realm?: Realm): boolean {
+  return hasProvider(realm, OAuthIdentityProviderProviderEnum.SAGE_BIONETWORKS)
+}
+
+function hasProvider(
+  realm?: Realm,
+  providerEnum?: OAuthIdentityProviderProviderEnum,
+): boolean {
   if (!realm?.identityProvider) return false
   return realm.identityProvider.some(
     (provider: any) =>
       instanceOfOAuthIdentityProvider(provider) &&
-      provider.provider === OAuthIdentityProviderProviderEnum.ARCUS_BIOSCIENCES,
+      provider.provider === providerEnum,
   )
 }

--- a/packages/synapse-types/src/FeatureFlags.ts
+++ b/packages/synapse-types/src/FeatureFlags.ts
@@ -22,9 +22,6 @@ export enum FeatureFlagEnum {
   // If enabled, show the Download Ineligible for Packaging Files button on the download cart page
   DOWNLOAD_CART_INELIGIBLE_FILE_DOWNLOADS = 'DOWNLOAD_CART_INELIGIBLE_FILE_DOWNLOADS',
 
-  // If enabled, provide the ability to login or create an account using the Sage Bionetworks IdP OAuth2 provider
-  SAGE_BIONETWORKS_IDP = 'SAGE_BIONETWORKS_IDP',
-
   // If enabled, show the SynapseChat dialog in portals
   PORTAL_CHAT = 'PORTAL_CHAT',
 


### PR DESCRIPTION
Instead of relying on a feature flag, look at the associated realm information.  If it contains the special SAGE_BIONETWORKS IdP, then treat it similarly to the ARCUS_BIO IdP UX.  To get to this UI, users will now need to enter the Sage Accounts login app with `appId` set to `sagebio.realms.test`

<img width="1364" height="823" alt="Screenshot 2026-04-29 at 4 34 40 PM" src="https://github.com/user-attachments/assets/ae456f9b-8dbb-46d5-b4b8-4463f15fd15b" />
