### PR TITLE
PORTALS-4243

### DIFF
--- a/apps/portals/digitalhealth/src/config/navbarConfig.ts
+++ b/apps/portals/digitalhealth/src/config/navbarConfig.ts
@@ -15,11 +15,11 @@ export const navbarConfig: NavbarConfig = {
       path: '/Explore',
       children: [
         { name: 'Collections', path: '/Explore/Collections' },
+        { name: 'Data', path: '/Explore/Data' },
         {
           name: 'Tools',
           path: '/Explore/Tools',
         },
-        { name: 'Data', path: '/Explore/Data' },
         { name: 'Publications', path: '/Explore/Publications' },
       ],
     },

--- a/apps/portals/digitalhealth/src/pages/HomePage.tsx
+++ b/apps/portals/digitalhealth/src/pages/HomePage.tsx
@@ -10,7 +10,7 @@ function HomePage() {
     <>
       <Header />
       <SectionLayout ContainerProps={{ className: 'home-spacer' }}>
-        <Goals entityId={'syn23518009'} />
+        <Goals entityId={'syn23518009'} itemsPerRow={4} />
       </SectionLayout>
       <div className={'home-bg-dark'}>
         <SectionLayout

--- a/packages/synapse-react-client/src/components/Goals/Goals.Desktop.tsx
+++ b/packages/synapse-react-client/src/components/Goals/Goals.Desktop.tsx
@@ -10,11 +10,12 @@ export default function GoalsDesktop({
   title,
   isAssetIcon,
   linkText = 'Explore',
-}: GoalsDataProps) {
+  cardWidth,
+}: GoalsDataProps & { cardWidth?: string }) {
   return (
     <Box
       className="Goals__Card"
-      sx={{ cursor: 'pointer', maxWidth: '335px', width: '335px' }}
+      sx={{ cursor: 'pointer', flex: `0 0 ${cardWidth ?? 'auto'}` }}
       onClick={() => window.open(link, '_self')}
     >
       <div

--- a/packages/synapse-react-client/src/components/Goals/Goals.tsx
+++ b/packages/synapse-react-client/src/components/Goals/Goals.tsx
@@ -14,6 +14,7 @@ export type GoalsProps = {
   entityId: string
   isAssetIcon?: boolean // If true, the asset will be used as an icon instead of a background image.
   linkText?: string
+  itemsPerRow?: number
 }
 
 export type GoalsDataProps = {
@@ -39,7 +40,7 @@ enum ExpectedColumns {
 const GOALS_DESKTOP_MIN_BREAKPOINT = 1200
 
 export function Goals(props: GoalsProps) {
-  const { entityId, isAssetIcon = false, linkText } = props
+  const { entityId, isAssetIcon = false, linkText, itemsPerRow = 3 } = props
   const showDesktop = useShowDesktop(GOALS_DESKTOP_MIN_BREAKPOINT)
   const queryBundleRequest: QueryBundleRequest = {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
@@ -131,6 +132,13 @@ export function Goals(props: GoalsProps) {
   }
 
   if (showDesktop) {
+    // Each card has margin:10px (20px horizontal) from .Goals__Card CSS.
+    // flex-basis must be the content width only; total row = N*(flex-basis+20) + (N-1)*gap.
+    // Subtract 0.5px epsilon to absorb sub-pixel rounding and prevent wrapping.
+    const horizontalMarginPerCard = 20
+    const cardWidth = `calc((100% - ${
+      itemsPerRow * horizontalMarginPerCard + (itemsPerRow - 1) * 7
+    }px) / ${itemsPerRow} - 0.5px)`
     return (
       <Box
         className={`Goals`}
@@ -138,12 +146,17 @@ export function Goals(props: GoalsProps) {
           display: 'flex',
           flexWrap: 'wrap',
           gap: '7px',
-          alignItems: 'stretch',
           justifyContent: 'center',
+          alignItems: 'stretch',
         }}
       >
         {goalsDataProps.map((props, index) => (
-          <GoalsDesktop key={index} {...props} linkText={linkText} />
+          <GoalsDesktop
+            key={index}
+            {...props}
+            linkText={linkText}
+            cardWidth={cardWidth}
+          />
         ))}
       </Box>
     )


### PR DESCRIPTION
<img width="1510" height="766" alt="Screenshot 2026-05-18 at 5 00 47 PM" src="https://github.com/user-attachments/assets/7a763d36-cdd3-4220-b2d8-3aa28ef5ceb8" />

Goals is also used in the following portal home pages:
arkportal
cancercomplexity
classic
genie
nf

And they look ok after the change:
<img width="1510" height="778" alt="Screenshot 2026-05-18 at 5 00 14 PM" src="https://github.com/user-attachments/assets/552a12b8-a83e-428b-a909-0f709e165280" />
<img width="1509" height="781" alt="Screenshot 2026-05-18 at 4 58 30 PM" src="https://github.com/user-attachments/assets/01475a23-5170-4576-8548-9a5906a1a8ce" />
<img width="1512" height="771" alt="Screenshot 2026-05-18 at 4 57 57 PM" src="https://github.com/user-attachments/assets/e382c17d-2c59-4a8a-a908-c1cc18346efc" />
<img width="1512" height="781" alt="Screenshot 2026-05-18 at 4 57 29 PM" src="https://github.com/user-attachments/assets/c89b1df5-1b5f-4891-b6e1-9af94a1a8cdd" />
<img width="1510" height="794" alt="Screenshot 2026-05-18 at 4 57 17 PM" src="https://github.com/user-attachments/assets/1eeb4112-058f-48a8-9427-e5a2c62e7ffc" />
<img width="1512" height="774" alt="Screenshot 2026-05-18 at 4 56 50 PM" src="https://github.com/user-attachments/assets/d9176fe2-d1a8-4aa9-83d1-364b13b3cd2a" />
