### PR TITLE
PORTALS-4242: Navbar with Search causes mobile menu to show up in an odd location

### DIFF
--- a/apps/synapse-portal-framework/src/components/HeaderSearchBoxV3.module.scss
+++ b/apps/synapse-portal-framework/src/components/HeaderSearchBoxV3.module.scss
@@ -14,7 +14,9 @@
 }
 
 .exampleSearchesSection {
-  display: none;
+  &.exampleSearchesSection {
+    display: none;
+  }
 }
 
 .exampleTermsContainer {

--- a/apps/synapse-portal-framework/src/ssg/PortalRoot.tsx
+++ b/apps/synapse-portal-framework/src/ssg/PortalRoot.tsx
@@ -55,7 +55,7 @@ export default function PortalRoot(props: PortalRootProps) {
   return (
     <PortalContextProvider value={portalContext}>
       <CookiesProvider>
-        <ThemeProvider theme={{ palette }} injectFirst>
+        <ThemeProvider theme={{ palette }}>
           <CssBaseline />
           <QueryClientProvider client={queryClient}>
             <DocumentMetadataProvider defaultTitle={portalContext.portalName}>

--- a/apps/synapse-portal-framework/src/ssg/PortalRoot.tsx
+++ b/apps/synapse-portal-framework/src/ssg/PortalRoot.tsx
@@ -55,7 +55,7 @@ export default function PortalRoot(props: PortalRootProps) {
   return (
     <PortalContextProvider value={portalContext}>
       <CookiesProvider>
-        <ThemeProvider theme={{ palette }}>
+        <ThemeProvider theme={{ palette }} injectFirst>
           <CssBaseline />
           <QueryClientProvider client={queryClient}>
             <DocumentMetadataProvider defaultTitle={portalContext.portalName}>


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/PORTALS-4242?search_id=f254d349-2a29-42fd-923e-51d926b7ca68

Could not reproduce locally in 'pnpm dev' but could reproduce in 'pnpm preview' (pre-rendered). I think module CSS loads later in 'pnpm dev' so modules win the cascade. But in 'pnpm preview', the prerendred HTML has the order as the CSS modules first then MUI/Emotion classes later, so MUI style wins. By using injectFirst, like the other SPA portals already do, we can let module CSS take precedence.

Sticky search + nav mobile:
<img width="1512" height="982" alt="Screenshot 2026-05-18 at 2 15 13 PM" src="https://github.com/user-attachments/assets/4ef0ed1a-c4df-42e8-9f34-1bdeea0f23b2" />
<img width="1512" height="982" alt="Screenshot 2026-05-18 at 2 15 19 PM" src="https://github.com/user-attachments/assets/b05642f4-0ddf-4b16-8a62-a8b0f934bae2" />

Sticky search + nav desktop and header search box styling:
Before:
<img width="1512" height="982" alt="A home for" src="https://github.com/user-attachments/assets/b0a1a8f4-46c7-46f3-a0ae-6d8c0bd9c662" />
After:
<img width="1512" height="982" alt="A home for" src="https://github.com/user-attachments/assets/c3fd9342-0fdc-4892-b764-b18cf1ec9ee0" />
