### PR TITLE
PORTALS-4265

### DIFF
--- a/apps/portals/eliteportal/src/config/routesConfig.tsx
+++ b/apps/portals/eliteportal/src/config/routesConfig.tsx
@@ -235,36 +235,82 @@ const routes: RouteObject[] = [
         lazy: () => import('@/pages/Overview').then(convertModuleToRouteObject),
       },
       {
+        path: 'Comparative Aging',
+        lazy: () =>
+          import('@/pages/ComparativeAging').then(convertModuleToRouteObject),
+      },
+      {
+        // TODO: Remove deprecated route once external references are updated
         path: 'Comparative Biology',
         lazy: () =>
-          import('@/pages/ComparativeBiology').then(convertModuleToRouteObject),
+          import('@/pages/ComparativeAging').then(convertModuleToRouteObject),
       },
       {
+        path: 'Longevity Resilience',
+        lazy: () =>
+          import('@/pages/LongevityResilience').then(
+            convertModuleToRouteObject,
+          ),
+      },
+      {
+        // TODO: Remove deprecated route once external references are updated
         path: 'Omics Profiles in Humans',
         lazy: () =>
-          import('@/pages/OmicsProfilesInHumans').then(
+          import('@/pages/LongevityResilience').then(
             convertModuleToRouteObject,
           ),
       },
       {
+        path: 'Translational Science',
+        lazy: () =>
+          import('@/pages/TranslationalScience').then(
+            convertModuleToRouteObject,
+          ),
+      },
+      {
+        // TODO: Remove deprecated route once external references are updated
         path: 'Translational Approaches',
         lazy: () =>
-          import('@/pages/TranslationalApproaches').then(
+          import('@/pages/TranslationalScience').then(
             convertModuleToRouteObject,
           ),
       },
       {
+        path: 'Biological Aging',
+        lazy: () =>
+          import('@/pages/BiologicalAging').then(convertModuleToRouteObject),
+      },
+      {
+        // TODO: Remove deprecated route once external references are updated
         path: 'AI Models',
-        lazy: () => import('@/pages/AIModels').then(convertModuleToRouteObject),
+        lazy: () =>
+          import('@/pages/BiologicalAging').then(convertModuleToRouteObject),
       },
       {
+        path: 'Healthspan',
+        lazy: () =>
+          import('@/pages/Healthspan').then(convertModuleToRouteObject),
+      },
+      {
+        // TODO: Remove deprecated route once external references are updated
         path: 'IPSCs',
-        lazy: () => import('@/pages/IPSCs').then(convertModuleToRouteObject),
+        lazy: () =>
+          import('@/pages/Healthspan').then(convertModuleToRouteObject),
       },
       {
+        path: 'Cognitive Resilience',
+        lazy: () =>
+          import('@/pages/CognitiveResilience').then(
+            convertModuleToRouteObject,
+          ),
+      },
+      {
+        // TODO: Remove deprecated route once external references are updated
         path: 'Organoids',
         lazy: () =>
-          import('@/pages/Organoids').then(convertModuleToRouteObject),
+          import('@/pages/CognitiveResilience').then(
+            convertModuleToRouteObject,
+          ),
       },
     ],
   },

--- a/apps/portals/eliteportal/src/pages/BiologicalAging.tsx
+++ b/apps/portals/eliteportal/src/pages/BiologicalAging.tsx
@@ -1,9 +1,9 @@
 import { SectionLayout } from '@sage-bionetworks/synapse-portal-framework/components/SectionLayout'
 import { Markdown } from 'synapse-react-client/components/Markdown/MarkdownSynapse'
 
-function AIModels() {
+function BiologicalAging() {
   return (
-    <SectionLayout title={'AI/ML Models'}>
+    <SectionLayout title={'Measuring Biological Aging'}>
       <Markdown
         ownerId="syn27229419"
         wikiId="630613"
@@ -13,4 +13,4 @@ function AIModels() {
   )
 }
 
-export default AIModels
+export default BiologicalAging

--- a/apps/portals/eliteportal/src/pages/CognitiveResilience.tsx
+++ b/apps/portals/eliteportal/src/pages/CognitiveResilience.tsx
@@ -1,16 +1,16 @@
 import { SectionLayout } from '@sage-bionetworks/synapse-portal-framework/components/SectionLayout'
 import { Markdown } from 'synapse-react-client/components/Markdown/MarkdownSynapse'
 
-function ComparativeBiology() {
+function CognitiveResilience() {
   return (
-    <SectionLayout title={'Comparative Biology'}>
+    <SectionLayout title={'Cognitive Resilience in Aging'}>
       <Markdown
         ownerId="syn27229419"
-        wikiId="630611"
+        wikiId="630615"
         loadingSkeletonRowCount={15}
       />
     </SectionLayout>
   )
 }
 
-export default ComparativeBiology
+export default CognitiveResilience

--- a/apps/portals/eliteportal/src/pages/ComparativeAging.tsx
+++ b/apps/portals/eliteportal/src/pages/ComparativeAging.tsx
@@ -1,16 +1,16 @@
 import { SectionLayout } from '@sage-bionetworks/synapse-portal-framework/components/SectionLayout'
 import { Markdown } from 'synapse-react-client/components/Markdown/MarkdownSynapse'
 
-function IPSCs() {
+function ComparativeAging() {
   return (
-    <SectionLayout title={'IPSCs'}>
+    <SectionLayout title={'Cross-species and Comparative Aging'}>
       <Markdown
         ownerId="syn27229419"
-        wikiId="630614"
+        wikiId="630611"
         loadingSkeletonRowCount={15}
       />
     </SectionLayout>
   )
 }
 
-export default IPSCs
+export default ComparativeAging

--- a/apps/portals/eliteportal/src/pages/Healthspan.tsx
+++ b/apps/portals/eliteportal/src/pages/Healthspan.tsx
@@ -1,16 +1,16 @@
 import { SectionLayout } from '@sage-bionetworks/synapse-portal-framework/components/SectionLayout'
 import { Markdown } from 'synapse-react-client/components/Markdown/MarkdownSynapse'
 
-function TranslationalApproaches() {
+function Healthspan() {
   return (
-    <SectionLayout title={'Translational Approaches'}>
+    <SectionLayout title={'Healthspan and Aging Trajectories'}>
       <Markdown
         ownerId="syn27229419"
-        wikiId="630612"
+        wikiId="630614"
         loadingSkeletonRowCount={15}
       />
     </SectionLayout>
   )
 }
 
-export default TranslationalApproaches
+export default Healthspan

--- a/apps/portals/eliteportal/src/pages/HomePage.tsx
+++ b/apps/portals/eliteportal/src/pages/HomePage.tsx
@@ -141,8 +141,8 @@ function HomePageInternal() {
       />
       <ImageCardGridWithLinks
         sql={whatWeDoSql}
-        title="What We Do"
-        summaryText="The ELITE Portal provides rich multi-omic datasets, computational tools, publications, and resources that empower researchers to discover novel therapeutic targets of health and disease. Learn more about our research domains and tools."
+        title="Research Themes"
+        summaryText="Use our research themes to explore the scientific topics this portal supports and find the datasets, variables, and resources most relevant to your work. The ELITE Portal provides rich multi-omic datasets, computational tools, publications, and resources that empower researchers to discover novel therapeutic targets that advance healthy aging and longevity."
         columnCount={3}
         heightPx={245}
       />

--- a/apps/portals/eliteportal/src/pages/LongevityResilience.tsx
+++ b/apps/portals/eliteportal/src/pages/LongevityResilience.tsx
@@ -1,16 +1,16 @@
 import { SectionLayout } from '@sage-bionetworks/synapse-portal-framework/components/SectionLayout'
 import { Markdown } from 'synapse-react-client/components/Markdown/MarkdownSynapse'
 
-function Organoids() {
+function LongevityResilience() {
   return (
-    <SectionLayout title={'Organoids'}>
+    <SectionLayout title={'Longevity and Resilience'}>
       <Markdown
         ownerId="syn27229419"
-        wikiId="630615"
+        wikiId="630616"
         loadingSkeletonRowCount={15}
       />
     </SectionLayout>
   )
 }
 
-export default Organoids
+export default LongevityResilience

--- a/apps/portals/eliteportal/src/pages/TranslationalScience.tsx
+++ b/apps/portals/eliteportal/src/pages/TranslationalScience.tsx
@@ -1,16 +1,16 @@
 import { SectionLayout } from '@sage-bionetworks/synapse-portal-framework/components/SectionLayout'
 import { Markdown } from 'synapse-react-client/components/Markdown/MarkdownSynapse'
 
-function OmicsProfilesInHumans() {
+function TranslationalScience() {
   return (
-    <SectionLayout title={'Omics Profiles in Humans'}>
+    <SectionLayout title={'Translational Science and Intervention'}>
       <Markdown
         ownerId="syn27229419"
-        wikiId="630616"
+        wikiId="630612"
         loadingSkeletonRowCount={15}
       />
     </SectionLayout>
   )
 }
 
-export default OmicsProfilesInHumans
+export default TranslationalScience


### PR DESCRIPTION
## Elite Portal Page Renaming

Six pages were renamed with updated URLs, component names, and page headings.

### Changes

| Old URL | New URL | New Page Heading |
|---------|---------|-----------------|
| `/AI Models` | `/Biological Aging` | Measuring Biological Aging |
| `/Omics Profiles in Humans` | `/Longevity Resilience` | Longevity and Resilience |
| `/IPSCs` | `/Healthspan` | Healthspan and Aging Trajectories |
| `/Comparative Biology` | `/Comparative Aging` | Cross-species and Comparative Aging |
| `/Translational Approaches` | `/Translational Science` | Translational Science and Intervention |
| `/Organoids` | `/Cognitive Resilience` | Cognitive Resilience in Aging |

### Files modified

- `src/config/routesConfig.tsx` — updated route `path` values and lazy import references

### Files created

- `src/pages/BiologicalAging.tsx`
- `src/pages/LongevityResilience.tsx`
- `src/pages/Healthspan.tsx`
- `src/pages/ComparativeAging.tsx`
- `src/pages/TranslationalScience.tsx`
- `src/pages/CognitiveResilience.tsx`

### Files deleted

- `src/pages/AIModels.tsx`
- `src/pages/OmicsProfilesInHumans.tsx`
- `src/pages/IPSCs.tsx`
- `src/pages/ComparativeBiology.tsx`
- `src/pages/TranslationalApproaches.tsx`
- `src/pages/Organoids.tsx`

### Backwards compatibility

Deprecated alias routes were added for all six old URLs, each marked with a
`TODO` comment to be removed once external references are updated:

- `/Comparative Biology` → serves `ComparativeAging`
- `/Omics Profiles in Humans` → serves `LongevityResilience`
- `/Translational Approaches` → serves `TranslationalScience`
- `/AI Models` → serves `BiologicalAging`
- `/IPSCs` → serves `Healthspan`
- `/Organoids` → serves `CognitiveResilience`