### PR TITLE
PORTALS-4247

### DIFF
--- a/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearch.test.tsx
+++ b/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearch.test.tsx
@@ -8,6 +8,7 @@ import { createWrapper } from '@/testutils/TestingLibraryUtils'
 import {
   ColumnSingleValueFilterOperator,
   QueryBundleRequest,
+  TextMatchesQueryFilter,
 } from '@sage-bionetworks/synapse-types'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -242,6 +243,82 @@ describe('FullTextSearch tests', () => {
         },
       })
     })
+    it('appends a new filter by default (replaceExistingFilter not set)', () => {
+      const columnModels = mockQueryResultBundle.columnModels
+      const ftsConfig: FTSConfig = { textMatchesMode: 'NATURAL_LANGUAGE' }
+      const existingFilter: TextMatchesQueryFilter = {
+        concreteType:
+          'org.sagebionetworks.repo.model.table.TextMatchesQueryFilter',
+        searchExpression: 'old search',
+        searchMode: 'NATURAL_LANGUAGE',
+      }
+      const initialRequest: QueryBundleRequest = {
+        entityId: 'syn123',
+        query: {
+          sql: 'SELECT * FROM syn123',
+          additionalFilters: [existingFilter],
+        },
+        partMask: 255,
+        concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+      }
+
+      const updatedRequest = updateQueryUsingSearchTerm(
+        initialRequest,
+        columnModels,
+        'new search',
+        ftsConfig,
+      )
+
+      expect(updatedRequest.query.additionalFilters).toHaveLength(2)
+    })
+
+    it('replaces all existing TextMatchesQueryFilters when replaceExistingFilter is true', () => {
+      const columnModels = mockQueryResultBundle.columnModels
+      const ftsConfig: FTSConfig = {
+        textMatchesMode: 'NATURAL_LANGUAGE',
+        replaceExistingFilter: true,
+      }
+      const existingFilters: TextMatchesQueryFilter[] = [
+        {
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TextMatchesQueryFilter',
+          searchExpression: 'old search one',
+          searchMode: 'NATURAL_LANGUAGE',
+        },
+        {
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TextMatchesQueryFilter',
+          searchExpression: 'old search two',
+          searchMode: 'NATURAL_LANGUAGE',
+        },
+      ]
+      const initialRequest: QueryBundleRequest = {
+        entityId: 'syn123',
+        query: {
+          sql: 'SELECT * FROM syn123',
+          additionalFilters: existingFilters,
+        },
+        partMask: 255,
+        concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+      }
+
+      const updatedRequest = updateQueryUsingSearchTerm(
+        initialRequest,
+        columnModels,
+        'new search',
+        ftsConfig,
+      )
+
+      expect(updatedRequest.query.additionalFilters).toEqual([
+        {
+          concreteType:
+            'org.sagebionetworks.repo.model.table.TextMatchesQueryFilter',
+          searchExpression: 'new search',
+          searchMode: 'NATURAL_LANGUAGE',
+        },
+      ])
+    })
+
     it('adds the appropriate QueryFilter when searching for Synapse ID', () => {
       const columnModels = mockQueryResultBundle.columnModels
       const searchQuery = 'syn123'

--- a/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearchUtils.ts
+++ b/packages/synapse-react-client/src/components/FullTextSearch/FullTextSearchUtils.ts
@@ -91,16 +91,29 @@ export function updateQueryUsingSearchTerm(
       searchText,
       ftsConfig,
     )
-    // PORTALS-2093: does this additional filter already exist?
-    const found = additionalFilters.find(
-      filter =>
-        filter.concreteType == textMatchesQueryFilter.concreteType &&
-        filter.searchExpression == textMatchesQueryFilter.searchExpression,
-    )
-    if (found) {
-      return queryBundleRequest
+    if (ftsConfig?.replaceExistingFilter) {
+      // Remove all existing TextMatchesQueryFilters, then add the new one
+      for (let i = additionalFilters.length - 1; i >= 0; i--) {
+        if (
+          additionalFilters[i].concreteType ===
+          textMatchesQueryFilter.concreteType
+        ) {
+          additionalFilters.splice(i, 1)
+        }
+      }
+      additionalFilters.push(textMatchesQueryFilter)
+    } else {
+      // PORTALS-2093: does this additional filter already exist?
+      const found = additionalFilters.find(
+        filter =>
+          filter.concreteType == textMatchesQueryFilter.concreteType &&
+          filter.searchExpression == textMatchesQueryFilter.searchExpression,
+      )
+      if (found) {
+        return queryBundleRequest
+      }
+      additionalFilters.push(textMatchesQueryFilter)
     }
-    additionalFilters.push(textMatchesQueryFilter)
   }
   queryBundleRequest.query.additionalFilters = additionalFilters
   return queryBundleRequest

--- a/packages/synapse-react-client/src/components/SearchQueryWrapperPlotNav/SearchQueryWrapperPlotNav.tsx
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapperPlotNav/SearchQueryWrapperPlotNav.tsx
@@ -177,6 +177,7 @@ export default function SearchQueryWrapperPlotNav(
               ftsConfig: {
                 textMatchesMode: 'NATURAL_LANGUAGE',
                 minSearchQueryLength: 1,
+                replaceExistingFilter: true,
                 getSuggestions: autocompleteFieldName
                   ? getSuggestions
                   : undefined,

--- a/packages/synapse-react-client/src/components/SynapseTable/SearchV2.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SearchV2.tsx
@@ -74,6 +74,12 @@ export type FTSConfig = {
    * Defaults to 3 (see PLFM-7011).
    */
   minSearchQueryLength?: number
+  /**
+   * When true, submitting a new search term replaces any existing TextMatchesQueryFilter
+   * in additionalFilters rather than appending a new one.
+   * Defaults to false (existing behaviour: filters accumulate).
+   */
+  replaceExistingFilter?: boolean
 }
 
 type InternalSearchProps = SearchV2Props & {


### PR DESCRIPTION
## PR #2814: PORTALS-4247 — `replaceExistingFilter` option for `FTSConfig`

---

### New `FTSConfig` option: `replaceExistingFilter`

A new optional boolean field `replaceExistingFilter` was added to `FTSConfig`
in `SearchV2.tsx`:

- **Default (`false`):** existing behavior — each search appends a new
  `TextMatchesQueryFilter` to `additionalFilters` (accumulating filters).
- **When `true`:** submitting a new search term first removes all existing
  `TextMatchesQueryFilter` entries from `additionalFilters`, then adds the
  new one. This gives a "replace, don't accumulate" search UX.

---

### `SearchQueryWrapperPlotNav` opts in

`SearchQueryWrapperPlotNav` now passes `replaceExistingFilter: true` in its
`ftsConfig`. Each new search in a Search Query Wrapper replaces the previous filter
rather than stacking filters.

---

### `FullTextSearchUtils.ts` — implementation

`updateQueryUsingSearchTerm` was updated to branch on `ftsConfig?.replaceExistingFilter`:

- **`true`:** iterates `additionalFilters` in reverse and splices out any
  entry whose `concreteType` matches `TextMatchesQueryFilter`, then pushes
  the new filter.
- **`false` / unset:** retains the existing duplicate-check logic
  (PORTALS-2093) and appends if not already present.

---

### New unit tests (`FullTextSearch.test.tsx`)

Two new tests were added to `updateQueryUsingSearchTerm`:

1. **Append by default** — verifies that without `replaceExistingFilter`,
   a second search results in two filters in `additionalFilters`.
2. **Replace when enabled** — verifies that with `replaceExistingFilter: true`,
   multiple pre-existing `TextMatchesQueryFilter` entries are removed and
   only the new filter remains.