### PR TITLE
PORTALS-4239 - SSR-compatible Markdown component

### DIFF
--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -65,6 +65,7 @@
     "clickable-json": "^1.15.1",
     "dagre": "^0.8.5",
     "dayjs": "^1.11.13",
+    "html-react-parser": "^6.1.3",
     "immutable": "4.3.8",
     "isomorphic-dompurify": "^3.7.1",
     "jotai": "^2.12.4",

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.ssr.test.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.ssr.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment node
+
+/**
+ * Server-side rendering (SSR) / SSG-prerender regression tests for
+ * MarkdownSynapse.
+ *
+ * These run in the `node` Vitest environment, where there is NO `document`,
+ * `window`, `DOMParser`, `Node`, or `HTMLElement` global. They guard against
+ * reintroducing browser-only globals into the markdown render path, which
+ * would crash React Router's `ssr: false` prerender step.
+ *
+ * Rendering is done with `react-dom/server`'s `renderToStaticMarkup` rather
+ * than Testing Library, since the latter requires a DOM.
+ */
+import { getUseQueryIdleMock } from '@/testutils/ReactQueryMockUtils'
+import {
+  useGetWikiAttachments,
+  useGetWikiPage,
+} from '@/synapse-queries/wiki/useWiki'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import MarkdownSynapse from './MarkdownSynapse'
+import { markdownToPlainText, stripHTML } from './MarkdownUtils'
+
+// The widget hooks would otherwise try to fetch data; stub them out so the
+// component renders purely from the `markdown` prop.
+vi.mock('@/synapse-queries/wiki/useWiki')
+
+const mockUseGetWikiPage = vi.mocked(useGetWikiPage)
+const mockUseGetWikiAttachments = vi.mocked(useGetWikiAttachments)
+
+describe('MarkdownSynapse SSR (node environment)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseGetWikiPage.mockReturnValue(getUseQueryIdleMock())
+    mockUseGetWikiAttachments.mockReturnValue(getUseQueryIdleMock())
+  })
+
+  it('confirms the test runs without browser DOM globals', () => {
+    expect(typeof document).toBe('undefined')
+    expect(typeof window).toBe('undefined')
+    expect(typeof DOMParser).toBe('undefined')
+    expect(typeof HTMLElement).toBe('undefined')
+  })
+
+  it('renders markdown to static HTML on the server', () => {
+    const markdown = [
+      '# Heading One',
+      '',
+      'Some **bold** and _italic_ text with a [link](https://www.synapse.org).',
+      '',
+      '## Heading Two',
+      '',
+      '- item one',
+      '- item two',
+    ].join('\n')
+
+    let html = ''
+    expect(() => {
+      html = renderToStaticMarkup(<MarkdownSynapse markdown={markdown} />)
+    }).not.toThrow()
+
+    expect(html).toContain('Heading One')
+    expect(html).toContain('Heading Two')
+    expect(html).toContain('item one')
+    expect(html).toContain('href="https://www.synapse.org"')
+  })
+
+  it('renders content with invalid nesting (block inside inline) without throwing', () => {
+    // A <div> nested inside an inline element exercises fixInvalidNesting,
+    // which previously walked a live DOM produced by `new DOMParser()`.
+    const markdown =
+      '<a href="https://www.synapse.org"><div>block content</div></a>'
+
+    let html = ''
+    expect(() => {
+      html = renderToStaticMarkup(<MarkdownSynapse markdown={markdown} />)
+    }).not.toThrow()
+
+    expect(html).toContain('block content')
+  })
+
+  it('stripHTML works without a DOM', () => {
+    expect(stripHTML('<p>Hello <strong>world</strong> &amp; friends</p>')).toBe(
+      'Hello world & friends',
+    )
+  })
+
+  it('markdownToPlainText works without a DOM', () => {
+    expect(markdownToPlainText('# Title\n\nSome **text**')).toContain('Title')
+    expect(markdownToPlainText('# Title\n\nSome **text**')).toContain('text')
+  })
+})

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.tsx
@@ -26,7 +26,15 @@ import markdownitSynapsePlugin from 'markdown-it-synapse'
 import markdownitSynapseHeading from 'markdown-it-synapse-heading'
 import markdownitMath from 'markdown-it-synapse-math'
 import markdownitSynapseTable from 'markdown-it-synapse-table'
-import { JSX, useEffect, useMemo, useRef } from 'react'
+import { ComponentProps, ElementType, useEffect, useMemo, useRef } from 'react'
+import {
+  htmlToDOM,
+  domToReact,
+  attributesToProps,
+  Element as DomElement,
+  type DOMNode,
+  type HTMLReactParserOptions,
+} from 'html-react-parser'
 import { ErrorBanner } from '../error/ErrorBanner'
 import { SkeletonTable } from '../Skeleton'
 import MarkdownWidget from './MarkdownWidget'
@@ -161,6 +169,105 @@ function MapParamsToMarkdownWidget(props: {
 }
 
 /**
+ * Builds the `html-react-parser` options used to convert the parsed markdown
+ * HTML tree into React elements.
+ *
+ * The `replace` callback handles the Synapse-specific cases (widgets, and the
+ * elements we render via MUI `Typography`/`Link`); every other element falls
+ * through to html-react-parser's default conversion, which maps attributes
+ * (e.g. `class` -> `className`, inline `style` string -> object), handles void
+ * elements, and assigns React keys to sibling elements.
+ *
+ * @param markdown The original (post-processing) markup string, forwarded to
+ * widgets that need the full markup (e.g. table of contents).
+ */
+function getParserOptions(markdown: string): HTMLReactParserOptions {
+  const options: HTMLReactParserOptions = {
+    replace: domNode => {
+      if (!(domNode instanceof DomElement)) {
+        // Text/comment nodes use default handling.
+        return
+      }
+
+      const widgetParams = domNode.attribs['data-widgetparams']
+      if (widgetParams) {
+        // Synapse widget
+        return (
+          <MapParamsToMarkdownWidget
+            widgetParams={widgetParams}
+            originalMarkup={markdown}
+          />
+        )
+      }
+
+      const tag = domNode.name.toLowerCase()
+      // attributesToProps remaps `class` -> `className`, parses the inline
+      // `style` string into an object, etc.
+      const props = attributesToProps(domNode.attribs) as ComponentProps<
+        typeof Typography
+      >
+      const children = domToReact(domNode.children as DOMNode[], options)
+
+      switch (tag) {
+        case 'p':
+        case 'span':
+        case 'ol':
+        case 'ul':
+          return (
+            <Typography
+              variant={'body1'}
+              {...props}
+              component={tag as ElementType}
+            >
+              {children}
+            </Typography>
+          )
+        case 'h1':
+          return (
+            <Typography
+              variant={'headline1'}
+              {...props}
+              component={tag as ElementType}
+            >
+              {children}
+            </Typography>
+          )
+        case 'h2':
+          return (
+            <Typography
+              variant={'headline2'}
+              {...props}
+              component={tag as ElementType}
+            >
+              {children}
+            </Typography>
+          )
+        case 'h3':
+          return (
+            <Typography
+              variant={'headline3'}
+              {...props}
+              component={tag as ElementType}
+            >
+              {children}
+            </Typography>
+          )
+        case 'a':
+          return (
+            <Link {...props} component={tag as ElementType}>
+              {children}
+            </Link>
+          )
+        default:
+          // Let html-react-parser render the element with default handling.
+          return
+      }
+    },
+  }
+  return options
+}
+
+/**
  * Component that process all the markdown and transforms it to the appropriate Synapse widgets.
  *
  * @returns JSX of the markdown into widgets
@@ -185,20 +292,23 @@ function RenderMarkdown(props: {
     return markup
   }, [markdown, renderInline])
 
-  const processedDocuments = useMemo(() => {
+  // Parse the markup into React elements. This uses html-react-parser, which
+  // is isomorphic (native DOMParser in the browser, htmlparser2 during
+  // SSR/SSG prerender) and produces `domhandler` nodes in both environments,
+  // so there is no dependency on `DOMParser`/`Node`/`HTMLElement` globals.
+  const content = useMemo(() => {
     if (markup.length > 0) {
-      const domParser = new DOMParser()
-      const document = domParser.parseFromString(markup, 'text/html')
-
-      fixInvalidNesting(document.body)
-
-      return document.body
+      const nodes = htmlToDOM(markup)
+      // Fix invalid HTML nesting (e.g. block elements inside <p>) before
+      // converting to React.
+      nodes.forEach(node => fixInvalidNesting(node))
+      return domToReact(nodes, getParserOptions(markup))
     }
     return null
   }, [markup])
 
-  if (processedDocuments) {
-    return <RecursiveRender element={processedDocuments} markdown={markup} />
+  if (content) {
+    return <>{content}</>
   }
 
   if (!isLoading && showPlaceholderIfNoWikiContent && markup === '') {
@@ -210,145 +320,6 @@ function RenderMarkdown(props: {
   }
 
   return
-}
-
-/**
- * recursiveRender will render react tree from HTML tree
- *
- * @param {Node} element This will be either a text Node or an HTMLElement
- * @param {string} markdown The original markdown, its kept as a special case for the table of contents widget
- * @returns {*}
- */
-
-function RecursiveRender(props: { element: Node; markdown: string }) {
-  const { element, markdown } = props
-  /*
-    Recursively render the html tree created from the markdown, there are a few cases:
-    1. element is Node and is text in which case it is simply rendered
-    2. element is an HTMLElement and is: a self closing tag, has no children (e.g. <br>), or its a synapse widget and is
-    rendered accordingly
-    3. element is an HTMLElement and has children so we loop through its childNodes, recurively render those, and then render its own tag
-    as the parent of those child nodes. Note - childNodes was specifically chosen over .children because text Nodes
-    would not come through .children
-  */
-  if (element.nodeType === Node.TEXT_NODE) {
-    // case 1.
-    return <>{element.textContent}</>
-  } else if (
-    element.nodeType === Node.ELEMENT_NODE &&
-    element instanceof HTMLElement
-  ) {
-    const Tag: keyof JSX.IntrinsicElements =
-      element.tagName.toLowerCase() as keyof JSX.IntrinsicElements
-    const widgetParams = element.getAttribute('data-widgetparams')
-
-    if (widgetParams) {
-      // case 2
-      // process widget
-      return (
-        <MapParamsToMarkdownWidget
-          widgetParams={widgetParams}
-          originalMarkup={markdown}
-        />
-      )
-    }
-    // manually add on props, depending on what comes through the markdown their could
-    // be unforseen issues with attributes being misnamed according to what react will respect
-    // e.g. class instead of className
-    const attributes = element.attributes
-    const rawProps: Record<string, string> = {}
-    for (let i = 0; i < attributes.length; i++) {
-      let name = ''
-      let value = ''
-      const attribute = attributes.item(i)
-      if (attribute) {
-        name = attribute.name
-        value = attribute.value
-      }
-      if (name && value) {
-        rawProps[name] = value
-      }
-    }
-
-    const { style: styleString, class: className, ...props } = rawProps
-    // Remap class to className
-    props.className = className
-    if (styleString) {
-      // React expects the `style` prop to be an object, not a string, so use
-      // the all-caps STYLE to pass the style string as a custom attribute
-      props.STYLE = styleString
-    }
-
-    if (element.childNodes.length === 0) {
-      // case 2
-      // e.g. self closing tag like <br/> or <img>
-      return <Tag {...props} />
-    }
-
-    // case 3
-    // recursively render children
-    const children = Array.from(element.childNodes).map((el, index) => {
-      return <RecursiveRender key={index} element={el} markdown={markdown} />
-    })
-    // Render tagName as parent element of the children below
-    switch (Tag) {
-      case 'p':
-        return (
-          <Typography variant={'body1'} {...props} component={Tag}>
-            {children}
-          </Typography>
-        )
-      case 'span':
-        return (
-          <Typography variant={'body1'} {...props} component={Tag}>
-            {children}
-          </Typography>
-        )
-      case 'h1':
-        return (
-          <Typography variant={'headline1'} {...props} component={Tag}>
-            {children}
-          </Typography>
-        )
-      case 'h2':
-        return (
-          <Typography variant={'headline2'} {...props} component={Tag}>
-            {children}
-          </Typography>
-        )
-      case 'h3':
-        return (
-          <Typography variant={'headline3'} {...props} component={Tag}>
-            {children}
-          </Typography>
-        )
-      case 'ol':
-        return (
-          <Typography variant={'body1'} {...props} component={Tag}>
-            {children}
-          </Typography>
-        )
-      case 'ul':
-        return (
-          <Typography variant={'body1'} {...props} component={Tag}>
-            {children}
-          </Typography>
-        )
-      case 'a':
-        return (
-          <Link {...props} component={Tag}>
-            {children}
-          </Link>
-        )
-      default:
-        if (Tag === 'body') {
-          // The component ultimately wraps this content, so if the tag is 'body', just render the children.
-          return children
-        }
-        return <Tag {...props}>{children}</Tag>
-    }
-  }
-  return null
 }
 
 /**

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownSynapse.tsx
@@ -293,9 +293,8 @@ function RenderMarkdown(props: {
   }, [markdown, renderInline])
 
   // Parse the markup into React elements. This uses html-react-parser, which
-  // is isomorphic (native DOMParser in the browser, htmlparser2 during
-  // SSR/SSG prerender) and produces `domhandler` nodes in both environments,
-  // so there is no dependency on `DOMParser`/`Node`/`HTMLElement` globals.
+  // is isomorphic and produces `domhandler` nodes in both environments,
+  // so there is no dependency on `DOMParser`/`Node`/`HTMLElement` browser globals.
   const content = useMemo(() => {
     if (markup.length > 0) {
       const nodes = htmlToDOM(markup)

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownUtils.test.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownUtils.test.tsx
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { isBlockLevelElement, fixInvalidNesting } from './MarkdownUtils'
+import {
+  Element as DomElement,
+  Text as DomText,
+  htmlToDOM,
+  type DOMNode,
+} from 'html-react-parser'
 
 vi.mock('./widget/MarkdownSynapsePlot', () => ({
   default: vi
@@ -7,130 +13,147 @@ vi.mock('./widget/MarkdownSynapsePlot', () => ({
     .mockReturnValue(<figure data-testid={'MarkdownSynapsePlot'}></figure>),
 }))
 
+/**
+ * Build a `domhandler` element node (the node type produced by
+ * `html-react-parser`'s `htmlToDOM` and consumed by `fixInvalidNesting`),
+ * wiring up parent references so the tree mirrors a parsed document.
+ */
+function el(
+  name: string,
+  attribs: Record<string, string> = {},
+  children: DOMNode[] = [],
+): DomElement {
+  const element = new DomElement(name, attribs, children)
+  children.forEach(child => {
+    child.parent = element
+  })
+  return element
+}
+
+function txt(data: string): DomText {
+  return new DomText(data)
+}
+
+/** Collect all element nodes in the tree (depth-first). */
+function allElements(nodes: DOMNode[]): DomElement[] {
+  const result: DomElement[] = []
+  const walk = (ns: DOMNode[]) => {
+    ns.forEach(node => {
+      if (node instanceof DomElement) {
+        result.push(node)
+        walk(node.children as DOMNode[])
+      }
+    })
+  }
+  walk(nodes)
+  return result
+}
+
+const findByTag = (nodes: DOMNode[], tag: string) =>
+  allElements(nodes).filter(e => e.name.toLowerCase() === tag)
+
+const findByAttrib = (nodes: DOMNode[], attr: string) =>
+  allElements(nodes).filter(e => attr in e.attribs)
+
 describe('MarkdownUtils DOM', () => {
   describe('isBlockLevelElement', () => {
     it('should return true for standard block elements', () => {
-      const p = document.createElement('p')
-      const div = document.createElement('div')
-      const h1 = document.createElement('h1')
-
-      expect(isBlockLevelElement(p)).toBe(true)
-      expect(isBlockLevelElement(div)).toBe(true)
-      expect(isBlockLevelElement(h1)).toBe(true)
+      expect(isBlockLevelElement(el('p'))).toBe(true)
+      expect(isBlockLevelElement(el('div'))).toBe(true)
+      expect(isBlockLevelElement(el('h1'))).toBe(true)
     })
 
     it('should return true for block Synapse widgets (data-widgetparams)', () => {
-      const widget = document.createElement('div')
-      widget.setAttribute('data-widgetparams', 'entitypreview?entityId=syn123')
+      const widget = el('div', {
+        'data-widgetparams': 'entitypreview?entityId=syn123',
+      })
 
       expect(isBlockLevelElement(widget)).toBe(true)
     })
 
     it('should return false for inline Synapse widgets (badge)', () => {
-      const widget = document.createElement('span')
-      widget.setAttribute('data-widgetparams', 'badge?alias=test')
+      const widget = el('span', { 'data-widgetparams': 'badge?alias=test' })
 
       expect(isBlockLevelElement(widget)).toBe(false)
     })
 
     it('should return false for inline elements', () => {
-      const span = document.createElement('span')
-      const textNode = document.createTextNode('Hello world')
-
-      expect(isBlockLevelElement(span)).toBe(false)
-      expect(isBlockLevelElement(textNode)).toBe(false)
+      expect(isBlockLevelElement(el('span'))).toBe(false)
+      expect(isBlockLevelElement(txt('Hello world'))).toBe(false)
     })
   })
 
   describe('fixInvalidNesting', () => {
     it('should swap <p> for <div> when it contains a block descendant', () => {
       // p > div
-      const p = document.createElement('p')
-      const inner = document.createElement('div')
-      inner.textContent = 'block'
-      p.appendChild(inner)
-      const container = document.createElement('div')
-      container.appendChild(p)
+      const p = el('p', {}, [el('div', {}, [txt('block')])])
+      const container = el('div', {}, [p])
 
       fixInvalidNesting(container)
 
-      expect(container.querySelector('p')).toBeNull()
-      expect(container.querySelector('div')).not.toBeNull()
+      expect(findByTag([container], 'p')).toHaveLength(0)
+      expect(findByTag([container], 'div').length).toBeGreaterThan(0)
     })
 
     it('should swap <a> for <div> when it contains a block descendant', () => {
       // a > div
-      const a = document.createElement('a')
-      a.setAttribute('href', 'https://synapse.org')
-      const inner = document.createElement('div')
-      inner.textContent = 'block'
-      a.appendChild(inner)
-      const container = document.createElement('div')
-      container.appendChild(a)
+      const a = el('a', { href: 'https://synapse.org' }, [
+        el('div', {}, [txt('block')]),
+      ])
+      const container = el('div', {}, [a])
 
       fixInvalidNesting(container)
 
-      expect(container.querySelector('a')).toBeNull()
-      const result = container.querySelector('[href]')
-      expect(result?.getAttribute('href')).toBe('https://synapse.org')
+      expect(findByTag([container], 'a')).toHaveLength(0)
+      const result = findByAttrib([container], 'href')
+      expect(result[0]?.attribs['href']).toBe('https://synapse.org')
     })
 
     it('should swap <button> for <div> when it contains a nested button', () => {
       // button > button
-      const outerButton = document.createElement('button')
-      const innerButton = document.createElement('button')
-      innerButton.textContent = 'Nested'
-      outerButton.appendChild(innerButton)
-
-      const container = document.createElement('div')
-      container.appendChild(outerButton)
+      const outerButton = el('button', {}, [el('button', {}, [txt('Nested')])])
+      const container = el('div', {}, [outerButton])
 
       fixInvalidNesting(container)
 
-      expect(container.querySelector('div')).not.toBeNull()
+      expect(findByTag([container], 'div').length).toBeGreaterThan(0)
 
-      const buttons = container.querySelectorAll('button')
+      const buttons = findByTag([container], 'button')
       expect(buttons).toHaveLength(1)
-      expect(buttons[0].textContent).toBe('Nested')
+      expect((buttons[0].children[0] as DomText).data).toBe('Nested')
     })
 
     it('should recursively fix nested violations', () => {
       // p > span > div
-      const p = document.createElement('p')
-      p.className = 'outer'
-      const span = document.createElement('span')
-      const inner = document.createElement('div')
-      inner.textContent = 'block'
-      span.appendChild(inner)
-      p.appendChild(span)
-      const container = document.createElement('div')
-      container.appendChild(p)
+      const p = el('p', { class: 'outer' }, [
+        el('span', {}, [el('div', {}, [txt('block')])]),
+      ])
+      const container = el('div', {}, [p])
 
       fixInvalidNesting(container)
 
       // The outer <p> should now be a <div>
-      const outer = container.querySelector('.outer')
-      expect(outer?.tagName.toLowerCase()).toBe('div')
+      const outer = findByAttrib([container], 'class').find(
+        e => e.attribs['class'] === 'outer',
+      )
+      expect(outer?.name.toLowerCase()).toBe('div')
     })
 
     it('should preserve all attributes during swap', () => {
       // p > div
-      const p = document.createElement('p')
-      p.id = 'main'
-      p.className = 'foo'
-      p.setAttribute('data-test', 'bar')
-      const inner = document.createElement('div')
-      inner.textContent = 'block'
-      p.appendChild(inner)
-      const container = document.createElement('div')
-      container.appendChild(p)
+      const p = el('p', { id: 'main', class: 'foo', 'data-test': 'bar' }, [
+        el('div', {}, [txt('block')]),
+      ])
+      const container = el('div', {}, [p])
 
       fixInvalidNesting(container)
 
-      const result = container.querySelector('#main')
-      expect(result?.tagName.toLowerCase()).toBe('div')
-      expect(result?.className).toBe('foo')
-      expect(result?.getAttribute('data-test')).toBe('bar')
+      const result = findByAttrib([container], 'id').find(
+        e => e.attribs['id'] === 'main',
+      )
+      expect(result?.name.toLowerCase()).toBe('div')
+      expect(result?.attribs['class']).toBe('foo')
+      expect(result?.attribs['data-test']).toBe('bar')
     })
 
     it('should preserve intentional whitespace but strip invalid table whitespace', () => {
@@ -139,55 +162,53 @@ describe('MarkdownUtils DOM', () => {
     <p>Word<span> </span>Word</p>
     <table>  <tr><td>Test</td></tr>  </table>
   `
-      const doc = new DOMParser().parseFromString(html, 'text/html')
-
-      fixInvalidNesting(doc.body)
+      const nodes = htmlToDOM(html)
+      nodes.forEach(node => fixInvalidNesting(node))
 
       // intentional whitespace is preserved
-      const p = doc.body.querySelector('p')
-      expect(p?.textContent).toBe('Word Word')
-      expect(doc.body.querySelector('span')?.textContent).toBe(' ')
+      const span = findByTag(nodes, 'span')[0]
+      expect((span.children[0] as DomText).data).toBe(' ')
 
       // whitespace in table is stripped
-      const tr = doc.body.querySelector('tr')!
+      const tr = findByTag(nodes, 'tr')[0]
       // tr should only have one child (the <td>), no whitespace text nodes
-      expect(tr.childNodes).toHaveLength(1)
-      expect(tr.firstChild?.nodeName.toLowerCase()).toBe('td')
+      expect(tr.children).toHaveLength(1)
+      expect((tr.children[0] as DomElement).name.toLowerCase()).toBe('td')
     })
 
     it('should swap <p> for <div> when it contains a block widget', () => {
       // p > span[data-widgetparams]
-      const doc = new DOMParser().parseFromString(
-        '<p><span data-widgetparams="plot?synapseId=syn123"></span></p>',
-        'text/html',
-      )
+      const p = el('p', {}, [
+        el('span', { 'data-widgetparams': 'plot?synapseId=syn123' }),
+      ])
+      const container = el('div', {}, [p])
 
-      fixInvalidNesting(doc.body)
+      fixInvalidNesting(container)
 
-      expect(doc.body.querySelector('p')).toBeNull()
-      expect(doc.body.querySelector('[data-widgetparams]')).not.toBeNull()
+      expect(findByTag([container], 'p')).toHaveLength(0)
+      expect(findByAttrib([container], 'data-widgetparams').length).toBe(1)
     })
 
     it('should not swap <p> for a badge widget (inline widget)', () => {
-      const doc = new DOMParser().parseFromString(
-        '<p><span data-widgetparams="badge?alias=jsmith"></span></p>',
-        'text/html',
-      )
+      const p = el('p', {}, [
+        el('span', { 'data-widgetparams': 'badge?alias=jsmith' }),
+      ])
+      const container = el('div', {}, [p])
 
-      fixInvalidNesting(doc.body)
+      fixInvalidNesting(container)
 
-      expect(doc.body.querySelector('p')).not.toBeNull()
+      expect(findByTag([container], 'p').length).toBe(1)
     })
 
     it('should not modify valid inline nesting', () => {
       // p > span
-      const html = '<p>Just some <span>text</span></p>'
-      const doc = new DOMParser().parseFromString(html, 'text/html')
+      const p = el('p', {}, [txt('Just some '), el('span', {}, [txt('text')])])
+      const container = el('div', {}, [p])
 
-      fixInvalidNesting(doc.body)
+      fixInvalidNesting(container)
 
-      expect(doc.body.querySelector('p')).not.toBeNull()
-      expect(doc.body.querySelector('span')).not.toBeNull()
+      expect(findByTag([container], 'p').length).toBe(1)
+      expect(findByTag([container], 'span').length).toBe(1)
     })
   })
 })

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownUtils.ts
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownUtils.ts
@@ -3,6 +3,12 @@ import { RefObject } from 'react'
 import { MarkdownSynapseProps } from './MarkdownSynapse'
 import MarkdownIt from 'markdown-it'
 import { truncateString } from '@/utils/functions/StringUtils'
+import {
+  htmlToDOM,
+  Element as DomElement,
+  Text as DomText,
+  type DOMNode,
+} from 'html-react-parser'
 
 /**
  * Find all math identified elements of the form [id^=\"mathjax-\"]
@@ -126,10 +132,29 @@ export function handleLinkClicks(event: MouseEvent) {
   }
 }
 
+/**
+ * Extracts the plain text content from an HTML string. Implemented with an
+ * isomorphic HTML parser (rather than `document.createElement`) so it can run
+ * during server-side rendering / SSG prerender as well as in the browser.
+ */
 export function stripHTML(myHtmlString: string): string {
-  const el = document.createElement('div')
-  el.innerHTML = myHtmlString
-  return el.textContent || el.innerText || ''
+  if (!myHtmlString) {
+    return ''
+  }
+  const collectText = (nodes: DOMNode[]): string =>
+    nodes
+      .map(node => {
+        if (node instanceof DomText) {
+          return node.data
+        }
+        if (node instanceof DomElement) {
+          return collectText(node.children as DOMNode[])
+        }
+        return ''
+      })
+      .join('')
+
+  return collectText(htmlToDOM(myHtmlString))
 }
 
 export function transformStringIntoMarkdownProps(
@@ -215,27 +240,25 @@ const tableTags = ['table', 'thead', 'tbody', 'tr', 'tfoot']
 // Widget types that render inline elements and should not be treated as block-level
 const inlineWidgetTypes = ['badge', 'image', 'imageLink', 'buttonlink']
 
-const isInlineContainer = (node: Node): boolean => {
-  if (node.nodeType !== Node.ELEMENT_NODE) {
+const isInlineContainer = (node: DOMNode): boolean => {
+  if (!(node instanceof DomElement)) {
     return false
   }
 
-  const element = node as HTMLElement
-  const tag = element.tagName.toLowerCase()
+  const tag = node.name.toLowerCase()
   return inlineTags.includes(tag)
 }
 
 // Check if a node is a block level element
-export const isBlockLevelElement = (node: Node): boolean => {
-  if (node.nodeType !== Node.ELEMENT_NODE) {
+export const isBlockLevelElement = (node: DOMNode): boolean => {
+  if (!(node instanceof DomElement)) {
     return false
   }
 
-  const element = node as HTMLElement
-  const tag = element.tagName.toLowerCase()
+  const tag = node.name.toLowerCase()
   const isStandardBlock = blockLevelTags.includes(tag)
 
-  const widgetParams = element.getAttribute('data-widgetparams')
+  const widgetParams = node.attribs['data-widgetparams'] ?? null
   const isWidget =
     widgetParams !== null &&
     !inlineWidgetTypes.includes(widgetParams.split('?')[0])
@@ -243,7 +266,7 @@ export const isBlockLevelElement = (node: Node): boolean => {
   return isStandardBlock || isWidget
 }
 
-function isValidNesting(child: HTMLElement, ancestor: HTMLElement): boolean {
+function isValidNesting(child: DomElement, ancestor: DomElement): boolean {
   // case 1: block level elements cannot be inside of inline containers
   if (isBlockLevelElement(child) && isInlineContainer(ancestor)) {
     return false
@@ -251,14 +274,14 @@ function isValidNesting(child: HTMLElement, ancestor: HTMLElement): boolean {
 
   // case 2: buttons cannot be nested inside of other buttons
   if (
-    ancestor.tagName.toLowerCase() === 'button' &&
-    child.tagName.toLowerCase() === 'button'
+    ancestor.name.toLowerCase() === 'button' &&
+    child.name.toLowerCase() === 'button'
   ) {
     return false
   }
 
   // A <p> tag cannot contain block-level elements (including other <p> tags)
-  if (ancestor.tagName.toLowerCase() === 'p' && isBlockLevelElement(child)) {
+  if (ancestor.name.toLowerCase() === 'p' && isBlockLevelElement(child)) {
     return false
   }
 
@@ -268,30 +291,40 @@ function isValidNesting(child: HTMLElement, ancestor: HTMLElement): boolean {
 /**
  * Fixes invalid HTML nesting (e.g., <div> inside <p>) in a single O(n) pass.
  * It compares the current 'node' against a stack of its 'ancestors'.
- * @param node - The current DOM node being inspected.
- * @param ancestors - An array of the current node's parent elements
+ *
+ * Operates on the `domhandler` node tree produced by `html-react-parser`'s
+ * `htmlToDOM`, so it runs identically in the browser and during SSR/SSG
+ * prerender (no dependency on a live DOM, `DOMParser`, or `HTMLElement`).
+ * @param node - The current node being inspected.
+ * @param ancestors - An array of the current node's ancestor elements
  */
 export function fixInvalidNesting(
-  node: Node,
-  ancestors: HTMLElement[] = [],
+  node: DOMNode,
+  ancestors: DomElement[] = [],
 ): void {
   // Whitespace-only text nodes are invalid children of table structure elements and must be removed.
-  if (node.nodeType === Node.TEXT_NODE) {
-    const parentTag = (node.parentNode as HTMLElement)?.tagName?.toLowerCase()
+  if (node instanceof DomText) {
+    const parent = node.parent
+    const parentTag =
+      parent instanceof DomElement ? parent.name.toLowerCase() : undefined
 
-    if (tableTags.includes(parentTag) && !node.textContent?.trim()) {
-      node.parentNode?.removeChild(node)
+    if (parentTag && tableTags.includes(parentTag) && !node.data?.trim()) {
+      const siblings = (parent as DomElement).children
+      const index = siblings.indexOf(node)
+      if (index !== -1) {
+        siblings.splice(index, 1)
+      }
     }
 
     return
   }
 
   // We only care about element nodes
-  if (node.nodeType !== Node.ELEMENT_NODE) {
+  if (!(node instanceof DomElement)) {
     return
   }
 
-  const element = node as HTMLElement
+  const element = node
 
   // We check the current element against every ancestor in the stack to see if there is any invalid nesting.
   // We iterate backwards (from immediate parent to root) so we fix the closest invalid container first.
@@ -300,33 +333,19 @@ export function fixInvalidNesting(
 
     // if the nesting is invalid
     if (!isValidNesting(element, ancestor)) {
-      // change the ancestor to a div
-      const div = element.ownerDocument.createElement('div')
-
-      // Preserve all original attributes
-      Array.from(ancestor.attributes).forEach(attr =>
-        div.setAttribute(attr.name, attr.value),
-      )
-
-      // Move all children from the old element to the new <div>
-      while (ancestor.firstChild) {
-        div.appendChild(ancestor.firstChild)
-      }
-
-      // replace the ancestor with the new div
-      if (ancestor.parentNode) {
-        ancestor.parentNode.replaceChild(div, ancestor)
-      }
-
-      ancestors[i] = div // Update our local stack to reference to the new div
+      // Demote the ancestor to a <div> in place. Renaming preserves the
+      // existing attributes (`attribs`) and children, so no node surgery is
+      // required.
+      ancestor.name = 'div'
     }
   }
 
   // Push the current element to the stack before traversing children
   ancestors.push(element)
 
-  Array.from(element.childNodes).forEach(child => {
-    fixInvalidNesting(child, ancestors)
+  // Iterate over a copy because invalid table whitespace may be removed.
+  Array.from(element.children).forEach(child => {
+    fixInvalidNesting(child as DOMNode, ancestors)
   })
 
   // Pop the current element off the stack after traversing its children

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1936,6 +1936,9 @@ importers:
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
+      html-react-parser:
+        specifier: ^6.1.3
+        version: 6.1.3(@types/react@19.2.14)(react@19.2.5)
       immutable:
         specifier: 4.3.8
         version: 4.3.8
@@ -7359,12 +7362,20 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domain-browser@4.22.0:
     resolution: {integrity: sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==}
     engines: {node: '>=10'}
 
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
@@ -7379,6 +7390,10 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
@@ -7387,6 +7402,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -7511,6 +7530,10 @@ packages:
   entities@6.0.0:
     resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -8214,6 +8237,9 @@ packages:
   hsluv@0.0.3:
     resolution: {integrity: sha512-08iL2VyCRbkQKBySkSh6m8zMUa3sADAxGVWs3Z1aPcUkTJeK0ETG4Fc27tEmQBGUAXZjIsXOZqBvacuVNSC/fQ==}
 
+  html-dom-parser@8.0.0:
+    resolution: {integrity: sha512-cWLJ8mt930VceOzVfY/J+T1ou9v3ENT0BgWqy5aEZjdFp37TYLXULjX8u0vD2rBpFAkK5IofOPl0y4Gq0QLIyA==}
+
   html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
@@ -8233,6 +8259,19 @@ packages:
     resolution: {integrity: sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==}
     engines: {node: '>=12'}
     hasBin: true
+
+  html-react-parser@6.1.3:
+    resolution: {integrity: sha512-CTsKtLJA23cgTbcJYT8vgHAPSqGY7NM+/mv+Tv6I0DqkLCa3FlceK2htH8AwlGa03BopqnVvK/XHqQq7HAw/sg==}
+    peerDependencies:
+      '@types/react': 19.2.14
+      react: 0.14 || 15 || 16 || 17 || 18 || 19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
 
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
@@ -8326,6 +8365,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   inline-style-prefixer@4.0.2:
     resolution: {integrity: sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==}
@@ -9983,6 +10025,9 @@ packages:
       plotly.js: '>1.34.0'
       react: '>0.13.0'
 
+  react-property@2.0.2:
+    resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
+
   react-reflex@4.2.7:
     resolution: {integrity: sha512-MojP7nzowxoJLGp060fIaQ1oF+Aah/kJn29kotKCmk3fsp2YxO8NmPPoS6XagPe8DAL7PzK6woJ/HlBlW+dSwg==}
     peerDependencies:
@@ -10689,6 +10734,12 @@ packages:
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
+
+  style-to-js@2.0.0:
+    resolution: {integrity: sha512-amkl/SwHF/Gb430+eOiN+XToZ6VsD2nota1kCXps4k1xagZOniEVNm8zKYm7RrGm2Q6d6hjnZdqebFIunoSJng==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   stylis@3.5.0:
     resolution: {integrity: sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw==}
@@ -16822,9 +16873,17 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domain-browser@4.22.0: {}
 
   domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
 
   domexception@4.0.0:
     dependencies:
@@ -16837,6 +16896,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   dompurify@3.3.3:
     optionalDependencies:
@@ -16853,6 +16916,12 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dot-case@3.0.4:
     dependencies:
@@ -16974,6 +17043,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.0: {}
+
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 
@@ -17809,6 +17880,11 @@ snapshots:
 
   hsluv@0.0.3: {}
 
+  html-dom-parser@8.0.0:
+    dependencies:
+      domhandler: 6.0.1
+      htmlparser2: 12.0.0
+
   html-encoding-sniffer@3.0.0:
     dependencies:
       whatwg-encoding: 2.0.0
@@ -17834,6 +17910,23 @@ snapshots:
       param-case: 3.0.4
       relateurl: 0.2.7
       terser: 5.42.0
+
+  html-react-parser@6.1.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      domhandler: 6.0.1
+      html-dom-parser: 8.0.0
+      react: 19.2.5
+      react-property: 2.0.2
+      style-to-js: 2.0.0
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  htmlparser2@12.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
 
   http-proxy-agent@5.0.0:
     dependencies:
@@ -17920,6 +18013,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  inline-style-parser@0.2.7: {}
 
   inline-style-prefixer@4.0.2:
     dependencies:
@@ -20011,6 +20106,8 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.5
 
+  react-property@2.0.2: {}
+
   react-reflex@4.2.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -20886,6 +20983,14 @@ snapshots:
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
+
+  style-to-js@2.0.0:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   stylis@3.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1487,7 +1487,7 @@ importers:
         version: 0.16.22
       lodash:
         specifier: ^4.17.21
-        version: 4.17.21
+        version: 4.17.23
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1686,13 +1686,13 @@ importers:
     devDependencies:
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.0)
+        version: 6.0.4(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.2)
       '@rollup/plugin-node-resolve':
         specifier: ^15.3.1
-        version: 15.3.1(rollup@4.60.0)
+        version: 15.3.1(rollup@4.60.2)
       '@rollup/plugin-terser':
         specifier: ^1.0.0
-        version: 1.0.0(rollup@4.60.0)
+        version: 1.0.0(rollup@4.60.2)
       c8:
         specifier: ^8.0.1
         version: 8.0.1
@@ -1707,7 +1707,7 @@ importers:
         version: 10.8.2
       rollup:
         specifier: ^4.60.0
-        version: 4.60.0
+        version: 4.60.2
 
   packages/markdown-it-synapse:
     devDependencies:
@@ -2795,10 +2795,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
@@ -2890,9 +2886,6 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.0':
-    resolution: {integrity: sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==}
-
   '@csstools/css-syntax-patches-for-csstree@1.1.2':
     resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
     peerDependencies:
@@ -2919,26 +2912,8 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/core@1.4.3':
-    resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
-
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
-
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/runtime@1.4.3':
-    resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
-
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
-
-  '@emnapi/wasi-threads@1.0.2':
-    resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
-
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -3410,9 +3385,6 @@ packages:
     resolution: {integrity: sha512-Le5XZUjnVqVjkgLYv6yyWgALat/0HpB1XaCPuCZ+GCFki9NvXloSZITIJ0H+wRW7mb9At1SxvohKBbNQbrr/cw==}
     engines: {node: '>=18.0.0'}
 
-  '@hyperjump/json-pointer@1.1.1':
-    resolution: {integrity: sha512-M0T3s7TC2JepoWPMZQn1W6eYhFh06OXwpMqL+8c5wMVpvnCKNsPgpu9u7WyCI03xVQti8JAeAy4RzUa6SYlJLA==}
-
   '@hyperjump/json-pointer@1.1.2':
     resolution: {integrity: sha512-zPNgu1zdhtjQHFNLGzvEsLDsLOEvhRj6u6ktIQmlz7YPESv5uF8SnAe3Dq0oL6gZ6OGWSLq2n7pphRNF6Hpg6w==}
 
@@ -3423,9 +3395,6 @@ packages:
 
   '@hyperjump/pact@1.4.0':
     resolution: {integrity: sha512-01Q7VY6BcAkp9W31Fv+ciiZycxZHGlR2N6ba9BifgyclHYHdbaZgITo0U6QMhYRlem4k8pf8J31/tApxvqAz8A==}
-
-  '@hyperjump/uri@1.3.2':
-    resolution: {integrity: sha512-OFo5oxuSEz1ktF/LDdBTptlnPyZ66jywLO4fJRuAhnr7NGnsiL2CPoj1JRVaDqVy0nXvWNsC8O8Muw9DR++eEg==}
 
   '@hyperjump/uri@1.3.4':
     resolution: {integrity: sha512-aUVWwu2GtC/cU4DwdTM+b+5jjboM6wft6vNg1+7pUTk/nNRNaBYcYhaEnCir9eRLBbkcGPkiEO7XRUlcDkxj4Q==}
@@ -4086,6 +4055,7 @@ packages:
 
   '@nx/shared-fs-cache@5.0.2':
     resolution: {integrity: sha512-q6665rOfr1+etT31xZOmW6MpBnasiN4bEz441JSbgtfepfbhD2JESUIWMzJuR/SkGrGrlB1alkhekqScQ3kTbQ==}
+    deprecated: This package has been deprecated. See https://nx.dev/docs/reference/deprecated/self-hosted-cache-packages for details
     peerDependencies:
       nx: '>= 18 < 23'
 
@@ -4853,15 +4823,6 @@ packages:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
     engines: {node: '>= 8.0.0'}
 
-  '@rollup/pluginutils@5.1.4':
-    resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
@@ -4871,19 +4832,9 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.60.0':
-    resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.60.0':
-    resolution: {integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.60.2':
@@ -4891,19 +4842,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.0':
-    resolution: {integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.60.2':
     resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.60.0':
-    resolution: {integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.60.2':
@@ -4911,19 +4852,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.0':
-    resolution: {integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.60.2':
     resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.60.0':
-    resolution: {integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.60.2':
@@ -4931,23 +4862,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
-    resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
-    resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
@@ -4955,23 +4874,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.0':
-    resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.60.0':
-    resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
@@ -4979,23 +4886,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.0':
-    resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.60.0':
-    resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
@@ -5003,23 +4898,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
-    resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.0':
-    resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
@@ -5027,23 +4910,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
-    resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.0':
-    resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
@@ -5051,21 +4922,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.0':
-    resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.60.0':
-    resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -5075,51 +4934,25 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.0':
-    resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.0':
-    resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
-    cpu: [x64]
-    os: [openbsd]
-
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
     cpu: [x64]
     os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.60.0':
-    resolution: {integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==}
-    cpu: [arm64]
-    os: [openharmony]
 
   '@rollup/rollup-openharmony-arm64@4.60.2':
     resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.0':
-    resolution: {integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.60.2':
     resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.60.0':
-    resolution: {integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.60.2':
@@ -5127,18 +4960,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.0':
-    resolution: {integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-gnu@4.60.2':
     resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.60.0':
-    resolution: {integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==}
     cpu: [x64]
     os: [win32]
 
@@ -5193,10 +5016,6 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
-
-  '@smithy/abort-controller@4.0.2':
-    resolution: {integrity: sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==}
-    engines: {node: '>=18.0.0'}
 
   '@smithy/abort-controller@4.2.12':
     resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
@@ -5278,10 +5097,6 @@ packages:
     resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.1.2':
-    resolution: {integrity: sha512-EqOy3xaEGQpsKxLlzYstDRJ8eY90CbyBP4cl+w7r45mE60S8YliyL9AgWsdWcyNiB95E2PMqHBEv67nNl1zLfg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/middleware-endpoint@4.4.27':
     resolution: {integrity: sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==}
     engines: {node: '>=18.0.0'}
@@ -5326,10 +5141,6 @@ packages:
     resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/shared-ini-file-loader@4.0.2':
-    resolution: {integrity: sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/shared-ini-file-loader@4.4.7':
     resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
     engines: {node: '>=18.0.0'}
@@ -5340,10 +5151,6 @@ packages:
 
   '@smithy/smithy-client@4.12.7':
     resolution: {integrity: sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/smithy-client@4.2.2':
-    resolution: {integrity: sha512-3AnHfsMdq9Wg7+3BeR1HuLWI9+DMA/SoHVpCWq6xSsa52ikNd6nlF/wFzdpHyGtVa+Aji6lMgvwOF4sGcVA7SA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.13.1':
@@ -5684,9 +5491,6 @@ packages:
 
   '@turf/meta@6.5.0':
     resolution: {integrity: sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==}
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -6243,9 +6047,6 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
-
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
@@ -6325,9 +6126,6 @@ packages:
 
   array-range@1.0.1:
     resolution: {integrity: sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA==}
-
-  array-rearrange@2.2.2:
-    resolution: {integrity: sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w==}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
@@ -7166,9 +6964,6 @@ packages:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
 
-  decimal.js@10.5.0:
-    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
-
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
@@ -7772,9 +7567,6 @@ packages:
   fast-shallow-equal@1.0.0:
     resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
 
-  fast-uri@3.0.6:
-    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
-
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -8003,10 +7795,6 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@13.0.0:
-    resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
-    engines: {node: 20 || >=22}
-
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -8069,11 +7857,6 @@ packages:
   glslify@7.1.1:
     resolution: {integrity: sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==}
     hasBin: true
-
-  goober@2.1.18:
-    resolution: {integrity: sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==}
-    peerDependencies:
-      csstype: ^3.0.10
 
   goober@2.1.19:
     resolution: {integrity: sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==}
@@ -8138,10 +7921,6 @@ packages:
 
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
-
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
@@ -8326,10 +8105,6 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
-  is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
-    engines: {node: '>= 0.4'}
-
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
@@ -8374,10 +8149,6 @@ packages:
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
-
-  is-iexplorer@1.0.0:
-    resolution: {integrity: sha512-YeLzceuwg3K6O0MLM3UyUUjKAlyULetwryFp1mHy1I5PfArK0AEqlfa+MR4gkJjcbuJXoDJCvXbyqZVf5CR2Sg==}
     engines: {node: '>=0.10.0'}
 
   is-in-browser@1.1.3:
@@ -8571,10 +8342,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -8891,9 +8658,6 @@ packages:
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
@@ -9110,10 +8874,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -9220,11 +8980,6 @@ packages:
     resolution: {integrity: sha512-lOSUW1IqKDKfeOdwHdwTCCo49BngV83KXRPMI9GDk7Fha6fjhzv2ozNPbrm+h+uh9CCIhM9fkvDtspGfb46bpw==}
     peerDependencies:
       react: '*'
-
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -9568,10 +9323,6 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
-
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -9699,10 +9450,6 @@ packages:
       browserslist: '>= 4'
       postcss: '>= 8'
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -9734,9 +9481,6 @@ packages:
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
-
-  probe-image-size@7.2.3:
-    resolution: {integrity: sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==}
 
   probe-image-size@7.3.0:
     resolution: {integrity: sha512-7CaDeBwiAbh6ohXsvLbAZhO7wzsZAmaevfxe39qvCwRh8LyaZfDlBGGLU1CCTgrTLtCOdwBBhjOrIHaIIimHfQ==}
@@ -10161,9 +9905,6 @@ packages:
   regl-line2d@3.1.3:
     resolution: {integrity: sha512-fkgzW+tTn4QUQLpFKsUIE0sgWdCmXAM3ctXcCgoGBZTSX5FE2A0M7aynz7nrZT5baaftLrk9te54B+MEq4QcSA==}
 
-  regl-scatter2d@3.3.1:
-    resolution: {integrity: sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==}
-
   regl-scatter2d@3.4.0:
     resolution: {integrity: sha512-DavKQlHsI+iHZuLgOL+yGkg+sPd94CS+7FCBWkcQ6s/TbaNfUsF9eN591fjjSWIoKrGNfb/SEGhsXR5lXjqZ2w==}
 
@@ -10218,11 +9959,6 @@ packages:
   resolve@0.6.3:
     resolution: {integrity: sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg==}
 
-  resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
-
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
@@ -10272,11 +10008,6 @@ packages:
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rollup@4.60.0:
-    resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   rollup@4.60.2:
@@ -10750,12 +10481,6 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
-  thingies@2.5.0:
-    resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
-    engines: {node: '>=10.18'}
-    peerDependencies:
-      tslib: ^2
-
   thingies@2.6.0:
     resolution: {integrity: sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==}
     engines: {node: '>=10.18'}
@@ -10795,10 +10520,6 @@ packages:
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -11020,10 +10741,6 @@ packages:
     resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
     engines: {node: '>=18.17'}
 
-  undici@7.24.1:
-    resolution: {integrity: sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.24.6:
     resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
     engines: {node: '>=20.18.1'}
@@ -11150,9 +10867,6 @@ packages:
 
   validate.io-number@1.0.3:
     resolution: {integrity: sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg==}
-
-  very-small-parser@1.14.0:
-    resolution: {integrity: sha512-+0/uA9aGygbu83G/NRVCTNX3WpCTIXC1oXTriXCI26zniP/AhtMso+25YZJAaB6HcaXjmJxLemvRK1IK4gTKKA==}
 
   very-small-parser@1.15.0:
     resolution: {integrity: sha512-KGmFbbVlMLKVLt0cnyNrTwt2WCNzSntTXK1y9yxvxxJm9hA64EJEtmke3xw1PAH70OeHJN7Os7DDz5Fxl75ehQ==}
@@ -11604,7 +11318,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.1.1':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -11914,9 +11628,9 @@ snapshots:
   '@aws-sdk/lib-storage@3.803.0(@aws-sdk/client-s3@3.1019.0)':
     dependencies:
       '@aws-sdk/client-s3': 3.1019.0
-      '@smithy/abort-controller': 4.0.2
-      '@smithy/middleware-endpoint': 4.1.2
-      '@smithy/smithy-client': 4.2.2
+      '@smithy/abort-controller': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.27
+      '@smithy/smithy-client': 4.12.7
       buffer: 5.6.0
       events: 3.3.0
       stream-browserify: 3.0.0
@@ -12297,8 +12011,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/runtime@7.28.6': {}
-
   '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
@@ -12387,8 +12099,6 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.0': {}
-
   '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
@@ -12405,48 +12115,19 @@ snapshots:
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
-    optional: true
-
-  '@emnapi/core@1.4.3':
-    dependencies:
-      '@emnapi/wasi-threads': 1.0.2
-      tslib: 2.8.1
-
-  '@emnapi/core@1.9.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.0
-      tslib: 2.8.1
 
   '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.4.3':
-    dependencies:
-      tslib: 2.8.1
-
-  '@emnapi/runtime@1.9.1':
-    dependencies:
-      tslib: 2.8.1
-
-  '@emnapi/wasi-threads@1.0.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@emnapi/wasi-threads@1.2.0':
     dependencies:
       tslib: 2.8.1
 
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.28.6
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -12481,7 +12162,7 @@ snapshots:
 
   '@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
@@ -12507,7 +12188,7 @@ snapshots:
 
   '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.3.1
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
@@ -12786,24 +12467,20 @@ snapshots:
       content-type: 1.0.5
       just-curry-it: 5.3.0
 
-  '@hyperjump/json-pointer@1.1.1': {}
-
   '@hyperjump/json-pointer@1.1.2': {}
 
   '@hyperjump/json-schema@1.16.1(@hyperjump/browser@1.3.1)':
     dependencies:
       '@hyperjump/browser': 1.3.1
-      '@hyperjump/json-pointer': 1.1.1
+      '@hyperjump/json-pointer': 1.1.2
       '@hyperjump/pact': 1.4.0
-      '@hyperjump/uri': 1.3.2
+      '@hyperjump/uri': 1.3.4
       content-type: 1.0.5
       json-stringify-deterministic: 1.0.12
       just-curry-it: 5.3.0
       uuid: 9.0.1
 
   '@hyperjump/pact@1.4.0': {}
-
-  '@hyperjump/uri@1.3.2': {}
 
   '@hyperjump/uri@1.3.4': {}
 
@@ -12980,7 +12657,7 @@ snapshots:
       '@jsonjoy.com/json-pointer': 17.65.0(tslib@2.8.1)
       '@jsonjoy.com/util': 17.65.0(tslib@2.8.1)
       hyperdyperid: 1.2.0
-      thingies: 2.5.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
@@ -13009,7 +12686,7 @@ snapshots:
       '@jsonjoy.com/util': 17.65.0(tslib@2.8.1)
       rxjs: 7.8.2
       sonic-forest: 1.2.1(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
@@ -13145,7 +12822,7 @@ snapshots:
       diff: 8.0.4
       lodash: 4.17.23
       minimatch: 10.2.3
-      resolve: 1.22.11
+      resolve: 1.22.12
       semver: 7.5.4
       source-map: 0.6.1
       typescript: 5.8.2
@@ -13176,7 +12853,7 @@ snapshots:
 
   '@mui/icons-material@7.1.1(@mui/material@7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@mui/material': 7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
@@ -13205,7 +12882,7 @@ snapshots:
 
   '@mui/private-theming@7.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@mui/utils': 7.1.1(@types/react@19.2.14)(react@19.2.5)
       prop-types: 15.8.1
       react: 19.2.5
@@ -13214,7 +12891,7 @@ snapshots:
 
   '@mui/styled-engine@7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
@@ -13227,7 +12904,7 @@ snapshots:
 
   '@mui/system@7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@mui/private-theming': 7.1.1(@types/react@19.2.14)(react@19.2.5)
       '@mui/styled-engine': 7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       '@mui/types': 7.4.3(@types/react@19.2.14)
@@ -13249,7 +12926,7 @@ snapshots:
 
   '@mui/utils@7.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@mui/types': 7.4.3(@types/react@19.2.14)
       '@types/prop-types': 15.7.14
       clsx: 2.1.1
@@ -13261,7 +12938,7 @@ snapshots:
 
   '@mui/x-data-grid@8.5.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mui/system@7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@mui/material': 7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mui/system': 7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
       '@mui/utils': 7.1.1(@types/react@19.2.14)(react@19.2.5)
@@ -13280,7 +12957,7 @@ snapshots:
 
   '@mui/x-date-pickers@8.4.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mui/system@7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(date-fns@2.30.0)(dayjs@1.11.13)(moment@2.30.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@mui/material': 7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mui/system': 7.1.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
       '@mui/utils': 7.1.1(@types/react@19.2.14)(react@19.2.5)
@@ -13319,14 +12996,14 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
-      '@tybys/wasm-util': 0.10.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
-      '@emnapi/core': 1.4.3
-      '@emnapi/runtime': 1.4.3
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.9.0
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -13875,7 +13552,7 @@ snapshots:
       react-refresh: 0.14.2
       react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       semver: 7.7.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       valibot: 1.2.0(typescript@6.0.3)
       vite: 8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
       vite-node: 3.2.2(@types/node@22.19.13)(lightningcss@1.32.0)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
@@ -13986,7 +13663,7 @@ snapshots:
   '@rjsf/core@6.0.0-beta.10(@rjsf/utils@6.0.0-beta.10(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@rjsf/utils': 6.0.0-beta.10(react@19.2.5)
-      lodash: 4.17.21
+      lodash: 4.17.23
       lodash-es: 4.17.21
       markdown-to-jsx: 7.7.6(react@19.2.5)
       nanoid: 5.1.5
@@ -14005,10 +13682,10 @@ snapshots:
 
   '@rjsf/utils@6.0.0-beta.10(react@19.2.5)':
     dependencies:
-      fast-uri: 3.0.6
+      fast-uri: 3.1.0
       json-schema-merge-allof: 0.8.1
       jsonpointer: 5.0.1
-      lodash: 4.17.21
+      lodash: 4.17.23
       lodash-es: 4.17.21
       nanoid: 5.1.5
       react: 19.2.5
@@ -14017,9 +13694,9 @@ snapshots:
   '@rjsf/validator-ajv8@6.0.0-beta.10(@rjsf/utils@6.0.0-beta.10(react@19.2.5))':
     dependencies:
       '@rjsf/utils': 6.0.0-beta.10(react@19.2.5)
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      lodash: 4.17.21
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      lodash: 4.17.23
       lodash-es: 4.17.21
 
   '@rolldown/binding-android-arm64@1.0.3':
@@ -14084,14 +13761,14 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-babel@6.0.4(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.0)':
+  '@rollup/plugin-babel@6.0.4(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.2)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@rollup/pluginutils': 5.1.4(rollup@4.60.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
     optionalDependencies:
       '@types/babel__core': 7.20.5
-      rollup: 4.60.0
+      rollup: 4.60.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14103,198 +13780,107 @@ snapshots:
     optionalDependencies:
       rollup: 4.60.2
 
-  '@rollup/plugin-node-resolve@15.3.1(rollup@4.60.0)':
+  '@rollup/plugin-node-resolve@15.3.1(rollup@4.60.2)':
     dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.60.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
-      resolve: 1.22.11
+      resolve: 1.22.12
     optionalDependencies:
-      rollup: 4.60.0
+      rollup: 4.60.2
 
-  '@rollup/plugin-terser@1.0.0(rollup@4.60.0)':
+  '@rollup/plugin-terser@1.0.0(rollup@4.60.2)':
     dependencies:
       serialize-javascript: 7.0.5
       smob: 1.5.0
       terser: 5.42.0
     optionalDependencies:
-      rollup: 4.60.0
+      rollup: 4.60.2
 
   '@rollup/pluginutils@4.2.1':
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.2
 
-  '@rollup/pluginutils@5.1.4(rollup@4.60.0)':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.4
-    optionalDependencies:
-      rollup: 4.60.0
-
-  '@rollup/pluginutils@5.1.4(rollup@4.60.2)':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.4
-    optionalDependencies:
-      rollup: 4.60.2
-
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.60.2
 
-  '@rollup/rollup-android-arm-eabi@4.60.0':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.60.2':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.60.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.0':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.60.2':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.60.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.60.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.0':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.60.2':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.60.0':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.60.2':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.60.0':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.0':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.60.2':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.0':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-win32-x64-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.60.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
@@ -14361,11 +13947,6 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
-
-  '@smithy/abort-controller@4.0.2':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
 
   '@smithy/abort-controller@4.2.12':
     dependencies:
@@ -14494,17 +14075,6 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.1.2':
-    dependencies:
-      '@smithy/core': 3.23.12
-      '@smithy/middleware-serde': 4.2.15
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/shared-ini-file-loader': 4.0.2
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-middleware': 4.2.12
-      tslib: 2.8.1
-
   '@smithy/middleware-endpoint@4.4.27':
     dependencies:
       '@smithy/core': 3.23.12
@@ -14580,11 +14150,6 @@ snapshots:
     dependencies:
       '@smithy/types': 4.13.1
 
-  '@smithy/shared-ini-file-loader@4.0.2':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/shared-ini-file-loader@4.4.7':
     dependencies:
       '@smithy/types': 4.13.1
@@ -14605,16 +14170,6 @@ snapshots:
     dependencies:
       '@smithy/core': 3.23.12
       '@smithy/middleware-endpoint': 4.4.27
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.20
-      tslib: 2.8.1
-
-  '@smithy/smithy-client@4.2.2':
-    dependencies:
-      '@smithy/core': 3.23.12
-      '@smithy/middleware-endpoint': 4.1.2
       '@smithy/middleware-stack': 4.2.12
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
@@ -14798,7 +14353,7 @@ snapshots:
   '@storybook/react-vite@10.3.4(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1))
-      '@rollup/pluginutils': 5.1.4(rollup@4.60.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
       '@storybook/builder-vite': 10.3.4(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1))
       '@storybook/react': 10.3.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       empathic: 2.0.0
@@ -14806,7 +14361,7 @@ snapshots:
       react: 19.2.5
       react-docgen: 8.0.2
       react-dom: 19.2.5(react@19.2.5)
-      resolve: 1.22.11
+      resolve: 1.22.12
       storybook: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tsconfig-paths: 4.2.0
       vite: 8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
@@ -14935,7 +14490,7 @@ snapshots:
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       chalk: 4.1.2
@@ -14954,7 +14509,7 @@ snapshots:
 
   '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -15000,14 +14555,9 @@ snapshots:
     dependencies:
       '@turf/helpers': 6.5.0
 
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@tybys/wasm-util@0.9.0':
     dependencies:
@@ -15390,7 +14940,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.4
       semver: 7.7.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -15514,7 +15064,7 @@ snapshots:
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@types/node@22.19.13)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0)(msw@2.10.2(@types/node@22.19.13)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1))
 
@@ -15579,7 +15129,7 @@ snapshots:
 
   '@welldone-software/why-did-you-render@10.0.1(react@19.2.5)':
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
       react: 19.2.5
 
   '@x0k/json-schema-merge@1.0.2':
@@ -15592,7 +15142,7 @@ snapshots:
 
   '@yarnpkg/parsers@3.0.2':
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       tslib: 2.8.1
 
   '@zkochan/js-yaml@0.0.7':
@@ -15632,9 +15182,9 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv-formats@2.1.1(ajv@8.17.1):
+  ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -15646,13 +15196,6 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.17.1:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.0.6
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   ajv@8.18.0:
     dependencies:
@@ -15719,8 +15262,6 @@ snapshots:
       array-bounds: 1.0.1
 
   array-range@1.0.1: {}
-
-  array-rearrange@2.2.2: {}
 
   asap@2.0.6: {}
 
@@ -15805,7 +15346,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
       cosmiconfig: 7.1.0
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
@@ -16332,7 +15873,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -16487,7 +16028,7 @@ snapshots:
   cssstyle@6.2.0:
     dependencies:
       '@asamuzakjp/css-color': 5.0.1
-      '@csstools/css-syntax-patches-for-csstree': 1.1.0
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
       css-tree: 3.2.1
       lru-cache: 11.2.7
 
@@ -16532,7 +16073,7 @@ snapshots:
       commander: 2.20.3
       d3-array: 1.2.4
       d3-geo: 1.12.1
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   d3-geo@1.12.1:
     dependencies:
@@ -16589,7 +16130,7 @@ snapshots:
   dagre@0.8.5:
     dependencies:
       graphlib: 2.1.8
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   data-uri-to-buffer@6.0.2: {}
 
@@ -16637,8 +16178,6 @@ snapshots:
   decamelize@1.2.0: {}
 
   decamelize@4.0.0: {}
-
-  decimal.js@10.5.0: {}
 
   decimal.js@10.6.0: {}
 
@@ -16946,7 +16485,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   es5-ext@0.10.64:
     dependencies:
@@ -17198,7 +16737,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -17278,8 +16817,6 @@ snapshots:
   fast-shallow-equal@0.1.1: {}
 
   fast-shallow-equal@1.0.0: {}
-
-  fast-uri@3.0.6: {}
 
   fast-uri@3.1.0: {}
 
@@ -17408,7 +16945,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       mime-types: 2.1.35
 
   from2@2.3.0:
@@ -17418,7 +16955,7 @@ snapshots:
 
   front-matter@4.0.2:
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
 
   fs-constants@1.0.0: {}
 
@@ -17466,7 +17003,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-node-dimensions@1.2.1: {}
@@ -17545,15 +17082,9 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.9
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
-
-  glob@13.0.0:
-    dependencies:
-      minimatch: 10.2.4
-      minipass: 7.1.2
-      path-scurry: 2.0.0
 
   glob@13.0.6:
     dependencies:
@@ -17642,7 +17173,7 @@ snapshots:
       graceful-fs: 4.2.11
       inherits: 2.0.4
       map-limit: 0.0.1
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   glslify@7.1.1:
     dependencies:
@@ -17656,15 +17187,11 @@ snapshots:
       glslify-bundle: 5.1.1
       glslify-deps: 1.3.2
       minimist: 1.2.8
-      resolve: 1.22.11
+      resolve: 1.22.12
       stack-trace: 0.0.9
       static-eval: 2.1.1
       through2: 2.0.5
       xtend: 4.0.2
-
-  goober@2.1.18(csstype@3.2.3):
-    dependencies:
-      csstype: 3.2.3
 
   goober@2.1.19(csstype@3.2.3):
     dependencies:
@@ -17676,7 +17203,7 @@ snapshots:
 
   graphlib@2.1.8:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   graphql@16.11.0: {}
 
@@ -17728,10 +17255,6 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
-
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
 
   hasown@2.0.3:
     dependencies:
@@ -17922,10 +17445,6 @@ snapshots:
 
   is-callable@1.2.7: {}
 
-  is-core-module@2.16.1:
-    dependencies:
-      hasown: 2.0.2
-
   is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.3
@@ -17958,8 +17477,6 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
-
-  is-iexplorer@1.0.0: {}
 
   is-in-browser@1.1.3: {}
 
@@ -17999,7 +17516,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   is-retry-allowed@2.2.0: {}
 
@@ -18151,10 +17668,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
@@ -18169,7 +17682,7 @@ snapshots:
       cssom: 0.5.0
       cssstyle: 2.3.0
       data-urls: 3.0.2
-      decimal.js: 10.5.0
+      decimal.js: 10.6.0
       domexception: 4.0.0
       escodegen: 2.1.0
       form-data: 4.0.5
@@ -18198,7 +17711,7 @@ snapshots:
     dependencies:
       cssstyle: 4.3.1
       data-urls: 5.0.0
-      decimal.js: 10.5.0
+      decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -18238,7 +17751,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.1
+      undici: 7.24.6
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -18296,10 +17809,10 @@ snapshots:
       nano-css: 5.6.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       pojo-dump: 1.4.0(tslib@2.8.1)
       sonic-forest: 1.2.1(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
-      very-small-parser: 1.14.0
+      very-small-parser: 1.15.0
     optionalDependencies:
       rxjs: 7.8.2
     transitivePeerDependencies:
@@ -18318,13 +17831,13 @@ snapshots:
 
   json-schema-compare@0.2.2:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   json-schema-merge-allof@0.8.1:
     dependencies:
       compute-lcm: 1.1.2
       json-schema-compare: 0.2.2
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   json-schema-traverse@0.4.1: {}
 
@@ -18560,8 +18073,6 @@ snapshots:
 
   lodash.throttle@4.1.1: {}
 
-  lodash@4.17.21: {}
-
   lodash@4.17.23: {}
 
   log-symbols@4.1.0:
@@ -18671,7 +18182,7 @@ snapshots:
   markdown-it-testgen@0.1.6:
     dependencies:
       chai: 1.10.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       object-assign: 4.1.1
 
   markdown-it@13.0.2:
@@ -18784,8 +18295,6 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@7.1.2: {}
-
   minipass@7.1.3: {}
 
   mkdirp-classic@0.5.3: {}
@@ -18812,7 +18321,7 @@ snapshots:
       find-up: 5.0.0
       glob: 8.1.0
       he: 1.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       log-symbols: 4.1.0
       minimatch: 5.1.9
       ms: 2.1.3
@@ -18952,12 +18461,10 @@ snapshots:
       nano-css: 5.6.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-use: 17.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      thingies: 2.5.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
     transitivePeerDependencies:
       - react-dom
       - tslib
-
-  nanoid@3.3.11: {}
 
   nanoid@3.3.12: {}
 
@@ -19448,11 +18955,6 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
-  path-scurry@2.0.0:
-    dependencies:
-      lru-cache: 11.2.7
-      minipass: 7.1.3
-
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.7
@@ -19562,11 +19064,11 @@ snapshots:
       parse-svg-path: 0.1.2
       point-in-polygon: 1.1.0
       polybooljs: 1.2.2
-      probe-image-size: 7.2.3
+      probe-image-size: 7.3.0
       regl: '@plotly/regl@2.1.2'
       regl-error2d: 2.0.12
       regl-line2d: 3.1.3
-      regl-scatter2d: 3.3.1
+      regl-scatter2d: 3.4.0
       regl-splom: 1.0.14
       strongly-connected-components: 1.0.1
       superscript-text: 1.0.0
@@ -19666,12 +19168,6 @@ snapshots:
       postcss-browser-comments: 4.0.0(browserslist@4.28.1)(postcss@8.5.15)
       sanitize.css: 13.0.0
 
-  postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
@@ -19703,14 +19199,6 @@ snapshots:
       react-is: 18.3.1
 
   prismjs@1.30.0: {}
-
-  probe-image-size@7.2.3:
-    dependencies:
-      lodash.merge: 4.6.2
-      needle: 2.9.1
-      stream-parser: 0.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   probe-image-size@7.3.0:
     dependencies:
@@ -19870,7 +19358,7 @@ snapshots:
       '@types/doctrine': 0.0.9
       '@types/resolve': 1.20.6
       doctrine: 3.0.0
-      resolve: 1.22.11
+      resolve: 1.22.12
       strip-indent: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -19909,7 +19397,7 @@ snapshots:
 
   react-error-boundary@3.1.4(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       react: 19.2.5
 
   react-focus-lock@1.6.5(encoding@0.1.13)(react@19.2.5):
@@ -19924,7 +19412,7 @@ snapshots:
   react-hot-toast@2.5.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       csstype: 3.2.3
-      goober: 2.1.18(csstype@3.2.3)
+      goober: 2.1.19(csstype@3.2.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
@@ -19995,7 +19483,7 @@ snapshots:
 
   react-reflex@4.2.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       lodash.throttle: 4.1.1
       prop-types: 15.8.1
       react: 19.2.5
@@ -20007,7 +19495,7 @@ snapshots:
 
   react-resize-detector@10.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
@@ -20030,7 +19518,7 @@ snapshots:
 
   react-select@5.10.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
       '@floating-ui/dom': 1.7.0
@@ -20090,7 +19578,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -20152,7 +19640,7 @@ snapshots:
 
   react-vtree@3.0.0-beta.3(react-dom@19.2.5(react@19.2.5))(react-window@1.8.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       react-merge-refs: 1.1.0
@@ -20164,7 +19652,7 @@ snapshots:
 
   react-window@1.8.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       memoize-one: 5.2.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -20264,24 +19752,6 @@ snapshots:
       pick-by-alias: 1.2.0
       to-float32: 1.1.0
 
-  regl-scatter2d@3.3.1:
-    dependencies:
-      '@plotly/point-cluster': 3.1.9
-      array-range: 1.0.1
-      array-rearrange: 2.2.2
-      clamp: 1.0.1
-      color-id: 1.1.0
-      color-normalize: 1.5.0
-      color-rgba: 2.1.1
-      flatten-vertex-data: 1.0.2
-      glslify: 7.1.1
-      is-iexplorer: 1.0.0
-      object-assign: 4.1.1
-      parse-rect: 1.2.0
-      pick-by-alias: 1.2.0
-      to-float32: 1.1.0
-      update-diff: 1.1.0
-
   regl-scatter2d@3.4.0:
     dependencies:
       '@plotly/point-cluster': 3.1.9
@@ -20304,7 +19774,7 @@ snapshots:
       parse-rect: 1.2.0
       pick-by-alias: 1.2.0
       raf: 3.4.1
-      regl-scatter2d: 3.3.1
+      regl-scatter2d: 3.4.0
 
   regl@2.1.1: {}
 
@@ -20335,12 +19805,6 @@ snapshots:
   resolve.exports@2.0.3: {}
 
   resolve@0.6.3: {}
-
-  resolve@1.22.11:
-    dependencies:
-      is-core-module: 2.16.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
 
   resolve@1.22.12:
     dependencies:
@@ -20379,7 +19843,7 @@ snapshots:
 
   rimraf@6.1.2:
     dependencies:
-      glob: 13.0.0
+      glob: 13.0.6
       package-json-from-dist: 1.0.1
 
   ripemd160@2.0.3:
@@ -20407,37 +19871,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.3
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
-
-  rollup@4.60.0:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.0
-      '@rollup/rollup-android-arm64': 4.60.0
-      '@rollup/rollup-darwin-arm64': 4.60.0
-      '@rollup/rollup-darwin-x64': 4.60.0
-      '@rollup/rollup-freebsd-arm64': 4.60.0
-      '@rollup/rollup-freebsd-x64': 4.60.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.0
-      '@rollup/rollup-linux-arm64-gnu': 4.60.0
-      '@rollup/rollup-linux-arm64-musl': 4.60.0
-      '@rollup/rollup-linux-loong64-gnu': 4.60.0
-      '@rollup/rollup-linux-loong64-musl': 4.60.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.0
-      '@rollup/rollup-linux-ppc64-musl': 4.60.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.0
-      '@rollup/rollup-linux-riscv64-musl': 4.60.0
-      '@rollup/rollup-linux-s390x-gnu': 4.60.0
-      '@rollup/rollup-linux-x64-gnu': 4.60.0
-      '@rollup/rollup-linux-x64-musl': 4.60.0
-      '@rollup/rollup-openbsd-x64': 4.60.0
-      '@rollup/rollup-openharmony-arm64': 4.60.0
-      '@rollup/rollup-win32-arm64-msvc': 4.60.0
-      '@rollup/rollup-win32-ia32-msvc': 4.60.0
-      '@rollup/rollup-win32-x64-gnu': 4.60.0
-      '@rollup/rollup-win32-x64-msvc': 4.60.0
-      fsevents: 2.3.3
 
   rollup@4.60.2:
     dependencies:
@@ -20601,7 +20034,7 @@ snapshots:
 
   shortid@2.2.17:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
 
   side-channel-list@1.0.0:
     dependencies:
@@ -20697,7 +20130,7 @@ snapshots:
       escape-html: 1.0.3
       glob: 7.2.3
       gzip-size: 6.0.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       open: 7.4.2
       source-map: 0.7.4
       temp: 0.9.4
@@ -20967,10 +20400,6 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
-  thingies@2.5.0(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
-
   thingies@2.6.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
@@ -21002,11 +20431,6 @@ snapshots:
   tinycolor2@1.6.0: {}
 
   tinyexec@1.1.1: {}
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -21184,8 +20608,6 @@ snapshots:
 
   undici@6.24.0: {}
 
-  undici@7.24.1: {}
-
   undici@7.24.6: {}
 
   universal-cookie@4.0.4:
@@ -21240,7 +20662,7 @@ snapshots:
 
   use-deep-compare-effect@1.8.1(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       dequal: 2.0.3
       react: 19.2.5
 
@@ -21311,8 +20733,6 @@ snapshots:
 
   validate.io-number@1.0.3: {}
 
-  very-small-parser@1.14.0: {}
-
   very-small-parser@1.15.0: {}
 
   vite-node@3.2.2(@types/node@22.19.13)(lightningcss@1.32.0)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1):
@@ -21339,7 +20759,7 @@ snapshots:
   vite-plugin-dts@4.5.3(@types/node@22.19.13)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)):
     dependencies:
       '@microsoft/api-extractor': 7.57.7(@types/node@22.19.13)
-      '@rollup/pluginutils': 5.1.4(rollup@4.60.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
       '@volar/typescript': 2.4.13
       '@vue/language-core': 2.2.0(typescript@6.0.3)
       compare-versions: 6.1.1
@@ -21395,7 +20815,7 @@ snapshots:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       vite: 8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
 
   vite-plugin-svgr@5.2.0(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)):
@@ -21414,9 +20834,9 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.15
       rollup: 4.60.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.13
       fsevents: 2.3.3
@@ -21467,7 +20887,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
       why-is-node-running: 2.3.0
@@ -21497,7 +20917,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
       why-is-node-running: 2.3.0
@@ -21527,7 +20947,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
       why-is-node-running: 2.3.0
@@ -21557,7 +20977,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@22.19.13)(esbuild@0.27.7)(sass@1.98.0)(terser@5.42.0)(tsx@4.19.4)(yaml@2.7.1)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
Make MarkdownSynapse SSR-compatible by removing usage of DOMParser. DOMParser was originally only used to fix invalid HTML, but by introducing html-react-parser we could simplify that logic and also replace our custom parsing logic.

-----

When trying to get the NF portal home page to render under SSG (#2815), I ran into an issue where an error would be thrown by the MarkdownSynapse component because it used a browser API that was not available in node.

To fix it, I brought in a new dependency, html-react-parser. In addition to fixing the immediate problem of relying on browser-only APIs, this library also replaces our recursive HTML-to-React logic with its own.


