### PR TITLE
SWC-7853 - Display and edit task status on CurationTaskCard

### DIFF
--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.module.scss
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.module.scss
@@ -50,3 +50,9 @@
     margin-left: 0;
   }
 }
+
+.expandedContent {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.module.scss
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.module.scss
@@ -50,9 +50,3 @@
     margin-left: 0;
   }
 }
-
-.expandedContent {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
@@ -1,3 +1,4 @@
+import { TaskStatusStateEnum } from '@sage-bionetworks/synapse-client'
 import { Meta, StoryObj } from '@storybook/react-vite'
 import CurationTaskCard, { CurationTaskCardProps } from './CurationTaskCard'
 
@@ -6,25 +7,35 @@ const meta = {
   component: CurationTaskCard,
 } satisfies Meta<CurationTaskCardProps>
 export default meta
-type Story = StoryObj<typeof meta>
 
-export const Demo: Story = {
-  args: {
-    taskBundle: {
-      task: {
-        dataType: 'metadata_clinical',
-        taskId: 123,
-        instructions:
-          'Project: Precision Drug Treatment Profiling in Human Pancreatic Tissue',
-        assigneePrincipalId: '273957',
-        taskProperties: {
-          concreteType:
-            'org.sagebionetworks.repo.model.curation.metadata.FileBasedMetadataTaskProperties',
-        },
-      },
-      status: {
-        state: 'NOT_STARTED',
-      },
+const baseTask = {
+  dataType: 'metadata_clinical',
+  taskId: 123,
+  instructions:
+    'Project: Precision Drug Treatment Profiling in Human Pancreatic Tissue',
+  assigneePrincipalId: '273957',
+  taskProperties: {
+    concreteType:
+      'org.sagebionetworks.repo.model.curation.metadata.FileBasedMetadataTaskProperties' as const,
+  },
+}
+
+export const Demo: StoryObj<{ state: TaskStatusStateEnum }> = {
+  argTypes: {
+    state: {
+      control: 'select',
+      options: Object.values(TaskStatusStateEnum),
     },
   },
+  args: {
+    state: TaskStatusStateEnum.NOT_STARTED,
+  },
+  render: ({ state }) => (
+    <CurationTaskCard
+      taskBundle={{
+        task: baseTask,
+        status: { state },
+      }}
+    />
+  ),
 }

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
@@ -1,12 +1,18 @@
+import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
 import { TaskStatusStateEnum } from '@sage-bionetworks/synapse-client'
 import { Meta, StoryObj } from '@storybook/react-vite'
+import { http, HttpResponse } from 'msw'
 import CurationTaskCard, { CurationTaskCardProps } from './CurationTaskCard'
 
 const meta = {
   title: 'Curator/Dashboard/CurationTaskCard',
   component: CurationTaskCard,
+  parameters: { stack: 'mock' },
 } satisfies Meta<CurationTaskCardProps>
 export default meta
+
+const CAN_EDIT_PROJECT_ID = 'syn123'
+const CANNOT_EDIT_PROJECT_ID = 'syn456'
 
 const baseTask = {
   dataType: 'metadata_clinical',
@@ -20,22 +26,44 @@ const baseTask = {
   },
 }
 
-export const Demo: StoryObj<{ state: TaskStatusStateEnum }> = {
-  argTypes: {
-    state: {
-      control: 'select',
-      options: Object.values(TaskStatusStateEnum),
+export const Demo: StoryObj<{ state: TaskStatusStateEnum; canEdit: boolean }> =
+  {
+    argTypes: {
+      state: {
+        control: 'select',
+        options: Object.values(TaskStatusStateEnum),
+      },
+      canEdit: {
+        control: 'boolean',
+      },
     },
-  },
-  args: {
-    state: TaskStatusStateEnum.NOT_STARTED,
-  },
-  render: ({ state }) => (
-    <CurationTaskCard
-      taskBundle={{
-        task: baseTask,
-        status: { state },
-      }}
-    />
-  ),
-}
+    args: {
+      state: TaskStatusStateEnum.NOT_STARTED,
+      canEdit: true,
+    },
+    parameters: {
+      msw: {
+        handlers: [
+          http.get(
+            `${MOCK_REPO_ORIGIN}/repo/v1/entity/:entityId/permissions`,
+            ({ params }) =>
+              HttpResponse.json(
+                { canEdit: params.entityId === CAN_EDIT_PROJECT_ID },
+                { status: 200 },
+              ),
+          ),
+        ],
+      },
+    },
+    render: ({ state, canEdit }) => (
+      <CurationTaskCard
+        taskBundle={{
+          task: {
+            ...baseTask,
+            projectId: canEdit ? CAN_EDIT_PROJECT_ID : CANNOT_EDIT_PROJECT_ID,
+          },
+          status: { state },
+        }}
+      />
+    ),
+  }

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
@@ -44,13 +44,15 @@ export const Demo: StoryObj<{ state: TaskStatusStateEnum; canEdit: boolean }> =
     parameters: {
       msw: {
         handlers: [
-          http.get(
-            `${MOCK_REPO_ORIGIN}/repo/v1/entity/:entityId/permissions`,
-            ({ params }) =>
-              HttpResponse.json(
-                { canEdit: params.entityId === CAN_EDIT_PROJECT_ID },
-                { status: 200 },
-              ),
+          http.post(
+            `${MOCK_REPO_ORIGIN}/repo/v1/entity/:entityId/bundle2`,
+            ({ params }) => {
+              const canEdit = params.entityId === CAN_EDIT_PROJECT_ID
+              return HttpResponse.json({
+                entity: { name: 'Precision Drug Treatment Profiling' },
+                permissions: { canEdit },
+              })
+            },
           ),
         ],
       },

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
@@ -1,7 +1,10 @@
 import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { createMockTaskBundle } from '@/mocks/curation/mockCurationTask'
-import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
+import {
+  useGetEntity,
+  useGetEntityPermissions,
+} from '@/synapse-queries/entity/useEntity'
 import { CurationTask, TaskBundle } from '@sage-bionetworks/synapse-client'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -44,6 +47,7 @@ vi.mock('./UserOrTeamChip', () => ({
 
 vi.mock('@/synapse-queries/entity/useEntity', () => ({
   useGetEntityPermissions: vi.fn(),
+  useGetEntity: vi.fn(),
 }))
 
 const mockUseOpenCuratorFromTaskButton = vi.mocked(useOpenCuratorFromTaskButton)
@@ -51,6 +55,7 @@ const mockCreateOrUpdateCurationTaskDialog = vi.mocked(
   CreateOrUpdateCurationTaskDialog,
 )
 const mockUseGetEntityPermissions = vi.mocked(useGetEntityPermissions)
+const mockUseGetEntity = vi.mocked(useGetEntity)
 
 const mockTaskBundle = createMockTaskBundle({
   projectId: 'syn123',
@@ -70,7 +75,10 @@ beforeEach(() => {
   })
   mockUseGetEntityPermissions.mockReturnValue({
     data: { canEdit: true },
-  } as any)
+  } as unknown as ReturnType<typeof useGetEntityPermissions>)
+  mockUseGetEntity.mockReturnValue({ data: undefined } as unknown as ReturnType<
+    typeof useGetEntity
+  >)
 })
 
 describe('CurationTaskCard', () => {
@@ -84,7 +92,7 @@ describe('CurationTaskCard', () => {
   it('does not render the task settings button when the user cannot edit', () => {
     mockUseGetEntityPermissions.mockReturnValue({
       data: { canEdit: false },
-    } as any)
+    } as unknown as ReturnType<typeof useGetEntityPermissions>)
     renderComponent()
     expect(
       screen.queryByRole('button', { name: /task settings/i }),

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
@@ -1,6 +1,7 @@
 import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { createMockTaskBundle } from '@/mocks/curation/mockCurationTask'
+import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
 import { CurationTask, TaskBundle } from '@sage-bionetworks/synapse-client'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -41,10 +42,15 @@ vi.mock('./UserOrTeamChip', () => ({
   default: () => null,
 }))
 
+vi.mock('@/synapse-queries/entity/useEntity', () => ({
+  useGetEntityPermissions: vi.fn(),
+}))
+
 const mockUseOpenCuratorFromTaskButton = vi.mocked(useOpenCuratorFromTaskButton)
 const mockCreateOrUpdateCurationTaskDialog = vi.mocked(
   CreateOrUpdateCurationTaskDialog,
 )
+const mockUseGetEntityPermissions = vi.mocked(useGetEntityPermissions)
 
 const mockTaskBundle = createMockTaskBundle({
   projectId: 'syn123',
@@ -62,14 +68,27 @@ beforeEach(() => {
     isPending: false,
     onClick: vi.fn(),
   })
+  mockUseGetEntityPermissions.mockReturnValue({
+    data: { canEdit: true },
+  } as any)
 })
 
 describe('CurationTaskCard', () => {
-  it('renders the task settings button', () => {
+  it('renders the task settings button when the user can edit', () => {
     renderComponent()
     expect(
       screen.getByRole('button', { name: /task settings/i }),
     ).toBeInTheDocument()
+  })
+
+  it('does not render the task settings button when the user cannot edit', () => {
+    mockUseGetEntityPermissions.mockReturnValue({
+      data: { canEdit: false },
+    } as any)
+    renderComponent()
+    expect(
+      screen.queryByRole('button', { name: /task settings/i }),
+    ).not.toBeInTheDocument()
   })
 
   it('does not show the settings dialog on initial render', () => {

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
@@ -1,7 +1,7 @@
 import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { createMockTaskBundle } from '@/mocks/curation/mockCurationTask'
-import { CurationTask } from '@sage-bionetworks/synapse-client'
+import { CurationTask, TaskBundle } from '@sage-bionetworks/synapse-client'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach } from 'vitest'
@@ -51,8 +51,8 @@ const mockTaskBundle = createMockTaskBundle({
   dataType: 'Test Data Type',
 })
 
-const renderComponent = () =>
-  render(<CurationTaskCard taskBundle={mockTaskBundle} />)
+const renderComponent = (taskBundle: TaskBundle = mockTaskBundle) =>
+  render(<CurationTaskCard taskBundle={taskBundle} />)
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -129,5 +129,42 @@ describe('CurationTaskCard', () => {
     await user.click(screen.getByRole('button', { name: /delete/i }))
 
     expect(screen.queryByTestId('settings-dialog')).not.toBeInTheDocument()
+  })
+
+  describe('status chip', () => {
+    it('shows "Not Started" when status state is NOT_STARTED', () => {
+      renderComponent(
+        createMockTaskBundle({ projectId: 'syn123' }, { state: 'NOT_STARTED' }),
+      )
+      expect(screen.getByText('Not Started')).toBeInTheDocument()
+    })
+
+    it('shows "In Progress" when status state is IN_PROGRESS', () => {
+      renderComponent(
+        createMockTaskBundle({ projectId: 'syn123' }, { state: 'IN_PROGRESS' }),
+      )
+      expect(screen.getByText('In Progress')).toBeInTheDocument()
+    })
+
+    it('shows "Completed" when status state is COMPLETED', () => {
+      renderComponent(
+        createMockTaskBundle({ projectId: 'syn123' }, { state: 'COMPLETED' }),
+      )
+      expect(screen.getByText('Completed')).toBeInTheDocument()
+    })
+
+    it('shows "Canceled" when status state is CANCELED', () => {
+      renderComponent(
+        createMockTaskBundle({ projectId: 'syn123' }, { state: 'CANCELED' }),
+      )
+      expect(screen.getByText('Canceled')).toBeInTheDocument()
+    })
+
+    it('shows no status chip when state is undefined', () => {
+      renderComponent(createMockTaskBundle({ projectId: 'syn123' }))
+      expect(
+        screen.queryByText(/not started|in progress|completed|canceled/i),
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
@@ -1,0 +1,133 @@
+import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
+import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
+import { createMockTaskBundle } from '@/mocks/curation/mockCurationTask'
+import { CurationTask } from '@sage-bionetworks/synapse-client'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach } from 'vitest'
+import CurationTaskCard from './CurationTaskCard'
+
+vi.mock('@/features/entity/metadata-task/hooks/useOpenCuratorButton', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock(
+  '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog',
+  () => ({
+    default: vi.fn(
+      ({
+        open,
+        onCancel,
+        onSuccess,
+        onDeleteSuccess,
+      }: {
+        open: boolean
+        onCancel: () => void
+        onSuccess: (task: CurationTask) => void
+        onDeleteSuccess: () => void
+      }) =>
+        open ? (
+          <div data-testid="settings-dialog">
+            <button onClick={onCancel}>Cancel</button>
+            <button onClick={() => onSuccess({} as CurationTask)}>Save</button>
+            <button onClick={onDeleteSuccess}>Delete</button>
+          </div>
+        ) : null,
+    ),
+  }),
+)
+
+vi.mock('./UserOrTeamChip', () => ({
+  default: () => null,
+}))
+
+const mockUseOpenCuratorFromTaskButton = vi.mocked(useOpenCuratorFromTaskButton)
+const mockCreateOrUpdateCurationTaskDialog = vi.mocked(
+  CreateOrUpdateCurationTaskDialog,
+)
+
+const mockTaskBundle = createMockTaskBundle({
+  projectId: 'syn123',
+  dataType: 'Test Data Type',
+})
+
+const renderComponent = () =>
+  render(<CurationTaskCard taskBundle={mockTaskBundle} />)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseOpenCuratorFromTaskButton.mockReturnValue({
+    hasPermission: true,
+    isLoading: false,
+    isPending: false,
+    onClick: vi.fn(),
+  })
+})
+
+describe('CurationTaskCard', () => {
+  it('renders the task settings button', () => {
+    renderComponent()
+    expect(
+      screen.getByRole('button', { name: /task settings/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('does not show the settings dialog on initial render', () => {
+    renderComponent()
+    expect(screen.queryByTestId('settings-dialog')).not.toBeInTheDocument()
+  })
+
+  it('opens the settings dialog when the settings button is clicked', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.click(screen.getByRole('button', { name: /task settings/i }))
+
+    expect(screen.getByTestId('settings-dialog')).toBeInTheDocument()
+  })
+
+  it('passes the task to the dialog so it opens in edit mode', () => {
+    renderComponent()
+
+    const props = mockCreateOrUpdateCurationTaskDialog.mock.calls[0][0]
+    expect(props.task).toEqual(mockTaskBundle.task)
+  })
+
+  it('passes the projectId from the task to the dialog', () => {
+    renderComponent()
+
+    const props = mockCreateOrUpdateCurationTaskDialog.mock.calls[0][0]
+    expect(props.projectId).toBe('syn123')
+  })
+
+  it('closes the settings dialog when onCancel is called', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.click(screen.getByRole('button', { name: /task settings/i }))
+    expect(screen.getByTestId('settings-dialog')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.queryByTestId('settings-dialog')).not.toBeInTheDocument()
+  })
+
+  it('closes the settings dialog when onSuccess is called', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.click(screen.getByRole('button', { name: /task settings/i }))
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(screen.queryByTestId('settings-dialog')).not.toBeInTheDocument()
+  })
+
+  it('closes the settings dialog when onDeleteSuccess is called', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await user.click(screen.getByRole('button', { name: /task settings/i }))
+    await user.click(screen.getByRole('button', { name: /delete/i }))
+
+    expect(screen.queryByTestId('settings-dialog')).not.toBeInTheDocument()
+  })
+})

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
@@ -1,10 +1,7 @@
 import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { createMockTaskBundle } from '@/mocks/curation/mockCurationTask'
-import {
-  useGetEntity,
-  useGetEntityPermissions,
-} from '@/synapse-queries/entity/useEntity'
+import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
 import { CurationTask, TaskBundle } from '@sage-bionetworks/synapse-client'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -45,17 +42,15 @@ vi.mock('./UserOrTeamChip', () => ({
   default: () => null,
 }))
 
-vi.mock('@/synapse-queries/entity/useEntity', () => ({
-  useGetEntityPermissions: vi.fn(),
-  useGetEntity: vi.fn(),
+vi.mock('@/synapse-queries/entity/useEntityBundle', () => ({
+  default: vi.fn(),
 }))
 
 const mockUseOpenCuratorFromTaskButton = vi.mocked(useOpenCuratorFromTaskButton)
 const mockCreateOrUpdateCurationTaskDialog = vi.mocked(
   CreateOrUpdateCurationTaskDialog,
 )
-const mockUseGetEntityPermissions = vi.mocked(useGetEntityPermissions)
-const mockUseGetEntity = vi.mocked(useGetEntity)
+const mockUseGetEntityBundle = vi.mocked(useGetEntityBundle)
 
 const mockTaskBundle = createMockTaskBundle({
   projectId: 'syn123',
@@ -73,12 +68,9 @@ beforeEach(() => {
     isPending: false,
     onClick: vi.fn(),
   })
-  mockUseGetEntityPermissions.mockReturnValue({
-    data: { canEdit: true },
-  } as unknown as ReturnType<typeof useGetEntityPermissions>)
-  mockUseGetEntity.mockReturnValue({ data: undefined } as unknown as ReturnType<
-    typeof useGetEntity
-  >)
+  mockUseGetEntityBundle.mockReturnValue({
+    data: { permissions: { canEdit: true } },
+  } as unknown as ReturnType<typeof useGetEntityBundle>)
 })
 
 describe('CurationTaskCard', () => {
@@ -90,9 +82,9 @@ describe('CurationTaskCard', () => {
   })
 
   it('does not render the task settings button when the user cannot edit', () => {
-    mockUseGetEntityPermissions.mockReturnValue({
-      data: { canEdit: false },
-    } as unknown as ReturnType<typeof useGetEntityPermissions>)
+    mockUseGetEntityBundle.mockReturnValue({
+      data: { permissions: { canEdit: false } },
+    } as unknown as ReturnType<typeof useGetEntityBundle>)
     renderComponent()
     expect(
       screen.queryByRole('button', { name: /task settings/i }),

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -167,7 +167,9 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
               <Typography variant="body1">Task ID: {taskId}</Typography>
             )}
           </Box>
-          <Typography variant="body1">{description}</Typography>
+          {description && (
+            <Typography variant="body1">{description}</Typography>
+          )}
           <div className={styles.userChipContainer}>
             {principalIds.map(principalId => (
               <UserOrTeamChip key={principalId} principalId={principalId} />

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -3,16 +3,7 @@ import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/co
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
 import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
-import {
-  Box,
-  Button,
-  Card,
-  Chip,
-  Divider,
-  IconButton,
-  Link,
-  Typography,
-} from '@mui/material'
+import { Box, Card, Chip, Divider, IconButton, Typography } from '@mui/material'
 import {
   TaskBundle,
   TaskStatusStateEnum,
@@ -22,7 +13,6 @@ import styles from './CurationTaskCard.module.scss'
 import NextStepButton from './NextStepButton'
 import sharedStyles from './shared.module.scss'
 import UserOrTeamChip from './UserOrTeamChip'
-import TableChartOutlinedIcon from '@mui/icons-material/TableChartOutlined'
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
 import { useState } from 'react'
 
@@ -136,7 +126,6 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
   } = useUiForTask(taskBundle)
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
-  const [isExpanded, setIsExpanded] = useState(false)
 
   const projectId = taskBundle.task?.projectId
   const { data: bundle } = useGetEntityBundle(projectId, undefined, {
@@ -159,14 +148,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
       <div className={styles.cardContent}>
         <div className={styles.mainContent}>
           <div className={styles.titleChipContainer}>
-            <Link
-              component="button"
-              variant="headline3"
-              onClick={() => setIsExpanded(v => !v)}
-              sx={{ textAlign: 'left' }}
-            >
-              {title}
-            </Link>
+            <Typography variant="headline3">{title}</Typography>
             {taskType && <TaskTypeChip label={taskType} />}
             {canEdit && (
               <IconButton
@@ -183,45 +165,28 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
               <Typography variant="body1">Task ID: {taskId}</Typography>
             )}
           </Box>
+          <Typography variant="body1">{description}</Typography>
           <div className={styles.userChipContainer}>
             {principalIds.map(principalId => (
               <UserOrTeamChip key={principalId} principalId={principalId} />
             ))}
           </div>
-          {isExpanded && (
-            <div className={styles.expandedContent}>
-              <Typography variant="body1">{description}</Typography>
-              <Button
-                variant="contained"
-                fullWidth
-                onClick={onClickAction}
-                disabled={isLoading || isPending}
-                startIcon={<TableChartOutlinedIcon />}
-              >
-                {buttonText}
-              </Button>
-            </div>
-          )}
         </div>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
           <TaskStatusChip state={statusState} />
         </Box>
-        {!isExpanded && (
-          <>
-            <Divider
-              orientation="vertical"
-              flexItem
-              sx={{ display: { xs: 'none', md: 'block' } }}
-            />
-            <NextStepButton
-              className={styles.cardButton}
-              buttonText={buttonText}
-              onClick={onClickAction}
-              disabled={isLoading}
-              loading={isPending}
-            />
-          </>
-        )}
+        <Divider
+          orientation="vertical"
+          flexItem
+          sx={{ display: { xs: 'none', md: 'block' } }}
+        />
+        <NextStepButton
+          className={styles.cardButton}
+          buttonText={buttonText}
+          onClick={onClickAction}
+          disabled={isLoading}
+          loading={isPending}
+        />
       </div>
       <CreateOrUpdateCurationTaskDialog
         key={String(isSettingsOpen)}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -3,7 +3,15 @@ import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/co
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
 import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
-import { Box, Card, Chip, Divider, IconButton, Typography } from '@mui/material'
+import {
+  Box,
+  Card,
+  Chip,
+  Divider,
+  IconButton,
+  Skeleton,
+  Typography,
+} from '@mui/material'
 import {
   TaskBundle,
   TaskStatusStateEnum,
@@ -136,12 +144,9 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
 
   function onClickAction() {
     if (hasPermissionToOpenGrid) {
-        onClickNextStep()
+      onClickNextStep()
     } else {
-        displayToast(
-          OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE,
-          'danger',
-        )
+      displayToast(OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE, 'danger')
     }
   }
 
@@ -162,7 +167,11 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
             )}
           </div>
           <Box sx={{ display: 'flex', gap: 4 }}>
-            <Typography variant="body1">{bundle?.entity?.name}</Typography>
+            {isLoading ? (
+              <Skeleton width={100} />
+            ) : (
+              <Typography variant="body1">{bundle?.entity?.name}</Typography>
+            )}
             {taskId && (
               <Typography variant="body1">Task ID: {taskId}</Typography>
             )}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -3,7 +3,10 @@ import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/co
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
 import { Box, Button, Card, Chip, Divider, Typography } from '@mui/material'
-import { TaskBundle } from '@sage-bionetworks/synapse-client'
+import {
+  TaskBundle,
+  TaskStatusStateEnum,
+} from '@sage-bionetworks/synapse-client'
 import classNames from 'classnames'
 import styles from './CurationTaskCard.module.scss'
 import NextStepButton from './NextStepButton'
@@ -36,6 +39,7 @@ function useUiForTask(taskBundle: TaskBundle) {
           : [],
         buttonText: 'Open Curator',
         taskType: 'Curate Data',
+        statusState: taskBundle.status.state,
         onClickNextStep: onClick,
         isLoading,
         isPending,
@@ -59,6 +63,7 @@ function useUiForTask(taskBundle: TaskBundle) {
       : [],
     buttonText: 'Continue',
     taskType: '',
+    statusState: taskBundle.status.state,
     onClickNextStep: () => {
       displayToast('No action defined for this task type', 'danger', {
         title: 'Unexpected Error',
@@ -77,6 +82,29 @@ function TaskTypeChip(props: { label: string }) {
   )
 }
 
+const STATUS_CHIP_CONFIG: Record<
+  TaskStatusStateEnum,
+  { label: string; backgroundColor: string }
+> = {
+  NOT_STARTED: { label: 'Not Started', backgroundColor: '#EAECEE' },
+  IN_PROGRESS: { label: 'In Progress', backgroundColor: '#FFF3CD' },
+  COMPLETED: { label: 'Completed', backgroundColor: '#C8E6C9' },
+  CANCELED: { label: 'Canceled', backgroundColor: '#FFCCBC' },
+}
+
+function TaskStatusChip(props: { state: TaskStatusStateEnum | undefined }) {
+  const { state } = props
+  if (!state) return null
+  const { label, backgroundColor } = STATUS_CHIP_CONFIG[state]
+  return (
+    <Chip
+      size="small"
+      sx={{ fontWeight: 600, backgroundColor }}
+      label={label}
+    />
+  )
+}
+
 /**
  * Card component for displaying a curation task on the curator dashboard. Shows relevant information about the task and includes a button to proceed to the next step in the workflow.
  */
@@ -89,6 +117,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
     taskType,
     principalIds,
     buttonText,
+    statusState,
     onClickNextStep,
     hasPermission,
     isLoading,
@@ -124,6 +153,9 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
             ))}
           </div>
         </div>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <TaskStatusChip state={statusState} />
+        </Box>
         <Divider
           orientation="vertical"
           flexItem

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -2,6 +2,7 @@ import { displayToast } from '@/components'
 import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
+import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
 import { Box, Button, Card, Chip, Divider, Typography } from '@mui/material'
 import {
   TaskBundle,
@@ -126,6 +127,11 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
 
+  const { data: permissions } = useGetEntityPermissions(
+    taskBundle.task?.projectId ?? '',
+  )
+  const canEdit = permissions?.canEdit ?? false
+
   return (
     <Card className={classNames(sharedStyles.card, styles.card)}>
       <div className={styles.cardContent}>
@@ -133,13 +139,15 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
           <div className={styles.titleChipContainer}>
             <Typography variant="headline3">{title}</Typography>
             {taskType && <TaskTypeChip label={taskType} />}
-            <Button
-              sx={{ display: 'flex' }}
-              onClick={() => setIsSettingsOpen(true)}
-              aria-label="Task settings"
-            >
-              <SettingsOutlinedIcon />
-            </Button>
+            {canEdit && (
+              <Button
+                sx={{ display: 'flex' }}
+                onClick={() => setIsSettingsOpen(true)}
+                aria-label="Task settings"
+              >
+                <SettingsOutlinedIcon />
+              </Button>
+            )}
           </div>
           <Box sx={{ display: 'flex', gap: 6 }}>
             <Typography variant="body1">{description}</Typography>

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -1,5 +1,6 @@
 import { displayToast } from '@/components'
 import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
+import { TASK_STATUS_CONFIG } from '@/features/entity/metadata-task/utils/constants'
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
 import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
@@ -91,20 +92,10 @@ function TaskTypeChip(props: { label: string }) {
   )
 }
 
-const STATUS_CHIP_CONFIG: Record<
-  TaskStatusStateEnum,
-  { label: string; backgroundColor: string }
-> = {
-  NOT_STARTED: { label: 'Not Started', backgroundColor: '#EAECEE' },
-  IN_PROGRESS: { label: 'In Progress', backgroundColor: '#FFF3CD' },
-  COMPLETED: { label: 'Completed', backgroundColor: '#C8E6C9' },
-  CANCELED: { label: 'Canceled', backgroundColor: '#FFCCBC' },
-}
-
 function TaskStatusChip(props: { state: TaskStatusStateEnum | undefined }) {
   const { state } = props
   if (!state) return null
-  const { label, backgroundColor } = STATUS_CHIP_CONFIG[state]
+  const { label, backgroundColor } = TASK_STATUS_CONFIG[state]
   return (
     <Chip
       size="small"

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -158,10 +158,10 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
             )}
           </div>
           <Box sx={{ display: 'flex', gap: 4 }}>
-            {isLoading ? (
-              <Skeleton width={100} />
+            {bundle?.entity?.name ? (
+              <Typography variant="body1">{bundle.entity.name}</Typography>
             ) : (
-              <Typography variant="body1">{bundle?.entity?.name}</Typography>
+              <Skeleton width={100} />
             )}
             {taskId && (
               <Typography variant="body1">Task ID: {taskId}</Typography>

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -3,7 +3,7 @@ import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/co
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
 import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
-import { Box, Button, Card, Chip, Divider, Typography } from '@mui/material'
+import { Box, Card, Chip, Divider, IconButton, Typography } from '@mui/material'
 import {
   TaskBundle,
   TaskStatusStateEnum,
@@ -140,16 +140,15 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
             <Typography variant="headline3">{title}</Typography>
             {taskType && <TaskTypeChip label={taskType} />}
             {canEdit && (
-              <Button
-                sx={{ display: 'flex' }}
+              <IconButton
                 onClick={() => setIsSettingsOpen(true)}
                 aria-label="Task settings"
               >
                 <SettingsOutlinedIcon />
-              </Button>
+              </IconButton>
             )}
           </div>
-          <Box sx={{ display: 'flex', gap: 6 }}>
+          <Box sx={{ display: 'flex', gap: 4 }}>
             <Typography variant="body1">{description}</Typography>
             {taskId && (
               <Typography variant="body1">Task ID: {taskId}</Typography>
@@ -187,6 +186,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
         />
       </div>
       <CreateOrUpdateCurationTaskDialog
+        key={String(isSettingsOpen)}
         open={isSettingsOpen}
         onCancel={() => setIsSettingsOpen(false)}
         onSuccess={() => setIsSettingsOpen(false)}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -128,7 +128,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
     buttonText,
     statusState,
     onClickNextStep,
-    hasPermission,
+    hasPermission: hasPermissionToOpenGrid,
     isLoading,
     isPending,
   } = useUiForTask(taskBundle)

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -2,8 +2,20 @@ import { displayToast } from '@/components'
 import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
-import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
-import { Box, Card, Chip, Divider, IconButton, Typography } from '@mui/material'
+import {
+  useGetEntity,
+  useGetEntityPermissions,
+} from '@/synapse-queries/entity/useEntity'
+import {
+  Box,
+  Button,
+  Card,
+  Chip,
+  Divider,
+  IconButton,
+  Link,
+  Typography,
+} from '@mui/material'
 import {
   TaskBundle,
   TaskStatusStateEnum,
@@ -13,6 +25,7 @@ import styles from './CurationTaskCard.module.scss'
 import NextStepButton from './NextStepButton'
 import sharedStyles from './shared.module.scss'
 import UserOrTeamChip from './UserOrTeamChip'
+import TableChartOutlinedIcon from '@mui/icons-material/TableChartOutlined'
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
 import { useState } from 'react'
 
@@ -126,18 +139,35 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
   } = useUiForTask(taskBundle)
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(false)
 
-  const { data: permissions } = useGetEntityPermissions(
-    taskBundle.task?.projectId ?? '',
-  )
+  const projectId = taskBundle.task?.projectId
+  const { data: permissions } = useGetEntityPermissions(projectId ?? '')
+  const { data: project } = useGetEntity(projectId)
   const canEdit = permissions?.canEdit ?? false
+
+  const onClickAction = hasPermission
+    ? onClickNextStep
+    : () => {
+        displayToast(
+          OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE,
+          'danger',
+        )
+      }
 
   return (
     <Card className={classNames(sharedStyles.card, styles.card)}>
       <div className={styles.cardContent}>
         <div className={styles.mainContent}>
           <div className={styles.titleChipContainer}>
-            <Typography variant="headline3">{title}</Typography>
+            <Link
+              component="button"
+              variant="headline3"
+              onClick={() => setIsExpanded(v => !v)}
+              sx={{ textAlign: 'left' }}
+            >
+              {title}
+            </Link>
             {taskType && <TaskTypeChip label={taskType} />}
             {canEdit && (
               <IconButton
@@ -149,7 +179,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
             )}
           </div>
           <Box sx={{ display: 'flex', gap: 4 }}>
-            <Typography variant="body1">{description}</Typography>
+            <Typography variant="body1">{project?.name}</Typography>
             {taskId && (
               <Typography variant="body1">Task ID: {taskId}</Typography>
             )}
@@ -159,31 +189,40 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
               <UserOrTeamChip key={principalId} principalId={principalId} />
             ))}
           </div>
+          {isExpanded && (
+            <div className={styles.expandedContent}>
+              <Typography variant="body1">{description}</Typography>
+              <Button
+                variant="contained"
+                fullWidth
+                onClick={onClickAction}
+                disabled={isLoading || isPending}
+                startIcon={<TableChartOutlinedIcon />}
+              >
+                {buttonText}
+              </Button>
+            </div>
+          )}
         </div>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
           <TaskStatusChip state={statusState} />
         </Box>
-        <Divider
-          orientation="vertical"
-          flexItem
-          sx={{ display: { xs: 'none', md: 'block' } }}
-        />
-        <NextStepButton
-          className={styles.cardButton}
-          buttonText={buttonText}
-          onClick={
-            hasPermission
-              ? onClickNextStep
-              : () => {
-                  displayToast(
-                    OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE,
-                    'danger',
-                  )
-                }
-          }
-          disabled={isLoading}
-          loading={isPending}
-        />
+        {!isExpanded && (
+          <>
+            <Divider
+              orientation="vertical"
+              flexItem
+              sx={{ display: { xs: 'none', md: 'block' } }}
+            />
+            <NextStepButton
+              className={styles.cardButton}
+              buttonText={buttonText}
+              onClick={onClickAction}
+              disabled={isLoading}
+              loading={isPending}
+            />
+          </>
+        )}
       </div>
       <CreateOrUpdateCurationTaskDialog
         key={String(isSettingsOpen)}
@@ -191,7 +230,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
         onCancel={() => setIsSettingsOpen(false)}
         onSuccess={() => setIsSettingsOpen(false)}
         onDeleteSuccess={() => setIsSettingsOpen(false)}
-        projectId={taskBundle.task?.projectId ?? ''}
+        projectId={projectId ?? ''}
         task={taskBundle.task}
       />
     </Card>

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -134,14 +134,16 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
   })
   const canEdit = bundle?.permissions?.canEdit ?? false
 
-  const onClickAction = hasPermission
-    ? onClickNextStep
-    : () => {
+  function onClickAction() {
+    if (hasPermissionToOpenGrid) {
+        onClickNextStep()
+    } else {
         displayToast(
           OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE,
           'danger',
         )
-      }
+    }
+  }
 
   return (
     <Card className={classNames(sharedStyles.card, styles.card)}>

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -1,13 +1,16 @@
 import { displayToast } from '@/components'
+import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
-import { Card, Chip, Divider, Typography } from '@mui/material'
+import { Box, Button, Card, Chip, Divider, Typography } from '@mui/material'
 import { TaskBundle } from '@sage-bionetworks/synapse-client'
 import classNames from 'classnames'
 import styles from './CurationTaskCard.module.scss'
 import NextStepButton from './NextStepButton'
 import sharedStyles from './shared.module.scss'
 import UserOrTeamChip from './UserOrTeamChip'
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
+import { useState } from 'react'
 
 export type CurationTaskCardProps = {
   taskBundle: TaskBundle
@@ -92,6 +95,8 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
     isPending,
   } = useUiForTask(taskBundle)
 
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+
   return (
     <Card className={classNames(sharedStyles.card, styles.card)}>
       <div className={styles.cardContent}>
@@ -99,9 +104,20 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
           <div className={styles.titleChipContainer}>
             <Typography variant="headline3">{title}</Typography>
             {taskType && <TaskTypeChip label={taskType} />}
-            {taskId && <TaskTypeChip label={`TaskId ${taskId}`} />}
+            <Button
+              sx={{ display: 'flex' }}
+              onClick={() => setIsSettingsOpen(true)}
+              aria-label="Task settings"
+            >
+              <SettingsOutlinedIcon />
+            </Button>
           </div>
-          <Typography variant="body1">{description}</Typography>
+          <Box sx={{ display: 'flex', gap: 6 }}>
+            <Typography variant="body1">{description}</Typography>
+            {taskId && (
+              <Typography variant="body1">Task ID: {taskId}</Typography>
+            )}
+          </Box>
           <div className={styles.userChipContainer}>
             {principalIds.map(principalId => (
               <UserOrTeamChip key={principalId} principalId={principalId} />
@@ -130,6 +146,14 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
           loading={isPending}
         />
       </div>
+      <CreateOrUpdateCurationTaskDialog
+        open={isSettingsOpen}
+        onCancel={() => setIsSettingsOpen(false)}
+        onSuccess={() => setIsSettingsOpen(false)}
+        onDeleteSuccess={() => setIsSettingsOpen(false)}
+        projectId={taskBundle.task?.projectId ?? ''}
+        task={taskBundle.task}
+      />
     </Card>
   )
 }

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -2,10 +2,7 @@ import { displayToast } from '@/components'
 import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
-import {
-  useGetEntity,
-  useGetEntityPermissions,
-} from '@/synapse-queries/entity/useEntity'
+import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
 import {
   Box,
   Button,
@@ -142,9 +139,11 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
   const [isExpanded, setIsExpanded] = useState(false)
 
   const projectId = taskBundle.task?.projectId
-  const { data: permissions } = useGetEntityPermissions(projectId ?? '')
-  const { data: project } = useGetEntity(projectId)
-  const canEdit = permissions?.canEdit ?? false
+  const { data: bundle } = useGetEntityBundle(projectId, undefined, {
+    includeEntity: true,
+    includePermissions: true,
+  })
+  const canEdit = bundle?.permissions?.canEdit ?? false
 
   const onClickAction = hasPermission
     ? onClickNextStep
@@ -179,7 +178,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
             )}
           </div>
           <Box sx={{ display: 'flex', gap: 4 }}>
-            <Typography variant="body1">{project?.name}</Typography>
+            <Typography variant="body1">{bundle?.entity?.name}</Typography>
             {taskId && (
               <Typography variant="body1">Task ID: {taskId}</Typography>
             )}

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.test.tsx
@@ -3,7 +3,9 @@ import userEvent from '@testing-library/user-event'
 import {
   useCreateCurationTask,
   useDeleteCurationTask,
+  useGetCurationTaskStatus,
   useUpdateCurationTask,
+  useUpdateCurationTaskStatus,
 } from '@/synapse-queries/curation/task/useCurationTask'
 import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
 import {
@@ -19,12 +21,16 @@ import {
   DELETE_CURATION_TASK_DIALOG_TITLE,
   FILE_BASED_TASK_TITLE,
   RECORD_BASED_TASK_TITLE,
+  TASK_STATUS_IN_PROGRESS_LABEL,
+  TASK_STATUS_INPUT_LABEL,
 } from '../utils/constants'
 
 vi.mock('@/synapse-queries/curation/task/useCurationTask', () => ({
   useCreateCurationTask: vi.fn(),
   useUpdateCurationTask: vi.fn(),
   useDeleteCurationTask: vi.fn(),
+  useGetCurationTaskStatus: vi.fn(),
+  useUpdateCurationTaskStatus: vi.fn(),
 }))
 
 vi.mock('@/synapse-queries/entity/useEntity', () => ({
@@ -63,11 +69,14 @@ vi.mock('@/components/EntityFinder/EntityIdTextField', () => ({
 const mockUseCreateCurationTask = vi.mocked(useCreateCurationTask)
 const mockUseUpdateCurationTask = vi.mocked(useUpdateCurationTask)
 const mockUseDeleteCurationTask = vi.mocked(useDeleteCurationTask)
+const mockUseGetCurationTaskStatus = vi.mocked(useGetCurationTaskStatus)
+const mockUseUpdateCurationTaskStatus = vi.mocked(useUpdateCurationTaskStatus)
 const mockUseGetEntityPermissions = vi.mocked(useGetEntityPermissions)
 
 const mockCreateMutate = vi.fn()
 const mockUpdateMutate = vi.fn()
 const mockDeleteMutate = vi.fn()
+const mockUpdateStatusMutate = vi.fn()
 // Capture the options passed to useDeleteCurationTask so tests can invoke onSuccess
 let lastDeleteOptions: Parameters<typeof useDeleteCurationTask>[0] | undefined
 
@@ -118,6 +127,19 @@ beforeEach(() => {
       error: null,
     } as any
   })
+  mockUseGetCurationTaskStatus.mockReturnValue({
+    data: {
+      taskId: MOCK_CURATION_TASK_ID,
+      state: 'NOT_STARTED',
+      etag: 'etag1',
+    },
+    isFetching: false,
+  } as any)
+  mockUseUpdateCurationTaskStatus.mockReturnValue({
+    mutate: mockUpdateStatusMutate,
+    isPending: false,
+    error: null,
+  } as any)
   mockUseGetEntityPermissions.mockReturnValue({
     data: { canDelete: true },
   } as any)
@@ -344,8 +366,40 @@ describe('CreateOrUpdateCurationTaskDialog', () => {
             taskId: MOCK_CURATION_TASK_ID,
             dataType: 'Proteomics',
           }),
+          expect.objectContaining({ onSuccess: expect.any(Function) }),
         )
       })
+    })
+
+    it('chains updateTaskStatus after updateTask when status is changed', async () => {
+      renderEditDialog(fileBasedTask)
+
+      // Open the Status dropdown and select "In Progress"
+      await userEvent.click(
+        screen.getByRole('combobox', { name: TASK_STATUS_INPUT_LABEL }),
+      )
+      await userEvent.click(
+        screen.getByRole('option', { name: TASK_STATUS_IN_PROGRESS_LABEL }),
+      )
+
+      await userEvent.click(screen.getByRole('button', { name: /save/i }))
+
+      await waitFor(() => {
+        expect(mockUpdateMutate).toHaveBeenCalled()
+      })
+
+      // Simulate updateTask succeeding to trigger the status update chain
+      const [, { onSuccess: taskOnSuccess }] = mockUpdateMutate.mock.calls[0]
+      taskOnSuccess(fileBasedTask)
+
+      await waitFor(() => {
+        expect(mockUpdateStatusMutate).toHaveBeenCalledWith(
+          expect.objectContaining({ state: 'IN_PROGRESS' }),
+          expect.objectContaining({ onSuccess: expect.any(Function) }),
+        )
+      })
+      // onSuccess (close dialog) is deferred until the status update also succeeds
+      expect(defaultProps.onSuccess).not.toHaveBeenCalled()
     })
 
     it('shows API error alert when update fails', () => {

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.test.tsx
@@ -370,7 +370,7 @@ describe('CreateOrUpdateCurationTaskDialog', () => {
       })
     })
 
-    it('skips updateTask and only calls updateTaskStatus when only status is changed', async () => {
+    it('calls updateTaskStatus when only status is changed', async () => {
       renderEditDialog(fileBasedTask)
 
       // Change only the status — no task field changes
@@ -384,7 +384,6 @@ describe('CreateOrUpdateCurationTaskDialog', () => {
       await userEvent.click(screen.getByRole('button', { name: /save/i }))
 
       await waitFor(() => {
-        expect(mockUpdateMutate).not.toHaveBeenCalled()
         expect(mockUpdateStatusMutate).toHaveBeenCalledWith(
           expect.objectContaining({ state: 'IN_PROGRESS' }),
         )

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.test.tsx
@@ -21,9 +21,10 @@ import {
   DELETE_CURATION_TASK_DIALOG_TITLE,
   FILE_BASED_TASK_TITLE,
   RECORD_BASED_TASK_TITLE,
-  TASK_STATUS_IN_PROGRESS_LABEL,
+  TASK_STATUS_CONFIG,
   TASK_STATUS_INPUT_LABEL,
 } from '../utils/constants'
+import { TaskStatusStateEnum } from '@sage-bionetworks/synapse-client'
 
 vi.mock('@/synapse-queries/curation/task/useCurationTask', () => ({
   useCreateCurationTask: vi.fn(),
@@ -378,7 +379,9 @@ describe('CreateOrUpdateCurationTaskDialog', () => {
         screen.getByRole('combobox', { name: TASK_STATUS_INPUT_LABEL }),
       )
       await userEvent.click(
-        screen.getByRole('option', { name: TASK_STATUS_IN_PROGRESS_LABEL }),
+        screen.getByRole('option', {
+          name: TASK_STATUS_CONFIG[TaskStatusStateEnum.IN_PROGRESS].label,
+        }),
       )
 
       await userEvent.click(screen.getByRole('button', { name: /save/i }))
@@ -408,7 +411,9 @@ describe('CreateOrUpdateCurationTaskDialog', () => {
         screen.getByRole('combobox', { name: TASK_STATUS_INPUT_LABEL }),
       )
       await userEvent.click(
-        screen.getByRole('option', { name: TASK_STATUS_IN_PROGRESS_LABEL }),
+        screen.getByRole('option', {
+          name: TASK_STATUS_CONFIG[TaskStatusStateEnum.IN_PROGRESS].label,
+        }),
       )
 
       await userEvent.click(screen.getByRole('button', { name: /save/i }))

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.test.tsx
@@ -110,12 +110,12 @@ beforeEach(() => {
   mockUpdateMutate.mockResolvedValue({})
   mockDeleteMutate.mockResolvedValue(undefined)
   mockUseCreateCurationTask.mockReturnValue({
-    mutate: mockCreateMutate,
+    mutateAsync: mockCreateMutate,
     isPending: false,
     error: null,
   } as any)
   mockUseUpdateCurationTask.mockReturnValue({
-    mutate: mockUpdateMutate,
+    mutateAsync: mockUpdateMutate,
     isPending: false,
     error: null,
   } as any)
@@ -136,7 +136,7 @@ beforeEach(() => {
     isFetching: false,
   } as any)
   mockUseUpdateCurationTaskStatus.mockReturnValue({
-    mutate: mockUpdateStatusMutate,
+    mutateAsync: mockUpdateStatusMutate,
     isPending: false,
     error: null,
   } as any)
@@ -255,7 +255,7 @@ describe('CreateOrUpdateCurationTaskDialog', () => {
 
     it('shows API error alert when create fails', async () => {
       mockUseCreateCurationTask.mockReturnValue({
-        mutate: mockCreateMutate,
+        mutateAsync: mockCreateMutate,
         isPending: false,
         error: { reason: 'Something went wrong' },
       } as any)
@@ -366,15 +366,45 @@ describe('CreateOrUpdateCurationTaskDialog', () => {
             taskId: MOCK_CURATION_TASK_ID,
             dataType: 'Proteomics',
           }),
-          expect.objectContaining({ onSuccess: expect.any(Function) }),
         )
       })
     })
 
-    it('chains updateTaskStatus after updateTask when status is changed', async () => {
+    it('skips updateTask and only calls updateTaskStatus when only status is changed', async () => {
       renderEditDialog(fileBasedTask)
 
-      // Open the Status dropdown and select "In Progress"
+      // Change only the status — no task field changes
+      await userEvent.click(
+        screen.getByRole('combobox', { name: TASK_STATUS_INPUT_LABEL }),
+      )
+      await userEvent.click(
+        screen.getByRole('option', { name: TASK_STATUS_IN_PROGRESS_LABEL }),
+      )
+
+      await userEvent.click(screen.getByRole('button', { name: /save/i }))
+
+      await waitFor(() => {
+        expect(mockUpdateMutate).not.toHaveBeenCalled()
+        expect(mockUpdateStatusMutate).toHaveBeenCalledWith(
+          expect.objectContaining({ state: 'IN_PROGRESS' }),
+        )
+      })
+    })
+
+    it('chains updateTaskStatus after updateTask and passes updated etag when both change', async () => {
+      const updatedEtag = 'new-etag-from-server'
+      mockUpdateMutate.mockResolvedValue({
+        ...fileBasedTask,
+        etag: updatedEtag,
+      })
+      renderEditDialog(fileBasedTask)
+
+      // Change a task field
+      const dataTypeInput = screen.getByLabelText(/Task Name/i)
+      await userEvent.clear(dataTypeInput)
+      await userEvent.type(dataTypeInput, 'Proteomics')
+
+      // Change status
       await userEvent.click(
         screen.getByRole('combobox', { name: TASK_STATUS_INPUT_LABEL }),
       )
@@ -386,25 +416,18 @@ describe('CreateOrUpdateCurationTaskDialog', () => {
 
       await waitFor(() => {
         expect(mockUpdateMutate).toHaveBeenCalled()
-      })
-
-      // Simulate updateTask succeeding to trigger the status update chain
-      const [, { onSuccess: taskOnSuccess }] = mockUpdateMutate.mock.calls[0]
-      taskOnSuccess(fileBasedTask)
-
-      await waitFor(() => {
         expect(mockUpdateStatusMutate).toHaveBeenCalledWith(
-          expect.objectContaining({ state: 'IN_PROGRESS' }),
-          expect.objectContaining({ onSuccess: expect.any(Function) }),
+          expect.objectContaining({ state: 'IN_PROGRESS', etag: updatedEtag }),
+        )
+        expect(defaultProps.onSuccess).toHaveBeenCalledWith(
+          expect.objectContaining({ etag: updatedEtag }),
         )
       })
-      // onSuccess (close dialog) is deferred until the status update also succeeds
-      expect(defaultProps.onSuccess).not.toHaveBeenCalled()
     })
 
     it('shows API error alert when update fails', () => {
       mockUseUpdateCurationTask.mockReturnValue({
-        mutate: mockUpdateMutate,
+        mutateAsync: mockUpdateMutate,
         isPending: false,
         error: { reason: 'Update failed' },
       } as any)

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
@@ -700,7 +700,7 @@ export default function CreateOrUpdateCurationTaskDialog(
           )}
           <Button
             variant="contained"
-            onClick={() => void handleSave()}
+            onClick={() => void handleSave().catch(noop)}
             disabled={isPending || selectedConcreteType === null}
           >
             Save

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
@@ -700,6 +700,7 @@ export default function CreateOrUpdateCurationTaskDialog(
           )}
           <Button
             variant="contained"
+            // errors surfaced via react-query error state
             onClick={() => void handleSave().catch(noop)}
             disabled={isPending || selectedConcreteType === null}
           >

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
@@ -313,28 +313,13 @@ export default function CreateOrUpdateCurationTaskDialog(
   async function handleSave() {
     const payload = buildTaskPayload()
     if (isEditMode) {
-      const statusChanged =
+      const latestTask = await updateTask(payload)
+
+      if (
         pendingStatusState !== undefined &&
-        pendingStatusState !== currentTaskStatus?.state
-
-      // Only call updateTask when mutable task fields actually changed.
-      // This lets users who can only update status (not the task itself)
-      // save without hitting a 403 on the task PUT.
-      const taskFieldsChanged =
-        payload.dataType !== task.dataType ||
-        payload.instructions !== task.instructions ||
-        payload.assigneePrincipalId !== task.assigneePrincipalId ||
-        payload.taskProperties?.suggestedAuthorizationMode !==
-          task.taskProperties?.suggestedAuthorizationMode
-
-      let latestTask: CurationTask = task
-      if (taskFieldsChanged) {
-        latestTask = await updateTask(payload)
-      }
-
-      if (statusChanged && currentTaskStatus != null) {
-        // CurationTask and TaskStatus share the same etag. Use the etag from
-        // the latest task so the status PUT isn't rejected with a 412.
+        pendingStatusState !== currentTaskStatus?.state &&
+        currentTaskStatus != null
+      ) {
         await updateTaskStatus({
           ...currentTaskStatus,
           state: pendingStatusState,

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
@@ -58,11 +58,8 @@ import {
   AUTH_MODE_SOURCE_BENEFACTOR_TOOLTIP,
   COLLABORATORS_TOOLTIP,
   CREATE_CURATION_TASK_DIALOG_TITLE,
-  TASK_STATUS_CANCELED_LABEL,
-  TASK_STATUS_COMPLETED_LABEL,
-  TASK_STATUS_IN_PROGRESS_LABEL,
+  TASK_STATUS_CONFIG,
   TASK_STATUS_INPUT_LABEL,
-  TASK_STATUS_NOT_STARTED_LABEL,
   DELETE_CURATION_TASK_CONFIRMATION_PROMPT,
   DELETE_CURATION_TASK_DIALOG_TITLE,
   DELETE_CURATION_TASK_ERROR_TOAST_PREFIX,
@@ -618,18 +615,11 @@ export default function CreateOrUpdateCurationTaskDialog(
                     setPendingStatusState(e.target.value as TaskStatusStateEnum)
                   }
                 >
-                  <MenuItem value={TaskStatusStateEnum.NOT_STARTED}>
-                    {TASK_STATUS_NOT_STARTED_LABEL}
-                  </MenuItem>
-                  <MenuItem value={TaskStatusStateEnum.IN_PROGRESS}>
-                    {TASK_STATUS_IN_PROGRESS_LABEL}
-                  </MenuItem>
-                  <MenuItem value={TaskStatusStateEnum.COMPLETED}>
-                    {TASK_STATUS_COMPLETED_LABEL}
-                  </MenuItem>
-                  <MenuItem value={TaskStatusStateEnum.CANCELED}>
-                    {TASK_STATUS_CANCELED_LABEL}
-                  </MenuItem>
+                  {Object.values(TaskStatusStateEnum).map(state => (
+                    <MenuItem key={state} value={state}>
+                      {TASK_STATUS_CONFIG[state].label}
+                    </MenuItem>
+                  ))}
                 </Select>
               </StyledFormControl>
             )}

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
@@ -12,7 +12,9 @@ import WizardChoiceButtonGroup from '@/components/WizardChoiceButton/WizardChoic
 import {
   useCreateCurationTask,
   useDeleteCurationTask,
+  useGetCurationTaskStatus,
   useUpdateCurationTask,
+  useUpdateCurationTaskStatus,
 } from '@/synapse-queries/curation/task/useCurationTask'
 import { EntityTypeGroup } from '@/utils/functions/EntityTypeUtils'
 import { HelpTwoTone } from '@mui/icons-material'
@@ -27,8 +29,10 @@ import {
   Grid,
   IconButton,
   InputLabel,
+  MenuItem,
   Radio,
   RadioGroup,
+  Select,
   Stack,
   Tooltip,
   Typography,
@@ -39,6 +43,7 @@ import {
   EntityType,
   FileBasedMetadataTaskPropertiesConcreteTypeEnum,
   RecordBasedMetadataTaskPropertiesConcreteTypeEnum,
+  TaskStatusStateEnum,
 } from '@sage-bionetworks/synapse-client'
 import { TYPE_FILTER } from '@sage-bionetworks/synapse-types'
 import { useState } from 'react'
@@ -53,6 +58,11 @@ import {
   AUTH_MODE_SOURCE_BENEFACTOR_TOOLTIP,
   COLLABORATORS_TOOLTIP,
   CREATE_CURATION_TASK_DIALOG_TITLE,
+  TASK_STATUS_CANCELED_LABEL,
+  TASK_STATUS_COMPLETED_LABEL,
+  TASK_STATUS_IN_PROGRESS_LABEL,
+  TASK_STATUS_INPUT_LABEL,
+  TASK_STATUS_NOT_STARTED_LABEL,
   DELETE_CURATION_TASK_CONFIRMATION_PROMPT,
   DELETE_CURATION_TASK_DIALOG_TITLE,
   DELETE_CURATION_TASK_ERROR_TOAST_PREFIX,
@@ -205,6 +215,17 @@ export default function CreateOrUpdateCurationTaskDialog(
     string | null
   >(null)
 
+  // Task status (edit mode only)
+  const { data: currentTaskStatus, isFetching: isStatusFetching } =
+    useGetCurationTaskStatus(task?.taskId ?? 0, {
+      enabled: isEditMode && task?.taskId != null,
+    })
+  // undefined = user hasn't changed the status yet
+  const [pendingStatusState, setPendingStatusState] = useState<
+    TaskStatusStateEnum | undefined
+  >(undefined)
+  const displayedStatusState = pendingStatusState ?? currentTaskStatus?.state
+
   const {
     mutate: createTask,
     isPending: isCreatePending,
@@ -219,11 +240,13 @@ export default function CreateOrUpdateCurationTaskDialog(
     mutate: updateTask,
     isPending: isUpdatePending,
     error: updateError,
-  } = useUpdateCurationTask({
-    onSuccess: updated => {
-      onSuccess(updated)
-    },
-  })
+  } = useUpdateCurationTask()
+
+  const {
+    mutate: updateTaskStatus,
+    isPending: isStatusUpdatePending,
+    error: statusUpdateError,
+  } = useUpdateCurationTaskStatus()
 
   const { mutate: deleteTask, isPending: isDeletePending } =
     useDeleteCurationTask({
@@ -240,8 +263,12 @@ export default function CreateOrUpdateCurationTaskDialog(
       },
     })
 
-  const isPending = isCreatePending || isUpdatePending || isDeletePending
-  const error = createError ?? updateError
+  const isPending =
+    isCreatePending ||
+    isUpdatePending ||
+    isDeletePending ||
+    isStatusUpdatePending
+  const error = createError ?? updateError ?? statusUpdateError
 
   const isTaskPropertiesValid =
     (selectedConcreteType === FILE_BASED_CONCRETE_TYPE &&
@@ -289,7 +316,21 @@ export default function CreateOrUpdateCurationTaskDialog(
   function handleSave() {
     const payload = buildTaskPayload()
     if (isEditMode) {
-      updateTask(payload)
+      const statusChanged =
+        pendingStatusState !== undefined &&
+        pendingStatusState !== currentTaskStatus?.state
+      updateTask(payload, {
+        onSuccess: updatedTask => {
+          if (statusChanged && currentTaskStatus != null) {
+            updateTaskStatus(
+              { ...currentTaskStatus, state: pendingStatusState },
+              { onSuccess: () => onSuccess(updatedTask) },
+            )
+          } else {
+            onSuccess(updatedTask)
+          }
+        },
+      })
     } else {
       createTask(payload)
     }
@@ -565,6 +606,35 @@ export default function CreateOrUpdateCurationTaskDialog(
         </Grid>
         <Grid size={{ xs: 12, sm: 6 }}>
           <Stack gap={3}>
+            {isEditMode && (
+              <FormControl fullWidth>
+                <InputLabel id="dlg-task-status-label">
+                  {TASK_STATUS_INPUT_LABEL}
+                </InputLabel>
+                <Select
+                  labelId="dlg-task-status-label"
+                  value={displayedStatusState ?? ''}
+                  label={TASK_STATUS_INPUT_LABEL}
+                  disabled={isStatusFetching}
+                  onChange={e =>
+                    setPendingStatusState(e.target.value as TaskStatusStateEnum)
+                  }
+                >
+                  <MenuItem value={TaskStatusStateEnum.NOT_STARTED}>
+                    {TASK_STATUS_NOT_STARTED_LABEL}
+                  </MenuItem>
+                  <MenuItem value={TaskStatusStateEnum.IN_PROGRESS}>
+                    {TASK_STATUS_IN_PROGRESS_LABEL}
+                  </MenuItem>
+                  <MenuItem value={TaskStatusStateEnum.COMPLETED}>
+                    {TASK_STATUS_COMPLETED_LABEL}
+                  </MenuItem>
+                  <MenuItem value={TaskStatusStateEnum.CANCELED}>
+                    {TASK_STATUS_CANCELED_LABEL}
+                  </MenuItem>
+                </Select>
+              </FormControl>
+            )}
             {assigneeField}
             {authModeField}
           </Stack>

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
@@ -228,23 +228,19 @@ export default function CreateOrUpdateCurationTaskDialog(
   const displayedStatusState = pendingStatusState ?? currentTaskStatus?.state
 
   const {
-    mutate: createTask,
+    mutateAsync: createTask,
     isPending: isCreatePending,
     error: createError,
-  } = useCreateCurationTask({
-    onSuccess: created => {
-      onSuccess(created)
-    },
-  })
+  } = useCreateCurationTask()
 
   const {
-    mutate: updateTask,
+    mutateAsync: updateTask,
     isPending: isUpdatePending,
     error: updateError,
   } = useUpdateCurationTask()
 
   const {
-    mutate: updateTaskStatus,
+    mutateAsync: updateTaskStatus,
     isPending: isStatusUpdatePending,
     error: statusUpdateError,
   } = useUpdateCurationTaskStatus()
@@ -314,26 +310,42 @@ export default function CreateOrUpdateCurationTaskDialog(
     }
   }
 
-  function handleSave() {
+  async function handleSave() {
     const payload = buildTaskPayload()
     if (isEditMode) {
       const statusChanged =
         pendingStatusState !== undefined &&
         pendingStatusState !== currentTaskStatus?.state
-      updateTask(payload, {
-        onSuccess: updatedTask => {
-          if (statusChanged && currentTaskStatus != null) {
-            updateTaskStatus(
-              { ...currentTaskStatus, state: pendingStatusState },
-              { onSuccess: () => onSuccess(updatedTask) },
-            )
-          } else {
-            onSuccess(updatedTask)
-          }
-        },
-      })
+
+      // Only call updateTask when mutable task fields actually changed.
+      // This lets users who can only update status (not the task itself)
+      // save without hitting a 403 on the task PUT.
+      const taskFieldsChanged =
+        payload.dataType !== task.dataType ||
+        payload.instructions !== task.instructions ||
+        payload.assigneePrincipalId !== task.assigneePrincipalId ||
+        payload.taskProperties?.suggestedAuthorizationMode !==
+          task.taskProperties?.suggestedAuthorizationMode
+
+      let latestTask: CurationTask = task
+      if (taskFieldsChanged) {
+        latestTask = await updateTask(payload)
+      }
+
+      if (statusChanged && currentTaskStatus != null) {
+        // CurationTask and TaskStatus share the same etag. Use the etag from
+        // the latest task so the status PUT isn't rejected with a 412.
+        await updateTaskStatus({
+          ...currentTaskStatus,
+          state: pendingStatusState,
+          etag: latestTask.etag,
+        })
+      }
+
+      onSuccess(latestTask)
     } else {
-      createTask(payload)
+      const created = await createTask(payload)
+      onSuccess(created)
     }
   }
 
@@ -713,7 +725,7 @@ export default function CreateOrUpdateCurationTaskDialog(
           )}
           <Button
             variant="contained"
-            onClick={handleSave}
+            onClick={() => void handleSave()}
             disabled={isPending || selectedConcreteType === null}
           >
             Save

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
@@ -90,6 +90,7 @@ import {
 } from '../utils/constants'
 import noop from 'lodash-es/noop'
 import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
+import { StyledFormControl } from '@/components/styled'
 
 export type CreateOrUpdateCurationTaskDialogProps = {
   open: boolean
@@ -607,7 +608,7 @@ export default function CreateOrUpdateCurationTaskDialog(
         <Grid size={{ xs: 12, sm: 6 }}>
           <Stack gap={3}>
             {isEditMode && (
-              <FormControl fullWidth>
+              <StyledFormControl fullWidth>
                 <InputLabel id="dlg-task-status-label">
                   {TASK_STATUS_INPUT_LABEL}
                 </InputLabel>
@@ -633,7 +634,7 @@ export default function CreateOrUpdateCurationTaskDialog(
                     {TASK_STATUS_CANCELED_LABEL}
                   </MenuItem>
                 </Select>
-              </FormControl>
+              </StyledFormControl>
             )}
             {assigneeField}
             {authModeField}

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
@@ -610,7 +610,7 @@ export default function CreateOrUpdateCurationTaskDialog(
                   labelId="dlg-task-status-label"
                   value={displayedStatusState ?? ''}
                   label={TASK_STATUS_INPUT_LABEL}
-                  disabled={isStatusFetching}
+                  disabled={isStatusFetching || currentTaskStatus == null}
                   onChange={e =>
                     setPendingStatusState(e.target.value as TaskStatusStateEnum)
                   }

--- a/packages/synapse-react-client/src/features/entity/metadata-task/utils/constants.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/utils/constants.ts
@@ -61,6 +61,12 @@ export const AUTH_MODE_CHANGED_WARNING =
   'Changing the Authorization Mode will clear the active session ID on this task. Any in-progress grid session linked to this task will no longer be associated with it.'
 export const GENERIC_SAVE_ERROR_MESSAGE = 'An error occurred. Please try again.'
 
+export const TASK_STATUS_INPUT_LABEL = 'Status'
+export const TASK_STATUS_NOT_STARTED_LABEL = 'Not Started'
+export const TASK_STATUS_IN_PROGRESS_LABEL = 'In Progress'
+export const TASK_STATUS_COMPLETED_LABEL = 'Completed'
+export const TASK_STATUS_CANCELED_LABEL = 'Canceled'
+
 export const DELETE_CURATION_TASK_DIALOG_TITLE = 'Delete Task'
 export const DELETE_CURATION_TASK_CONFIRMATION_PROMPT =
   'Are you sure you want to delete this task? This action cannot be undone.'

--- a/packages/synapse-react-client/src/features/entity/metadata-task/utils/constants.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/utils/constants.ts
@@ -1,3 +1,5 @@
+import { TaskStatusStateEnum } from '@sage-bionetworks/synapse-client'
+
 export const OPEN_CURATOR_ERROR_TITLE =
   'An error occurred while trying to open Curator'
 export const OPEN_CURATOR_UNAUTHORIZED_ERROR_MESSAGE =
@@ -62,10 +64,16 @@ export const AUTH_MODE_CHANGED_WARNING =
 export const GENERIC_SAVE_ERROR_MESSAGE = 'An error occurred. Please try again.'
 
 export const TASK_STATUS_INPUT_LABEL = 'Status'
-export const TASK_STATUS_NOT_STARTED_LABEL = 'Not Started'
-export const TASK_STATUS_IN_PROGRESS_LABEL = 'In Progress'
-export const TASK_STATUS_COMPLETED_LABEL = 'Completed'
-export const TASK_STATUS_CANCELED_LABEL = 'Canceled'
+
+export const TASK_STATUS_CONFIG: Record<
+  TaskStatusStateEnum,
+  { label: string; backgroundColor: string }
+> = {
+  NOT_STARTED: { label: 'Not Started', backgroundColor: '#EAECEE' },
+  IN_PROGRESS: { label: 'In Progress', backgroundColor: '#FFF3CD' },
+  COMPLETED: { label: 'Completed', backgroundColor: '#C8E6C9' },
+  CANCELED: { label: 'Canceled', backgroundColor: '#FFCCBC' },
+}
 
 export const DELETE_CURATION_TASK_DIALOG_TITLE = 'Delete Task'
 export const DELETE_CURATION_TASK_CONFIRMATION_PROMPT =

--- a/packages/synapse-react-client/src/synapse-queries/curation/task/useCurationTask.ts
+++ b/packages/synapse-react-client/src/synapse-queries/curation/task/useCurationTask.ts
@@ -116,9 +116,11 @@ export function useUpdateCurationTaskStatus(
         { taskId: taskStatus.taskId!, taskStatus },
       ),
     onSuccess: (data, variables, context) => {
-      // Invalidate both the status query and the task query using the ID key
       queryClient.invalidateQueries({
         queryKey: keyFactory.getCurationTaskIdKey(variables.taskId!),
+      })
+      queryClient.invalidateQueries({
+        queryKey: keyFactory.getAllCurationTaskListKey(),
       })
 
       if (options?.onSuccess) {


### PR DESCRIPTION
- Add curation task status pill to CurationTaskCard
- Move taskId into description div
- Create settings button that opens useCreateOrUpdateCurationTaskDialog if user has edit permission to the project
- Add dropdown to modify task status in useCreateOrUpdateCurationTaskDialog

<img width="2530" height="422" alt="image" src="https://github.com/user-attachments/assets/1a8f10e1-60bd-4ab8-89d2-c5e20fb7faae" />

expanded content
<img width="2524" height="638" alt="image" src="https://github.com/user-attachments/assets/147544de-06aa-48e1-b542-380211c2f111" />

