### PR TITLE
SWC-7608 memoize cell components

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/columns/AutocompleteMultipleEnumColumn.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/AutocompleteMultipleEnumColumn.test.tsx
@@ -923,6 +923,61 @@ describe('autocompleteMultipleEnumColumn', () => {
       ).toBeInTheDocument()
     })
 
+    it('uses the latest rowData when deleting a memoized chip (stale-closure regression)', async () => {
+      // GridAutocompleteChip is memoized and compares onDelete identity. To
+      // keep that identity stable across renders, AutocompleteMultipleEnumCell
+      // maintains a per-index onDelete map; each callback reads the latest
+      // rowData via a ref at click time.
+      //
+      // The naive alternative — passing MUI's getTagProps().onDelete straight
+      // through — would defeat memoization (fresh closure each render) and,
+      // if the chip were memoized anyway, would invoke a closure over the OLD
+      // value array, silently dropping any newly-appended value.
+      const mockSetRowData = vi.fn()
+      const mockStopEditing = vi.fn()
+      const TestCell = createTestCell(['a', 'b', 'c'], 'string')
+
+      const { rerender } = render(
+        <TestCell
+          rowData={['a', 'b']}
+          setRowData={mockSetRowData}
+          focus={true}
+          active={true}
+          stopEditing={mockStopEditing}
+        />,
+      )
+      expect(screen.getByText('a')).toBeInTheDocument()
+      expect(screen.getByText('b')).toBeInTheDocument()
+
+      // Append 'c'. Chips for 'a' and 'b' are memoized (same option, active,
+      // data-tag-index, and the per-index onDelete is identity-stable), so
+      // they skip re-rendering.
+      rerender(
+        <TestCell
+          rowData={['a', 'b', 'c']}
+          setRowData={mockSetRowData}
+          focus={true}
+          active={true}
+          stopEditing={mockStopEditing}
+        />,
+      )
+      expect(screen.getByText('c')).toBeInTheDocument()
+
+      // Click the X on the original 'a' chip. The stable onDelete reads the
+      // latest rowData via the parent's ref and removes 'a' from
+      // ['a', 'b', 'c'] → ['b', 'c']. A stale closure would yield ['b'],
+      // losing 'c'.
+      const chipA = screen.getByText('a').closest('.MuiChip-root')
+      expect(chipA).not.toBeNull()
+      const deleteIcon = chipA!.querySelector('[data-testid="CancelIcon"]')
+      expect(deleteIcon).not.toBeNull()
+      await userEvent.click(deleteIcon as HTMLElement)
+
+      await waitFor(() => {
+        expect(mockSetRowData).toHaveBeenCalledWith(['b', 'c'])
+      })
+    })
+
     it('commits a selected option when the grid deactivates the cell mid-click', async () => {
       // Regression: the dropdown renders in a portal outside the grid cell's DOM.
       // react-datasheet-grid sees the mousedown as an outside click and fires active=false

--- a/packages/synapse-react-client/src/components/DataGrid/columns/AutocompleteMultipleEnumColumn.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/AutocompleteMultipleEnumColumn.tsx
@@ -121,9 +121,15 @@ function AutocompleteMultipleEnumCell({
     handleClose,
   } = useGridAutocompleteState({ active, stopEditing })
 
-  const safeRowData = createSafeRowData(rowData)
-  const optionsWithLabels = choices.map(createOptionFromValue)
-  const selectedOptions = safeRowData.map(createOptionFromValue)
+  const safeRowData = useMemo(() => createSafeRowData(rowData), [rowData])
+  const optionsWithLabels = useMemo(
+    () => choices.map(createOptionFromValue),
+    [choices],
+  )
+  const selectedOptions = useMemo(
+    () => safeRowData.map(createOptionFromValue),
+    [safeRowData],
+  )
   const effectiveLimitTags = active ? -1 : limitTags
 
   // Create tooltip content showing all values
@@ -211,6 +217,39 @@ function AutocompleteMultipleEnumCell({
     }
   }, [localInputState, colType, safeRowData])
 
+  // Per-index chip onDelete handlers. MUI's getTagProps recreates onDelete on
+  // every render (it closes over the current value array), which defeats
+  // memoization of GridAutocompleteChip. We provide our own stable function
+  // for each index that reads the latest rowData via refs at call time —
+  // identical to the chip's behavior, but without the per-render churn.
+  const rowDataRef = useRef(rowData)
+  useLayoutEffect(() => {
+    rowDataRef.current = rowData
+  })
+  const handleChangeRef = useRef(handleChange)
+  useLayoutEffect(() => {
+    handleChangeRef.current = handleChange
+  })
+  const chipDeleteFnsRef = useRef<Map<number, () => void>>(new Map())
+  const getChipDelete = useCallback((index: number) => {
+    let fn = chipDeleteFnsRef.current.get(index)
+    if (!fn) {
+      fn = () => {
+        const current = createSafeRowData(rowDataRef.current)
+        const next = current.filter((_, i) => i !== index)
+        // Route through handleChange so notifyOptionCommitted, menu cleanup,
+        // and clearValue substitution match the dropdown delete path.
+        handleChangeRef.current(
+          null as unknown as React.SyntheticEvent,
+          next.map(createOptionFromValue),
+          'removeOption',
+        )
+      }
+      chipDeleteFnsRef.current.set(index, fn)
+    }
+    return fn
+  }, [])
+
   return (
     <Tooltip
       title={tooltipContent}
@@ -261,7 +300,16 @@ function AutocompleteMultipleEnumCell({
           onBlur={handleBlur}
           renderValue={(tagValue, getTagProps) =>
             tagValue.map((option, index) => {
-              const { key, ...tagProps } = getTagProps({ index })
+              // Discard MUI's onDelete — its closure is rebuilt each render,
+              // which would defeat chip memoization. We pass our own stable
+              // per-index onDelete that reads the latest rowData via refs.
+              const {
+                key,
+                onDelete: _muiOnDelete,
+                ...tagProps
+              } = getTagProps({
+                index,
+              })
               const optionValue =
                 typeof option === 'string' ? option : option.value
               return (
@@ -269,6 +317,7 @@ function AutocompleteMultipleEnumCell({
                   key={key}
                   option={optionValue}
                   active={active}
+                  onDelete={getChipDelete(index)}
                   {...tagProps}
                 />
               )

--- a/packages/synapse-react-client/src/components/DataGrid/columns/DateTimeColumn.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/DateTimeColumn.tsx
@@ -1,6 +1,8 @@
 import DateTimePicker from '@/components/DateTimePicker/DateTimePicker'
+import { SxProps, Theme } from '@mui/material'
 import dayjs, { Dayjs } from 'dayjs'
 import { JSONSchema7Type } from 'json-schema'
+import { memo, useCallback, useLayoutEffect, useMemo, useRef } from 'react'
 import {
   CellComponent,
   CellProps,
@@ -11,40 +13,86 @@ export type DateTimeCellProps = CellProps & {
   colType?: JSONSchema7Type
 }
 
+const DATE_TIME_BASE_SX: SxProps<Theme> = {
+  width: '100%',
+  height: '100%',
+  '& .MuiInputBase-root': {
+    height: '100%',
+    backgroundColor: 'inherit',
+  },
+}
+
 export function DateTimeCell({
   rowData,
   setRowData,
   disabled,
   colType,
 }: DateTimeCellProps) {
+  // Stable ref so memo(DateTimeCell) can use default shallow comparison —
+  // react-datasheet-grid recreates setRowData on every render, but its behavior
+  // is stable for a given cell position.
+  const setRowDataRef = useRef(setRowData)
+  useLayoutEffect(() => {
+    setRowDataRef.current = setRowData
+  })
+
+  const handleChange = useCallback(
+    (newValue: string | Dayjs | null) => {
+      if (newValue == null) {
+        setRowDataRef.current(null)
+      } else if (colType === 'number') {
+        // Assume unix millisecond timestamp
+        setRowDataRef.current(dayjs(newValue).valueOf())
+      } else {
+        // colType is 'string' or unspecified, use ISO string
+        setRowDataRef.current(dayjs(newValue).toISOString())
+      }
+    },
+    [colType],
+  )
+
+  const sx = useMemo<SxProps<Theme>>(
+    () => ({
+      ...DATE_TIME_BASE_SX,
+      // When disabled, allow selecting the entire cell
+      pointerEvents: disabled ? 'none' : undefined,
+    }),
+    [disabled],
+  )
+
+  const value = useMemo(() => (rowData ? dayjs(rowData) : null), [rowData])
+
   return (
     <DateTimePicker
       disabled={disabled}
-      value={rowData ? dayjs(rowData) : null}
-      onChange={(newValue: string | Dayjs | null) => {
-        if (newValue == null) {
-          setRowData(null)
-        } else if (colType === 'number') {
-          // Assume unix millisecond timestamp
-          setRowData(dayjs(newValue).valueOf())
-        } else {
-          // colType is 'string' or unspecified, use ISO string
-          setRowData(dayjs(newValue).toISOString())
-        }
-      }}
-      sx={{
-        // When disabled, allow selecting the entire cell
-        pointerEvents: disabled ? 'none' : undefined,
-        width: '100%',
-        height: '100%',
-        '& .MuiInputBase-root': {
-          height: '100%',
-          backgroundColor: 'inherit',
-        },
-      }}
+      value={value}
+      onChange={handleChange}
+      sx={sx}
     />
   )
 }
+
+// Memoize the cell component to prevent unnecessary re-renders.
+// react-datasheet-grid provides a new setRowData function instance on each
+// render, so we must ignore that callback identity here and only compare the
+// props that affect rendering.
+export function areDateTimeCellPropsEqual(
+  prevProps: DateTimeCellProps,
+  nextProps: DateTimeCellProps,
+) {
+  return (
+    prevProps.rowData === nextProps.rowData &&
+    prevProps.disabled === nextProps.disabled &&
+    prevProps.colType === nextProps.colType &&
+    prevProps.focus === nextProps.focus &&
+    prevProps.active === nextProps.active
+  )
+}
+
+export const MemoizedDateTimeCell = memo(
+  DateTimeCell,
+  areDateTimeCellPropsEqual,
+)
 
 export type DateTimeColumnProps = {
   colType?: JSONSchema7Type
@@ -55,7 +103,7 @@ export function dateTimeColumn({
 }: DateTimeColumnProps): Partial<Column> {
   return {
     component: ((props: DateTimeCellProps) => (
-      <DateTimeCell {...props} colType={colType} />
+      <MemoizedDateTimeCell {...props} colType={colType} />
     )) as CellComponent,
     copyValue: ({ rowData }) => rowData,
     pasteValue: ({ value }) => value,

--- a/packages/synapse-react-client/src/components/DataGrid/columns/GridAutocompleteChip.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/GridAutocompleteChip.tsx
@@ -4,14 +4,15 @@ import { memo, useMemo } from 'react'
 import { castCellValueToString } from './AutocompleteColumn'
 import { AutocompleteMultipleEnumOption } from './AutocompleteMultipleEnumColumn'
 
-const GRID_AUTOCOMPLETE_CHIP_BASE_SX: SxProps<Theme> = {
+const GRID_AUTOCOMPLETE_CHIP_BASE_SX = {
   fontSize: '0.75rem',
   height: '24px',
   margin: '1px',
   flexShrink: 0,
-}
+} as const
 
-export interface GridAutocompleteChipProps extends Omit<ChipProps, 'label'> {
+export interface GridAutocompleteChipProps
+  extends Omit<ChipProps, 'label' | 'sx'> {
   option: AutocompleteMultipleEnumOption
   active?: boolean
 }
@@ -19,7 +20,6 @@ export interface GridAutocompleteChipProps extends Omit<ChipProps, 'label'> {
 function GridAutocompleteChipInner({
   option,
   active = false,
-  sx: sxProp,
   ...chipProps
 }: GridAutocompleteChipProps) {
   const label = useMemo(() => castCellValueToString(option), [option])
@@ -27,9 +27,8 @@ function GridAutocompleteChipInner({
     () => ({
       ...GRID_AUTOCOMPLETE_CHIP_BASE_SX,
       maxWidth: active ? 'none' : '120px',
-      ...sxProp,
     }),
-    [active, sxProp],
+    [active],
   )
   return <Chip {...chipProps} label={label} sx={sx} />
 }
@@ -48,10 +47,9 @@ function areGridAutocompleteChipPropsEqual(
     prev.onDelete === next.onDelete &&
     prev.disabled === next.disabled &&
     prev.tabIndex === next.tabIndex &&
-    (prev as Record<string, unknown>)['data-tag-index'] ===
-      (next as Record<string, unknown>)['data-tag-index'] &&
-    prev.className === next.className &&
-    prev.sx === next.sx
+    (prev as { 'data-tag-index'?: number })['data-tag-index'] ===
+      (next as { 'data-tag-index'?: number })['data-tag-index'] &&
+    prev.className === next.className
   )
 }
 

--- a/packages/synapse-react-client/src/components/DataGrid/columns/GridAutocompleteChip.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/GridAutocompleteChip.tsx
@@ -1,29 +1,61 @@
-import { Chip, ChipProps } from '@mui/material'
+import { Chip, ChipProps, SxProps, Theme } from '@mui/material'
+import isEqual from 'lodash-es/isEqual'
+import { memo, useMemo } from 'react'
 import { castCellValueToString } from './AutocompleteColumn'
 import { AutocompleteMultipleEnumOption } from './AutocompleteMultipleEnumColumn'
+
+const GRID_AUTOCOMPLETE_CHIP_BASE_SX: SxProps<Theme> = {
+  fontSize: '0.75rem',
+  height: '24px',
+  margin: '1px',
+  flexShrink: 0,
+}
 
 export interface GridAutocompleteChipProps extends Omit<ChipProps, 'label'> {
   option: AutocompleteMultipleEnumOption
   active?: boolean
 }
 
-export function GridAutocompleteChip({
+function GridAutocompleteChipInner({
   option,
   active = false,
+  sx: sxProp,
   ...chipProps
 }: GridAutocompleteChipProps) {
+  const label = useMemo(() => castCellValueToString(option), [option])
+  const sx = useMemo<SxProps<Theme>>(
+    () => ({
+      ...GRID_AUTOCOMPLETE_CHIP_BASE_SX,
+      maxWidth: active ? 'none' : '120px',
+      ...sxProp,
+    }),
+    [active, sxProp],
+  )
+  return <Chip {...chipProps} label={label} sx={sx} />
+}
+
+// Memoization contract: callers must pass stable references for onDelete and
+// other handler/style props. AutocompleteMultipleEnumCell satisfies this by
+// maintaining a per-index onDelete map keyed off refs to the latest state.
+// `option` is compared deeply because enum values may be objects/arrays.
+function areGridAutocompleteChipPropsEqual(
+  prev: GridAutocompleteChipProps,
+  next: GridAutocompleteChipProps,
+) {
   return (
-    <Chip
-      {...chipProps}
-      label={castCellValueToString(option)}
-      sx={{
-        maxWidth: active ? 'none' : '120px',
-        fontSize: '0.75rem',
-        height: '24px',
-        margin: '1px',
-        flexShrink: 0,
-        ...chipProps.sx,
-      }}
-    />
+    isEqual(prev.option, next.option) &&
+    prev.active === next.active &&
+    prev.onDelete === next.onDelete &&
+    prev.disabled === next.disabled &&
+    prev.tabIndex === next.tabIndex &&
+    (prev as Record<string, unknown>)['data-tag-index'] ===
+      (next as Record<string, unknown>)['data-tag-index'] &&
+    prev.className === next.className &&
+    prev.sx === next.sx
   )
 }
+
+export const GridAutocompleteChip = memo(
+  GridAutocompleteChipInner,
+  areGridAutocompleteChipPropsEqual,
+)


### PR DESCRIPTION
Manually memoize the Autocomplete and DateTime column components that are missed by react router.