### PR TITLE
SWC-7854 grid column updates

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/components/ColumnHeaderWithTooltip.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ColumnHeaderWithTooltip.test.tsx
@@ -1,44 +1,42 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import { ColumnHeaderWithTooltip } from './ColumnHeaderWithTooltip'
 
 describe('ColumnHeaderWithTooltip', () => {
-  it('renders column name without tooltip when no description', () => {
+  it('renders column name', () => {
     render(<ColumnHeaderWithTooltip name="myColumn" />)
-
     expect(screen.getByText('myColumn')).toBeInTheDocument()
   })
 
-  it('renders column name with help icon when description is provided', async () => {
-    const user = userEvent.setup()
+  it('uses column name as native title when no description', () => {
+    render(<ColumnHeaderWithTooltip name="myColumn" />)
+    expect(screen.getByTitle('myColumn')).toBeInTheDocument()
+  })
 
+  it('uses description as native title when description is provided', () => {
     render(
       <ColumnHeaderWithTooltip
         name="myColumn"
         description="This is a helpful description"
       />,
     )
-
-    const columnHeader = screen.getByText('myColumn')
-    expect(columnHeader).toBeInTheDocument()
-
-    // Help icon should be present
-    const helpButton = screen.getByRole('button')
-    expect(helpButton).toBeInTheDocument()
-
-    // Hover over the help icon to show tooltip
-    await user.hover(helpButton)
-
-    // Tooltip should appear
     expect(
-      await screen.findByText('This is a helpful description'),
+      screen.getByTitle('This is a helpful description'),
     ).toBeInTheDocument()
   })
 
-  it('renders only the name when description is empty string', () => {
+  it('falls back to column name as title when description is empty string', () => {
     render(<ColumnHeaderWithTooltip name="myColumn" description="" />)
+    expect(screen.getByTitle('myColumn')).toBeInTheDocument()
+  })
 
-    expect(screen.getByText('myColumn')).toBeInTheDocument()
+  it('does not render a help icon', () => {
+    render(
+      <ColumnHeaderWithTooltip
+        name="myColumn"
+        description="Some description"
+      />,
+    )
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 })

--- a/packages/synapse-react-client/src/components/DataGrid/components/ColumnHeaderWithTooltip.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ColumnHeaderWithTooltip.test.tsx
@@ -29,14 +29,4 @@ describe('ColumnHeaderWithTooltip', () => {
     render(<ColumnHeaderWithTooltip name="myColumn" description="" />)
     expect(screen.getByTitle('myColumn')).toBeInTheDocument()
   })
-
-  it('does not render a help icon', () => {
-    render(
-      <ColumnHeaderWithTooltip
-        name="myColumn"
-        description="Some description"
-      />,
-    )
-    expect(screen.queryByRole('button')).not.toBeInTheDocument()
-  })
 })

--- a/packages/synapse-react-client/src/components/DataGrid/components/ColumnHeaderWithTooltip.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ColumnHeaderWithTooltip.tsx
@@ -1,5 +1,5 @@
 import { Box, IconButton, Tooltip } from '@mui/material'
-import { HelpTwoTone, PushPin, PushPinOutlined } from '@mui/icons-material'
+import { PushPin, PushPinOutlined } from '@mui/icons-material'
 import { TOOLTIP_DELAY_SHOW } from '@/components/SynapseTable/SynapseTableConstants'
 
 type ColumnHeaderWithTooltipProps = {
@@ -11,8 +11,9 @@ type ColumnHeaderWithTooltipProps = {
 }
 
 /**
- * Renders a column header with an optional help icon showing the column description.
- * Adopts the help icon pattern from ColumnHeader for consistent UX.
+ * Renders a column header. When a description is provided, hovering the column
+ * name shows it as a native tooltip; otherwise the column name is shown (useful
+ * for truncated headers). An optional pin icon is shown on the right.
  */
 export function ColumnHeaderWithTooltip({
   name,
@@ -41,24 +42,13 @@ export function ColumnHeaderWithTooltip({
           whiteSpace: 'nowrap',
           minWidth: 0,
         }}
-        title={name} // Native tooltip for truncated text
+        title={description || name}
       >
         {name}
       </Box>
 
       {/* Icons area - fixed size, never shrinks */}
       <Box sx={{ display: 'flex', gap: 0.5, flexShrink: 0 }}>
-        {description && (
-          <Tooltip
-            title={description}
-            placement="top"
-            enterNextDelay={TOOLTIP_DELAY_SHOW}
-          >
-            <IconButton size="small" color="inherit">
-              <HelpTwoTone fontSize="inherit" />
-            </IconButton>
-          </Tooltip>
-        )}
         {showPinIcon && onTogglePin && (
           <Tooltip
             title={isPinned ? 'Unpin column' : 'Pin column'}

--- a/packages/synapse-react-client/src/components/DataGrid/components/ColumnHeaderWithTooltip.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ColumnHeaderWithTooltip.tsx
@@ -5,6 +5,7 @@ import { TOOLTIP_DELAY_SHOW } from '@/components/SynapseTable/SynapseTableConsta
 type ColumnHeaderWithTooltipProps = {
   name: string
   description?: string
+  isRequired?: boolean
   showPinIcon?: boolean
   isPinned?: boolean
   onTogglePin?: () => void
@@ -18,6 +19,7 @@ type ColumnHeaderWithTooltipProps = {
 export function ColumnHeaderWithTooltip({
   name,
   description,
+  isRequired = false,
   showPinIcon = false,
   isPinned = false,
   onTogglePin,
@@ -45,6 +47,11 @@ export function ColumnHeaderWithTooltip({
         title={description || name}
       >
         {name}
+        {isRequired && (
+          <Box component="span" sx={{ color: 'error.main', ml: 0.25 }}>
+            *
+          </Box>
+        )}
       </Box>
 
       {/* Icons area - fixed size, never shrinks */}

--- a/packages/synapse-react-client/src/components/DataGrid/components/ColumnHeaderWithTooltip.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ColumnHeaderWithTooltip.tsx
@@ -26,6 +26,7 @@ export function ColumnHeaderWithTooltip({
 }: ColumnHeaderWithTooltipProps) {
   return (
     <Box
+      data-column-id={name}
       sx={{
         display: 'grid',
         gridTemplateColumns: 'minmax(0, 1fr) auto',

--- a/packages/synapse-react-client/src/components/DataGrid/hooks/useColumnResizeHandles.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/hooks/useColumnResizeHandles.test.ts
@@ -31,6 +31,41 @@ describe('useColumnResizeHandles', () => {
     return cell
   }
 
+  // Mirrors the DOM produced by ColumnHeaderWithTooltip: a root div with
+  // data-column-id, a text span that may include an asterisk (*) for required
+  // columns, and an optional icons span.  textContent will be "Column A*" so
+  // any code that still reads textContent would fail to match the column id.
+  const createMockCellWithDataAttribute = (
+    columnName: string,
+    isRequired: boolean = false,
+    width: number = 150,
+  ) => {
+    const cell = document.createElement('div')
+    cell.className = 'dsg-cell'
+
+    const headerRoot = document.createElement('div')
+    headerRoot.dataset.columnId = columnName
+
+    const textSpan = document.createElement('span')
+    textSpan.textContent = columnName
+    headerRoot.appendChild(textSpan)
+
+    if (isRequired) {
+      const asterisk = document.createElement('span')
+      asterisk.textContent = '*'
+      headerRoot.appendChild(asterisk)
+    }
+
+    cell.appendChild(headerRoot)
+
+    Object.defineProperty(cell, 'offsetWidth', {
+      value: width,
+      configurable: true,
+    })
+    Object.defineProperty(cell, 'offsetLeft', { value: 0, configurable: true })
+    return cell
+  }
+
   // Helper to trigger ResizeObserver callback and initialize handles
   const triggerInitialization = () => {
     if (resizeObserverCallback && mockWrapperRef.current) {
@@ -1052,6 +1087,50 @@ describe('useColumnResizeHandles', () => {
       }).not.toThrow()
 
       expect(document.querySelectorAll('.column-resize-handle')).toHaveLength(0)
+    })
+
+    it('creates handles for required columns whose textContent includes an asterisk', () => {
+      // Regression: ColumnHeaderWithTooltip appends a "*" span for required
+      // columns, changing the cell textContent from "Column A" to "Column A*".
+      // syncHandles must use data-column-id instead of textContent so the
+      // column lookup succeeds.
+
+      // Replace the plain-text cells with ColumnHeaderWithTooltip-style cells
+      // where one column is required (textContent will be "Column A*").
+      while (mockHeaderRow.children.length > 1) {
+        mockHeaderRow.removeChild(mockHeaderRow.lastChild!)
+      }
+      mockHeaderRow.appendChild(
+        createMockCellWithDataAttribute('Column A', true, 150),
+      )
+      mockHeaderRow.appendChild(
+        createMockCellWithDataAttribute('Column B', false, 200),
+      )
+
+      const colValues: Column[] = [
+        { id: 'Column A', title: 'Column A' } as Column,
+        { id: 'Column B', title: 'Column B' } as Column,
+      ]
+
+      renderHook(() =>
+        useColumnResizeHandles({
+          wrapperRef: mockWrapperRef,
+          colValues,
+          onColumnResize: mockOnColumnResize,
+        }),
+      )
+
+      triggerInitialization()
+
+      const handles = document.querySelectorAll<HTMLElement>(
+        '.column-resize-handle',
+      )
+      // Both columns should get a handle; previously "Column A" was skipped
+      // because "Column A*" !== "Column A".
+      expect(handles).toHaveLength(2)
+      const names = Array.from(handles).map(h => h.dataset.columnName)
+      expect(names).toContain('Column A')
+      expect(names).toContain('Column B')
     })
 
     it('should handle missing header row', () => {

--- a/packages/synapse-react-client/src/components/DataGrid/hooks/useColumnResizeHandles.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/hooks/useColumnResizeHandles.test.ts
@@ -31,13 +31,12 @@ describe('useColumnResizeHandles', () => {
     return cell
   }
 
-  // Mirrors the DOM produced by ColumnHeaderWithTooltip: a root div with
-  // data-column-id, a text span that may include an asterisk (*) for required
-  // columns, and an optional icons span.  textContent will be "Column A*" so
-  // any code that still reads textContent would fail to match the column id.
+  // Creates a header cell whose data-column-id differs from its visible
+  // textContent, verifying that the hook uses the attribute for column lookup
+  // rather than textContent.
   const createMockCellWithDataAttribute = (
     columnName: string,
-    isRequired: boolean = false,
+    displayText: string,
     width: number = 150,
   ) => {
     const cell = document.createElement('div')
@@ -47,14 +46,8 @@ describe('useColumnResizeHandles', () => {
     headerRoot.dataset.columnId = columnName
 
     const textSpan = document.createElement('span')
-    textSpan.textContent = columnName
+    textSpan.textContent = displayText
     headerRoot.appendChild(textSpan)
-
-    if (isRequired) {
-      const asterisk = document.createElement('span')
-      asterisk.textContent = '*'
-      headerRoot.appendChild(asterisk)
-    }
 
     cell.appendChild(headerRoot)
 
@@ -1089,22 +1082,23 @@ describe('useColumnResizeHandles', () => {
       expect(document.querySelectorAll('.column-resize-handle')).toHaveLength(0)
     })
 
-    it('creates handles for required columns whose textContent includes an asterisk', () => {
-      // Regression: ColumnHeaderWithTooltip appends a "*" span for required
-      // columns, changing the cell textContent from "Column A" to "Column A*".
-      // syncHandles must use data-column-id instead of textContent so the
-      // column lookup succeeds.
-
-      // Replace the plain-text cells with ColumnHeaderWithTooltip-style cells
-      // where one column is required (textContent will be "Column A*").
+    it('creates handles when a cell has a data-column-id that does not match its textContent', () => {
+      // syncHandles must use data-column-id for column lookup, not textContent.
+      // If it fell back to textContent the findIndex call would fail and no
+      // handle would be created for that column.
       while (mockHeaderRow.children.length > 1) {
         mockHeaderRow.removeChild(mockHeaderRow.lastChild!)
       }
+      // 'Column A' id, but visible text is something else entirely
       mockHeaderRow.appendChild(
-        createMockCellWithDataAttribute('Column A', true, 150),
+        createMockCellWithDataAttribute(
+          'Column A',
+          'Displayed differently',
+          150,
+        ),
       )
       mockHeaderRow.appendChild(
-        createMockCellWithDataAttribute('Column B', false, 200),
+        createMockCellWithDataAttribute('Column B', 'Also different', 200),
       )
 
       const colValues: Column[] = [
@@ -1125,8 +1119,6 @@ describe('useColumnResizeHandles', () => {
       const handles = document.querySelectorAll<HTMLElement>(
         '.column-resize-handle',
       )
-      // Both columns should get a handle; previously "Column A" was skipped
-      // because "Column A*" !== "Column A".
       expect(handles).toHaveLength(2)
       const names = Array.from(handles).map(h => h.dataset.columnName)
       expect(names).toContain('Column A')

--- a/packages/synapse-react-client/src/components/DataGrid/hooks/useColumnResizeHandles.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/hooks/useColumnResizeHandles.ts
@@ -234,7 +234,8 @@ class ColumnResizeManager {
       // Prefer the data-column-id attribute set by ColumnHeaderWithTooltip over
       // textContent, which can include extra characters (e.g. the required "*").
       const columnId =
-        cellElement.querySelector('[data-column-id]')?.dataset.columnId ??
+        cellElement.querySelector<HTMLElement>('[data-column-id]')?.dataset
+          .columnId ??
         cellElement.textContent?.trim() ??
         ''
 

--- a/packages/synapse-react-client/src/components/DataGrid/hooks/useColumnResizeHandles.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/hooks/useColumnResizeHandles.ts
@@ -231,14 +231,17 @@ class ColumnResizeManager {
 
       const cellElement = cell as HTMLElement
 
-      // Get the column name from the cell's text content
-      // This is more reliable than using DOM index with virtualization
-      const cellText = cellElement.textContent?.trim() || ''
+      // Prefer the data-column-id attribute set by ColumnHeaderWithTooltip over
+      // textContent, which can include extra characters (e.g. the required "*").
+      const columnId =
+        cellElement.querySelector('[data-column-id]')?.dataset.columnId ??
+        cellElement.textContent?.trim() ??
+        ''
 
       // Find the actual column index in colValues by matching the id (column name)
       // Note: col.title may be a React element (e.g. ColumnHeaderWithTooltip), so we use col.id
       const actualColumnIndex = this.colValues.findIndex(
-        col => col.id === cellText,
+        col => col.id === columnId,
       )
 
       if (actualColumnIndex !== -1) {

--- a/packages/synapse-react-client/src/components/DataGrid/utils/columnFactory.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/columnFactory.tsx
@@ -143,6 +143,7 @@ function createBaseColumn(config: ColumnConfig, columnImpl: any) {
       <ColumnHeaderWithTooltip
         name={config.columnName}
         description={config.description}
+        isRequired={config.isRequired}
         showPinIcon={config.showPinIcon}
         isPinned={config.isPinned}
         onTogglePin={config.onTogglePin}

--- a/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
+++ b/packages/synapse-react-client/src/style/components/_data-grid-extra.scss
@@ -154,7 +154,13 @@ $remote-selection-colors:
 }
 
 // Header & selection styles
-.dsg-cell-header.header-cell-required {
+.dsg-cell-header:not(.dsg-cell-gutter) {
+  background-color: #dbdde1;
+  font-weight: bold;
+  color: black;
+}
+
+.dsg-cell-header.header-upsert-key {
   background-color: #395979;
   color: white;
   font-weight: bold;


### PR DESCRIPTION
- remove column help icon and replace the column title tooltip with the schema description
- change background of header cells to gray
- required columns have a red asterisk
<img width="458" height="98" alt="columns" src="https://github.com/user-attachments/assets/52c6fffa-4697-4a8c-92ad-b5171c8673da" />

