### PR TITLE
SWC-7780 - disable adding new row with enter key

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/DataGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/DataGrid.tsx
@@ -258,7 +258,7 @@ export default function DataGrid(props: DataGridProps) {
         ref={gridRef}
         value={rowValues}
         columns={colValues}
-        autoAddRow={!entityIsView}
+        autoAddRow={false}
         disableSmartDelete
         addRowsComponent={addRowsComponent}
         contextMenuComponent={contextMenuComponent}


### PR DESCRIPTION
 set DataGrid autoAddRow prop to false to disable adding new rows with the enter key