### PR TITLE
[Challenge Portal] UI updates for challenge registration

### DIFF
--- a/packages/synapse-react-client/src/components/ChallengeRegisterButton/ChallengeRegisterButton.test.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeRegisterButton/ChallengeRegisterButton.test.tsx
@@ -94,7 +94,7 @@ describe('ChallengeRegisterButton', () => {
     const { user } = renderComponent()
 
     const button = await screen.findByRole('button', {
-      name: 'Register for this Challenge',
+      name: 'Complete Registration',
     })
 
     await user.click(button)

--- a/packages/synapse-react-client/src/components/ChallengeRegisterButton/ChallengeRegisterButton.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeRegisterButton/ChallengeRegisterButton.tsx
@@ -7,6 +7,7 @@ import {
 import React from 'react'
 import { SynapseClientError, useSynapseContext } from '@/utils'
 import ExitToAppIcon from '@mui/icons-material/ExitToApp'
+import PendingActionsIcon from '@mui/icons-material/PendingActions'
 import { Box } from '@mui/material'
 import { useEffect } from 'react'
 import SpinnerButton from '../SpinnerButton/SpinnerButton'
@@ -64,6 +65,7 @@ const ChallengeRegisterButton = ({
     userSubmissionTeams && userSubmissionTeams.results.length > 0
   const isMemberOfBothParticipantAndSubmissionTeams =
     isRegistered && hasSubmissionTeam
+  const isMemberOfParticipantTeamOnly = isRegistered && !hasSubmissionTeam
 
   const error =
     getChallengeError || getTeamMembershipError || getSubmissionTeamsError
@@ -81,26 +83,50 @@ const ChallengeRegisterButton = ({
 
   return (
     <Box>
-      {!isMemberOfBothParticipantAndSubmissionTeams && (
+      {!isMemberOfBothParticipantAndSubmissionTeams &&
+        !isMemberOfParticipantTeamOnly && (
+          <SpinnerButton
+            disableElevation={true}
+            variant="contained"
+            onClick={() =>
+              isAuthenticated && onJoinClick ? onJoinClick() : undefined
+            }
+            sx={{
+              color: 'white',
+              backgroundColor: '#109488',
+              fontSize: '1.12em',
+              textTransform: 'none',
+              padding: '4px 18px',
+              fontWeight: 400,
+              ':hover': { color: 'white', backgroundColor: '#109488' },
+              ':active': { color: 'white', backgroundColor: '#109488' },
+              ':visited': { color: 'white', backgroundColor: '#109488' },
+            }}
+          >
+            Register for this Challenge
+          </SpinnerButton>
+        )}
+      {isMemberOfParticipantTeamOnly && (
         <SpinnerButton
           disableElevation={true}
           variant="contained"
+          endIcon={<PendingActionsIcon />}
           onClick={() =>
             isAuthenticated && onJoinClick ? onJoinClick() : undefined
           }
           sx={{
-            color: 'white',
-            backgroundColor: '#109488',
+            color: '#4A2E1B',
+            backgroundColor: '#FFD486',
             fontSize: '1.12em',
             textTransform: 'none',
             padding: '4px 18px',
             fontWeight: 400,
-            ':hover': { color: 'white', backgroundColor: '#109488' },
-            ':active': { color: 'white', backgroundColor: '#109488' },
-            ':visited': { color: 'white', backgroundColor: '#109488' },
+            ':hover': { color: '#4A2E1B', backgroundColor: '#FFD486' },
+            ':active': { color: '#4A2E1B', backgroundColor: '#FFD486' },
+            ':visited': { color: '#4A2E1B', backgroundColor: '#FFD486' },
           }}
         >
-          Register for this Challenge
+          Complete Registration
         </SpinnerButton>
       )}
       {isMemberOfBothParticipantAndSubmissionTeams && (

--- a/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.test.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.test.tsx
@@ -23,10 +23,10 @@ async function renderComponent(props: ChallengeRequirementsModalProps) {
 
   const dialog = await screen.findByRole('dialog')
   await within(dialog).findByRole('heading', {
-    name: 'Challenge Terms and Conditions',
+    name: 'Challenge Registration (Step 1 of 2): Terms and Conditions',
   })
   const registerButton = await within(dialog).findByRole('button', {
-    name: /Register|Continue/,
+    name: 'Next Step',
   })
   const cancelButton = await within(dialog).findByRole('button', {
     name: 'Cancel',

--- a/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.tsx
@@ -127,7 +127,7 @@ export default function ChallengeRequirementsModal(
 
   return (
     <AccessRequirementList
-      dialogTitle={`Challenge Terms and Conditions`}
+      dialogTitle={`Challenge Registration (Step 1 of 2): Terms and Conditions`}
       subjectId={participantTeamId}
       subjectType={RestrictableObjectType.TEAM}
       teamId={challenge?.participantTeamId}

--- a/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.tsx
@@ -104,9 +104,7 @@ export default function ChallengeRequirementsModal(
 
   // It's possible that the user joined the team, but requirements on the team changed since they became a member
   // They do not need to re-join the team, but they should still be prompted to accept the requirements
-  let registerButtonText = teamMembershipStatus?.isMember
-    ? 'Continue'
-    : 'Register'
+  let registerButtonText = 'Next Step'
   if (registrationIsPending) {
     registerButtonText = 'Registering...'
   }

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.test.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.test.tsx
@@ -59,7 +59,7 @@ describe('ChallengeTeamWizard tests', () => {
   it('Shows the modal and starts on the "select team" step', async () => {
     const { dialog } = renderComponent()
     await within(dialog).findByRole('heading', {
-      name: 'Select Your Challenge Team',
+      name: 'Challenge Registration (Step 2 of 2): Select Your Submission Team',
     })
   })
 
@@ -83,7 +83,7 @@ describe('ChallengeTeamWizard tests', () => {
     await user.click(joinTeamButton)
 
     await within(dialog).findByRole('heading', {
-      name: 'Registration Successful!',
+      name: 'Challenge Registration (Step 2 of 2): Registration Successful!',
     })
 
     await within(dialog).findByText(`You have successfully joined team`, {
@@ -117,7 +117,7 @@ describe('ChallengeTeamWizard tests', () => {
     await user.click(requestToJoinTeamButton)
 
     await within(dialog).findByRole('heading', {
-      name: 'Request Team Membership',
+      name: 'Challenge Registration (Step 2 of 2): Request Team Membership',
     })
     await within(dialog).findByText(
       'The following message will be sent to the Team Manager(s)',
@@ -134,7 +134,7 @@ describe('ChallengeTeamWizard tests', () => {
     await user.click(sendRequestButton)
 
     await within(dialog).findByRole('heading', {
-      name: 'Request Sent',
+      name: 'Challenge Registration (Step 2 of 2): Request Sent',
     })
 
     await within(dialog).findByText(
@@ -169,7 +169,7 @@ describe('ChallengeTeamWizard tests', () => {
     await user.click(viewInvitationButton)
 
     await within(dialog).findByRole('heading', {
-      name: 'Invitation to Join Team',
+      name: 'Challenge Registration (Step 2 of 2): Invitation to Join Team',
     })
     await within(dialog).findByText('Do you want to accept this invitation?')
 
@@ -180,7 +180,7 @@ describe('ChallengeTeamWizard tests', () => {
     await user.click(acceptInvitationButton)
 
     await within(dialog).findByRole('heading', {
-      name: 'Registration Successful!',
+      name: 'Challenge Registration (Step 2 of 2): Registration Successful!',
     })
 
     await within(dialog).findByText(`You have successfully joined team`, {
@@ -227,7 +227,7 @@ describe('ChallengeTeamWizard tests', () => {
 
     await user.click(createNewTeamButton)
     await within(dialog).findByRole('heading', {
-      name: 'Create Team',
+      name: 'Challenge Registration (Step 2 of 2): Create Team',
     })
     const teamNameField = await within(dialog).findByRole('textbox', {
       name: 'Team Name',
@@ -241,7 +241,7 @@ describe('ChallengeTeamWizard tests', () => {
     await user.click(finishCreatingTeamButton)
 
     await within(dialog).findByRole('heading', {
-      name: 'Registration Successful!',
+      name: 'Challenge Registration (Step 2 of 2): Registration Successful!',
     })
 
     await within(dialog).findByText(`You have successfully created team`, {

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
@@ -403,7 +403,9 @@ function ChallengeTeamWizard(props: ChallengeTeamWizardProps) {
       onCancel={hide}
       open={isShowingModal}
       actions={actions}
-      title={getStepDialogTitle(step)}
+      title={`Challenge Registration (Step 2 of 2): ${getStepDialogTitle(
+        step,
+      )}`}
       content={
         <SynapseErrorBoundary>
           <Box

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
@@ -39,7 +39,7 @@ enum ChallengeTeamWizardStep {
 function getStepDialogTitle(step: ChallengeTeamWizardStep) {
   switch (step) {
     case ChallengeTeamWizardStep.SELECT_YOUR_CHALLENGE_TEAM:
-      return 'Select Your Challenge Team'
+      return 'Select Your Submission Team'
     case ChallengeTeamWizardStep.ACCEPT_INVITATION:
       return 'Invitation to Join Team'
     case ChallengeTeamWizardStep.JOIN_REQUEST_FORM:


### PR DESCRIPTION
It is currently not explicitly clear to the user that they must be part of the Participant team _and_ a submission team in order for them to access the submission tool widgets. This PR aims to improve the registration UX (with changes approved by Adam H).

### Changelog

* Add a yellow SpinnerButton that appears when registration is incomplete (when the user has joined the Participants team but not a submission team)
* Update modal button from "Register" to "Next Step" to indicate there are more steps to registration
* Include a stepper indicator to the modal title: "Challenge Registration (Step x of 2)"
* Update tests to reflect the new button text and header titles

### Preview

* **New workflow:**

   <img width="512" alt="Screenshot 2026-05-14 at 15 13 20" src="https://github.com/user-attachments/assets/5a0702b1-eaa5-4343-858c-369bb037cce3" />

   ↓

   <img width="512"  alt="Screenshot 2026-05-14 at 15 13 27" src="https://github.com/user-attachments/assets/390cddbb-dc86-4eba-bbb2-26e20f3defa8" />

   ↓

   <img width="512" alt="Screenshot 2026-05-14 at 15 13 36" src="https://github.com/user-attachments/assets/96d807c9-266d-4872-8628-af1123d5d897" />

   ↓

   <img width="512" alt="Screenshot 2026-05-14 at 15 15 02" src="https://github.com/user-attachments/assets/6b4f360d-ee70-47b5-adef-0b1c2d62b26e" />

* **If user leaves pop-up window before completing step 2:**

   <img width="474" height="302" alt="Screenshot 2026-05-14 at 15 13 50" src="https://github.com/user-attachments/assets/471744d2-b92b-42aa-9ce0-50908c81a6c1" />

### Testing

```
$ pnpm --no-coverage --filter synapse-react-client test ChallengeRegisterButton.test.tsx
...

 ✓ src/components/ChallengeRegisterButton/ChallengeRegisterButton.test.tsx (5 tests) 143ms
   ✓ ChallengeRegisterButton (5)
     ✓ Prompts to register when not a member of the participant team or any submission teams 77ms
     ✓ Prompts to register when not a member of the participant team 18ms
     ✓ Prompts to register when not a member of a submission team 19ms
     ✓ Prompts to leave when on both participant and submission teams 20ms
     ✓ Invokes the callback on error 8ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  15:41:22
   Duration  7.53s (transform 2.50s, setup 160ms, import 6.85s, tests 143ms, environment 259ms)
```
```
$ pnpm --no-coverage --filter synapse-react-client test ChallengeTeamWizard.test.tsx
...

 ✓ src/components/ChallengeTeamWizard/ChallengeTeamWizard.test.tsx (6 tests) 2739ms
   ✓ ChallengeTeamWizard tests (6)
     ✓ Shows the modal and starts on the "select team" step 124ms
     ✓ handles joining a team where canPublicJoin is true  527ms
     ✓ handles submitting a request to a team where the current user can request membership  527ms
     ✓ handles joining a team where the current user has an open invitation  508ms
     ✓ prevents submitting a request to a team where an open request already exists 274ms
     ✓ allows creating a new submission team  778ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  11:10:24
   Duration  10.02s (transform 3.43s, setup 140ms, import 6.79s, tests 2.74s, environment 240ms)
```
```
$ pnpm --no-coverage --filter synapse-react-client test ChallengeRequirementsModal.test.tsx
...

 ✓ src/components/ChallengeRequirementsModal/ChallengeRequirementsModal.test.tsx (4 tests) 815ms
   ✓ ChallengeRequirementsModal (4)
     ✓ Shows a set of requirements. Once the user fulfills those requirements, they can click 'Register' to join the participant team.  344ms
     ✓ Calls onCancel when the user clicks the cancel button 155ms
     ✓ Calls onCancel when the user clicks the close button 154ms
     ✓ Calls onCancel when the user rejects AR terms 159ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  12:31:11
   Duration  7.49s (transform 2.92s, setup 138ms, import 6.20s, tests 815ms, environment 234ms)
```