### PR TITLE
feat: add tcia.collection to bioregistry rules

### DIFF
--- a/packages/synapse-react-client/src/components/GenericCard/BioregistryRules.ts
+++ b/packages/synapse-react-client/src/components/GenericCard/BioregistryRules.ts
@@ -2,7 +2,7 @@
 // This file is auto-generated. Do not edit manually.
 // Generated from bioregistry.io API based on collection.yaml
 
-const onMatch = (value: string) => `https://bioregistry.io/${value}`;
+const onMatch = (value: string) => `https://bioregistry.io/${value}`
 
 export const bioregistryRules = [
   {
@@ -78,7 +78,8 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(brenda:(?:(?:\d+\.-\.-\.-)|(?:\d+\.\d+\.-\.-)|(?:\d+\.\d+\.\d+\.-)|(?:\d+\.\d+\.\d+\.\d+)))/,
+    regex:
+      /(brenda:(?:(?:\d+\.-\.-\.-)|(?:\d+\.\d+\.-\.-)|(?:\d+\.\d+\.\d+\.-)|(?:\d+\.\d+\.\d+\.\d+)))/,
     onMatch,
   },
   {
@@ -110,7 +111,8 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(cellxgene.collection:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/,
+    regex:
+      /(cellxgene.collection:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/,
     onMatch,
   },
   {
@@ -250,7 +252,8 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(ec:\d{1,2}(?:(?:(?:\.\d{1,3}){1,3})|(?:\.\d+){2}\.[nB]\d{1,3}|\.-\.-\.-|\.\d{1,3}\.-\.-|\.\d{1,3}\.\d{1,3}\.-)?)/,
+    regex:
+      /(ec:\d{1,2}(?:(?:(?:\.\d{1,3}){1,3})|(?:\.\d+){2}\.[nB]\d{1,3}|\.-\.-\.-|\.\d{1,3}\.-\.-|\.\d{1,3}\.\d{1,3}\.-)?)/,
     onMatch,
   },
   {
@@ -282,7 +285,8 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(ensembl:(?:(?:ENS[FPTG]\d{11}(?:\.\d+)?)|(?:FB\w{2}\d{7})|(?:Y[A-Z]{2}\d{3}[a-zA-Z](?:\-[A-Z])?)|(?:[A-Z_a-z0-9]+(?:\.)?(?:t)?(?:\d+)?(?:[a-z])?)))/,
+    regex:
+      /(ensembl:(?:(?:ENS[FPTG]\d{11}(?:\.\d+)?)|(?:FB\w{2}\d{7})|(?:Y[A-Z]{2}\d{3}[a-zA-Z](?:\-[A-Z])?)|(?:[A-Z_a-z0-9]+(?:\.)?(?:t)?(?:\d+)?(?:[a-z])?)))/,
     onMatch,
   },
   {
@@ -382,11 +386,13 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(icd10:(?:(?:[XVI]+)|(?:[A-Z][0-9]+(?:(?:-[A-Z][0-9]+)|(?:\.[0-9]))?)))/,
+    regex:
+      /(icd10:(?:(?:[XVI]+)|(?:[A-Z][0-9]+(?:(?:-[A-Z][0-9]+)|(?:\.[0-9]))?)))/,
     onMatch,
   },
   {
-    regex: /(icd9:(?:(?:\d{1,3}-\d{1,3})|(?:(?:\d\d\d|V\d\d|E[8-9]\d\d)(?:\.\d{1,2})?)))/,
+    regex:
+      /(icd9:(?:(?:\d{1,3}-\d{1,3})|(?:(?:\d\d\d|V\d\d|E[8-9]\d\d)(?:\.\d{1,2})?)))/,
     onMatch,
   },
   {
@@ -406,7 +412,8 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(inchi:InChI\=1S?\/[A-Za-z0-9\.]+(?:\+[0-9]+)?(?:\/[cnpqbtmsih][A-Za-z0-9\-\+\(?:\)\,\/\?\;\.]+)*)/,
+    regex:
+      /(inchi:InChI\=1S?\/[A-Za-z0-9\.]+(?:\+[0-9]+)?(?:\/[cnpqbtmsih][A-Za-z0-9\-\+\(?:\)\,\/\?\;\.]+)*)/,
     onMatch,
   },
   {
@@ -414,7 +421,8 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(insdc:(?:[A-Z]\d{5}|[A-Z]{2}\d{6}|[A-Z]{4,6}\d{8,10}|[A-J][A-Z]{2}\d{5})(?:\.\d+)?)/,
+    regex:
+      /(insdc:(?:[A-Z]\d{5}|[A-Z]{2}\d{6}|[A-Z]{4,6}\d{8,10}|[A-J][A-Z]{2}\d{5})(?:\.\d+)?)/,
     onMatch,
   },
   {
@@ -446,7 +454,8 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(kegg:(?:(?:[CHDEGTMKR]\d+)|(?:\w+:[\w\d\.-]*)|(?:\w{2,4}\d{5})|(?:[a-z]{3,5})))/,
+    regex:
+      /(kegg:(?:(?:[CHDEGTMKR]\d+)|(?:\w+:[\w\d\.-]*)|(?:\w{2,4}\d{5})|(?:[a-z]{3,5})))/,
     onMatch,
   },
   {
@@ -486,11 +495,11 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(mesh:(?:C|D|M)\d{6,9})/,
+    regex: /(mesh:(?:C|D|Q)\d+)/,
     onMatch,
   },
   {
-    regex: /(metabolights:MTBLS\d+)/,
+    regex: /(metabolights:MTBL[CS]\d+)/,
     onMatch,
   },
   {
@@ -674,7 +683,8 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(refseq:(?:(?:(?:AC|AP|NC|NG|NM|NP|NR|NT|NW|WP|XM|XP|XR|YP|ZP)_\d+)|(?:NZ_[A-Z]{2,4}\d+))(?:\.\d+)?)/,
+    regex:
+      /(refseq:(?:(?:(?:AC|AP|NC|NG|NM|NP|NR|NT|NW|WP|XM|XP|XR|YP|ZP)_\d+)|(?:NZ_[A-Z]{2,4}\d+))(?:\.\d+)?)/,
     onMatch,
   },
   {
@@ -746,7 +756,8 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(string:(?:(?:[A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])|(?:[O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])|(?:[0-9][A-Za-z0-9]{3})))/,
+    regex:
+      /(string:(?:(?:[A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])|(?:[O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])|(?:[0-9][A-Za-z0-9]{3})))/,
     onMatch,
   },
   {
@@ -755,6 +766,10 @@ export const bioregistryRules = [
   },
   {
     regex: /(tcdb:\d+(?:\.[A-Z])?(?:\.\d+)?(?:\.\d+)?(?:\.\d+)?)/,
+    onMatch,
+  },
+  {
+    regex: /(tcia.collection:[A-Za-z0-9][A-Za-z0-9_\-\.]*[A-Za-z0-9])/,
     onMatch,
   },
   {
@@ -770,11 +785,13 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(uniprot:(?:(?:[A-N,R-Z][0-9](?:[A-Z][A-Z, 0-9][A-Z, 0-9][0-9]){1,2})|(?:[O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(?:\.\d+)?))/,
+    regex:
+      /(uniprot:(?:(?:[A-N,R-Z][0-9](?:[A-Z][A-Z, 0-9][A-Z, 0-9][0-9]){1,2})|(?:[O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(?:\.\d+)?(?:-\d+)?(?:#PRO_\d+)?))/,
     onMatch,
   },
   {
-    regex: /(uniprot.isoform:(?:[A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])|(?:[O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(?:\-\d+))/,
+    regex:
+      /(uniprot.isoform:(?:[A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])|(?:[O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(?:\-\d+))/,
     onMatch,
   },
   {
@@ -782,7 +799,8 @@ export const bioregistryRules = [
     onMatch,
   },
   {
-    regex: /(uniref:UniRef(?:100|90|50)_(?:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2}|UPI[A-F0-9]{10}))/,
+    regex:
+      /(uniref:UniRef(?:100|90|50)_(?:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2}|UPI[A-F0-9]{10}))/,
     onMatch,
   },
   {


### PR DESCRIPTION
## Summary
- Adds `tcia.collection` (The Cancer Imaging Archive collection identifier) to the bioregistry linking rules
- Also includes minor regex updates for `mesh`, `metabolights`, and `uniprot` generated from the upstream [bioregistry-collection](https://github.com/Sage-Bionetworks/bioregistry-collection) repo

## Test plan
- [x] Verify `tcia.collection` identifiers auto-link correctly on Synapse.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)