### PR TITLE
PORTALS-4159: ADKP Homepage Redesign: New facet-based explore component

### DIFF
--- a/apps/portals/adknowledgeportal/src/config/resources.ts
+++ b/apps/portals/adknowledgeportal/src/config/resources.ts
@@ -11,6 +11,8 @@ export const projectsSql = 'SELECT * FROM syn17024229 ORDER BY isFeatured DESC'
 export const publicationsSql = 'SELECT * FROM syn20448807'
 export const studiesSql = 'SELECT * FROM syn17083367 ORDER BY isFeatured DESC'
 export const programsSql = 'SELECT * FROM syn17024173'
+export const dataTypeSql = 'SELECT * FROM syn75201966'
+export const exploreQuerySql = 'SELECT * FROM syn17083367'
 
 export const experimentalModelsSql =
   'select * from syn22219805 ORDER BY isFeatured DESC'

--- a/apps/portals/adknowledgeportal/src/config/resources.ts
+++ b/apps/portals/adknowledgeportal/src/config/resources.ts
@@ -12,7 +12,8 @@ export const publicationsSql = 'SELECT * FROM syn20448807'
 export const studiesSql = 'SELECT * FROM syn17083367 ORDER BY isFeatured DESC'
 export const programsSql = 'SELECT * FROM syn17024173'
 export const dataTypeSql = 'SELECT * FROM syn75201966'
-export const exploreQuerySql = 'SELECT * FROM syn17083367'
+export const exploreQuerySql =
+  'SELECT * FROM syn17083367 ORDER BY isFeatured DESC'
 
 export const experimentalModelsSql =
   'select * from syn22219805 ORDER BY isFeatured DESC'

--- a/apps/portals/adknowledgeportal/src/config/style/_style_overrides.scss
+++ b/apps/portals/adknowledgeportal/src/config/style/_style_overrides.scss
@@ -1,5 +1,6 @@
 :root {
   --adkp-accent-color: #684b84;
+  --data-explorer-title-color: var(--adkp-accent-color);
   --adkp-button-gradient: linear-gradient(180deg, #443471 0%, #5a488f 100%);
   --adkp-button-border-color: #32243f;
   --Brand-dark: #1f3042;

--- a/apps/portals/adknowledgeportal/src/pages/HomePageV2.tsx
+++ b/apps/portals/adknowledgeportal/src/pages/HomePageV2.tsx
@@ -1,6 +1,7 @@
 import AdknowledgeCard from '@sage-bionetworks/synapse-portal-framework/components/adknowledge/AdknowledgeCard/AdknowledgeCard'
 import { SectionLayout } from '@sage-bionetworks/synapse-portal-framework/components/SectionLayout'
 import MailchimpSubscribeSection from 'synapse-react-client/components/MailchimpSubscribeSection/MailchimpSubscribeSection'
+import DataExplorer from 'synapse-react-client/components/DataExplorer/DataExplorer'
 import AdknowledgeHeader from '@sage-bionetworks/synapse-portal-framework/components/adknowledge/AdknowledgeHeader/AdknowledgeHeader'
 import { WordPressNews } from 'synapse-react-client/components/SynapseHomepageV2/WordPressNews'
 import FloatingBlobsBackground from 'synapse-react-client/components/SynapseHomepageV2/FloatingBlobsBackground'
@@ -42,9 +43,33 @@ function HomePageInternal() {
     Image: ContributeIcon,
   }
 
+  const dataExplorerTextSection = {
+    sql: 'syn75201966',
+    title: 'Our portal has more than a petabyte of data..',
+    buttonText: 'Explore Alzheimer’s Data',
+    subtitle: (
+      <>
+        <div style={{ marginBottom: '10px' }}>
+          Including over 265,000 files from 60+ assays and in 50+ different file
+          formats, from 175 studies.
+        </div>
+        Our data encompasses a wide range of modalities, ensuring comprehensive
+        coverage for in -depth Alzheimer's research and discovery.
+      </>
+    ),
+  }
+
   return (
     <div className="HomePageV2">
       <AdknowledgeHeader />
+      <SectionLayout
+        ContainerProps={{
+          className: 'home-spacer',
+        }}
+      >
+        <DataExplorer {...dataExplorerTextSection} />
+      </SectionLayout>
+
       <SectionLayout
         ContainerProps={{
           sx: { marginBottom: '80px' },

--- a/apps/portals/adknowledgeportal/src/pages/HomePageV2.tsx
+++ b/apps/portals/adknowledgeportal/src/pages/HomePageV2.tsx
@@ -6,7 +6,7 @@ import AdknowledgeHeader from '@sage-bionetworks/synapse-portal-framework/compon
 import { WordPressNews } from 'synapse-react-client/components/SynapseHomepageV2/WordPressNews'
 import FloatingBlobsBackground from 'synapse-react-client/components/SynapseHomepageV2/FloatingBlobsBackground'
 import AdknowledgePrograms from '@sage-bionetworks/synapse-portal-framework/components/adknowledge/AdknowledgePrograms/AdknowledgePrograms'
-import { programsSql } from '@/config/resources'
+import { dataTypeSql, exploreQuerySql, programsSql } from '@/config/resources'
 import { HomePageThemeProvider } from '@/themes/HomePageThemeProvider'
 import { ReactComponent as CavaticaLogo } from '../assets/cavatica.svg'
 import { ReactComponent as TerraLogo } from '../assets/terra.svg'
@@ -15,6 +15,8 @@ import { ReactComponent as ContributeIcon } from '../assets/contribution.svg'
 import { ReactComponent as AgoraIcon } from '../assets/agora.svg'
 import { ReactComponent as ModelADIcon } from '../assets/modelAD.svg'
 import styles from './HomePageV2.module.scss'
+
+const FILTER_COLUMN_NAME = 'DataType_All'
 
 function HomePageInternal() {
   const agoraCard = {
@@ -44,9 +46,10 @@ function HomePageInternal() {
   }
 
   const dataExplorerTextSection = {
-    sql: 'syn75201966',
+    sql: dataTypeSql,
     title: 'Our portal has more than a petabyte of data..',
     buttonText: 'Explore Alzheimer’s Data',
+    buttonLink: '/Explore/Data',
     subtitle: (
       <>
         <div style={{ marginBottom: '10px' }}>
@@ -54,9 +57,12 @@ function HomePageInternal() {
           formats, from 175 studies.
         </div>
         Our data encompasses a wide range of modalities, ensuring comprehensive
-        coverage for in -depth Alzheimer's research and discovery.
+        coverage for in-depth Alzheimer's research and discovery.
       </>
     ),
+    explorePath: '/Explore/Studies',
+    exploreQuerySql,
+    filterColumnName: FILTER_COLUMN_NAME,
   }
 
   return (

--- a/apps/synapse-portal-framework/src/components/SectionLayout.tsx
+++ b/apps/synapse-portal-framework/src/components/SectionLayout.tsx
@@ -10,7 +10,7 @@ type SectionLayoutProps = PropsWithChildren<{
   /** JSX override for rendering. 'title' (string) is still required for hash-based scroll */
   titleNode?: React.ReactNode
   centerTitle?: boolean
-  subtitle?: string
+  subtitle?: React.ReactNode
   helpText?: string
 }>
 

--- a/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.module.scss
+++ b/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.module.scss
@@ -1,0 +1,22 @@
+.dataExplorerTitle:global(.MuiTypography-root) {
+  color: var(--adkp-accent-color);
+  font-size: 36px;
+  line-height: 40px; /* 111.111% */
+  margin-bottom: 10px;
+}
+
+.dataExplorerSubtitle:global(.MuiTypography-root) {
+  line-height: 140%;
+}
+
+.dataExplorerTextContainer {
+  gap: 16px;
+}
+
+.dataExplorerContainer {
+  display: flex;
+  padding: 40px;
+  align-items: flex-start;
+  gap: 60px;
+  flex: 1 0 0;
+}

--- a/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.module.scss
+++ b/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.module.scss
@@ -15,13 +15,13 @@
 
 .dataExplorerTextContainer {
   gap: 16px;
-  flex: 0 0 40%;
-  max-width: 40%;
+  flex: 0 0 30%;
+  max-width: 30%;
 }
 
 .dataExplorerContainer {
   display: flex;
-  padding: 40px;
+  padding: 40px 0;
   align-items: flex-start;
   gap: 60px;
   flex: 1 0 0;
@@ -42,9 +42,10 @@
   font-size: 19.8px;
   font-weight: 400;
   line-height: 26.4px;
-  white-space: nowrap;
-  overflow: hidden;
+  flex: 0 1 auto;
   min-width: 0;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .dataRowInner {
@@ -102,9 +103,10 @@
 }
 
 .dataRowNamePill {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 8px;
+  flex: 1 1 0;
   min-width: 0;
 }
 
@@ -120,6 +122,7 @@
   font-size: 14px;
   font-weight: 400;
   line-height: 24px; /* 171.429% */
+  flex-shrink: 0;
 }
 
 .viewCta {
@@ -135,7 +138,7 @@
   opacity: 0;
   white-space: nowrap;
   color: var(--synapse-primary-action-color, #4d558d);
-  background: linear-gradient(to right, transparent, #fff 75%);
+  background: linear-gradient(to right, transparent, #fff 25%, #fff 100%);
   border-radius: 0 2px 2px 0;
   transition: opacity 200ms ease;
 }

--- a/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.module.scss
+++ b/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.module.scss
@@ -1,5 +1,5 @@
 .dataExplorerTitle:global(.MuiTypography-root) {
-  color: var(--adkp-accent-color);
+  color: var(--data-explorer-title-color, var(--synapse-primary-action-color));
   font-size: 36px;
   line-height: 40px; /* 111.111% */
   margin-bottom: 10px;
@@ -9,8 +9,14 @@
   line-height: 140%;
 }
 
+.dataExplorerButton {
+  width: fit-content;
+}
+
 .dataExplorerTextContainer {
   gap: 16px;
+  flex: 0 0 40%;
+  max-width: 40%;
 }
 
 .dataExplorerContainer {
@@ -19,4 +25,129 @@
   align-items: flex-start;
   gap: 60px;
   flex: 1 0 0;
+}
+
+.dataContainer {
+  display: inline-grid;
+  row-gap: 8px;
+  column-gap: 8px;
+  flex: 1 1 60%;
+  min-width: 0;
+  grid-template-rows: repeat(9, fit-content(100%));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.dataRowTitle {
+  color: var(--synapse-primary-action-color, #4d558d);
+  font-size: 19.8px;
+  font-weight: 400;
+  line-height: 26.4px;
+  white-space: nowrap;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.dataRowInner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex: 1;
+  min-width: 0;
+}
+
+.dataRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8.8px 26.4px;
+  min-height: 66.6px;
+  gap: 17.6px;
+  justify-self: stretch;
+  position: relative;
+  border-radius: 3.3px;
+  border: 1px solid transparent;
+  text-decoration: none !important;
+  transition: background-color 200ms ease, border-color 200ms ease,
+    box-shadow 200ms ease, transform 200ms ease;
+
+  &:hover {
+    background-color: #fff;
+    border-color: #e1e1e1;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1);
+    transform: scale(1.1);
+    z-index: 1;
+    .viewCta {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+}
+
+.dataRowLeft {
+  display: inline-flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+  flex: 1;
+}
+
+.iconContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 49px;
+  height: 49px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dataRowNamePill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.fileCount {
+  display: flex;
+  padding: 4px 8px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  border-radius: 80px;
+  border: 1px solid #d8d5e0;
+  color: #787090;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 24px; /* 171.429% */
+}
+
+.viewCta {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: inline-flex;
+  align-items: center;
+  padding-right: 26.4px;
+  padding-left: 40px;
+  gap: 4px;
+  opacity: 0;
+  white-space: nowrap;
+  color: var(--synapse-primary-action-color, #4d558d);
+  background: linear-gradient(to right, transparent, #fff 75%);
+  border-radius: 0 2px 2px 0;
+  transition: opacity 200ms ease;
+}
+
+.viewCtaText {
+  color: var(--synapse-primary-action-color, #4d558d);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 26.4px; /* 165% */
+}
+
+.viewCtaIcon:global(.MuiSvgIcon-root) {
+  font-size: 24px;
+  color: var(--synapse-primary-action-color, #5a488f);
 }

--- a/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.stories.ts
+++ b/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.stories.ts
@@ -51,7 +51,7 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const ADKPHomepage: Story = {
+export const Default: Story = {
   parameters: {
     chromatic: { viewports: [600, 1200] },
     msw: {
@@ -75,5 +75,8 @@ export const ADKPHomepage: Story = {
     subtitle: 'Some more text',
     buttonText: 'Button text',
     buttonLink: '',
+    explorePath: '/Explore/Studies',
+    exploreQuerySql: 'SELECT * FROM syn17083367',
+    filterColumnName: 'DataType_All',
   },
 }

--- a/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.stories.ts
+++ b/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.stories.ts
@@ -1,0 +1,79 @@
+import { getHandlersForTableQuery } from '@/mocks/msw/handlers/tableQueryHandlers'
+import { registerTableQueryResult } from '@/mocks/msw/handlers/tableQueryService'
+import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
+import { QueryResultBundle } from '@sage-bionetworks/synapse-types'
+import { Meta, StoryObj } from '@storybook/react-vite'
+import DataExplorer from './DataExplorer'
+
+const TABLE_ID = 'syn75201966'
+
+const mockDataExplorerQueryResult: QueryResultBundle = {
+  concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
+  selectColumns: [
+    { name: 'datatype', columnType: 'STRING' },
+    { name: 'icon', columnType: 'FILEHANDLEID' },
+    { name: 'hexColor', columnType: 'STRING' },
+    { name: 'fileCount', columnType: 'INTEGER' },
+  ],
+  queryResult: {
+    concreteType: 'org.sagebionetworks.repo.model.table.QueryResult',
+    queryResults: {
+      concreteType: 'org.sagebionetworks.repo.model.table.RowSet',
+      tableId: TABLE_ID,
+      etag: 'DEFAULT',
+      headers: [
+        { name: 'datatype', columnType: 'STRING', id: '1' },
+        { name: 'icon', columnType: 'FILEHANDLEID', id: '2' },
+        { name: 'hexColor', columnType: 'STRING', id: '3' },
+        { name: 'fileCount', columnType: 'INTEGER', id: '4' },
+      ],
+      rows: [
+        { values: ['Test 1', null, '#8B5CF6', '42318'] },
+        { values: ['Test 2', null, '#6366F1', '18204'] },
+        { values: ['Test 3', null, '#3B82F6', '65821'] },
+        { values: ['Test 4', null, '#10B981', '9471'] },
+        { values: ['Test 5', null, '#F59E0B', '7652'] },
+        { values: ['Test 6', null, '#EF4444', '3309'] },
+      ],
+    },
+  },
+}
+
+const meta = {
+  title: 'Home Page/DataExplorer',
+  component: DataExplorer,
+  parameters: {
+    stack: 'mock',
+  },
+} satisfies Meta<typeof DataExplorer>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const ADKPHomepage: Story = {
+  parameters: {
+    chromatic: { viewports: [600, 1200] },
+    msw: {
+      handlers: [...getHandlersForTableQuery(MOCK_REPO_ORIGIN)],
+    },
+  },
+  loaders: [
+    () => {
+      registerTableQueryResult(
+        {
+          sql: 'SELECT * FROM syn75201966',
+          sort: [{ column: 'order', direction: 'ASC' }],
+        },
+        mockDataExplorerQueryResult,
+      )
+    },
+  ],
+  args: {
+    sql: 'SELECT * FROM syn75201966',
+    title: 'Some text',
+    subtitle: 'Some more text',
+    buttonText: 'Button text',
+    buttonLink: '',
+  },
+}

--- a/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.tsx
+++ b/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.tsx
@@ -142,6 +142,7 @@ export default function DataExplorer({
           const dataType = row.values[datatypeColIndex] ?? ''
           const hexColor = row.values[hexColorColIndex] ?? undefined
           const rowUrl = rowUrls[index]
+          const fileCount = row.values[fileCountColIndex] ?? ''
           return (
             <a key={row.rowId} className={styles.dataRow} href={rowUrl}>
               <div className={styles.dataRowInner}>
@@ -161,9 +162,9 @@ export default function DataExplorer({
                     <Typography className={styles.dataRowTitle}>
                       {dataType}
                     </Typography>
-                    <div className={styles.fileCount}>
-                      {row.values[fileCountColIndex] ?? '10'}
-                    </div>
+                    {fileCount && (
+                      <div className={styles.fileCount}>{fileCount}</div>
+                    )}
                   </div>
                 </div>
                 {rowUrl && (

--- a/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.tsx
+++ b/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.tsx
@@ -1,6 +1,15 @@
 import { Button, Typography, Stack } from '@mui/material'
+import { useEffect, useMemo, useState } from 'react'
 import styles from './DataExplorer.module.scss'
 import { useSmartLink } from '../SmartLink/useSmartLink'
+import { parseEntityIdFromSqlStatement } from '@/utils/functions'
+import { QueryBundleRequest } from '@sage-bionetworks/synapse-types'
+import { SynapseConstants } from '@/utils'
+import useGetQueryResultBundle from '@/synapse-queries/entity/useGetQueryResultBundle'
+import { getFieldIndex } from '@/utils/functions/queryUtils'
+import { generateEncodedPathAndQueryForSelectedFacetURL } from '../QueryWrapper'
+import ImageFromSynapseTable from '../ImageFromSynapseTable'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 
 type DataExplorerProps = {
   title?: React.ReactNode
@@ -8,16 +17,93 @@ type DataExplorerProps = {
   buttonText?: string
   buttonLink?: string
   sql: string
+  explorePath?: string
+  exploreQuerySql?: string
+  filterColumnName?: string
+}
+
+enum ExpectedColumns {
+  DATATYPE = 'datatype',
+  ICON = 'icon',
+  HEX_COLOR = 'hexColor',
+  FILE_COUNT = 'fileCount',
 }
 
 export default function DataExplorer({
+  sql,
   title,
   subtitle,
   buttonText,
   buttonLink,
+  explorePath,
+  exploreQuerySql,
+  filterColumnName,
 }: DataExplorerProps) {
   const hasTextSection = title || subtitle || buttonText
   const smartLinkProps = useSmartLink(buttonLink)
+
+  const entityId = parseEntityIdFromSqlStatement(sql)
+
+  const queryBundleRequest: QueryBundleRequest = {
+    partMask:
+      SynapseConstants.BUNDLE_MASK_QUERY_SELECT_COLUMNS |
+      SynapseConstants.BUNDLE_MASK_QUERY_RESULTS,
+    concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+    entityId,
+    query: {
+      sql,
+      sort: [{ column: 'order', direction: 'ASC' }],
+    },
+  }
+
+  const { data: queryResultBundle } =
+    useGetQueryResultBundle(queryBundleRequest)
+
+  const dataRows = useMemo(
+    () => queryResultBundle?.queryResult?.queryResults.rows ?? [],
+    [queryResultBundle],
+  )
+
+  const datatypeColIndex = getFieldIndex(
+    ExpectedColumns.DATATYPE,
+    queryResultBundle,
+  )
+
+  const iconColIndex = getFieldIndex(ExpectedColumns.ICON, queryResultBundle)
+
+  const hexColorColIndex = getFieldIndex(
+    ExpectedColumns.HEX_COLOR,
+    queryResultBundle,
+  )
+
+  const fileCountColIndex = getFieldIndex(
+    ExpectedColumns.FILE_COUNT,
+    queryResultBundle,
+  )
+
+  const [rowUrls, setRowUrls] = useState<string[]>([])
+
+  useEffect(() => {
+    if (!explorePath || !filterColumnName || !exploreQuerySql) return
+
+    Promise.all(
+      dataRows.map(row => {
+        const dataType = row.values[datatypeColIndex]
+        if (!dataType) return Promise.resolve(explorePath)
+        return generateEncodedPathAndQueryForSelectedFacetURL(
+          explorePath,
+          exploreQuerySql,
+          [{ facet: filterColumnName, facetValue: dataType }],
+        )
+      }),
+    ).then(setRowUrls)
+  }, [
+    dataRows,
+    datatypeColIndex,
+    explorePath,
+    exploreQuerySql,
+    filterColumnName,
+  ])
 
   return (
     <div className={styles.dataExplorerContainer}>
@@ -32,20 +118,65 @@ export default function DataExplorer({
             </Typography>
           )}
           {subtitle && (
-            <Typography variant="body1" className={styles.dataExplorerSubtitle}>
+            <Typography
+              variant="body1"
+              component="div"
+              className={styles.dataExplorerSubtitle}
+            >
               {subtitle}
             </Typography>
           )}
-          <Button
-            variant="contained"
-            className={styles.dataExplorerButton}
-            {...smartLinkProps}
-          >
-            {buttonText}
-          </Button>
+          {buttonText && (
+            <Button
+              variant="contained"
+              className={styles.dataExplorerButton}
+              {...smartLinkProps}
+            >
+              {buttonText}
+            </Button>
+          )}
         </Stack>
       )}
-      <>Right Section</>
+      <div className={styles.dataContainer}>
+        {dataRows.map((row, index) => {
+          const dataType = row.values[datatypeColIndex] ?? ''
+          const hexColor = row.values[hexColorColIndex] ?? undefined
+          const rowUrl = rowUrls[index]
+          return (
+            <a key={row.rowId} className={styles.dataRow} href={rowUrl}>
+              <div className={styles.dataRowInner}>
+                <div className={styles.dataRowLeft}>
+                  <div
+                    className={styles.iconContainer}
+                    style={hexColor ? { backgroundColor: hexColor } : undefined}
+                  >
+                    <ImageFromSynapseTable
+                      tableId={entityId}
+                      fileHandleId={row.values[iconColIndex]}
+                      alt={row.values[datatypeColIndex] ?? ''}
+                      style={{ width: 49, height: 49 }}
+                    />
+                  </div>
+                  <div className={styles.dataRowNamePill}>
+                    <Typography className={styles.dataRowTitle}>
+                      {dataType}
+                    </Typography>
+                    <div className={styles.fileCount}>
+                      {row.values[fileCountColIndex] ?? '10'}
+                    </div>
+                  </div>
+                </div>
+                {rowUrl && (
+                  <div className={styles.viewCta}>
+                    <span className={styles.viewCtaText}>View</span>
+                    <ArrowForwardIcon className={styles.viewCtaIcon} />
+                  </div>
+                )}
+              </div>
+            </a>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.tsx
+++ b/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.tsx
@@ -1,0 +1,51 @@
+import { Button, Typography, Stack } from '@mui/material'
+import styles from './DataExplorer.module.scss'
+import { useSmartLink } from '../SmartLink/useSmartLink'
+
+type DataExplorerProps = {
+  title?: React.ReactNode
+  subtitle?: React.ReactNode
+  buttonText?: string
+  buttonLink?: string
+  sql: string
+}
+
+export default function DataExplorer({
+  title,
+  subtitle,
+  buttonText,
+  buttonLink,
+}: DataExplorerProps) {
+  const hasTextSection = title || subtitle || buttonText
+  const smartLinkProps = useSmartLink(buttonLink)
+
+  return (
+    <div className={styles.dataExplorerContainer}>
+      {hasTextSection && (
+        <Stack className={styles.dataExplorerTextContainer}>
+          {title && (
+            <Typography
+              variant="headline1"
+              className={styles.dataExplorerTitle}
+            >
+              {title}
+            </Typography>
+          )}
+          {subtitle && (
+            <Typography variant="body1" className={styles.dataExplorerSubtitle}>
+              {subtitle}
+            </Typography>
+          )}
+          <Button
+            variant="contained"
+            className={styles.dataExplorerButton}
+            {...smartLinkProps}
+          >
+            {buttonText}
+          </Button>
+        </Stack>
+      )}
+      <>Right Section</>
+    </div>
+  )
+}

--- a/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.tsx
+++ b/packages/synapse-react-client/src/components/DataExplorer/DataExplorer.tsx
@@ -88,7 +88,7 @@ export default function DataExplorer({
 
     Promise.all(
       dataRows.map(row => {
-        const dataType = row.values[datatypeColIndex]
+        const dataType = row.values[datatypeColIndex]?.trim()
         if (!dataType) return Promise.resolve(explorePath)
         return generateEncodedPathAndQueryForSelectedFacetURL(
           explorePath,


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/jira/software/c/projects/PLFM/boards/238?assignee=712020%3Aa7fbbeb0-d7a6-443a-9dd4-246363ff09dd&selectedIssue=PORTALS-4159

<img width="1512" height="982" alt="Screenshot 2026-06-02 at 1 04 43 PM" src="https://github.com/user-attachments/assets/5add179e-d196-47ff-90d6-4b12c305d27d" />
<img width="1512" height="982" alt="Screenshot 2026-06-02 at 1 05 17 PM" src="https://github.com/user-attachments/assets/ffc783fd-6e84-461a-85bd-a579c9872bb8" />
<img width="1512" height="982" alt="Screenshot 2026-06-02 at 1 05 23 PM" src="https://github.com/user-attachments/assets/a4df931c-8c72-4065-8cce-9a5c624ada60" />

Removed the '10' fallback, confirming fileCount looks good in storybook:
<img width="1512" height="982" alt="Screenshot 2026-06-02 at 1 25 07 PM" src="https://github.com/user-attachments/assets/e06ae981-58f5-4d9b-aa65-f6d026a31453" />



Storybook:
<img width="1512" height="982" alt="Screenshot 2026-06-02 at 1 22 02 PM" src="https://github.com/user-attachments/assets/f1676ee2-af6d-45dd-ba19-caba1a0d935d" />

