### PR TITLE
PORTALS-4269

### DIFF
--- a/packages/synapse-react-client/src/style/components/_cards.scss
+++ b/packages/synapse-react-client/src/style/components/_cards.scss
@@ -298,9 +298,6 @@
     > * {
       margin-left: 15px;
     }
-    > table {
-      margin-left: 0;
-    }
 
     &.hasIcon {
       @media (min-width: map.get(SRC.$breakpoints, 'medium')) {


### PR DESCRIPTION
After the fix:

<img width="973" height="446" alt="Screenshot 2026-06-01 at 9 45 13 PM" src="https://github.com/user-attachments/assets/9cca0bbc-682f-4188-8299-733e8cfde698" />

The change was clearly made for when the footer table is shown on mobile, but I think it's less noticeable.  So let's keep the old margin-left 15px for all children:

<img width="1412" height="529" alt="Screenshot 2026-06-01 at 9 45 23 PM" src="https://github.com/user-attachments/assets/d2fbde7a-12c0-48a1-a156-95c42634034f" />

<img width="723" height="596" alt="Screenshot 2026-06-01 at 9 45 32 PM" src="https://github.com/user-attachments/assets/f0683100-fde2-42d7-938b-e0041fe2cb10" />
