### PR TITLE
PORTALS-4300

### DIFF
--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
@@ -1,8 +1,10 @@
 import {
+  AsynchronousJobStatus,
   FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
   FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE_VALUE,
   FacetColumnResultRange,
   QueryBundleRequest,
+  QueryResultBundle,
   TEXT_MATCHES_QUERY_FILTER_CONCRETE_TYPE_VALUE,
 } from '@sage-bionetworks/synapse-types'
 import type {
@@ -12,6 +14,7 @@ import type {
 import dayjs from 'dayjs'
 import { describe, expect, it } from 'vitest'
 import {
+  getNextPageParamForSearchQueryResults,
   searchQueryResultsToQueryResultBundle,
   toSearchIndexQuery,
 } from './SearchQueryUseQueryOptions'
@@ -40,6 +43,91 @@ const MINIMAL_SEARCH_INDEX_QUERY: SearchIndexQuery = {
   concreteType: 'org.sagebionetworks.repo.model.search.table.SearchIndexQuery',
   searchIndexId: SEARCH_INDEX_ID,
 }
+
+function makeAsyncStatusWithRows(
+  rowCount: number,
+  queryCount?: number,
+  size?: number,
+): AsynchronousJobStatus<SearchIndexQuery, QueryResultBundle> {
+  return {
+    jobState: 'COMPLETE',
+    responseBody: {
+      concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
+      queryCount,
+      queryResult: {
+        concreteType: 'org.sagebionetworks.repo.model.table.QueryResult',
+        queryResults: {
+          concreteType: 'org.sagebionetworks.repo.model.table.RowSet',
+          tableId: 'syn1',
+          etag: 'etag',
+          headers: [],
+          rows: Array.from({ length: rowCount }).map((_, i) => ({
+            rowId: i,
+            values: [],
+          })),
+        },
+      },
+    },
+    requestBody: {
+      concreteType:
+        'org.sagebionetworks.repo.model.search.table.SearchIndexQuery',
+      searchIndexId: SEARCH_INDEX_ID,
+      searchQuery: {
+        size,
+      },
+    },
+  }
+}
+
+describe('getNextPageParamForSearchQueryResults', () => {
+  it('returns undefined when the last page has fewer rows than the requested page size', () => {
+    const firstPage = makeAsyncStatusWithRows(25, undefined, 25)
+    const lastPage = makeAsyncStatusWithRows(7, undefined, 25)
+
+    const result = getNextPageParamForSearchQueryResults(lastPage, [
+      firstPage,
+      lastPage,
+    ])
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined when the last page is empty', () => {
+    const firstPage = makeAsyncStatusWithRows(25, undefined, 25)
+    const lastPage = makeAsyncStatusWithRows(0, undefined, 25)
+
+    const result = getNextPageParamForSearchQueryResults(lastPage, [
+      firstPage,
+      lastPage,
+    ])
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined when fetched rows already meet queryCount', () => {
+    const firstPage = makeAsyncStatusWithRows(25, 30, 25)
+    const lastPage = makeAsyncStatusWithRows(5, 30, 25)
+
+    const result = getNextPageParamForSearchQueryResults(lastPage, [
+      firstPage,
+      lastPage,
+    ])
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns the next offset when another full page is possible', () => {
+    const firstPage = makeAsyncStatusWithRows(25, 100, 25)
+    const lastPage = makeAsyncStatusWithRows(25, 100, 25)
+
+    const result = getNextPageParamForSearchQueryResults(lastPage, [
+      firstPage,
+      lastPage,
+    ])
+
+    expect(result).toBe(50)
+  })
+})
 
 // ---------------------------------------------------------------------------
 // toSearchIndexQuery

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
@@ -51,6 +51,13 @@ function makeAsyncStatusWithRows(
 ): AsynchronousJobStatus<SearchIndexQuery, QueryResultBundle> {
   return {
     jobState: 'COMPLETE',
+    jobCanceling: false,
+    etag: 'etag',
+    jobId: 'job1',
+    startedByUserId: 1,
+    startedOn: '2024-01-01T00:00:00.000Z',
+    changedOn: '2024-01-01T00:00:00.000Z',
+    runtimeMS: 0,
     responseBody: {
       concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
       queryCount,

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -91,6 +91,36 @@ export type SearchTableQueryUseQueryOptions = {
   >
 }
 
+export function getNextPageParamForSearchQueryResults(
+  lastPage: AsynchronousJobStatus<SearchIndexQuery, QueryResultBundle>,
+  allPages: AsynchronousJobStatus<SearchIndexQuery, QueryResultBundle>[],
+): number | string | undefined {
+  const rowsInLastPage =
+    lastPage.responseBody?.queryResult?.queryResults.rows?.length ?? 0
+  const requestedPageSize = lastPage.requestBody?.searchQuery?.size
+  const totalRows = lastPage.responseBody?.queryCount
+  const fetchedRows = allPages.reduce(
+    (acc, page) =>
+      acc + (page.responseBody?.queryResult?.queryResults.rows?.length ?? 0),
+    0,
+  )
+
+  if (rowsInLastPage === 0) {
+    return undefined
+  }
+
+  // A short page means we've reached the end, even when total hits is missing or stale.
+  if (requestedPageSize != null && rowsInLastPage < requestedPageSize) {
+    return undefined
+  }
+
+  if (totalRows != null && fetchedRows >= totalRows) {
+    return undefined
+  }
+
+  return fetchedRows
+}
+
 /**
  * Converts a QueryBundleRequest (used internally for state management) into a SearchIndexQuery
  * that can be sent to the SearchQueryServicesApi.
@@ -478,17 +508,7 @@ export function getSearchQueryUseQueryOptions(
         lastPage: AsynchronousJobStatus<SearchIndexQuery, QueryResultBundle>,
         allPages: AsynchronousJobStatus<SearchIndexQuery, QueryResultBundle>[],
       ): number | string | undefined => {
-        const totalRows = lastPage.responseBody?.queryCount
-        const fetchedRows = allPages.reduce(
-          (acc, page) =>
-            acc +
-            (page.responseBody?.queryResult?.queryResults.rows?.length ?? 0),
-          0,
-        )
-        if (totalRows != null && fetchedRows >= totalRows) {
-          return undefined
-        }
-        return fetchedRows
+        return getNextPageParamForSearchQueryResults(lastPage, allPages)
       },
       queryFn: (context: { pageParam?: number | string }) => {
         const offset =


### PR DESCRIPTION
Corrected infinite pagination behavior for SearchQueryWrapper so the View More button no longer appears when there are no more results.

### Logic update
- Added a dedicated pagination helper in SearchQueryUseQueryOptions:
  - getNextPageParamForSearchQueryResults
- Updated next-page detection to stop pagination when:
  - the last page is empty, or
  - the last page has fewer rows than the requested page size, or
  - total fetched rows have reached/exceeded queryCount (when queryCount is available).
- Wired rowDataInfiniteQueryOptions.getNextPageParam to use this helper.

### Why this resolves the bug
- View More visibility depends on hasNextPage.
- hasNextPage is now computed with a reliable terminal-page check (short page detection), so it correctly flips to false when the final page is not full.

### Test coverage added
- Added focused unit tests for getNextPageParamForSearchQueryResults to verify:
  - short final page => no next page
  - empty final page => no next page
  - fetched rows meeting queryCount => no next page
  - full page with remaining results => next offset returned