### PR TITLE
PORTALS-4285: Add Sankey plot with very a specific configuration (roo…

### DIFF
--- a/apps/portals/ampals/src/config/resources.ts
+++ b/apps/portals/ampals/src/config/resources.ts
@@ -7,6 +7,7 @@ export const programsSql = 'SELECT * FROM syn64941043'
 export const goalsTableEntityId = 'syn66051704'
 export const filesSql = `SELECT * FROM syn66271104`
 
+export const sankeyPlotSql = `SELECT source, count(source) FROM syn66496326 group by source`
 export const partnersSql = `SELECT * FROM syn68804819`
 
 export const enabledAnalysisPlatforms: ExternalAnalysisPlatform[] = [

--- a/apps/portals/ampals/src/pages/HomePage.tsx
+++ b/apps/portals/ampals/src/pages/HomePage.tsx
@@ -10,10 +10,12 @@ import headerSvg from '../config/style/header.svg?url'
 import CardGridWithLinks from 'synapse-react-client/components/CardGridWithLinks/CardGridWithLinks'
 import GoalsV3 from 'synapse-react-client/components/GoalsV3/GoalsV3'
 import PortalFeaturedPartners from 'synapse-react-client/components/PortalFeaturedPartners/PortalFeaturedPartners'
+import SynapseSankeyPlot from 'synapse-react-client/components/Plot/SynapseSankeyPlot'
 import {
   datasetsSql,
   goalsTableEntityId,
   partnersSql,
+  sankeyPlotSql,
 } from '@/config/resources'
 import { ReactComponent as DatasetsIcon } from '../../src/config/style/datasets.svg'
 import { ReactComponent as FilesIcon } from '../../src/config/style/files.svg'
@@ -139,6 +141,7 @@ export default function HomePage() {
             projects: ProjectsIcon,
           }}
         />
+        <SynapseSankeyPlot sql={sankeyPlotSql} rootLabel="All Datasets" />
       </SectionLayout>
       {/* <AMPALSExploreTheData sql={upsetPlotSql} /> */}
       <HowToAccessData />

--- a/packages/synapse-react-client/src/components/Plot/Plot.tsx
+++ b/packages/synapse-react-client/src/components/Plot/Plot.tsx
@@ -2,12 +2,16 @@ import { PlotParams } from 'react-plotly.js'
 import createPlotlyComponent from './safe-react-plotly-factory'
 import { lazy, Suspense } from 'react'
 
-// Lazy-load plotly.js since it is very large!
-const safeESModule = <T,>(a: T | { default: T }): T => {
+// We want to bundle browser-compatible code, but use ESM (`"type": "module"` in package.json) when we use Node (e.g. tests).
+// esbuild (used by Vite in development mode) has a quirk where this will cause packages react-plotly.js/factory to be
+// imported in 'node mode', which breaks imports in the browser.
+// For further explanation and source of workaround, see: https://github.com/evanw/esbuild/issues/2480#issuecomment-1970337003
+export const safeESModule = <T,>(a: T | { default: T }): T => {
   const b = a as any
   return b.__esModule || b[Symbol.toStringTag] === 'Module' ? b.default : b
 }
 
+// Lazy-load plotly.js-basic-dist (scatter, bar, pie, scattergl traces).
 const LazyLoadedPlot = lazy(async () => {
   const Plotly = await import('plotly.js-basic-dist')
   const plotly = safeESModule(Plotly)
@@ -15,7 +19,8 @@ const LazyLoadedPlot = lazy(async () => {
 })
 
 /**
- * Wrapper around react-plotly.js, lazy loads the plotly.js library.
+ * Wrapper around react-plotly.js, lazy loads plotly.js-basic-dist.
+ * Use this for standard chart types (bar, scatter, pie).
  * @param props
  * @constructor
  */
@@ -23,6 +28,27 @@ export function Plot(props: PlotParams) {
   return (
     <Suspense>
       <LazyLoadedPlot {...props} />
+    </Suspense>
+  )
+}
+
+// Lazy-load the full plotly.js bundle which includes all trace types (e.g. Sankey).
+const LazyLoadedFullBundlePlot = lazy(async () => {
+  const Plotly = await import('plotly.js')
+  const plotly = safeESModule(Plotly)
+  return { default: createPlotlyComponent(plotly) }
+})
+
+/**
+ * Wrapper around react-plotly.js, lazy loads the full plotly.js bundle.
+ * Use this for trace types not available in plotly.js-basic-dist, such as Sankey.
+ * @param props
+ * @constructor
+ */
+export function PlotFullBundle(props: PlotParams) {
+  return (
+    <Suspense>
+      <LazyLoadedFullBundlePlot {...props} />
     </Suspense>
   )
 }

--- a/packages/synapse-react-client/src/components/Plot/Plot.tsx
+++ b/packages/synapse-react-client/src/components/Plot/Plot.tsx
@@ -2,10 +2,7 @@ import { PlotParams } from 'react-plotly.js'
 import createPlotlyComponent from './safe-react-plotly-factory'
 import { lazy, Suspense } from 'react'
 
-// We want to bundle browser-compatible code, but use ESM (`"type": "module"` in package.json) when we use Node (e.g. tests).
-// esbuild (used by Vite in development mode) has a quirk where this will cause packages react-plotly.js/factory to be
-// imported in 'node mode', which breaks imports in the browser.
-// For further explanation and source of workaround, see: https://github.com/evanw/esbuild/issues/2480#issuecomment-1970337003
+// Lazy-load plotly.js since it is very large!
 export const safeESModule = <T,>(a: T | { default: T }): T => {
   const b = a as any
   return b.__esModule || b[Symbol.toStringTag] === 'Module' ? b.default : b

--- a/packages/synapse-react-client/src/components/Plot/SynapseSankeyPlot.stories.tsx
+++ b/packages/synapse-react-client/src/components/Plot/SynapseSankeyPlot.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from '@storybook/react-vite'
+import SynapseSankeyPlot from './SynapseSankeyPlot'
+
+const meta = {
+  title: 'Components/SynapseSankeyPlot',
+  component: SynapseSankeyPlot,
+} satisfies Meta
+export default meta
+type Story = StoryObj<typeof meta>
+
+const TABLE_ID = 'syn66496326'
+const SQL = `SELECT source, count(source) FROM ${TABLE_ID} group by source`
+
+export const SourcesByDataset: Story = {
+  args: {
+    sql: SQL,
+    rootLabel: 'All Datasets',
+    // title: 'Datasets by Source',
+  },
+}

--- a/packages/synapse-react-client/src/components/Plot/SynapseSankeyPlot.tsx
+++ b/packages/synapse-react-client/src/components/Plot/SynapseSankeyPlot.tsx
@@ -1,0 +1,121 @@
+import React, { lazy, Suspense } from 'react'
+import { useGetFullTableQueryResults } from '@/synapse-queries'
+import { SynapseConstants } from '@/utils'
+import { parseEntityIdFromSqlStatement } from '@/utils/functions/SqlFunctions'
+import { Skeleton } from '@mui/material'
+import { QueryBundleRequest } from '@sage-bionetworks/synapse-types'
+import type { Data, Layout, SankeyData } from 'plotly.js'
+import { PlotParams } from 'react-plotly.js'
+import createPlotlyComponent from './safe-react-plotly-factory'
+
+// Lazy-load the full plotly.js bundle (not the basic dist) since Sankey is not
+// included in plotly.js-basic-dist.
+const safeESModule = <T,>(a: T | { default: T }): T => {
+  const b = a as any
+  return b.__esModule || b[Symbol.toStringTag] === 'Module' ? b.default : b
+}
+
+const LazyLoadedSankeyPlot = lazy(async () => {
+  const Plotly = await import('plotly.js')
+  const plotly = safeESModule(Plotly)
+  return { default: createPlotlyComponent(plotly) }
+})
+
+function SankeyPlot(props: PlotParams) {
+  return (
+    <Suspense>
+      <LazyLoadedSankeyPlot {...props} />
+    </Suspense>
+  )
+}
+
+export type SynapseSankeyPlotProps = {
+  /** SQL query whose first column provides node labels and second column provides link values */
+  sql: string
+  /** Label for the root node that links to every row returned by the query */
+  rootLabel: string
+  /** Optional plot title */
+  title?: string
+}
+
+export const SynapseSankeyPlot = (
+  props: SynapseSankeyPlotProps,
+): React.ReactNode => {
+  const { sql, rootLabel, title } = props
+
+  const queryRequest: QueryBundleRequest = {
+    concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+    partMask: SynapseConstants.BUNDLE_MASK_QUERY_RESULTS,
+    entityId: parseEntityIdFromSqlStatement(sql),
+    query: {
+      sql,
+    },
+  }
+
+  const { data: queryData, isLoading } =
+    useGetFullTableQueryResults(queryRequest)
+
+  if (isLoading) {
+    return <Skeleton width={'100%'} height={'500px'} />
+  }
+  if (!queryData) {
+    return <></>
+  }
+
+  const rows = queryData.queryResult?.queryResults.rows ?? []
+  if (rows.length === 0) {
+    return <></>
+  }
+
+  // Build Sankey nodes and links.
+  // Node 0: rootLabel (the shared source node)
+  // Nodes 1..N: the label from column 0 of each query row (target nodes)
+  const sources: number[] = []
+  const targets: number[] = []
+  const values: number[] = []
+
+  rows.forEach((row, index) => {
+    values.push(Number(row.values[1] ?? 0))
+    sources.push(0)
+    targets.push(index + 1)
+  })
+
+  const total = values.reduce((sum, v) => sum + v, 0)
+
+  // Plotly Sankey processes <br> via convertToTspans(), rendering the count on a second line.
+  const nodeLabels: string[] = [`${rootLabel}<br>n=${total}`]
+  rows.forEach(row => {
+    const label = row.values[0] ?? ''
+    const value = Number(row.values[1] ?? 0)
+    nodeLabels.push(`${label}<br>n=${value}`)
+  })
+
+  const sankeyData: Partial<SankeyData>[] = [
+    {
+      type: 'sankey',
+      node: {
+        label: nodeLabels,
+      },
+      link: {
+        source: sources,
+        target: targets,
+        value: values,
+      },
+    },
+  ]
+
+  const layout: Partial<Layout> = {
+    title,
+  }
+
+  return (
+    <SankeyPlot
+      style={{ width: '100%', height: '450px' }}
+      layout={layout}
+      data={sankeyData as Data[]}
+      config={{ displayModeBar: false }}
+    />
+  )
+}
+
+export default SynapseSankeyPlot

--- a/packages/synapse-react-client/src/components/Plot/SynapseSankeyPlot.tsx
+++ b/packages/synapse-react-client/src/components/Plot/SynapseSankeyPlot.tsx
@@ -1,33 +1,11 @@
-import React, { lazy, Suspense } from 'react'
+import React from 'react'
 import { useGetFullTableQueryResults } from '@/synapse-queries'
 import { SynapseConstants } from '@/utils'
 import { parseEntityIdFromSqlStatement } from '@/utils/functions/SqlFunctions'
 import { Skeleton } from '@mui/material'
 import { QueryBundleRequest } from '@sage-bionetworks/synapse-types'
 import type { Data, Layout, SankeyData } from 'plotly.js'
-import { PlotParams } from 'react-plotly.js'
-import createPlotlyComponent from './safe-react-plotly-factory'
-
-// Lazy-load the full plotly.js bundle (not the basic dist) since Sankey is not
-// included in plotly.js-basic-dist.
-const safeESModule = <T,>(a: T | { default: T }): T => {
-  const b = a as any
-  return b.__esModule || b[Symbol.toStringTag] === 'Module' ? b.default : b
-}
-
-const LazyLoadedSankeyPlot = lazy(async () => {
-  const Plotly = await import('plotly.js')
-  const plotly = safeESModule(Plotly)
-  return { default: createPlotlyComponent(plotly) }
-})
-
-function SankeyPlot(props: PlotParams) {
-  return (
-    <Suspense>
-      <LazyLoadedSankeyPlot {...props} />
-    </Suspense>
-  )
-}
+import { PlotFullBundle } from './Plot'
 
 export type SynapseSankeyPlotProps = {
   /** SQL query whose first column provides node labels and second column provides link values */
@@ -109,7 +87,7 @@ export const SynapseSankeyPlot = (
   }
 
   return (
-    <SankeyPlot
+    <PlotFullBundle
       style={{ width: '100%', height: '450px' }}
       layout={layout}
       data={sankeyData as Data[]}

--- a/packages/synapse-react-client/src/components/Plot/index.ts
+++ b/packages/synapse-react-client/src/components/Plot/index.ts
@@ -4,6 +4,8 @@ import { UpsetPlot } from './UpsetPlot'
 import type { UpsetPlotProps } from './UpsetPlot'
 import { SynapsePlot } from './SynapsePlot'
 import type { SynapsePlotProps } from './SynapsePlot'
+import { SynapseSankeyPlot } from './SynapseSankeyPlot'
+import type { SynapseSankeyPlotProps } from './SynapseSankeyPlot'
 import type { ClickCallbackParams } from './types'
 import type { GraphItem } from './types'
 export {
@@ -13,6 +15,8 @@ export {
   UpsetPlotProps,
   SynapsePlot,
   SynapsePlotProps,
+  SynapseSankeyPlot,
+  SynapseSankeyPlotProps,
   ClickCallbackParams,
   GraphItem,
 }


### PR DESCRIPTION
…t, broken into x rows, each with an associated count value), driven by a Synapse query

Storybook: 
<img width="1417" height="752" alt="Screenshot 2026-06-11 at 4 52 57 PM" src="https://github.com/user-attachments/assets/5004f661-9600-4228-aaa4-b8fe5b29701e" />

<img width="1005" height="409" alt="Screenshot 2026-06-11 at 4 53 06 PM" src="https://github.com/user-attachments/assets/035ea547-6ae1-4e11-a8de-d3a20f009a1b" />


ALS KP:
<img width="1424" height="757" alt="Screenshot 2026-06-11 at 5 02 59 PM" src="https://github.com/user-attachments/assets/55422863-bada-4258-9c1a-da771f7eadaa" />

