### PR TITLE
PORTALS-4256

### DIFF
--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
@@ -587,21 +587,15 @@ describe('searchQueryResultsToQueryResultBundle', () => {
       facetType: 'enumeration' as const,
       facetValues: [{ value: 'HTAN', count: 3, isSelected: false }],
     }
-    const facetAge = {
-      concreteType:
-        'org.sagebionetworks.repo.model.table.FacetColumnResultRange' as const,
-      columnName: 'age',
-      facetType: 'range' as const,
-      columnMin: '0',
-      columnMax: '100',
-    }
-    // Server returns facets in a different order than columnModels
+    // Server returns facets in a different order than columnModels.
+    // Note: the server never returns FacetColumnResultRange; the age facet is synthesized
+    // from columnModels by searchQueryResultsToQueryResultBundle.
     const results: SearchQueryResults = {
       concreteType: 'org.sagebionetworks.repo.model.search.SearchQueryResults',
       totalHits: 5,
       hits: [],
       selectColumns: [],
-      facets: [facetOrgan, facetConsortium, facetAge],
+      facets: [facetOrgan, facetConsortium],
     }
     // columnModels order: consortium → age → organ
     const columnModels = [
@@ -805,40 +799,6 @@ describe('searchQueryResultsToQueryResultBundle', () => {
     expect(facet.facetType).toBe('range')
     expect(facet.columnMin).toBe('')
     expect(facet.columnMax).toBe('')
-  })
-
-  it('does not synthesize when a range facet for the column already exists in server results', () => {
-    const existingFacet: FacetColumnResultRange = {
-      concreteType:
-        'org.sagebionetworks.repo.model.table.FacetColumnResultRange',
-      facetType: 'range',
-      columnName: 'event_date',
-      columnMin: '1000000',
-      columnMax: '2000000',
-    }
-    const results: SearchQueryResults = {
-      concreteType: 'org.sagebionetworks.repo.model.search.SearchQueryResults',
-      totalHits: 0,
-      hits: [],
-      selectColumns: [],
-      facets: [existingFacet],
-    }
-    const result = searchQueryResultsToQueryResultBundle(
-      results,
-      MINIMAL_SEARCH_INDEX_QUERY,
-      [
-        {
-          id: 'c1',
-          name: 'event_date',
-          columnType: 'DATE',
-          facetType: 'range',
-        },
-      ],
-    )
-    expect(result.facets).toHaveLength(1)
-    expect((result.facets![0] as FacetColumnResultRange).columnMin).toBe(
-      '1000000',
-    )
   })
 
   it('converts unix millisecond rangeFilter values to YYYY-MM-DD for synthesized DATE facet selectedMin and selectedMax', () => {

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
@@ -1,6 +1,7 @@
 import {
   FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
   FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE_VALUE,
+  FacetColumnResultRange,
   QueryBundleRequest,
   TEXT_MATCHES_QUERY_FILTER_CONCRETE_TYPE_VALUE,
 } from '@sage-bionetworks/synapse-types'
@@ -8,6 +9,7 @@ import type {
   SearchIndexQuery,
   SearchQueryResults,
 } from '@sage-bionetworks/synapse-client'
+import dayjs from 'dayjs'
 import { describe, expect, it } from 'vitest'
 import {
   searchQueryResultsToQueryResultBundle,
@@ -124,6 +126,80 @@ describe('toSearchIndexQuery', () => {
     ])
   })
 
+  it('converts DATE range filter values from YYYY-MM-DD to unix milliseconds', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleRequest({
+        selectedFacets: [
+          {
+            concreteType: FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+            columnName: 'event_date',
+            min: '2021-06-01',
+            max: '2021-12-31',
+          },
+        ],
+      }),
+      SEARCH_INDEX_ID,
+      [
+        {
+          id: 'c1',
+          name: 'event_date',
+          columnType: 'DATE',
+          facetType: 'range',
+        },
+      ],
+    )
+    const rf = result.searchQuery?.rangeFilters![0]
+    expect(rf?.min).toBe(String(dayjs('2021-06-01').valueOf()))
+    expect(rf?.max).toBe(String(dayjs('2021-12-31').valueOf()))
+  })
+
+  it('passes non-DATE range filter values through unchanged', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleRequest({
+        selectedFacets: [
+          {
+            concreteType: FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+            columnName: 'year',
+            min: '1996',
+            max: '1999',
+          },
+        ],
+      }),
+      SEARCH_INDEX_ID,
+      [{ id: 'c1', name: 'year', columnType: 'INTEGER', facetType: 'range' }],
+    )
+    const rf = result.searchQuery?.rangeFilters![0]
+    expect(rf?.min).toBe('1996')
+    expect(rf?.max).toBe('1999')
+  })
+
+  it('keeps undefined range filter bounds as undefined without conversion', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleRequest({
+        selectedFacets: [
+          {
+            concreteType: FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+            columnName: 'event_date',
+            min: undefined,
+            max: '2021-12-31',
+          },
+        ],
+      }),
+      SEARCH_INDEX_ID,
+      [
+        {
+          id: 'c1',
+          name: 'event_date',
+          columnType: 'DATE',
+          facetType: 'range',
+        },
+      ],
+    )
+    const rf = result.searchQuery?.rangeFilters![0]
+    expect(rf?.min).toBeUndefined()
+    expect(rf?.max).toBe(String(dayjs('2021-12-31').valueOf()))
+  })
+
   it('keeps enumeration and range selectedFacets separate', () => {
     const result = toSearchIndexQuery(
       makeQueryBundleRequest({
@@ -203,6 +279,24 @@ describe('toSearchIndexQuery', () => {
       [{ id: 'c1', name: 'description', columnType: 'STRING' }],
     )
     expect(result.searchQuery?.facetRequests).toBeUndefined()
+  })
+
+  it('excludes range-type columns from facetRequests, keeping only enumeration columns', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleRequest(),
+      SEARCH_INDEX_ID,
+      [
+        { id: 'c1', name: 'year', columnType: 'INTEGER', facetType: 'range' },
+        {
+          id: 'c2',
+          name: 'consortium',
+          columnType: 'STRING',
+          facetType: 'enumeration',
+        },
+      ],
+    )
+    expect(result.searchQuery?.facetRequests).toHaveLength(1)
+    expect(result.searchQuery?.facetRequests![0].columnName).toBe('consortium')
   })
 
   it('produces undefined facetRequests when columnModels is not provided', () => {
@@ -638,5 +732,185 @@ describe('searchQueryResultsToQueryResultBundle', () => {
     expect(rows[1].values).toEqual(['Beta'])
     expect(rows[1].rowId).toBe(2)
     expect(rows[1].versionNumber).toBe(3)
+  })
+
+  // ---- Synthetic FacetColumnResultRange for DATE / DOUBLE range columns ----
+
+  it('synthesizes a FacetColumnResultRange for DATE range columns absent from server results', () => {
+    const results: SearchQueryResults = {
+      concreteType: 'org.sagebionetworks.repo.model.search.SearchQueryResults',
+      totalHits: 0,
+      hits: [],
+      selectColumns: [],
+    }
+    const result = searchQueryResultsToQueryResultBundle(
+      results,
+      MINIMAL_SEARCH_INDEX_QUERY,
+      [
+        {
+          id: 'c1',
+          name: 'event_date',
+          columnType: 'DATE',
+          facetType: 'range',
+        },
+      ],
+    )
+    expect(result.facets).toHaveLength(1)
+    const facet = result.facets![0] as FacetColumnResultRange
+    expect(facet.columnName).toBe('event_date')
+    expect(facet.facetType).toBe('range')
+    expect(facet.columnMin).toBe('')
+    expect(facet.columnMax).toBe('')
+  })
+
+  it('synthesizes a FacetColumnResultRange for DOUBLE range columns absent from server results', () => {
+    const results: SearchQueryResults = {
+      concreteType: 'org.sagebionetworks.repo.model.search.SearchQueryResults',
+      totalHits: 0,
+      hits: [],
+      selectColumns: [],
+    }
+    const result = searchQueryResultsToQueryResultBundle(
+      results,
+      MINIMAL_SEARCH_INDEX_QUERY,
+      [
+        {
+          id: 'c1',
+          name: 'score',
+          columnType: 'DOUBLE',
+          facetType: 'range',
+        },
+      ],
+    )
+    expect(result.facets).toHaveLength(1)
+    expect(result.facets![0].columnName).toBe('score')
+    expect(result.facets![0].facetType).toBe('range')
+  })
+
+  it('synthesizes a FacetColumnResultRange for INTEGER range columns absent from server results', () => {
+    const results: SearchQueryResults = {
+      concreteType: 'org.sagebionetworks.repo.model.search.SearchQueryResults',
+      totalHits: 0,
+      hits: [],
+      selectColumns: [],
+    }
+    const result = searchQueryResultsToQueryResultBundle(
+      results,
+      MINIMAL_SEARCH_INDEX_QUERY,
+      [{ id: 'c1', name: 'year', columnType: 'INTEGER', facetType: 'range' }],
+    )
+    expect(result.facets).toHaveLength(1)
+    const facet = result.facets![0] as FacetColumnResultRange
+    expect(facet.columnName).toBe('year')
+    expect(facet.facetType).toBe('range')
+    expect(facet.columnMin).toBe('')
+    expect(facet.columnMax).toBe('')
+  })
+
+  it('does not synthesize when a range facet for the column already exists in server results', () => {
+    const existingFacet: FacetColumnResultRange = {
+      concreteType:
+        'org.sagebionetworks.repo.model.table.FacetColumnResultRange',
+      facetType: 'range',
+      columnName: 'event_date',
+      columnMin: '1000000',
+      columnMax: '2000000',
+    }
+    const results: SearchQueryResults = {
+      concreteType: 'org.sagebionetworks.repo.model.search.SearchQueryResults',
+      totalHits: 0,
+      hits: [],
+      selectColumns: [],
+      facets: [existingFacet],
+    }
+    const result = searchQueryResultsToQueryResultBundle(
+      results,
+      MINIMAL_SEARCH_INDEX_QUERY,
+      [
+        {
+          id: 'c1',
+          name: 'event_date',
+          columnType: 'DATE',
+          facetType: 'range',
+        },
+      ],
+    )
+    expect(result.facets).toHaveLength(1)
+    expect((result.facets![0] as FacetColumnResultRange).columnMin).toBe(
+      '1000000',
+    )
+  })
+
+  it('converts unix millisecond rangeFilter values to YYYY-MM-DD for synthesized DATE facet selectedMin and selectedMax', () => {
+    const minMs = dayjs('2021-06-01').valueOf()
+    const maxMs = dayjs('2021-12-31').valueOf()
+    const query: SearchIndexQuery = {
+      ...MINIMAL_SEARCH_INDEX_QUERY,
+      searchQuery: {
+        rangeFilters: [
+          { key: 'event_date', min: String(minMs), max: String(maxMs) },
+        ],
+      },
+    }
+    const results: SearchQueryResults = {
+      concreteType: 'org.sagebionetworks.repo.model.search.SearchQueryResults',
+      totalHits: 0,
+      hits: [],
+      selectColumns: [],
+    }
+    const result = searchQueryResultsToQueryResultBundle(results, query, [
+      { id: 'c1', name: 'event_date', columnType: 'DATE', facetType: 'range' },
+    ])
+    const facet = result.facets![0] as FacetColumnResultRange
+    expect(facet.selectedMin).toBe('2021-06-01')
+    expect(facet.selectedMax).toBe('2021-12-31')
+  })
+
+  it('leaves selectedMin and selectedMax undefined when no matching rangeFilter exists in the query', () => {
+    const results: SearchQueryResults = {
+      concreteType: 'org.sagebionetworks.repo.model.search.SearchQueryResults',
+      totalHits: 0,
+      hits: [],
+      selectColumns: [],
+    }
+    const result = searchQueryResultsToQueryResultBundle(
+      results,
+      MINIMAL_SEARCH_INDEX_QUERY, // no rangeFilters
+      [
+        {
+          id: 'c1',
+          name: 'event_date',
+          columnType: 'DATE',
+          facetType: 'range',
+        },
+      ],
+    )
+    const facet = result.facets![0] as FacetColumnResultRange
+    expect(facet.selectedMin).toBeUndefined()
+    expect(facet.selectedMax).toBeUndefined()
+  })
+
+  it('supports one-sided synthesized ranges when only one rangeFilter bound is set', () => {
+    const maxMs = dayjs('2021-12-31').valueOf()
+    const query: SearchIndexQuery = {
+      ...MINIMAL_SEARCH_INDEX_QUERY,
+      searchQuery: {
+        rangeFilters: [
+          { key: 'event_date', min: undefined, max: String(maxMs) },
+        ],
+      },
+    }
+    const results: SearchQueryResults = {
+      concreteType: 'org.sagebionetworks.repo.model.search.SearchQueryResults',
+      totalHits: 0,
+      hits: [],
+      selectColumns: [],
+    }
+    const result = searchQueryResultsToQueryResultBundle(results, query, [
+      { id: 'c1', name: 'event_date', columnType: 'DATE', facetType: 'range' },
+    ])
+    const facet = result.facets![0] as FacetColumnResultRange
+    expect(facet.selectedMin).toBeUndefined()
+    expect(facet.selectedMax).toBe('2021-12-31')
   })
 })

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -250,16 +250,20 @@ export function searchQueryResultsToQueryResultBundle(
 
   const rawFacets = results.facets as QueryResultBundle['facets']
 
-  // Synthesize FacetColumnResultRange for range-type DATE/DOUBLE columns. The Search API's
+  // Synthesize FacetColumnResultRange for range-type DATE/DOUBLE/INTEGER columns. The Search API's
   // FacetRequest only produces terms aggregations and cannot return min/max stats, so these
   // entries will never appear in results.facets. columnMin/columnMax are empty strings
   // (unavailable from the server); selectedMin/selectedMax are derived from the query's
   // rangeFilters so any applied range filter is still reflected in the UI.
+  // Note: for INTEGER columns the RangeSlider requires real bounds, so the UI falls back to a
+  // plain Range number input when columnMin/columnMax are absent.
   const syntheticRangeFacets: FacetColumnResultRange[] = (columnModels ?? [])
     .filter(
       cm =>
         cm.facetType === 'range' &&
-        (cm.columnType === 'DATE' || cm.columnType === 'DOUBLE') &&
+        (cm.columnType === 'DATE' ||
+          cm.columnType === 'DOUBLE' ||
+          cm.columnType === 'INTEGER') &&
         !(rawFacets ?? []).some(
           f => f.columnName === cm.name && f.facetType === 'range',
         ),

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -263,7 +263,8 @@ export function searchQueryResultsToQueryResultBundle(
         cm.facetType === 'range' &&
         (cm.columnType === 'DATE' ||
           cm.columnType === 'DOUBLE' ||
-          cm.columnType === 'INTEGER'),
+          cm.columnType === 'INTEGER') &&
+        !(rawFacets ?? []).some(f => f.columnName === cm.name),
     )
     .map(cm => {
       const rangeFilter = query.searchQuery?.rangeFilters?.find(

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -38,6 +38,7 @@ import {
   UseSuspenseQueryOptions,
 } from '@tanstack/react-query'
 import { omit } from 'lodash-es'
+import dayjs from 'dayjs'
 import { useCallback, useMemo } from 'react'
 import { KeyFactory } from '@/synapse-queries/KeyFactory'
 
@@ -119,18 +120,33 @@ export function toSearchIndexQuery(
       )
       .map(f => ({ key: f.columnName, values: f.facetValues }))
 
-  // Build rangeFilters from range selectedFacets
+  // Build rangeFilters from range selectedFacets.
+  // DATE columns: the Range UI component emits formatted dates ("YYYY-MM-DD") but the
+  // Search API (OpenSearch) expects unix millisecond timestamps. Convert here.
   const rangeFilters: SearchKeyRange[] | undefined =
     queryBundleRequest.query.selectedFacets
       ?.filter(
         (f): f is FacetColumnRangeRequest =>
           f.concreteType === FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
       )
-      .map(f => ({
-        key: f.columnName,
-        min: f.min,
-        max: f.max,
-      }))
+      .map(f => {
+        const columnType = columnModels?.find(
+          cm => cm.name === f.columnName,
+        )?.columnType
+        const toApiValue = (v: string | undefined): string | undefined => {
+          if (!v || columnType !== 'DATE') return v
+          // Convert "YYYY-MM-DD" → unix ms; leave already-numeric values untouched
+          if (/^\d{4}-\d{2}-\d{2}$/.test(v)) {
+            return String(dayjs(v).valueOf())
+          }
+          return v
+        }
+        return {
+          key: f.columnName,
+          min: toApiValue(f.min),
+          max: toApiValue(f.max),
+        }
+      })
 
   // Extract queryText by concatenating all TextMatchesQueryFilter searchExpression values
   const textMatchesExpressions = queryBundleRequest.query.additionalFilters
@@ -252,6 +268,15 @@ export function searchQueryResultsToQueryResultBundle(
       const rangeFilter = query.searchQuery?.rangeFilters?.find(
         rf => rf.key === cm.name,
       )
+      // rangeFilters carry unix ms for DATE columns (converted in toSearchIndexQuery).
+      // Convert back to "YYYY-MM-DD" so the Range UI component can display them.
+      const toDisplayValue = (v: string | undefined): string | undefined => {
+        if (!v || cm.columnType !== 'DATE') return v
+        if (/^\d+$/.test(v)) {
+          return dayjs(parseInt(v)).format('YYYY-MM-DD')
+        }
+        return v
+      }
       return {
         concreteType:
           'org.sagebionetworks.repo.model.table.FacetColumnResultRange' as const,
@@ -259,8 +284,8 @@ export function searchQueryResultsToQueryResultBundle(
         columnName: cm.name,
         columnMin: '',
         columnMax: '',
-        selectedMin: rangeFilter?.min,
-        selectedMax: rangeFilter?.max,
+        selectedMin: toDisplayValue(rangeFilter?.min),
+        selectedMax: toDisplayValue(rangeFilter?.max),
       }
     })
 

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -263,10 +263,7 @@ export function searchQueryResultsToQueryResultBundle(
         cm.facetType === 'range' &&
         (cm.columnType === 'DATE' ||
           cm.columnType === 'DOUBLE' ||
-          cm.columnType === 'INTEGER') &&
-        !(rawFacets ?? []).some(
-          f => f.columnName === cm.name && f.facetType === 'range',
-        ),
+          cm.columnType === 'INTEGER'),
     )
     .map(cm => {
       const rangeFilter = query.searchQuery?.rangeFilters?.find(
@@ -300,23 +297,20 @@ export function searchQueryResultsToQueryResultBundle(
 
   // Reorder all facets to match the columnModels order so downstream components
   // (e.g. FacetFilterControls) render facets in the expected column order.
-  const orderedFacets: QueryResultBundle['facets'] =
-    rawFacets == null && syntheticRangeFacets.length === 0
-      ? undefined
-      : columnModels
-      ? [
-          ...allFacets
-            .filter(f => columnModels.some(cm => cm.name === f.columnName))
-            .sort(
-              (a, b) =>
-                columnModels.findIndex(cm => cm.name === a.columnName) -
-                columnModels.findIndex(cm => cm.name === b.columnName),
-            ),
-          ...allFacets.filter(
-            f => !columnModels.some(cm => cm.name === f.columnName),
+  const orderedFacets: QueryResultBundle['facets'] = columnModels
+    ? [
+        ...allFacets
+          .filter(f => columnModels.some(cm => cm.name === f.columnName))
+          .sort(
+            (a, b) =>
+              columnModels.findIndex(cm => cm.name === a.columnName) -
+              columnModels.findIndex(cm => cm.name === b.columnName),
           ),
-        ]
-      : allFacets
+        ...allFacets.filter(
+          f => !columnModels.some(cm => cm.name === f.columnName),
+        ),
+      ]
+    : allFacets
 
   return {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -7,6 +7,7 @@ import {
   ColumnModel,
   FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
   FacetColumnRangeRequest,
+  FacetColumnResultRange,
   FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE_VALUE,
   FacetColumnValuesRequest,
   QueryBundleRequest,
@@ -84,9 +85,11 @@ export function toSearchIndexQuery(
   searchIndexId: string,
   columnModels?: ColumnModel[],
 ): SearchIndexQuery {
-  // Build facetRequests from ColumnModels that have a facetType defined
+  // Build facetRequests from ColumnModels that have a facetType of 'enumeration'.
+  // Range columns are excluded: the Search API's FacetRequest only supports terms aggregations
+  // and cannot produce the min/max stats needed for FacetColumnResultRange.
   const facetRequests: FacetRequest[] | undefined = columnModels
-    ?.filter(cm => cm.facetType != null)
+    ?.filter(cm => cm.facetType === 'enumeration')
     .map(cm => {
       const facetReq: FacetRequest = { columnName: cm.name, maxValueCount: 100 }
       if (cm.facetSortConfig) {
@@ -229,24 +232,62 @@ export function searchQueryResultsToQueryResultBundle(
         }
       : undefined
 
-  // Reorder facets to match the columnModels order so downstream components
-  // (e.g. FacetFilterControls) render facets in the expected column order.
   const rawFacets = results.facets as QueryResultBundle['facets']
-  const orderedFacets =
-    columnModels && rawFacets
+
+  // Synthesize FacetColumnResultRange for range-type DATE/DOUBLE columns. The Search API's
+  // FacetRequest only produces terms aggregations and cannot return min/max stats, so these
+  // entries will never appear in results.facets. columnMin/columnMax are empty strings
+  // (unavailable from the server); selectedMin/selectedMax are derived from the query's
+  // rangeFilters so any applied range filter is still reflected in the UI.
+  const syntheticRangeFacets: FacetColumnResultRange[] = (columnModels ?? [])
+    .filter(
+      cm =>
+        cm.facetType === 'range' &&
+        (cm.columnType === 'DATE' || cm.columnType === 'DOUBLE') &&
+        !(rawFacets ?? []).some(
+          f => f.columnName === cm.name && f.facetType === 'range',
+        ),
+    )
+    .map(cm => {
+      const rangeFilter = query.searchQuery?.rangeFilters?.find(
+        rf => rf.key === cm.name,
+      )
+      return {
+        concreteType:
+          'org.sagebionetworks.repo.model.table.FacetColumnResultRange' as const,
+        facetType: 'range' as const,
+        columnName: cm.name,
+        columnMin: '',
+        columnMax: '',
+        selectedMin: rangeFilter?.min,
+        selectedMax: rangeFilter?.max,
+      }
+    })
+
+  const allFacets: NonNullable<QueryResultBundle['facets']> = [
+    ...(rawFacets ?? []),
+    ...syntheticRangeFacets,
+  ]
+
+  // Reorder all facets to match the columnModels order so downstream components
+  // (e.g. FacetFilterControls) render facets in the expected column order.
+  const orderedFacets: QueryResultBundle['facets'] =
+    rawFacets == null && syntheticRangeFacets.length === 0
+      ? undefined
+      : columnModels
       ? [
-          ...rawFacets
+          ...allFacets
             .filter(f => columnModels.some(cm => cm.name === f.columnName))
             .sort(
               (a, b) =>
                 columnModels.findIndex(cm => cm.name === a.columnName) -
                 columnModels.findIndex(cm => cm.name === b.columnName),
             ),
-          ...rawFacets.filter(
+          ...allFacets.filter(
             f => !columnModels.some(cm => cm.name === f.columnName),
           ),
         ]
-      : rawFacets
+      : allFacets
 
   return {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',

--- a/packages/synapse-react-client/src/components/widgets/Range.test.tsx
+++ b/packages/synapse-react-client/src/components/widgets/Range.test.tsx
@@ -68,6 +68,20 @@ describe('Range input test', () => {
     expect(errorMessage.classList.contains('SRC-danger-color')).toBe(true)
   })
 
+  it('should allow applying when only min is filled', async () => {
+    renderComponent({ initialValues: undefined })
+    await userEvent.type(getInput('min'), '5')
+    await userEvent.click(screen.getByRole('button', { name: 'Apply' }))
+    expect(mockCallback).toHaveBeenCalledWith({ min: '5', max: undefined })
+  })
+
+  it('should allow applying when only max is filled', async () => {
+    renderComponent({ initialValues: undefined })
+    await userEvent.type(getInput('max'), '10')
+    await userEvent.click(screen.getByRole('button', { name: 'Apply' }))
+    expect(mockCallback).toHaveBeenCalledWith({ min: undefined, max: '10' })
+  })
+
   describe('date range', () => {
     const initialValues = {
       min: new Date(2019, 0, 4).toISOString(),
@@ -108,6 +122,35 @@ describe('Range input test', () => {
         'Min value should be less than max value',
       )
       expect(errorMessage.classList.contains('SRC-danger-color')).toBe(true)
+    })
+
+    it('should render with empty min when initialValues.min is undefined', () => {
+      renderComponent({
+        type: 'date',
+        initialValues: {
+          min: undefined,
+          max: new Date(2019, 9, 3).toISOString(),
+        },
+      })
+      expect(getInput('min').value).toBe('')
+      expect(getInput('max').value).toBe('2019-10-03')
+    })
+
+    it('should call callbackFn with only the filled value when min is not set', async () => {
+      renderComponent({
+        type: 'date',
+        initialValues: {
+          min: undefined,
+          max: new Date(2019, 9, 3).toISOString(),
+        },
+      })
+      await userEvent.click(screen.getByRole('button', { name: 'Apply' }))
+      await waitFor(() =>
+        expect(mockCallback).toHaveBeenCalledWith({
+          min: undefined,
+          max: '2019-10-03',
+        }),
+      )
     })
   })
 })

--- a/packages/synapse-react-client/src/components/widgets/Range.tsx
+++ b/packages/synapse-react-client/src/components/widgets/Range.tsx
@@ -27,8 +27,12 @@ export function Range(props: RangeProps): React.ReactNode {
     props.type === 'number' && props.initialValues
       ? props.initialValues
       : (props.initialValues && {
-          min: dayjs(props.initialValues.min).format('YYYY-MM-DD'),
-          max: dayjs(props.initialValues.max).format('YYYY-MM-DD'),
+          min: props.initialValues.min
+            ? dayjs(props.initialValues.min).format('YYYY-MM-DD')
+            : undefined,
+          max: props.initialValues.max
+            ? dayjs(props.initialValues.max).format('YYYY-MM-DD')
+            : undefined,
         }) || {
           min: undefined,
           max: undefined,
@@ -40,12 +44,8 @@ export function Range(props: RangeProps): React.ReactNode {
 
     type: ControlType = 'number',
   ) => {
-    if (
-      min === null ||
-      min === undefined ||
-      max === null ||
-      max === undefined
-    ) {
+    // Treat null, undefined, and empty string as "no value" — one-sided ranges are always valid
+    if (min == null || min === '' || max == null || max === '') {
       setError(false)
       return true
     }
@@ -69,7 +69,11 @@ export function Range(props: RangeProps): React.ReactNode {
     type: ControlType = 'number',
   ) => {
     if (isValid(values, type)) {
-      callBackFn(values)
+      // Normalize empty strings to undefined so downstream code receives clean absent values
+      callBackFn({
+        min: values.min === '' ? undefined : values.min,
+        max: values.max === '' ? undefined : values.max,
+      })
     }
   }
 
@@ -105,6 +109,7 @@ export function Range(props: RangeProps): React.ReactNode {
                 }}
                 slotProps={{
                   textField: {
+                    error: false,
                     inputProps: {
                       'aria-label': 'min',
                     },
@@ -130,6 +135,7 @@ export function Range(props: RangeProps): React.ReactNode {
                 }}
                 slotProps={{
                   textField: {
+                    error: false,
                     inputProps: {
                       'aria-label': 'max',
                     },

--- a/packages/synapse-react-client/src/components/widgets/Range.tsx
+++ b/packages/synapse-react-client/src/components/widgets/Range.tsx
@@ -45,7 +45,7 @@ export function Range(props: RangeProps): React.ReactNode {
     type: ControlType = 'number',
   ) => {
     // Treat null, undefined, and empty string as "no value" — one-sided ranges are always valid
-    if (min == null || min === '' || max == null || max === '') {
+    if (isEmpty(min) || isEmpty(max)) {
       setError(false)
       return true
     }

--- a/packages/synapse-react-client/src/components/widgets/Range.tsx
+++ b/packages/synapse-react-client/src/components/widgets/Range.tsx
@@ -4,6 +4,7 @@ import { DatePicker } from '@mui/x-date-pickers'
 import { Box, Button, TextField } from '@mui/material'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import isEmpty from 'lodash-es/isEmpty'
 
 type ControlType = 'number' | 'date'
 

--- a/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilter.test.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilter.test.tsx
@@ -4,7 +4,7 @@ import { registerTableQueryResult } from '@/mocks/msw/handlers/tableQueryService
 import { server } from '@/mocks/msw/server'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
 import { DEFAULT_PAGE_SIZE, VALUE_NOT_SET } from '@/utils/SynapseConstants'
-import { Collapse as MockCollapse } from '@mui/material'
+import { Collapse as MockCollapse, CollapseProps } from '@mui/material'
 import {
   ColumnModel,
   ColumnTypeEnum,
@@ -19,14 +19,15 @@ import { Suspense } from 'react'
 import { QueryContextType, QueryWrapper, useQueryContext } from '../../../index'
 import { QueryVisualizationWrapper } from '../../QueryVisualizationWrapper'
 import { RangeValues } from '../Range'
-import RangeSlider from '../RangeSlider/RangeSlider'
+import RangeSlider, { RangeSliderProps } from '../RangeSlider/RangeSlider'
 import { RangeFacetFilter, RangeFacetFilterProps } from './RangeFacetFilter'
+import { RangeFacetFilterUI } from './RangeFacetFilterUI'
 
 let capturedOnApplyClicked: ((values: RangeValues) => void) | undefined
 
 vi.mock('../RangeSlider/RangeSlider', () => ({
   __esModule: true,
-  default: vi.fn((props: any) => {
+  default: vi.fn((props: RangeSliderProps) => {
     capturedOnApplyClicked = props.onApplyClicked
     return <div data-testid="RangeSlider"></div>
   }),
@@ -38,7 +39,7 @@ vi.mock(import('@mui/material'), async importOriginal => {
   const original = await importOriginal()
   return {
     ...original,
-    Collapse: vi.fn(props => (
+    Collapse: vi.fn((props: CollapseProps) => (
       <div data-testid="Collapse">{props.children}</div>
     )),
   }
@@ -414,5 +415,83 @@ describe('RangeFacetFilter tests', () => {
         ])
       })
     })
+  })
+})
+
+describe('RangeFacetFilterUI INTEGER without column bounds', () => {
+  it('renders a number Range input when columnMin and columnMax are absent', async () => {
+    render(
+      <RangeFacetFilterUI
+        label="Year"
+        facetResult={{}}
+        columnType="INTEGER"
+        onRangeValueSelected={vi.fn()}
+        onNotSetSelected={vi.fn()}
+        onAnySelected={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    )
+    const rangeOption = screen.getByLabelText('Range')
+    await userEvent.click(rangeOption)
+    // Should show Range (number inputs), not RangeSlider
+    expect(screen.queryByTestId('RangeSlider')).not.toBeInTheDocument()
+    const minInput = screen.getByLabelText<HTMLInputElement>('min')
+    expect(minInput.type).toBe('number')
+  })
+
+  it('renders a number Range input when columnMin and columnMax are empty strings', async () => {
+    // Synthesized facets from SearchQueryWrapper use '' for unavailable bounds
+    render(
+      <RangeFacetFilterUI
+        label="Year"
+        facetResult={{ columnMin: '', columnMax: '' }}
+        columnType="INTEGER"
+        onRangeValueSelected={vi.fn()}
+        onNotSetSelected={vi.fn()}
+        onAnySelected={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    )
+    const rangeOption = screen.getByLabelText('Range')
+    await userEvent.click(rangeOption)
+    expect(screen.queryByTestId('RangeSlider')).not.toBeInTheDocument()
+    const minInput = screen.getByLabelText<HTMLInputElement>('min')
+    expect(minInput.type).toBe('number')
+  })
+
+  it('renders a number Range input pre-filled when selectedMin and selectedMax are set', () => {
+    render(
+      <RangeFacetFilterUI
+        label="Year"
+        facetResult={{ selectedMin: '1997', selectedMax: '1999' }}
+        columnType="INTEGER"
+        onRangeValueSelected={vi.fn()}
+        onNotSetSelected={vi.fn()}
+        onAnySelected={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    )
+    // selectedMin is set, so radio should already be on Range
+    const minInput = screen.getByLabelText<HTMLInputElement>('min')
+    expect(minInput.type).toBe('number')
+    expect(minInput.value).toBe('1997')
+  })
+
+  it('renders a RangeSlider when real columnMin and columnMax bounds are provided', async () => {
+    render(
+      <RangeFacetFilterUI
+        label="Year"
+        facetResult={{ columnMin: '1996', columnMax: '1999' }}
+        columnType="INTEGER"
+        onRangeValueSelected={vi.fn()}
+        onNotSetSelected={vi.fn()}
+        onAnySelected={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    )
+    const rangeOption = screen.getByLabelText('Range')
+    await userEvent.click(rangeOption)
+    expect(screen.getByTestId('RangeSlider')).toBeInTheDocument()
+    expect(screen.queryByLabelText('min')).not.toBeInTheDocument()
   })
 })

--- a/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilterUI.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilterUI.tsx
@@ -116,7 +116,7 @@ export function RangeFacetFilterUI(props: RangeFacetFilterProps) {
           ) : (
             <>
               {columnType === 'INTEGER' &&
-                (columnMin != null && columnMax != null ? (
+                (columnMin && columnMax ? (
                   <RangeSlider
                     key="RangeSlider"
                     domain={[columnMin, columnMax]}

--- a/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilterUI.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilterUI.tsx
@@ -1,9 +1,6 @@
 import { FRIENDLY_VALUE_NOT_SET, VALUE_NOT_SET } from '@/utils/SynapseConstants'
 import { Collapse, FormControlLabel, Radio, RadioGroup } from '@mui/material'
-import {
-  ColumnType,
-  FacetColumnResultRange,
-} from '@sage-bionetworks/synapse-types'
+import { ColumnType } from '@sage-bionetworks/synapse-types'
 import dayjs from 'dayjs'
 import { useState } from 'react'
 import { Range, RangeValues } from '../Range'
@@ -22,10 +19,14 @@ export const options = [
 ]
 export type RangeFacetFilterProps = {
   label: string
-  facetResult: Pick<
-    FacetColumnResultRange,
-    'columnMin' | 'columnMax' | 'selectedMin' | 'selectedMax'
-  >
+  facetResult: {
+    /** The smallest value in the column. May be absent when the server cannot supply stats (e.g. Search API). */
+    columnMin?: string
+    /** The largest value in the column. May be absent when the server cannot supply stats (e.g. Search API). */
+    columnMax?: string
+    selectedMin?: string
+    selectedMax?: string
+  }
   columnType: ColumnType
   hideCollapsible?: boolean
   onRangeValueSelected: (values: RangeValues) => void
@@ -82,7 +83,7 @@ export function RangeFacetFilterUI(props: RangeFacetFilterProps) {
   }
 
   const [radioValue, setRadioValue] = useState(
-    getRadioValue(currentMin, hasAnyValue),
+    getRadioValue(currentMin ?? '', hasAnyValue),
   )
 
   return (
@@ -110,32 +111,38 @@ export function RangeFacetFilterUI(props: RangeFacetFilterProps) {
           ))}
         </RadioGroup>
         {radioValue === RadioValuesEnum.RANGE &&
-          (columnMin === columnMax ? (
+          (columnMin && columnMax && columnMin === columnMax ? (
             <label>{columnMax}</label>
           ) : (
             <>
-              {columnType === 'INTEGER' && (
-                <RangeSlider
-                  key="RangeSlider"
-                  domain={[columnMin, columnMax]}
-                  initialValues={{
-                    min: parseInt(currentMin),
-                    max: parseInt(currentMax),
-                  }}
-                  step={1}
-                  onApplyClicked={onRangeValueSelected}
-                >
-                  {'>'}
-                </RangeSlider>
-              )}
+              {columnType === 'INTEGER' &&
+                columnMin != null &&
+                columnMax != null && (
+                  <RangeSlider
+                    key="RangeSlider"
+                    domain={[columnMin, columnMax]}
+                    initialValues={{
+                      min: parseInt(currentMin ?? columnMin),
+                      max: parseInt(currentMax ?? columnMax),
+                    }}
+                    step={1}
+                    onApplyClicked={onRangeValueSelected}
+                  >
+                    {'>'}
+                  </RangeSlider>
+                )}
 
               {columnType === 'DATE' && (
                 <Range
                   key="Range"
                   initialValues={{
                     // From the backend, selectedMin is a formatted date (like "2021-06-15"), but columnMin is a unix timestamp in millis (like "1624651794856")
-                    min: selectedMin ?? dayjs(parseInt(columnMin)).toString(),
-                    max: selectedMax ?? dayjs(parseInt(columnMax)).toString(),
+                    min:
+                      selectedMin ??
+                      (columnMin ? dayjs(parseInt(columnMin)).toString() : ''),
+                    max:
+                      selectedMax ??
+                      (columnMax ? dayjs(parseInt(columnMax)).toString() : ''),
                   }}
                   type={rangeType}
                   onApplyClicked={onRangeValueSelected}
@@ -145,8 +152,8 @@ export function RangeFacetFilterUI(props: RangeFacetFilterProps) {
                 <Range
                   key="Range"
                   initialValues={{
-                    min: parseFloat(currentMin),
-                    max: parseFloat(currentMax),
+                    min: parseFloat(currentMin ?? '0'),
+                    max: parseFloat(currentMax ?? '0'),
                   }}
                   type={rangeType}
                   onApplyClicked={onRangeValueSelected}

--- a/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilterUI.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilterUI.tsx
@@ -116,8 +116,7 @@ export function RangeFacetFilterUI(props: RangeFacetFilterProps) {
           ) : (
             <>
               {columnType === 'INTEGER' &&
-                columnMin != null &&
-                columnMax != null && (
+                (columnMin != null && columnMax != null ? (
                   <RangeSlider
                     key="RangeSlider"
                     domain={[columnMin, columnMax]}
@@ -130,20 +129,42 @@ export function RangeFacetFilterUI(props: RangeFacetFilterProps) {
                   >
                     {'>'}
                   </RangeSlider>
-                )}
+                ) : (
+                  <Range
+                    key="Range"
+                    type="number"
+                    initialValues={
+                      currentMin || currentMax
+                        ? {
+                            min: currentMin ? parseInt(currentMin) : undefined,
+                            max: currentMax ? parseInt(currentMax) : undefined,
+                          }
+                        : undefined
+                    }
+                    onApplyClicked={onRangeValueSelected}
+                  />
+                ))}
 
               {columnType === 'DATE' && (
                 <Range
                   key="Range"
-                  initialValues={{
-                    // From the backend, selectedMin is a formatted date (like "2021-06-15"), but columnMin is a unix timestamp in millis (like "1624651794856")
-                    min:
-                      selectedMin ??
-                      (columnMin ? dayjs(parseInt(columnMin)).toString() : ''),
-                    max:
-                      selectedMax ??
-                      (columnMax ? dayjs(parseInt(columnMax)).toString() : ''),
-                  }}
+                  initialValues={
+                    selectedMin || selectedMax || columnMin || columnMax
+                      ? {
+                          // From the backend, selectedMin is a formatted date (like "2021-06-15"), but columnMin is a unix timestamp in millis (like "1624651794856")
+                          min:
+                            selectedMin ??
+                            (columnMin
+                              ? dayjs(parseInt(columnMin)).toString()
+                              : undefined),
+                          max:
+                            selectedMax ??
+                            (columnMax
+                              ? dayjs(parseInt(columnMax)).toString()
+                              : undefined),
+                        }
+                      : undefined
+                  }
                   type={rangeType}
                   onApplyClicked={onRangeValueSelected}
                 />
@@ -151,10 +172,14 @@ export function RangeFacetFilterUI(props: RangeFacetFilterProps) {
               {columnType === 'DOUBLE' && (
                 <Range
                   key="Range"
-                  initialValues={{
-                    min: parseFloat(currentMin ?? '0'),
-                    max: parseFloat(currentMax ?? '0'),
-                  }}
+                  initialValues={
+                    currentMin || currentMax
+                      ? {
+                          min: currentMin ? parseFloat(currentMin) : undefined,
+                          max: currentMax ? parseFloat(currentMax) : undefined,
+                        }
+                      : undefined
+                  }
                   type={rangeType}
                   onApplyClicked={onRangeValueSelected}
                 />


### PR DESCRIPTION
### Problem
`SearchQueryWrapper` uses the Synapse Search API (OpenSearch) as its data source. Unlike the standard Table Query API, the Search API cannot return `FacetColumnResultRange` results (min/max stats) for range-type columns, only terms aggregations. This caused range facet filters to be invisible, and DATE range values were sent to the API in the wrong format (`YYYY-MM-DD` instead of unix milliseconds).

---

### `SearchQueryUseQueryOptions.ts`

#### `toSearchIndexQuery`
- **Exclude range columns from `facetRequests`**: changed filter from `cm.facetType != null` to `cm.facetType === 'enumeration'`. The Search API's `FacetRequest` only supports terms aggregations; including range columns produced garbage bucket results.
- **DATE range filter conversion**: when building `rangeFilters` from `selectedFacets`, DATE column values formatted as `YYYY-MM-DD` are now converted to unix millisecond strings (as OpenSearch expects). Non-DATE and already-numeric values are passed through unchanged. One-sided ranges (`undefined` min or max) are preserved as `undefined`.

#### `searchQueryResultsToQueryResultBundle`
- **Synthetic `FacetColumnResultRange` facets**: since the Search API never returns range facets, they are now synthesised client-side for all `DATE`, `DOUBLE`, and `INTEGER` range columns that are absent from the server response. Synthesised facets use `columnMin: ''` / `columnMax: ''` (bounds unavailable) and populate `selectedMin` / `selectedMax` from the current query's `rangeFilters`. For DATE columns, unix ms values in `rangeFilters` are converted back to `YYYY-MM-DD` for display.
- **Facet ordering**: updated to merge server facets and synthetic facets before sorting by `columnModels` order.

---

### `RangeFacetFilterUI.tsx`

- **`facetResult` prop type**: `columnMin` and `columnMax` are now optional (`string | undefined`) instead of required. This reflects that the Search API cannot supply column statistics.
- **INTEGER fallback**: changed `columnMin != null && columnMax != null` guard to a truthiness check (`columnMin && columnMax`). When bounds are absent (empty string or undefined — as in synthesised facets), the component now renders a plain `Range type="number"` input instead of a `RangeSlider` that requires a valid numeric domain.
- **DATE `initialValues`**: changed from always passing `{ min: '...', max: '...' }` to passing `undefined` when no bounds or selected values are present. Avoids passing empty strings to `dayjs`, which would produce `"Invalid Date"`.
- **DOUBLE `initialValues`**: same guard — only passes `initialValues` when at least one bound is present, preventing `parseFloat('')` → `NaN`.
- **Single-column guard**: updated `columnMin === columnMax` label shortcut to also require both values to be truthy.
- **`getRadioValue` call**: `currentMin ?? ''` passed instead of bare `currentMin` (which could be `undefined` when bounds are absent).

---

### `Range.tsx`

- **`useState` initialiser**: guards `dayjs(...)` calls with a truthiness check on `initialValues.min` / `initialValues.max`. Previously, `dayjs(undefined).format('YYYY-MM-DD')` produced the string `"Invalid Date"`, which would then be sent to the backend causing a `number_format_exception`.
- **`isValid`**: treats empty string (`''`) the same as `null`/`undefined` — one-sided ranges (only min or only max filled) are always valid. Previously an empty max triggered `Number('') === 0`, causing a false `min > max` error.
- **`handleAppyChanges`**: normalises `''` to `undefined` in the callback so downstream code never receives empty strings.
- **DatePicker `error={false}`**: added `error: false` to `slotProps.textField` on both From and To `DatePicker` instances. Suppresses MUI's built-in red error outline when a date field is empty (valid for one-sided ranges).

---

### Tests

New tests added across three files (17 new test cases total):

| File | New tests |
|---|---|
| `SearchQueryUseQueryOptions.test.ts` | Range column exclusion from `facetRequests`; DATE YYYY-MM-DD → unix ms conversion; non-DATE passthrough; `undefined` bound preservation; synthesis for DATE, DOUBLE, INTEGER; no duplicate synthesis; unix ms → YYYY-MM-DD in `selectedMin`/`selectedMax`; absent `selectedMin`/`selectedMax`; one-sided synthesised range |
| `Range.test.tsx` | One-sided number apply (min only, max only); date init with `undefined` min shows empty input (not `"Invalid Date"`); one-sided date apply |
| `RangeFacetFilter.test.tsx` | INTEGER without bounds shows `Range` number input; INTEGER with empty-string bounds shows `Range` (not `RangeSlider`); INTEGER pre-filled from `selectedMin`/`selectedMax`; INTEGER with real bounds still shows `RangeSlider` |