### PR TITLE
PORTALS-4244

### DIFF
--- a/packages/synapse-react-client/src/components/Markdown/widget/MarkdownTableOfContents.test.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/widget/MarkdownTableOfContents.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import MarkdownTableOfContents from './MarkdownTableOfContents'
+
+describe('MarkdownTableOfContents', () => {
+  it('renders nothing when originalMarkup is empty', () => {
+    const { container } = render(<MarkdownTableOfContents originalMarkup="" />)
+    expect(container.querySelectorAll('a')).toHaveLength(0)
+  })
+
+  it('renders nothing when there are no headings with toc="true"', () => {
+    const markup = '<h1 id="SRC-header-1">Heading without toc attribute</h1>'
+    const { container } = render(
+      <MarkdownTableOfContents originalMarkup={markup} />,
+    )
+    expect(container.querySelectorAll('a')).toHaveLength(0)
+  })
+
+  it('renders a link for a heading marked with toc="true"', () => {
+    const markup = '<h1 id="SRC-header-1" toc="true">My Heading</h1>'
+    render(<MarkdownTableOfContents originalMarkup={markup} />)
+
+    const link = screen.getByRole('link', { name: 'My Heading' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveClass('link', 'toc-indent1')
+    expect(link).toHaveAttribute('data-anchor', 'SRC-header-1')
+  })
+
+  it('applies the correct indent class for each heading level', () => {
+    const markup = [
+      '<h1 id="SRC-header-1" toc="true">Level 1</h1>',
+      '<h2 id="SRC-header-2" toc="true">Level 2</h2>',
+      '<h3 id="SRC-header-3" toc="true">Level 3</h3>',
+      '<h4 id="SRC-header-4" toc="true">Level 4</h4>',
+      '<h5 id="SRC-header-5" toc="true">Level 5</h5>',
+      '<h6 id="SRC-header-6" toc="true">Level 6</h6>',
+    ].join('\n')
+    render(<MarkdownTableOfContents originalMarkup={markup} />)
+
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(6)
+    expect(links[0]).toHaveClass('toc-indent1')
+    expect(links[1]).toHaveClass('toc-indent2')
+    expect(links[2]).toHaveClass('toc-indent3')
+    expect(links[3]).toHaveClass('toc-indent4')
+    expect(links[4]).toHaveClass('toc-indent5')
+    expect(links[5]).toHaveClass('toc-indent6')
+  })
+
+  it('excludes headings that do not have toc="true"', () => {
+    const markup = [
+      '<h1 id="SRC-header-1" toc="true">Show me</h1>',
+      '<h2 id="SRC-header-2">Do not show me</h2>',
+    ].join('\n')
+    render(<MarkdownTableOfContents originalMarkup={markup} />)
+
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(1)
+    expect(links[0]).toHaveTextContent('Show me')
+  })
+
+  it('strips inner HTML from heading content so only plain text appears in the TOC link', () => {
+    const markup =
+      '<h1 id="SRC-header-1" toc="true">Hello <span><a href="#">@World</a></span></h1>'
+    render(<MarkdownTableOfContents originalMarkup={markup} />)
+
+    const link = screen.getByRole('link')
+    expect(link.textContent).toBe('Hello @World')
+    expect(link.textContent).not.toContain('<span')
+    expect(link.textContent).not.toContain('<a')
+  })
+
+  it('uses the heading id as the data-anchor on each link', () => {
+    const markup = [
+      '<h1 id="SRC-header-1" toc="true">Alpha</h1>',
+      '<h2 id="SRC-header-2" toc="true">Beta</h2>',
+    ].join('\n')
+    render(<MarkdownTableOfContents originalMarkup={markup} />)
+
+    expect(screen.getByRole('link', { name: 'Alpha' })).toHaveAttribute(
+      'data-anchor',
+      'SRC-header-1',
+    )
+    expect(screen.getByRole('link', { name: 'Beta' })).toHaveAttribute(
+      'data-anchor',
+      'SRC-header-2',
+    )
+  })
+})

--- a/packages/synapse-react-client/src/components/Markdown/widget/MarkdownTableOfContents.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/widget/MarkdownTableOfContents.tsx
@@ -1,3 +1,5 @@
+import { stripHTML } from '../MarkdownUtils'
+
 const TOC_CLASS = {
   1: 'toc-indent1',
   2: 'toc-indent2',
@@ -20,15 +22,16 @@ export default function MarkdownTableOfContents(
     /<h([1-6]) id="(.*)" .*toc="true">(.*)<\/h[1-6]>/gm
   let text = ''
   originalMarkup.replace(TOC_HEADER_REGEX_WITH_ID, (p1, p2, p3, p4) => {
-    text += p4
+    const headingText = stripHTML(p4)
+    text += headingText
     elements.push(
-      <div key={p4}>
+      <div key={headingText}>
         <a
           role="link"
           className={`link ${TOC_CLASS[Number(p2) as keyof typeof TOC_CLASS]}`}
           data-anchor={p3}
         >
-          {p4}
+          {headingText}
         </a>
       </div>,
     )


### PR DESCRIPTION
## Fix: Strip inner HTML from TOC heading entries

### PORTALS-4244

`MarkdownTableOfContents` displayed raw HTML markup as visible text in TOC
links when a heading contained inline HTML elements (e.g. user mention spans,
anchor tags, or wiki widget `<span>` elements). For example, a heading like:

    <h1 id="SRC-header-1" toc="true">Hello <span><a href="#">@World</a></span></h1>

would produce a TOC link whose text read `Hello <span><a href="#">@World</a></span>`
instead of `Hello @World`.

This matches the behaviour described in the SWC Java reference implementation
(`TableOfContentsWidgetViewImpl.java`), which explicitly strips inner HTML from
widget spans inside headings before building TOC entries.

### Fix

**`packages/synapse-react-client/src/components/Markdown/widget/MarkdownTableOfContents.tsx`**

- Imported the existing `stripHTML` utility from `MarkdownUtils`.
- Applied `stripHTML()` to the captured heading content (`p4`) before using it
  as the TOC link text and React `key`.

### Tests

**`packages/synapse-react-client/src/components/Markdown/widget/MarkdownTableOfContents.test.tsx`** *(new file)*

Unit tests covering:
- Empty markup and headings without `toc="true"` produce no links.
- A `toc="true"` heading renders a link with the correct text, CSS indent
  class, and `data-anchor` attribute.
- All six heading levels map to the correct `toc-indent1`–`toc-indent6` class.
- Headings without `toc="true"` are excluded from the TOC.
- Inner HTML is stripped so raw tags never appear as link text (regression test
  for the bug fixed above).
- `data-anchor` is correctly wired for multiple headings.