### PR TITLE
SWC-7815 - curator agent prompts

### DIFF
--- a/packages/synapse-react-client/src/components/SynapseChat/GridAgentChat.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/GridAgentChat.tsx
@@ -5,6 +5,12 @@ import { useState } from 'react'
 import DraggableDialog from '../DraggableDialog/DraggableDialog'
 import { SynapseChat } from './index'
 
+const suggestedPrompts = [
+  'Help me fill this out',
+  'Help me understand this',
+  'Find missing fields',
+]
+
 export type GridAgentChatProps = {
   gridSessionId: string
   usersReplicaId: number
@@ -36,12 +42,6 @@ export function GridAgentChat({
     gridSessionId,
     usersReplicaId,
   }
-
-  const suggestedPrompts = [
-    'Help me fill this out',
-    'Help me understand this',
-    'Find missing fields',
-  ]
 
   return (
     <DraggableDialog open={open} onClose={onClose} title={chatbotName}>

--- a/packages/synapse-react-client/src/components/SynapseChat/GridAgentChat.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/GridAgentChat.tsx
@@ -37,6 +37,12 @@ export function GridAgentChat({
     usersReplicaId,
   }
 
+  const suggestedPrompts = [
+    'Help me fill this out',
+    'Help me understand this',
+    'Find missing fields',
+  ]
+
   return (
     <DraggableDialog open={open} onClose={onClose} title={chatbotName}>
       <SynapseChat
@@ -52,6 +58,7 @@ export function GridAgentChat({
         externalSession={agentSession}
         setExternalSession={setAgentSession}
         externalChatState={chatState}
+        suggestedPrompts={suggestedPrompts}
       />
     </DraggableDialog>
   )

--- a/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.test.tsx
@@ -1,0 +1,157 @@
+import { useChatState } from '@/components/SynapseChat/useChatState'
+import { mockAgentSession } from '@/mocks/chat/mockChat'
+import {
+  useCreateAgentSession,
+  useUpdateAgentSession,
+} from '@/synapse-queries/chat/useChat'
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SynapseChat, SynapseChatProps } from './SynapseChat'
+
+vi.mock('@/synapse-queries/chat/useChat')
+vi.mock('@/components/SynapseChat/useChatState')
+
+const mockUseCreateAgentSession = vi.mocked(useCreateAgentSession)
+const mockUseUpdateAgentSession = vi.mocked(useUpdateAgentSession)
+const mockUseChatState = vi.mocked(useChatState)
+
+const mockSendChat = vi.fn()
+
+const defaultMockChatState = {
+  sendChat: mockSendChat,
+  pendingMessage: null,
+  chatJobIds: [],
+}
+
+const idleMutation = {
+  mutate: vi.fn(),
+  mutateAsync: vi.fn(),
+  data: undefined,
+  error: null,
+  isError: false,
+  isIdle: true,
+  isPending: false,
+  isSuccess: false,
+  failureCount: 0,
+  failureReason: null,
+  isPaused: false,
+  status: 'idle' as const,
+  variables: undefined,
+  submittedAt: 0,
+  reset: vi.fn(),
+  context: undefined,
+}
+
+const mockPrompts = [
+  'Help me fill this out',
+  'Help me understand this',
+  'Find missing fields',
+]
+
+const defaultProps: SynapseChatProps = {
+  externalSession: mockAgentSession,
+  externalChatState: defaultMockChatState,
+  showAccessLevelMenu: false,
+}
+
+function renderComponent(props?: Partial<SynapseChatProps>) {
+  const user = userEvent.setup()
+  render(<SynapseChat {...defaultProps} {...props} />, {
+    wrapper: createWrapper(),
+  })
+  return { user }
+}
+
+describe('SynapseChat - suggestedPrompts', () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockUseCreateAgentSession.mockReturnValue(idleMutation as any)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockUseUpdateAgentSession.mockReturnValue(idleMutation as any)
+    mockUseChatState.mockReturnValue(defaultMockChatState)
+  })
+
+  it('renders pill chips when suggestedPrompts are provided', () => {
+    renderComponent({ suggestedPrompts: mockPrompts })
+
+    mockPrompts.forEach(prompt => {
+      expect(screen.getByRole('button', { name: prompt })).toBeInTheDocument()
+    })
+  })
+
+  it('renders no pill chips when suggestedPrompts is omitted', () => {
+    renderComponent({ suggestedPrompts: undefined })
+
+    mockPrompts.forEach(prompt => {
+      expect(
+        screen.queryByRole('button', { name: prompt }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders no pill chips when suggestedPrompts is an empty array', () => {
+    renderComponent({ suggestedPrompts: [] })
+
+    mockPrompts.forEach(prompt => {
+      expect(
+        screen.queryByRole('button', { name: prompt }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('clicking a pill populates the text field without sending', async () => {
+    const { user } = renderComponent({ suggestedPrompts: mockPrompts })
+
+    await user.click(screen.getByRole('button', { name: mockPrompts[0] }))
+
+    expect(screen.getByRole('textbox')).toHaveValue(mockPrompts[0])
+    expect(mockSendChat).not.toHaveBeenCalled()
+  })
+
+  it('chips are disabled when no agent session exists', () => {
+    renderComponent({
+      suggestedPrompts: mockPrompts,
+      externalSession: undefined,
+    })
+
+    mockPrompts.forEach(prompt => {
+      expect(screen.getByRole('button', { name: prompt })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      )
+    })
+  })
+
+  it('chips are disabled while a message is pending', () => {
+    const pendingChatState = {
+      ...defaultMockChatState,
+      pendingMessage: 'waiting...',
+    }
+    renderComponent({
+      suggestedPrompts: mockPrompts,
+      externalChatState: pendingChatState,
+    })
+
+    mockPrompts.forEach(prompt => {
+      expect(screen.getByRole('button', { name: prompt })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      )
+    })
+  })
+
+  it('text input is present alongside pills', () => {
+    renderComponent({ suggestedPrompts: mockPrompts })
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+    mockPrompts.forEach(prompt => {
+      expect(screen.getByRole('button', { name: prompt })).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.test.tsx
@@ -2,6 +2,7 @@ import { useChatState } from '@/components/SynapseChat/useChatState'
 import { mockAgentSession } from '@/mocks/chat/mockChat'
 import {
   useCreateAgentSession,
+  useGetChatAgentTraceEvents,
   useUpdateAgentSession,
 } from '@/synapse-queries/chat/useChat'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
@@ -14,6 +15,7 @@ vi.mock('@/components/SynapseChat/useChatState')
 
 const mockUseCreateAgentSession = vi.mocked(useCreateAgentSession)
 const mockUseUpdateAgentSession = vi.mocked(useUpdateAgentSession)
+const mockUseGetChatAgentTraceEvents = vi.mocked(useGetChatAgentTraceEvents)
 const mockUseChatState = vi.mocked(useChatState)
 
 const mockSendChat = vi.fn()
@@ -74,6 +76,8 @@ describe('SynapseChat - suggestedPrompts', () => {
     mockUseCreateAgentSession.mockReturnValue(idleMutation as any)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockUseUpdateAgentSession.mockReturnValue(idleMutation as any)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockUseGetChatAgentTraceEvents.mockReturnValue({ data: undefined } as any)
     mockUseChatState.mockReturnValue(defaultMockChatState)
   })
 
@@ -128,7 +132,7 @@ describe('SynapseChat - suggestedPrompts', () => {
     })
   })
 
-  it('chips are disabled while a message is pending', () => {
+  it('chips are hidden while a message is pending', () => {
     const pendingChatState = {
       ...defaultMockChatState,
       pendingMessage: 'waiting...',
@@ -139,10 +143,23 @@ describe('SynapseChat - suggestedPrompts', () => {
     })
 
     mockPrompts.forEach(prompt => {
-      expect(screen.getByRole('button', { name: prompt })).toHaveAttribute(
-        'aria-disabled',
-        'true',
-      )
+      expect(
+        screen.queryByRole('button', { name: prompt }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('chips are hidden after a conversation has started', () => {
+    const activeChatState = { ...defaultMockChatState, chatJobIds: ['job-1'] }
+    renderComponent({
+      suggestedPrompts: mockPrompts,
+      externalChatState: activeChatState,
+    })
+
+    mockPrompts.forEach(prompt => {
+      expect(
+        screen.queryByRole('button', { name: prompt }),
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.tsx
@@ -282,24 +282,27 @@ export function SynapseChat({
           backgroundColor: 'white',
         }}
       >
-        {suggestedPrompts && suggestedPrompts.length > 0 && (
-          <Stack
-            direction="row"
-            spacing={1}
-            sx={{ pt: '8px', flexWrap: 'wrap', gap: 1 }}
-          >
-            {suggestedPrompts.map(prompt => (
-              <Chip
-                key={prompt}
-                label={prompt}
-                variant="outlined"
-                onClick={() => setUserChatTextfieldValue(prompt)}
-                disabled={!agentSession || !!pendingMessage}
-                sx={{ cursor: 'pointer' }}
-              />
-            ))}
-          </Stack>
-        )}
+        {suggestedPrompts &&
+          suggestedPrompts.length > 0 &&
+          chatJobIds.length === 0 &&
+          !pendingMessage && (
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{ pt: '8px', flexWrap: 'wrap', gap: 1 }}
+            >
+              {suggestedPrompts.map(prompt => (
+                <Chip
+                  key={prompt}
+                  label={prompt}
+                  variant="outlined"
+                  onClick={() => setUserChatTextfieldValue(prompt)}
+                  disabled={!agentSession}
+                  sx={{ cursor: 'pointer' }}
+                />
+              ))}
+            </Stack>
+          )}
         <Box
           component="form"
           sx={{

--- a/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.tsx
@@ -8,8 +8,10 @@ import { ArrowUpward } from '@mui/icons-material'
 import {
   Alert,
   Box,
+  Chip,
   IconButton,
   List,
+  Stack,
   TextField,
   Typography,
   useTheme,
@@ -52,6 +54,8 @@ export type SynapseChatProps = {
    * Called in the mutation onSuccess handler so it runs exactly once per response.
    */
   onChatResponse?: (responseText: string) => void
+  /** Optional list of prompt suggestions shown as clickable pills above the text input */
+  suggestedPrompts?: string[]
 }
 
 export type ChatInteraction = {
@@ -77,6 +81,7 @@ export function SynapseChat({
   externalChatState,
   showAccessLevelMenu = true,
   onChatResponse,
+  suggestedPrompts,
 }: SynapseChatProps) {
   const { accessToken } = useSynapseContext()
   const [localAgentSession, setLocalAgentSession] = useState<AgentSession>()
@@ -277,6 +282,24 @@ export function SynapseChat({
           backgroundColor: 'white',
         }}
       >
+        {suggestedPrompts && suggestedPrompts.length > 0 && (
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={{ pt: '8px', flexWrap: 'wrap', gap: 1 }}
+          >
+            {suggestedPrompts.map(prompt => (
+              <Chip
+                key={prompt}
+                label={prompt}
+                variant="outlined"
+                onClick={() => setUserChatTextfieldValue(prompt)}
+                disabled={!agentSession || !!pendingMessage}
+                sx={{ cursor: 'pointer' }}
+              />
+            ))}
+          </Stack>
+        )}
         <Box
           component="form"
           sx={{


### PR DESCRIPTION
Add a few pill prompts to the grid chat window.
</br>
On open/chat start
<img width="607" height="507" alt="ss1" src="https://github.com/user-attachments/assets/ac1ca4a7-2c66-441d-a1a4-a1226c909ecf" />

</br>
after starting a chat, prompts disappear
<img width="608" height="507" alt="ss" src="https://github.com/user-attachments/assets/347c9918-b146-40d2-8abe-e08bc65dff27" />

