### PR TITLE
PORTALS-4236

### DIFF
--- a/apps/synapse-portal-framework/src/components/Explore/ExploreWrapper.tsx
+++ b/apps/synapse-portal-framework/src/components/Explore/ExploreWrapper.tsx
@@ -2,11 +2,9 @@ import {
   NEGATIVE_RESPONSIVE_SIDE_MARGIN,
   RESPONSIVE_SIDE_PADDING,
 } from '@/utils'
-import { getPortalOrigin } from '@/utils/getPortalOrigin'
-import { useSetCanonicalUrl } from '@/utils/useSetCanonicalUrl'
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material'
 import { Box, Typography, useMediaQuery, useTheme } from '@mui/material'
-import { Suspense, useState } from 'react'
+import { useState } from 'react'
 import { Outlet, useLocation, useMatch, useNavigation } from 'react-router'
 import OrientationBanner from 'synapse-react-client/components/OrientationBanner/OrientationBanner'
 import { ExplorePageRoute, ExploreWrapperProps } from './ExploreWrapperProps'
@@ -15,7 +13,6 @@ import { useDocumentMetadata } from 'synapse-react-client/utils/context/Document
 import { matchPath } from 'react-router'
 import React from 'react'
 import { usePortalContext } from '@/components/PortalContext'
-import loadingScreen from 'synapse-react-client/components/LoadingScreen/LoadingScreen'
 
 function RouteMatchedOrientationBanner(props: {
   route: ExplorePageRoute
@@ -53,7 +50,7 @@ export default function ExploreWrapper(
       matchPath({ path: routePath, end: false }, effectivePathname),
     )
   })
-  const { portalName, portalKey } = usePortalContext()
+  const { portalName } = usePortalContext()
   const pageName =
     currentRoute?.displayName ??
     currentRoute?.path?.replaceAll('/', '') ??
@@ -61,10 +58,6 @@ export default function ExploreWrapper(
 
   const newTitle: string = `${portalName} - ${pageName}`
   useDocumentMetadata({ title: newTitle, priority: 50 })
-
-  // The canonical URL is the explore route with no searchParams
-  const origin = getPortalOrigin(portalKey)
-  useSetCanonicalUrl(new URL(pathname, origin).toString())
 
   return (
     <>
@@ -121,9 +114,7 @@ export default function ExploreWrapper(
           },
         }}
       >
-        <Suspense fallback={loadingScreen}>
-          <Outlet />
-        </Suspense>
+        <Outlet />
       </Box>
     </>
   )


### PR DESCRIPTION
## Fix: NF Portal Explore Tab Navigation Crash

### Problem

Clicking Explore tabs updated the URL but page content did not change, and the
browser console showed:

```
Uncaught TypeError: Cannot read properties of null (reading 'removeChild')
  at commitDeletionEffectsOnFiber (react-dom_client.js:7086)
```

### Root Cause

Two separate mechanisms were both managing the `<link rel="canonical">` element,
conflicting with React 19's HostHoistable DOM tracking:

1. **`createStaticMeta`** (in each Explore page: `studies.tsx`, `datasets.tsx`,
   etc.) emits a `{ tagName: 'link', rel: 'canonical', href: pageUrl }` descriptor.
   React Router's `<Meta />` renders this as a HostHoistable fiber (tag 26), inserts
   the element into `document.head`, and stores the DOM node as `fiber.stateNode`.

2. **`useSetCanonicalUrl`** (called in `ExploreWrapper.tsx`) runs in a `useEffect`
   and calls `document.head.removeChild(linkElement)` on the exact same element
   that React was tracking as `stateNode`.

When navigating between tabs, `<Meta />` re-rendered with the new route's meta.
Because the canonical `<link>` key is derived from
`JSON.stringify({ rel: 'canonical', href: pageUrl })` and `pageUrl` changes with
each tab, React treated the old and new canonical elements as different (different
keys), marking the old fiber for deletion.

In `commitDeletionEffectsOnFiber` (case 26 — HostHoistable), React runs:

```js
finishedRoot = deletedFiber.stateNode;
finishedRoot.parentNode.removeChild(finishedRoot); // CRASH: parentNode is null
```

Because `useSetCanonicalUrl` had already called `document.head.removeChild()` on
that element during its `useEffect` cleanup, `stateNode.parentNode` was `null`.

### Why `useSetCanonicalUrl` Was Redundant in ExploreWrapper

`ExploreWrapper` called:
```ts
useSetCanonicalUrl(new URL(pathname, origin).toString())
```

`createStaticMeta` for each Explore page already emits:
```ts
{ tagName: 'link', rel: 'canonical', href: new URL(location.pathname, origin).toString() }
```

Both produce the identical `origin + pathname` URL. `useSetCanonicalUrl` had no
effect on the canonical value — it only broke React's internal DOM tracking.

### Fix

Removed the redundant `useSetCanonicalUrl` call from `ExploreWrapper.tsx`, along
with the now-unused `getPortalOrigin` and `useSetCanonicalUrl` imports and the
`portalKey` destructure. React Router's `<Meta />` now has sole ownership of the
canonical `<link>` element. `stateNode.parentNode` remains `document.head`
throughout the fiber's lifetime, so deletion during navigation succeeds cleanly.
