### PR TITLE
PORTALS-4206: update custom Explore wrapper for B2AI Standards Regist…

### DIFF
--- a/apps/portals/b2ai.standards/src/pages/Explore.tsx
+++ b/apps/portals/b2ai.standards/src/pages/Explore.tsx
@@ -1,3 +1,7 @@
+import {
+  NEGATIVE_RESPONSIVE_SIDE_MARGIN,
+  RESPONSIVE_SIDE_PADDING,
+} from '@sage-bionetworks/synapse-portal-framework/utils'
 import { Box } from '@mui/material'
 import QueryWrapperPlotNav from 'synapse-react-client/components/QueryWrapperPlotNav/index'
 import { standardsQueryWrapperPlotNavProps } from '@/config/synapseConfigs/standards'
@@ -6,11 +10,15 @@ export default function ExploreWrapper() {
   return (
     <Box
       sx={{
-        '.QueryWrapperPlotNav > *': {
-          p: '0px 20px',
+        ...RESPONSIVE_SIDE_PADDING,
+        ['.TopLevelControls, .TotalQueryResults.hasFilters']: {
+          ...NEGATIVE_RESPONSIVE_SIDE_MARGIN,
+          mt: 0,
+          px: RESPONSIVE_SIDE_PADDING['px'],
         },
-        '.QueryWrapperPlotNav > .TopLevelControls': {
-          mt: '0',
+        '.TopLevelControls > div': {
+          px: 0,
+          py: 2.5,
         },
       }}
     >


### PR DESCRIPTION
…ry explorer (only one explore section, so we do not have the tabs)

Before:
<img width="1489" height="715" alt="Screenshot 2026-05-01 at 8 11 25 PM" src="https://github.com/user-attachments/assets/8d7096e5-2a30-468f-9e4c-7702eb2ff838" />

After:
<img width="1488" height="804" alt="Screenshot 2026-05-01 at 8 11 35 PM" src="https://github.com/user-attachments/assets/cf80658f-3572-4ebe-b815-467a323591ec" />

