### PR TITLE
PORTALS-4276

### DIFF
--- a/apps/synapse-portal-framework/src/components/Explore/ExploreWrapperTabs.module.scss
+++ b/apps/synapse-portal-framework/src/components/Explore/ExploreWrapperTabs.module.scss
@@ -4,7 +4,7 @@
   font-weight: 700;
   color: var(--synapse-gray-700);
   min-width: 100%;
-  padding: 8px 0;
+  padding: 8px 3px;
 
   @media (min-width: 601px) {
     min-width: unset;


### PR DESCRIPTION
Before:
<img width="435" height="199" alt="Screenshot 2026-06-05 at 10 00 00 AM" src="https://github.com/user-attachments/assets/19217e26-a931-4165-b9a9-92658f04ecc7" />

After:
<img width="633" height="290" alt="Screenshot 2026-06-05 at 10 12 23 AM" src="https://github.com/user-attachments/assets/756790cd-7c26-4dd9-ac09-bceb8973aa0f" />

