### PR TITLE
PORTALS-4277: Explore tab focus style does not appear on Firefox

### DIFF
--- a/apps/portals/arkportal/src/config/style/_style_overrides.scss
+++ b/apps/portals/arkportal/src/config/style/_style_overrides.scss
@@ -1,3 +1,8 @@
+// Accessible keyboard focus-ring color. See PORTALS-4277.
+:root {
+  --synapse-focus-color: #ac7058;
+}
+
 #header {
   height: fit-content;
   background-image: none;

--- a/apps/portals/eliteportal/src/config/style/_style_overrides.scss
+++ b/apps/portals/eliteportal/src/config/style/_style_overrides.scss
@@ -1,3 +1,8 @@
+// Accessible keyboard focus-ring color. See PORTALS-4277.
+:root {
+  --synapse-focus-color: #2f8d7c;
+}
+
 #header,
 #footer {
   background-color: var(--synapse-primary-action-color);

--- a/apps/synapse-portal-framework/src/components/Explore/ExploreWrapperTabs.module.scss
+++ b/apps/synapse-portal-framework/src/components/Explore/ExploreWrapperTabs.module.scss
@@ -20,4 +20,9 @@
   &:hover {
     border-bottom-color: var(--synapse-secondary-action-color);
   }
+  &:focus-visible,
+  &:global(.Mui-focusVisible) {
+    outline: 2px solid var(--synapse-focus-color);
+    outline-offset: -2px;
+  }
 }

--- a/packages/synapse-react-client/src/style/abstracts/_cssVariables.scss
+++ b/packages/synapse-react-client/src/style/abstracts/_cssVariables.scss
@@ -88,6 +88,7 @@
 
   // Primary / Secondary / Tertiary Action Colors
   --synapse-primary-action-color: #{v.$primary-action-color};
+  --synapse-focus-color: var(--synapse-primary-action-color);
   --synapse-primary-bgcolor-rgba: #{v.$primary-bgcolor-rgba};
   --synapse-secondary-action-color: #{v.$secondary-action-color};
   --synapse-tertiary-action-color: #{v.$tertiary-action-color};


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/PORTALS-4277

<img width="1512" height="982" alt="Screenshot 2026-06-22 at 5 23 20 PM" src="https://github.com/user-attachments/assets/62eb54cb-7761-4b07-8b42-ca1186e999cf" />
<img width="1512" height="982" alt="Screenshot 2026-06-22 at 5 23 33 PM" src="https://github.com/user-attachments/assets/3d92462e-2472-4d7a-8992-b15fcf182bd6" />
<img width="1512" height="982" alt="Collections" src="https://github.com/user-attachments/assets/19e22a3b-4d33-44ac-84f2-0ae0e1ff392e" />
<img width="1512" height="982" alt="Programs" src="https://github.com/user-attachments/assets/7daa4c46-50ee-413d-b167-2c766cd063eb" />
