### PR TITLE
SWC-7835 - disable feature flag & skip related tests

### DIFF
--- a/packages/synapse-react-client/src/features/entity/metadata-task/hooks/useOpenCuratorButton.test.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/hooks/useOpenCuratorButton.test.ts
@@ -252,7 +252,7 @@ describe('useOpenCuratorFromTaskButton', () => {
     })
   })
 
-  describe('when CURATOR_LINK_TASK_TO_GRID_SESSION is enabled', () => {
+  describe.skip('when CURATOR_LINK_TASK_TO_GRID_SESSION is enabled', () => {
     beforeEach(() => {
       mockUseGetFeatureFlag.mockImplementation(
         flag => flag === FeatureFlagEnum.CURATOR_LINK_TASK_TO_GRID_SESSION,

--- a/packages/synapse-react-client/src/features/entity/metadata-task/hooks/useOpenCuratorButton.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/hooks/useOpenCuratorButton.ts
@@ -34,9 +34,12 @@ export default function useOpenCuratorFromTaskButton(
 ): UseOpenCuratorFromTaskButtonReturn {
   const curationTask = taskBundle.task!
 
-  const isTaskLinkedSessionFlagEnabled = useGetFeatureFlag(
-    FeatureFlagEnum.CURATOR_LINK_TASK_TO_GRID_SESSION,
-  )
+  const isTaskLinkedSessionFlagEnabled =
+    useGetFeatureFlag(FeatureFlagEnum.CURATOR_LINK_TASK_TO_GRID_SESSION) &&
+    false // SWC-7835 - temporarily disable this feature flag
+  // We want to add an opt-in (PLFM-9686)
+  // Also the feature flag does not work because we did not bump synapse-client after adding the flag
+  // FeatureFlagEnum['CURATOR_LINK_TASK_TO_GRID_SESSION'] in the old version of synapse-client returns `undefined`.
 
   const {
     mutateAsync: getOrCreateLegacyGridSessionForUnassignedTask,


### PR DESCRIPTION
The feature flag does not work in stack 591 because we did not release synapse-react-client. Moreover, we do not want to release this functionality until PLFM-9686 is done. We may not deliver PLFM-9686 until a later stack.