### PR TITLE
PORTALS-4215: [ELITE] Rename and re-order Explore > sections

### DIFF
--- a/apps/portals-e2e/src/explore.spec.ts
+++ b/apps/portals-e2e/src/explore.spec.ts
@@ -20,7 +20,16 @@ const goToExploreTab = async (page: Page, exploreTab: string) => {
       await expect(page.getByLabel('Explore Sections')).toBeVisible()
       // Extract the main tab name from paths like "Cohort Builder/Individuals"
       const tabName = exploreTab.split('/')[0]
-      await expect(page.getByRole('tab', { name: tabName })).toBeVisible()
+      let expectedTabLabel = tabName
+      if (getPortal() === 'eliteportal') {
+        if (tabName === 'Data') expectedTabLabel = 'Files'
+        else if (tabName === 'Cohort Builder')
+          expectedTabLabel = 'Cohort Discovery'
+        else if (tabName === 'Computational Tools') expectedTabLabel = 'Tools'
+      }
+      await expect(
+        page.getByRole('tab', { name: expectedTabLabel }),
+      ).toBeVisible()
     })
 
     await dismissBanners(page)
@@ -81,14 +90,15 @@ const expectTopLevelControls = async (
       // Extract the main tab name from paths like "Cohort Builder/Individuals"
       const tabName = exploreTab.split('/')[0]
       let exploreTabHeading = tabName
-      if (
-        (getPortal() === 'arkportal' && tabName === 'All Data') ||
-        (getPortal() === 'eliteportal' && tabName === 'Data')
-      ) {
+      if (getPortal() === 'arkportal' && tabName === 'All Data') {
         exploreTabHeading = 'Data'
+      } else if (getPortal() === 'eliteportal') {
+        if (tabName === 'Data') exploreTabHeading = 'Files'
+        else if (tabName === 'Cohort Builder')
+          exploreTabHeading = 'Cohort Discovery'
+        else if (tabName === 'Computational Tools') exploreTabHeading = 'Tools'
       } else if (
-        (getPortal() === 'eliteportal' ||
-          getPortal() === 'adknowledgeportal') &&
+        getPortal() === 'adknowledgeportal' &&
         tabName === 'Cohort Builder'
       ) {
         exploreTabHeading = 'Participants'

--- a/apps/portals/eliteportal/src/config/navbarConfig.ts
+++ b/apps/portals/eliteportal/src/config/navbarConfig.ts
@@ -24,8 +24,6 @@ export const navbarConfig: NavbarConfig = {
       name: 'Explore',
       path: '/Explore',
       children: [
-        { name: 'Data', path: '/Explore/Data' },
-        { name: 'Cohort Builder', path: '/Explore/Cohort Builder/Individuals' },
         {
           name: 'Programs',
           path: '/Explore/Programs',
@@ -38,8 +36,13 @@ export const navbarConfig: NavbarConfig = {
           name: 'Studies',
           path: '/Explore/Studies',
         },
+        { name: 'Files', path: '/Explore/Data' },
+        {
+          name: 'Cohort Discovery',
+          path: '/Explore/Cohort Builder/Individuals',
+        },
         { name: 'Publications', path: '/Explore/Publications' },
-        { name: 'Computational Tools', path: '/Explore/Computational Tools' },
+        { name: 'Tools', path: '/Explore/Computational Tools' },
         { name: 'People', path: '/Explore/People' },
       ],
     },

--- a/apps/portals/eliteportal/src/config/synapseConfigs/cohortbuilder.ts
+++ b/apps/portals/eliteportal/src/config/synapseConfigs/cohortbuilder.ts
@@ -71,7 +71,7 @@ const participantsTableId =
 export const individualsViewQueryWrapperPlotNavProps: QueryWrapperPlotNavProps =
   {
     rgbIndex,
-    name: 'Participants',
+    name: 'Cohort Discovery',
     visibleColumnCount: 10,
     facetsToPlot: ['Sex', 'dataTypes', 'Assays', 'Diagnosis', 'fileFormat'],
     isRowSelectionVisible: true,

--- a/apps/portals/eliteportal/src/config/synapseConfigs/computational_tools.ts
+++ b/apps/portals/eliteportal/src/config/synapseConfigs/computational_tools.ts
@@ -52,7 +52,7 @@ const computationalToolsQueryWrapperPlotNavProps: QueryWrapperPlotNavProps = {
   sql: computationalSql,
   cardConfiguration: computationalCardConfiguration,
   shouldDeepLink: true,
-  name: 'Computational Tools',
+  name: 'Tools',
   facetsToPlot: ['project'],
   searchConfiguration: defaultSearchConfiguration,
 }

--- a/apps/portals/eliteportal/src/config/synapseConfigs/data.ts
+++ b/apps/portals/eliteportal/src/config/synapseConfigs/data.ts
@@ -10,7 +10,7 @@ const rgbIndex = 1
 
 export const dataQueryWrapperPlotNavProps: QueryWrapperPlotNavProps = {
   rgbIndex,
-  name: 'Data',
+  name: 'Files',
   enabledExternalAnalysisPlatforms: enabledAnalysisPlatforms,
   fileIdColumnName: 'id',
   fileNameColumnName: 'fileName',

--- a/apps/portals/eliteportal/src/pages/Explore/layout.tsx
+++ b/apps/portals/eliteportal/src/pages/Explore/layout.tsx
@@ -5,13 +5,6 @@ function ExploreLayout() {
     <ExploreWrapper
       explorePaths={[
         {
-          path: 'Data',
-        },
-        {
-          displayName: 'Cohort Builder',
-          path: 'Cohort Builder',
-        },
-        {
           path: 'Programs',
         },
         {
@@ -21,9 +14,18 @@ function ExploreLayout() {
           path: 'Studies',
         },
         {
+          displayName: 'Files',
+          path: 'Data',
+        },
+        {
+          displayName: 'Cohort Discovery',
+          path: 'Cohort Builder',
+        },
+        {
           path: 'Publications',
         },
         {
+          displayName: 'Tools',
           path: 'Computational Tools',
         },
         {


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/PORTALS-4215
Reorder order in Jira ticket has 'datasets' but we do not currently have that in ELITE.

I only changed these by displayed name:
<img width="1512" height="982" alt="Screenshot 2026-05-15 at 2 37 34 PM" src="https://github.com/user-attachments/assets/277e8338-3a59-4f51-a67c-314f44d2b355" />

<img width="1512" height="982" alt="Screenshot 2026-05-15 at 2 37 43 PM" src="https://github.com/user-attachments/assets/404e6f4a-9e9e-4945-b389-bf19bdfe164b" />

This section in homepage unchanged:
<img width="1512" height="982" alt="Screenshot 2026-05-15 at 2 40 37 PM" src="https://github.com/user-attachments/assets/7963e23d-e5fb-479c-9399-2eb749824095" />

Details page that has "Computational tools" tab unchanged:
<img width="1512" height="982" alt="Screenshot 2026-05-15 at 2 41 51 PM" src="https://github.com/user-attachments/assets/da1740ac-30cd-4cdf-8edf-87bb4d33c38d" />