### PR TITLE
[PORTALS-4304] Change default value for `versionNumber` to 1

### DIFF
--- a/packages/synapse-react-client/src/components/ChallengeSubmission/ChallengeSubmissionStepper.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/ChallengeSubmissionStepper.tsx
@@ -151,7 +151,7 @@ function ChallengeSubmissionStepper({
       userId: userId,
       evaluationId: selectedEval!,
       entityId: entity.id,
-      versionNumber: entity.versionNumber ?? -1,
+      versionNumber: entity.versionNumber ?? 1,
       teamId: teamId,
       contributors,
     }


### PR DESCRIPTION
Currently, Docker submissions fail in the Challenge Portal because `versionNumber` defaults to "-1" when not set, which is rejected by the `POST /evaluation/submission` endpoint. @jay-hodgson confirms that Synapse.org defaults to "1" in this case, so I will align with that behavior here too.

## Changelog
* Change default `versionNumber` from -1 to 1