### PR TITLE
SWC-7832 fix clearing cells with "null" string value

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/utils/DataGridUtils.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/DataGridUtils.test.ts
@@ -77,6 +77,24 @@ describe('DataGridUtils', () => {
       const b: DataGridRow = { a: '2' }
       expect(rowsAreIdentical(a, b)).toBe(false)
     })
+    it('does not conflate the literal string "null" with actual null', () => {
+      // Regression: source data encoding empty cells as the string "null"
+      // must remain distinct from a cleared (null) cell so that backspace
+      // produces an UPDATE rather than being filtered as a no-op.
+      const a: DataGridRow = { a: 'null' }
+      const b: DataGridRow = { a: null }
+      expect(rowsAreIdentical(a, b)).toBe(false)
+    })
+    it('does not conflate the literal string "undefined" with actual undefined', () => {
+      const a: DataGridRow = { a: 'undefined' }
+      const b: DataGridRow = { a: undefined }
+      expect(rowsAreIdentical(a, b)).toBe(false)
+    })
+    it('does not conflate numbers with their string representations', () => {
+      const a: DataGridRow = { a: 1 }
+      const b: DataGridRow = { a: '1' }
+      expect(rowsAreIdentical(a, b)).toBe(false)
+    })
   })
 
   describe('removeNoOpOperations', () => {

--- a/packages/synapse-react-client/src/components/DataGrid/utils/DataGridUtils.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/DataGridUtils.ts
@@ -30,7 +30,7 @@ export function rowsAreIdentical(a: DataGridRow, b: DataGridRow): boolean {
     // Treat null, undefined, and empty string as equivalent
     const isNullish = (v: unknown) => v === null || v === undefined || v === ''
     if (isNullish(aVal) && isNullish(bVal)) continue
-    if (String(aVal) !== String(bVal)) return false
+    if (!Object.is(aVal, bVal)) return false
   }
   return true
 }


### PR DESCRIPTION
In the nullish change check, values were compared by coercing to string. This made "null" and `null` equal. Instead, compare object types.