### PR TITLE
PORTALS-4204: follow-up, add sourceRepository, reorder and alias the …

### DIFF
--- a/apps/portals/cancercomplexity/src/config/synapseConfigs/datasets.tsx
+++ b/apps/portals/cancercomplexity/src/config/synapseConfigs/datasets.tsx
@@ -64,7 +64,6 @@ export const datasetSchema: TableToGenericCardMapping = {
     },
   },
   secondaryLabels: [
-    'externalLink',
     'overallDesign',
     'tumorType',
     'tissue',
@@ -72,6 +71,8 @@ export const datasetSchema: TableToGenericCardMapping = {
     'species',
     'fileFormats',
     'consortium',
+    'sourceRepository',
+    'externalLink',
   ],
   dataTypeIconNames: 'dataType',
   // override Download List to use downloadSynId
@@ -127,7 +128,7 @@ export const datasetsQueryWrapperPlotNavProps: QueryWrapperPlotNavProps = {
   shouldDeepLink: true,
   name: 'Datasets',
   sql: datasetsSql,
-  columnAliases,
+  columnAliases: { ...columnAliases, externalLink: 'Source Repository Link' },
   hideDownload: true,
   initialExpandedFacetControls: ['assay', 'species', 'tissue', 'theme'],
   searchConfiguration: {


### PR DESCRIPTION
…externalLink (for datasets only)

<img width="1496" height="774" alt="Screenshot 2026-05-15 at 9 52 41 AM" src="https://github.com/user-attachments/assets/c2d3e81a-53fc-4bb5-9a22-27610ebe985f" />
<img width="1108" height="675" alt="Screenshot 2026-05-15 at 9 52 24 AM" src="https://github.com/user-attachments/assets/ba3a02fb-7c49-404b-93ef-8a9e869eb980" />
