### PR TITLE
PORTALS-4234

### DIFF
--- a/packages/synapse-react-client/src/components/QueryWrapper/useOnQueryDataChange.ts
+++ b/packages/synapse-react-client/src/components/QueryWrapper/useOnQueryDataChange.ts
@@ -5,7 +5,7 @@ import {
   QueryResultBundle,
 } from '@sage-bionetworks/synapse-types'
 import { useTableQueryUseQueryOptions } from './TableQueryUseQueryOptions'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 type UseOnQueryDataChangeOptions = {
   queryBundleRequest: QueryBundleRequest
@@ -48,10 +48,17 @@ export default function useOnQueryDataChange(
     }
   }, [queryMetadata, queryMetadataIsLoading, rowData, rowDataIsLoading])
 
+  // Use a ref so we always call the latest onChange without including it in the
+  // effect dependency array. Including a frequently-recreated callback in deps
+  // causes the effect to re-fire on every render, creating an infinite loop when
+  // the parent updates state inside the callback.
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
+
   // mergedData is sometimes undefined, which useDeepCompareEffect doesn't like, so use useDeepCompareEffectNoCheck instead
   useDeepCompareEffectNoCheck(() => {
-    if (mergedData && onChange) {
-      onChange(mergedData)
+    if (mergedData) {
+      onChangeRef.current(mergedData)
     }
-  }, [mergedData, onChange])
+  }, [mergedData])
 }

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryWrapper.tsx
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryWrapper.tsx
@@ -8,7 +8,13 @@ import {
   QueryResultBundle,
 } from '@sage-bionetworks/synapse-types'
 import { Provider } from 'jotai'
-import { PropsWithChildren, useCallback, useEffect, useMemo } from 'react'
+import {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
 import { useDeepCompareMemoize } from 'use-deep-compare-effect'
 import {
   QueryContextProvider,
@@ -84,11 +90,17 @@ function SearchQueryResultBundleChangeNotifier({
     Omit<QueryResultBundle, 'queryResult'>
   >
   const { data } = useQuery(queryOpts)
+  // Use a ref so we always call the latest callback without including it in the
+  // effect dependency array. Including a frequently-recreated callback in deps
+  // causes the effect to re-fire on every render, creating an infinite loop when
+  // the parent updates state inside the callback.
+  const onQueryResultBundleChangeRef = useRef(onQueryResultBundleChange)
+  onQueryResultBundleChangeRef.current = onQueryResultBundleChange
   useEffect(() => {
     if (data) {
-      onQueryResultBundleChange(JSON.stringify(data))
+      onQueryResultBundleChangeRef.current(JSON.stringify(data))
     }
-  }, [data, onQueryResultBundleChange])
+  }, [data])
   return null
 }
 


### PR DESCRIPTION
## Bug: Maximum update depth exceeded on NF portal Search page

### Symptom

After searching from the sticky navbar, the user lands on `/Search/Files?SEARCH_TERM=<term>` and sees:

> Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.

The error originates in `<ForwardRef(InputBase)>` (MUI text field internals).

### Root Cause

An infinite render loop between `PortalSearchPage` and its child query wrappers.

**Step 1** — `PortalSearchPage` creates a new per-tab callback inline on every render:

```tsx
// New function reference on every render
onQueryResultBundleChange: (json: string) => {
  onQueryResultBundleChange(index, json, selectedTabIndex)
}
```

**Step 2** — Two hooks included this callback in their effect dependency arrays, so they re-fired every time the reference changed:

`useOnQueryDataChange.ts`:
```ts
useDeepCompareEffectNoCheck(() => {
  if (mergedData && onChange) {
    onChange(mergedData)
  }
}, [mergedData, onChange]) // ← onChange in deps causes re-fire on every render
```

`SearchQueryWrapper.tsx` (`SearchQueryResultBundleChangeNotifier`):
```ts
useEffect(() => {
  if (data) {
    onQueryResultBundleChange(JSON.stringify(data))
  }
}, [data, onQueryResultBundleChange]) // ← same problem
```

**The loop:** new lambda → effect fires → `setSearchPageTabsState` → re-render → new lambda → repeat.

### Fix

Store the callback in a ref updated during render. Remove it from the effect dependency array so effects only re-fire when **data** changes.

`useOnQueryDataChange.ts`:
```ts
// Before
useDeepCompareEffectNoCheck(() => {
  if (mergedData && onChange) {
    onChange(mergedData)
  }
}, [mergedData, onChange])

// After
const onChangeRef = useRef(onChange)
onChangeRef.current = onChange

useDeepCompareEffectNoCheck(() => {
  if (mergedData) {
    onChangeRef.current(mergedData)
  }
}, [mergedData])
```

`SearchQueryWrapper.tsx`:
```ts
// Before
useEffect(() => {
  if (data) {
    onQueryResultBundleChange(JSON.stringify(data))
  }
}, [data, onQueryResultBundleChange])

// After
const onQueryResultBundleChangeRef = useRef(onQueryResultBundleChange)
onQueryResultBundleChangeRef.current = onQueryResultBundleChange

useEffect(() => {
  if (data) {
    onQueryResultBundleChangeRef.current(JSON.stringify(data))
  }
}, [data])
```

### Files changed

| File | Change |
|------|--------|
| `packages/synapse-react-client/src/components/QueryWrapper/useOnQueryDataChange.ts` | Stabilise `onChange` via ref; remove from effect deps |
| `packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryWrapper.tsx` | Stabilise `onQueryResultBundleChange` via ref; remove from effect deps |