### PR TITLE
[Challenge Portal] Add "Back to Top" button on details page

### DIFF
--- a/apps/synapse-portal-framework/src/components/DetailsPageMenu.tsx
+++ b/apps/synapse-portal-framework/src/components/DetailsPageMenu.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { DetailsPageSectionLayoutType } from '@/components/DetailsPage/DetailsPageSectionLayout'
 import { scrollToWithOffset } from '@/utils'
 import { Button, Stack, Typography } from '@mui/material'
@@ -11,6 +11,15 @@ const DetailsPageMenu = ({
 }): React.ReactNode => {
   const location = useLocation()
   const navigate = useNavigate()
+  const [showBackToTop, setShowBackToTop] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => {
+      setShowBackToTop(window.scrollY > 500)
+    }
+    window.addEventListener('scroll', onScroll)
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
 
   function handleMenuClick(id: string) {
     navigate(`${location.search}#${id}`)
@@ -67,7 +76,7 @@ const DetailsPageMenu = ({
           {option.title}
         </Button>
       ))}
-      {
+      {showBackToTop && (
         <Button
           sx={{
             color: 'primary.main',
@@ -76,7 +85,7 @@ const DetailsPageMenu = ({
         >
           Back to Top
         </Button>
-      }
+      )}
     </Stack>
   )
 }

--- a/apps/synapse-portal-framework/src/components/DetailsPageMenu.tsx
+++ b/apps/synapse-portal-framework/src/components/DetailsPageMenu.tsx
@@ -67,6 +67,16 @@ const DetailsPageMenu = ({
           {option.title}
         </Button>
       ))}
+      {
+        <Button
+          sx={{
+            color: 'primary.main',
+          }}
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+        >
+          Back to Top
+        </Button>
+      }
     </Stack>
   )
 }

--- a/apps/synapse-portal-framework/src/components/DetailsPageMenu.tsx
+++ b/apps/synapse-portal-framework/src/components/DetailsPageMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { DetailsPageSectionLayoutType } from '@/components/DetailsPage/DetailsPageSectionLayout'
 import { scrollToWithOffset } from '@/utils'
 import { Button, Stack, Typography } from '@mui/material'

--- a/apps/synapse-portal-framework/src/components/DetailsPageMenu.tsx
+++ b/apps/synapse-portal-framework/src/components/DetailsPageMenu.tsx
@@ -83,7 +83,7 @@ const DetailsPageMenu = ({
           }}
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         >
-          Back to Top
+          ↑ Back to Top
         </Button>
       )}
     </Stack>

--- a/apps/synapse-portal-framework/src/components/DetailsPageMenu.tsx
+++ b/apps/synapse-portal-framework/src/components/DetailsPageMenu.tsx
@@ -15,7 +15,9 @@ const DetailsPageMenu = ({
 
   useEffect(() => {
     const onScroll = () => {
-      setShowBackToTop(window.scrollY > 500)
+      requestAnimationFrame(() => {
+        setShowBackToTop(window.scrollY > 500)
+      })
     }
     window.addEventListener('scroll', onScroll)
     return () => window.removeEventListener('scroll', onScroll)


### PR DESCRIPTION
On a Challenge Details page, navigation between the tabs currently require manual scrolling, which can get pretty tedious for the user when the tab content is lengthy, e.g. https://challenges.synapse.org/Challenges/DetailsPage/Task1?id=syn74274097

This PR introduces a "Back to Top" button to allow users to quickly return to the tabs.

## Changelog

* Add a "Back to Top" button to the side navbar
* Only show button when user has scrolled 500px
   * Otherwise, button will be hidden

## Preview

https://github.com/user-attachments/assets/862fa224-23d8-4132-98e4-86274b4ed87f

