### PR TITLE
SWC-7831 - display taskId in CurationTaskCard

### DIFF
--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
@@ -13,6 +13,7 @@ export const Demo: Story = {
     taskBundle: {
       task: {
         dataType: 'metadata_clinical',
+        taskId: 123,
         instructions:
           'Project: Precision Drug Treatment Profiling in Human Pancreatic Tissue',
         assigneePrincipalId: '273957',

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -27,6 +27,7 @@ function useUiForTask(taskBundle: TaskBundle) {
       return {
         title: taskBundle.task.dataType,
         description: taskBundle.task.instructions ?? '',
+        taskId: taskBundle.task.taskId,
         principalIds: taskBundle.task.assigneePrincipalId
           ? [taskBundle.task.assigneePrincipalId]
           : [],
@@ -49,6 +50,7 @@ function useUiForTask(taskBundle: TaskBundle) {
   return {
     title: taskBundle.task.dataType,
     description: taskBundle.task.instructions ?? '',
+    taskId: taskBundle.task.taskId!,
     principalIds: taskBundle.task.assigneePrincipalId
       ? [taskBundle.task.assigneePrincipalId]
       : [],
@@ -80,6 +82,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
   const {
     title,
     description,
+    taskId,
     taskType,
     principalIds,
     buttonText,
@@ -96,6 +99,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
           <div className={styles.titleChipContainer}>
             <Typography variant="headline3">{title}</Typography>
             {taskType && <TaskTypeChip label={taskType} />}
+            {taskId && <TaskTypeChip label={`TaskId ${taskId}`} />}
           </div>
           <Typography variant="body1">{description}</Typography>
           <div className={styles.userChipContainer}>


### PR DESCRIPTION
Add taskId chip to CurationTaskCard
<img width="1064" height="230" alt="ss" src="https://github.com/user-attachments/assets/45231c98-d5bf-4a31-a411-7ba38ac20e3a" />
