### PR TITLE
PORTALS-4248, PORTALS-4249

### DIFF
--- a/apps/synapse-portal-framework/src/components/HeaderSearchBox.tsx
+++ b/apps/synapse-portal-framework/src/components/HeaderSearchBox.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mui/material'
 import React from 'react'
 import PortalFullTextSearchField from './PortalSearch/PortalFullTextSearchField'
-import { useNavigate } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 import defaultStyles from './HeaderSearchBox.module.scss'
 import v2Styles from './HeaderSearchBoxV2.module.scss'
 import v3Styles from './HeaderSearchBoxV3.module.scss'
@@ -67,6 +67,7 @@ const HeaderSearchBox = ({
   const [mode, setMode] = useState<'Chat' | 'Search'>('Search')
   const theme = useTheme()
   const navigate = useNavigate()
+  const location = useLocation()
   const { isAuthenticated } = useSynapseContext()
   const chatDialogContext = useChatDialogContext()
   const isChatAvailable = chatDialogContext?.isChatAvailable
@@ -93,8 +94,9 @@ const HeaderSearchBox = ({
         if (role) {
           params.set(SEARCH_ROLE, role)
         }
+        const alreadyOnPath = location.pathname.startsWith(path)
         navigate({
-          pathname: path,
+          ...(alreadyOnPath ? {} : { pathname: path }),
           search: `?${params.toString()}`,
         })
       }

--- a/apps/synapse-portal-framework/src/components/PortalSearch/SearchParamAwareQueryWrapperPlotNav.tsx
+++ b/apps/synapse-portal-framework/src/components/PortalSearch/SearchParamAwareQueryWrapperPlotNav.tsx
@@ -91,6 +91,8 @@ function SearchParamAwareSearchQueryWrapperPlotNav({
         {...config}
         initQueryRequest={initQueryRequest}
         onQueryResultBundleChange={onQueryResultBundleChange}
+        hideSearchBarControl={true}
+        defaultShowSearchBar={false}
       />
     )
   }
@@ -157,6 +159,7 @@ function SearchParamAwareStandaloneQueryWrapperPlotNav({
         defaultShowSearchBox={false}
         hideVisualizationsControl={true}
         hideSearchBarControl={true}
+        defaultShowSearchBar={false}
         name={undefined}
       />
     )

--- a/apps/synapse-portal-framework/src/components/nf/NFBrowseToolsPage.tsx
+++ b/apps/synapse-portal-framework/src/components/nf/NFBrowseToolsPage.tsx
@@ -7,7 +7,7 @@ import advancedCellularModelsUrl from '@/components/assets/advanced-cellular-mod
 import clinicalAssessmentToolsUrl from '@/components/assets/clinical-assessment-tools.svg?url'
 import computationalToolsUrl from '@/components/assets/computational-tools.svg?url'
 import patientDerivedModelsUrl from '@/components/assets/patient-derived-models.svg?url'
-import { Box, Link, Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import { Query } from '@sage-bionetworks/synapse-types'
 import pluralize from 'pluralize'
 import { ReactElement, ReactNode } from 'react'
@@ -305,24 +305,6 @@ const NFBrowseToolsPage = (props: NFBrowseToolsPageProps): ReactNode => {
           }}
         >
           What Tools Can We Help You Find?
-        </Typography>
-        <Typography
-          variant="body1"
-          sx={{ textAlign: 'center', paddingBottom: '15px' }}
-        >
-          For the greatest success with your search, ensure your spelling is
-          correct and avoid pluralization or suffixes.
-        </Typography>
-        <Typography
-          variant="body1"
-          sx={{ textAlign: 'center', paddingBottom: '40px' }}
-        >
-          <Link
-            href="https://help.nf.synapse.org/NFdocs/Tips-for-Search.2640478225.html"
-            target="_blank"
-          >
-            Learn More About MySQL Full Text Search
-          </Link>
         </Typography>
         <Search onSearch={gotoExploreToolsWithFullTextSearch} />
         <Typography variant="sectionTitle" className="sectionTitle">

--- a/packages/synapse-react-client/src/components/SearchQueryWrapperPlotNav/SearchQueryWrapperPlotNav.tsx
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapperPlotNav/SearchQueryWrapperPlotNav.tsx
@@ -56,6 +56,8 @@ export type SearchQueryWrapperPlotNavProps = SearchQueryWrapperPlotNavOwnProps &
     | 'helpConfiguration'
     | 'hideCopyToClipboard'
     | 'hideVisualizationsControl'
+    | 'hideSearchBarControl'
+    | 'defaultShowSearchBar'
   > &
   Pick<TopLevelControlsProps, 'name' | 'hideQueryCount'> & {
     /** Optional initial query parameters. Only selectedFacets, additionalFilters, limit, and offset are used. */
@@ -148,8 +150,8 @@ export default function SearchQueryWrapperPlotNav(
           visibleColumnCount={props.visibleColumnCount}
           defaultShowPlots={props.defaultShowPlots}
           hideCopyToClipboard={props.hideCopyToClipboard}
-          hideSearchBarControl={false}
-          defaultShowSearchBar={true}
+          hideSearchBarControl={props.hideSearchBarControl ?? false}
+          defaultShowSearchBar={props.defaultShowSearchBar ?? true}
           showLastUpdatedOn={props.showLastUpdatedOn}
           noContentPlaceholderType={
             props.noContentPlaceholderType ??


### PR DESCRIPTION
## PR #2820 — PORTALS-4248, PORTALS-4249
---

### Summary

Two bug fixes related to portal search UX and the NF (NeuroFibromatosis) portal's Browse Tools page.

---

### Changes

#### 1. `HeaderSearchBox.tsx` — Fix navigation when already on the search path (PORTALS-4248)

Previously, navigating from the search box always set `pathname: path`, causing a full route re-render even when the user was already on the search results page. This broke the UX because the current object context was lost (I was searching Tools, and then another tab was auto-selected).

**Fix:** Uses `useLocation` to check if the browser is already on the target path. If so, omits `pathname` from the `navigate()` call so only the search params are updated.

```tsx
const alreadyOnPath = location.pathname.startsWith(path)
navigate({
  ...(alreadyOnPath ? {} : { pathname: path }),
  search: `?${params.toString()}`,
})
```

---

#### 2. `SearchQueryWrapperPlotNav.tsx` (SRC) — Expose `hideSearchBarControl` and `defaultShowSearchBar` as props

These two props were previously hardcoded (`false` and `true` respectively). They are now passed through as optional props with the same defaults, making the component more configurable.

---

#### 3. `SearchParamAwareQueryWrapperPlotNav.tsx` — Hide the search bar in param-aware variants

Both `SearchParamAwareSearchQueryWrapperPlotNav` and `SearchParamAwareStandaloneQueryWrapperPlotNav` now explicitly pass `hideSearchBarControl={true}` and `defaultShowSearchBar={false}`. This hides the redundant in-table search bar when the portal header search box is the intended entry point.

---

#### 4. `NFBrowseToolsPage.tsx` — Remove outdated search guidance text (PORTALS-4249)

Removes two `<Typography>` blocks containing search tips referencing MySQL full-text search quirks (spelling, pluralization, suffixes) and a link to an NF docs page. This copy is no longer accurate given updates to the search implementation.
