### PR TITLE
SWC-7834: filter out appIds that are the empty string or undefined

### DIFF
--- a/packages/synapse-react-client/src/components/SynapseSearchPageResults/SearchPagePortalBanners.tsx
+++ b/packages/synapse-react-client/src/components/SynapseSearchPageResults/SearchPagePortalBanners.tsx
@@ -52,7 +52,9 @@ export default function SearchPagePortalBanners({
 
   const rowSet = dataCatalogData?.responseBody?.queryResult?.queryResults
   const hasPortalBanners = !!rowSet && rowSet?.rows.length > 0
-  const appIds = rowSet?.rows.map(row => row.values[0]) as string[]
+  const appIds = rowSet?.rows
+    .map(row => row.values[0])
+    .filter((v): v is string => !!v) as string[]
 
   // Get source app configurations for the found portal app IDs
   const sourceAppConfigFilters: ColumnSingleValueQueryFilter[] =


### PR DESCRIPTION
<img width="991" height="506" alt="Screenshot 2026-05-21 at 9 58 25 AM" src="https://github.com/user-attachments/assets/86876817-bc9b-45f9-a2eb-56a9e9782fed" />
