### PR TITLE
PORTALS-4208

### DIFF
--- a/apps/synapse-portal-framework/src/ssg/createReactRouterConfig.ts
+++ b/apps/synapse-portal-framework/src/ssg/createReactRouterConfig.ts
@@ -83,14 +83,15 @@ export function createReactRouterConfig(
           ])
         }
 
-        // Exclude legacy /DetailsPage redirect routes from prerendering.
+        // Exclude legacy /DetailsPage redirect routes (and any sub-paths like
+        // /DetailsPage/Details) from prerendering.
         // Prerendering them creates S3 directory structures (DetailsPage/index.html)
         // that cause S3 to 302-redirect `/DetailsPage?id=X` → `/DetailsPage/`
         // while dropping the query string, breaking the client-side redirect.
         // CloudFront serves __spa-fallback.html for these 404s, so React Router
         // handles them client-side with the full URL (including query) intact.
         const staticPaths = getStaticPaths().filter(
-          p => !p.endsWith('/DetailsPage'),
+          p => !p.includes('/DetailsPage'),
         )
 
         return [...staticPaths, ...dynamicRoutes]


### PR DESCRIPTION
## Bug Fix: Legacy DetailsPage Redirect Drops Query String in Deployed NF Portal

### Problem

Visiting `/Explore/Studies/DetailsPage/Details?studyId=syn51133914` in the deployed portal
caused two bad redirects:
1. `/Explore/Studies/DetailsPage/Details?studyId=...` → `/Explore/Studies/DetailsPage/Details/`
2. `/Explore/Studies/DetailsPage/Details/` → `/Explore/Studies`

Locally the redirect worked correctly because the dev server always serves the
SPA's `index.html` for unknown paths. In production (S3 + CloudFront), the
behaviour depends on whether a pre-rendered file exists on S3.

### Root Cause

`createReactRouterConfig` filtered out legacy redirect routes from pre-rendering
using `.endsWith('/DetailsPage')`. The NF portal registers a **sub-path** of that
route:

```ts
route('Explore/Studies/DetailsPage/Details', 'pages/LegacyStudyRedirect.tsx', ...)