### PR TITLE
SWC-7057 Move local sharing settings button

### DIFF
--- a/packages/synapse-react-client/src/components/EntityAclEditor/EntityAclEditor.tsx
+++ b/packages/synapse-react-client/src/components/EntityAclEditor/EntityAclEditor.tsx
@@ -404,6 +404,16 @@ const EntityAclEditor = forwardRef(function EntityAclEditor(
           }
         />
       )}
+      {/* Create / delete local sharing settings button */}
+      {!isAfterUpload &&
+        !isProject &&
+        entityBundle.permissions.canEnableInheritance && (
+          <CreateOrDeleteLocalSharingSettingsButton
+            isInherited={updatedIsInherited}
+            setIsInherited={setUpdatedIsInherited}
+          />
+        )}
+      {error && <Alert severity="error">{error.message}</Alert>}
       <AclEditor
         isInherited={updatedIsInherited}
         canEdit={getCanEditResourceAccess(
@@ -444,16 +454,6 @@ const EntityAclEditor = forwardRef(function EntityAclEditor(
         onNotifyCheckboxChange={setNotifyNewAdditions}
         showAddRemovePublicButton={true}
       />
-      {/* Create / delete local sharing settings button */}
-      {!isAfterUpload &&
-        !isProject &&
-        entityBundle.permissions.canEnableInheritance && (
-          <CreateOrDeleteLocalSharingSettingsButton
-            isInherited={updatedIsInherited}
-            setIsInherited={setUpdatedIsInherited}
-          />
-        )}
-      {error && <Alert severity="error">{error.message}</Alert>}
     </Stack>
   )
 })

--- a/packages/synapse-react-client/src/components/EntityAclEditor/InheritanceMessage.tsx
+++ b/packages/synapse-react-client/src/components/EntityAclEditor/InheritanceMessage.tsx
@@ -79,7 +79,6 @@ export function InheritanceMessage(props: InheritanceMessageProps) {
         ) : (
           ''
         )}
-        and cannot be modified here.
       </Typography>
     )
   } else {


### PR DESCRIPTION
move local sharing settings button immediately below inheritance message. Modify InheritanceMessage text.
<img width="870" height="436" alt="ss" src="https://github.com/user-attachments/assets/1a732a8b-dfc8-4b9f-a457-58bc66b34f79" />

