### PR TITLE
PORTALS-4289

### DIFF
--- a/apps/portals/eliteportal/src/config/navbarConfig.tsx
+++ b/apps/portals/eliteportal/src/config/navbarConfig.tsx
@@ -1,4 +1,9 @@
 import { NavbarConfig } from '@sage-bionetworks/synapse-portal-framework/components/navbar/Navbar'
+import Navbar from '@sage-bionetworks/synapse-portal-framework/components/navbar/Navbar'
+
+export default function EliteNavbar() {
+  return <Navbar layout={'with-sticky-search'} />
+}
 
 export const navbarConfig: NavbarConfig = {
   routes: [
@@ -83,4 +88,5 @@ export const navbarConfig: NavbarConfig = {
     },
   ],
   isPortalsDropdownEnabled: true,
+  NavbarComponent: EliteNavbar,
 }

--- a/apps/portals/eliteportal/src/config/routesConfig.tsx
+++ b/apps/portals/eliteportal/src/config/routesConfig.tsx
@@ -312,6 +312,14 @@ const routes: RouteObject[] = [
             convertModuleToRouteObject,
           ),
       },
+      {
+        path: 'Search',
+        lazy: () => import('@/pages/Search').then(convertModuleToRouteObject),
+      },
+      {
+        path: 'Search/:resourceType',
+        lazy: () => import('@/pages/Search').then(convertModuleToRouteObject),
+      },
     ],
   },
 ]

--- a/apps/portals/eliteportal/src/config/searchConfig.ts
+++ b/apps/portals/eliteportal/src/config/searchConfig.ts
@@ -1,0 +1,49 @@
+import { PortalSearchTabConfig } from '@sage-bionetworks/synapse-portal-framework/components/PortalSearch/PortalSearchTabs'
+import { programsSearch } from '@/config/synapseConfigs/programs'
+import { projectsSearch } from '@/config/synapseConfigs/projects'
+import { studiesSearch } from '@/config/synapseConfigs/studies'
+import { datasetQueryWrapperPlotNavProps } from '@/config/synapseConfigs/datasets'
+import { publicationsSearch } from '@/config/synapseConfigs/publications'
+import { computationalToolsSearch } from '@/config/synapseConfigs/computational_tools'
+import { peopleSearch } from '@/config/synapseConfigs/people'
+
+export const searchPageTabs = [
+  {
+    title: 'Programs',
+    path: 'Programs',
+  },
+  {
+    title: 'Projects',
+    path: 'Projects',
+  },
+  {
+    title: 'Studies',
+    path: 'Studies',
+  },
+  {
+    title: 'Datasets',
+    path: 'Datasets',
+  },
+  {
+    title: 'Publications',
+    path: 'Publications',
+  },
+  {
+    title: 'Tools',
+    path: 'Tools',
+  },
+  {
+    title: 'People',
+    path: 'People',
+  },
+] as const satisfies PortalSearchTabConfig[]
+
+export const portalSearchPageConfigs = [
+  programsSearch,
+  projectsSearch,
+  studiesSearch,
+  { ...datasetQueryWrapperPlotNavProps, name: 'Datasets' },
+  publicationsSearch,
+  { ...computationalToolsSearch, name: 'Tools' },
+  peopleSearch,
+]

--- a/apps/portals/eliteportal/src/pages/HomePage.tsx
+++ b/apps/portals/eliteportal/src/pages/HomePage.tsx
@@ -15,7 +15,7 @@ import { GoalsV2 } from 'synapse-react-client/components/GoalsV2/GoalsV2'
 import ImageCardGridWithLinks from 'synapse-react-client/components/ImageCardGridWithLinks/ImageCardGridWithLinks'
 import PortalFeaturedPartners from 'synapse-react-client/components/PortalFeaturedPartners/PortalFeaturedPartners'
 import PortalFeatureHighlights from 'synapse-react-client/components/PortalFeatureHighlights/PortalFeatureHighlights'
-import PortalHomePageHeader from 'synapse-react-client/components/PortalHomePageHeader/PortalHomePageHeader'
+import ELITEHeader from '@sage-bionetworks/synapse-portal-framework/components/eliteportal/ELITEHeader'
 import PortalSectionHeader from 'synapse-react-client/components/PortalSectionHeader/PortalSectionHeader'
 import RecentPublicationsGrid from 'synapse-react-client/components/RecentPublicationsGrid/RecentPublicationsGrid'
 import { UpsetPlot } from 'synapse-react-client/components/Plot/UpsetPlot'
@@ -128,7 +128,7 @@ function HomePageInternal() {
   )
   return (
     <>
-      <PortalHomePageHeader
+      <ELITEHeader
         backgroundCss={`linear-gradient(90deg, #024472 45.5%, rgba(2, 68, 114, 0.00) 100%)`}
         title={title}
         description={description}

--- a/apps/portals/eliteportal/src/pages/Search.tsx
+++ b/apps/portals/eliteportal/src/pages/Search.tsx
@@ -1,0 +1,13 @@
+import { portalSearchPageConfigs, searchPageTabs } from '@/config/searchConfig'
+import ResourceSearchPage from '@sage-bionetworks/synapse-portal-framework/components/PortalSearch/ResourceSearchPage'
+
+function Search() {
+  return (
+    <ResourceSearchPage
+      portalSearchPageConfigs={portalSearchPageConfigs}
+      searchPageTabs={searchPageTabs}
+    />
+  )
+}
+
+export default Search

--- a/apps/synapse-portal-framework/src/components/eliteportal/ELITEHeader.tsx
+++ b/apps/synapse-portal-framework/src/components/eliteportal/ELITEHeader.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { Box, Typography } from '@mui/material'
+import HeaderSearchBox from '../HeaderSearchBox'
+
+type ELITEHeaderProps = {
+  backgroundCss: string
+  title: React.ReactNode
+  description: React.ReactNode
+  backgroundMp4?: string
+  backgroundMp4Css?: string
+}
+
+const ELITEHeader = ({
+  backgroundCss,
+  title,
+  description,
+  backgroundMp4,
+  backgroundMp4Css,
+}: ELITEHeaderProps): React.ReactNode => {
+  return (
+    <header id="header">
+      <Box
+        sx={{
+          background: backgroundCss,
+          position: 'relative',
+          display: 'flex',
+          flexDirection: { xs: 'column', lg: 'row' },
+          justifyContent: 'center',
+          alignItems: 'center',
+          padding: '20px 0',
+        }}
+      >
+        {backgroundMp4 && (
+          <Box
+            component="video"
+            autoPlay
+            loop
+            muted
+            playsInline
+            sx={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%',
+              objectFit: 'fill',
+              zIndex: 0,
+              background: backgroundMp4Css,
+            }}
+          >
+            <source src={backgroundMp4} type="video/mp4" />
+            Your browser does not support the video tag.
+          </Box>
+        )}
+        <Box
+          sx={{
+            flex: 1,
+            padding: { xs: '40px', lg: '40px 80px' },
+            zIndex: 1,
+          }}
+        >
+          <Typography
+            variant="headline2"
+            sx={{
+              fontWeight: 300,
+              lineHeight: '130%',
+              fontSize: { xs: '36px', md: '42px' },
+            }}
+          >
+            {title}
+          </Typography>
+          <Typography
+            sx={{ fontSize: '18px', lineHeight: '140%', marginTop: '15px' }}
+          >
+            {description}
+          </Typography>
+        </Box>
+        <HeaderSearchBox
+          searchExampleTerms={[
+            'whole genome sequencing',
+            'LLFS',
+            'RNAseq',
+            'proteomics aging',
+            'APOE cognitive aging',
+            'epigenetics',
+            'open access',
+            'longevity intervention',
+            'GWAS',
+            'healthspan',
+          ]}
+          searchPlaceholder="Search for longevity and aging data and resources"
+          path="/Search"
+          sx={{
+            flex: 1,
+            zIndex: 1,
+            '& > :first-child': {
+              background: 'rgba(184, 204, 226, 0.60)',
+            },
+          }}
+        />
+      </Box>
+    </header>
+  )
+}
+
+export default ELITEHeader


### PR DESCRIPTION
Add a new Portal Search route to ELITE, as well as nav bar item and a custom home page header (which contains the reusable search box)
<img width="1499" height="747" alt="Screenshot 2026-06-15 at 10 23 32 AM" src="https://github.com/user-attachments/assets/1d1ee2f0-0a78-44a7-9279-a74c2af46570" />
<img width="1499" height="797" alt="Screenshot 2026-06-15 at 10 25 04 AM" src="https://github.com/user-attachments/assets/f55c2703-d8dc-49a0-ba2f-d7b2fc544ef9" />
