### PR TITLE
PORTALS-4247:  Always show the PortalFullTextSearchField (continue to…

### DIFF
--- a/apps/synapse-portal-framework/src/components/PortalSearch/PortalSearchPage.tsx
+++ b/apps/synapse-portal-framework/src/components/PortalSearch/PortalSearchPage.tsx
@@ -96,39 +96,36 @@ export function PortalSearchPage(props: PortalSearchPageProps) {
       {configs.length !== 1 && selectedTabIndex != undefined && (
         <PortalSearchTabs tabConfig={searchPageTabsState} />
       )}
-      <Box sx={{ position: 'relative' }}>
-        <Box sx={{ position: 'relative', zIndex: 1 }}>
-          {configs.map((config, index) => {
-            const key = `searchResultTab-${selectedTabIndex}-${index}`
-            const sharedProps = {
-              isVisible: selectedTabIndex == index,
-              onQueryResultBundleChange: (newQueryResultBundleJSON: string) => {
-                onQueryResultBundleChange(
-                  index,
-                  newQueryResultBundleJSON,
-                  selectedTabIndex,
-                )
-              },
-            }
-            if (isSearchQueryWrapperPlotNavProps(config)) {
-              return (
-                <SearchParamAwareQueryWrapperPlotNav
-                  key={key}
-                  {...sharedProps}
-                  searchQueryWrapperPlotNavProps={config}
-                />
-              )
-            }
-            return (
-              <SearchParamAwareQueryWrapperPlotNav
-                key={key}
-                {...sharedProps}
-                standaloneQueryWrapperProps={config}
-              />
+
+      {configs.map((config, index) => {
+        const key = `searchResultTab-${selectedTabIndex}-${index}`
+        const sharedProps = {
+          isVisible: selectedTabIndex == index,
+          onQueryResultBundleChange: (newQueryResultBundleJSON: string) => {
+            onQueryResultBundleChange(
+              index,
+              newQueryResultBundleJSON,
+              selectedTabIndex,
             )
-          })}
-        </Box>
-      </Box>
+          },
+        }
+        if (isSearchQueryWrapperPlotNavProps(config)) {
+          return (
+            <SearchParamAwareQueryWrapperPlotNav
+              key={key}
+              {...sharedProps}
+              searchQueryWrapperPlotNavProps={config}
+            />
+          )
+        }
+        return (
+          <SearchParamAwareQueryWrapperPlotNav
+            key={key}
+            {...sharedProps}
+            standaloneQueryWrapperProps={config}
+          />
+        )
+      })}
       {selectedTabIndex == undefined && (
         <Box
           sx={{

--- a/apps/synapse-portal-framework/src/components/PortalSearch/PortalSearchPage.tsx
+++ b/apps/synapse-portal-framework/src/components/PortalSearch/PortalSearchPage.tsx
@@ -81,32 +81,22 @@ export function PortalSearchPage(props: PortalSearchPageProps) {
       sx={{
         px: { xs: '10px', lg: '50px' },
         pb: { xs: '10px', lg: '50px' },
-        pt: configs.length === 1 ? 0 : { xs: '10px', lg: '50px' },
+        pt: { xs: '10px', lg: '20px' },
       }}
     >
-      {configs.length !== 1 && (
-        <PortalFullTextSearchField
-          disabled={selectedTabIndex == undefined}
-          path={location.pathname}
-        />
-      )}
+      <PortalFullTextSearchField
+        disabled={selectedTabIndex == undefined}
+        path={location.pathname}
+      />
+      <Box
+        sx={{
+          pt: { xs: '10px', lg: '20px' },
+        }}
+      />
       {configs.length !== 1 && selectedTabIndex != undefined && (
         <PortalSearchTabs tabConfig={searchPageTabsState} />
       )}
       <Box sx={{ position: 'relative' }}>
-        {configs.length === 1 && (
-          <Box
-            sx={{
-              position: 'absolute',
-              top: 0,
-              left: { xs: '-10px', lg: '-50px' },
-              right: { xs: '-10px', lg: '-50px' },
-              height: '60px',
-              backgroundColor: 'var(--synapse-gray-200)',
-              zIndex: 0,
-            }}
-          />
-        )}
         <Box sx={{ position: 'relative', zIndex: 1 }}>
           {configs.map((config, index) => {
             const key = `searchResultTab-${selectedTabIndex}-${index}`


### PR DESCRIPTION
… always hide search control in plot nav from Search page).  Remove hacky gray box
Also fix the padding around search box.

<img width="1311" height="750" alt="Screenshot 2026-05-21 at 10 49 13 AM" src="https://github.com/user-attachments/assets/2895c7c7-63ba-404d-a0d6-9d2e335cd9c6" />

<img width="1310" height="650" alt="Screenshot 2026-05-21 at 10 51 13 AM" src="https://github.com/user-attachments/assets/6c026054-7ad0-4308-83d5-559685c117b7" />
