### PR TITLE
PORTALS-4119 - add github workflow precommit linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ apps/portals/*/public/deploy-date.txt
 
 .nx/key
 
+# actionlint binary (installed by scripts/install-actionlint.sh)
+/bin/
+
 # Claude worktrees
 .claude/worktrees
 # worktree setup sentinel (created during pnpm install in new worktrees)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "pnpm": ">=10.16.0 <11"
   },
   "scripts": {
-    "prepare": "husky",
+    "prepare": "husky && ./scripts/install-actionlint.sh",
+    "lint:actions": "./bin/actionlint",
     "build": "nx run-many --target=build",
     "lint": "nx run-many --target=lint --quiet",
     "test": "nx run-many --target=test --coverage",
@@ -40,6 +41,10 @@
     ],
     "*.{json,yml,scss,css,md}": [
       "oxfmt --write"
+      "prettier --write"
+    ],
+    ".github/workflows/*.{yml,yaml}": [
+      "./bin/actionlint"
     ]
   },
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     ],
     "*.{json,yml,scss,css,md}": [
       "oxfmt --write"
-      "prettier --write"
     ],
     ".github/workflows/*.{yml,yaml}": [
       "./bin/actionlint"

--- a/scripts/install-actionlint.sh
+++ b/scripts/install-actionlint.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Downloads the actionlint binary to ./bin/actionlint for the pre-commit hook.
+# Pinned to a specific version for reproducibility.
+set -euo pipefail
+
+ACTIONLINT_VERSION="1.7.12"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN_DIR="$REPO_ROOT/bin"
+BIN="$BIN_DIR/actionlint"
+
+if [ -x "$BIN" ] && [ "$("$BIN" -version 2>/dev/null | head -n1)" = "$ACTIONLINT_VERSION" ]; then
+  exit 0
+fi
+
+mkdir -p "$BIN_DIR"
+
+DOWNLOAD_URL="https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash"
+TMP_SCRIPT="$(mktemp)"
+trap 'rm -f "$TMP_SCRIPT"' EXIT
+
+if ! curl -fsSL "$DOWNLOAD_URL" -o "$TMP_SCRIPT"; then
+  echo "actionlint: failed to download installer; skipping (pre-commit will fail if invoked)" >&2
+  exit 0
+fi
+
+bash "$TMP_SCRIPT" "$ACTIONLINT_VERSION" "$BIN_DIR" >/dev/null
+echo "Installed actionlint $ACTIONLINT_VERSION to $BIN"


### PR DESCRIPTION
use actionlint to lint github workflow/action yaml files. Add script to install actionlint when running pnpm prepare. Add lint:actions script.
<img width="916" height="295" alt="ss" src="https://github.com/user-attachments/assets/4abcee04-ae67-4ae8-a528-82f935f305f3" />

