### PR TITLE
PORTALS-4315: new page in ampals

### DIFF
--- a/apps/portals/ampals/src/config/navbarConfig.ts
+++ b/apps/portals/ampals/src/config/navbarConfig.ts
@@ -58,6 +58,16 @@ export const navbarConfig: NavbarConfig = {
     {
       name: 'Data Access',
       path: '/Data Access',
+      children: [
+        {
+          name: 'Data Access Overview',
+          path: '/Data Access/Data Access Overview',
+        },
+        {
+          name: 'Approved Access Requests',
+          path: '/Data Access/Approved Access Requests',
+        },
+      ],
     },
     {
       name: 'Contribute Data',

--- a/apps/portals/ampals/src/config/routesConfig.tsx
+++ b/apps/portals/ampals/src/config/routesConfig.tsx
@@ -62,10 +62,22 @@ const routes: RouteObject[] = [
       },
       {
         path: 'Data Access',
-        lazy: () =>
-          import('@/pages/resources/ForResearchers').then(
-            convertModuleToRouteObject,
-          ),
+        children: [
+          {
+            path: 'Data Access Overview',
+            lazy: () =>
+              import('@/pages/resources/ForResearchers').then(
+                convertModuleToRouteObject,
+              ),
+          },
+          {
+            path: 'Approved Access Requests',
+            lazy: () =>
+              import('@/pages/resources/ApprovedAccessRequests').then(
+                convertModuleToRouteObject,
+              ),
+          },
+        ],
       },
       {
         path: 'Resources',

--- a/apps/portals/ampals/src/pages/resources/ApprovedAccessRequests.tsx
+++ b/apps/portals/ampals/src/pages/resources/ApprovedAccessRequests.tsx
@@ -1,0 +1,24 @@
+import AMPALSResearchPageLayout from '@sage-bionetworks/synapse-portal-framework/components/ampals/AMPALSResearchPageLayout'
+import { MarkdownSynapse } from 'synapse-react-client/components/Markdown/MarkdownSynapse'
+
+function ApprovedAccessRequests() {
+  return (
+    <AMPALSResearchPageLayout
+      headerTitle="Approved Access Requests"
+      sidebarTitle="IDU statements"
+    >
+      <MarkdownSynapse
+        ownerId="syn64892175"
+        wikiId="641026"
+        loadingSkeletonRowCount={50}
+      />
+      <MarkdownSynapse
+        ownerId="syn64892175"
+        wikiId="641027"
+        loadingSkeletonRowCount={50}
+      />
+    </AMPALSResearchPageLayout>
+  )
+}
+
+export default ApprovedAccessRequests


### PR DESCRIPTION
<img width="1495" height="326" alt="Screenshot 2026-06-24 at 9 43 17 AM" src="https://github.com/user-attachments/assets/b26e7c00-c411-4e69-a46a-7261fe8cf529" />

<img width="1460" height="579" alt="Screenshot 2026-06-24 at 9 43 28 AM" src="https://github.com/user-attachments/assets/a744ec2f-6194-476a-b43f-7e2cc07c71ed" />

<img width="1464" height="695" alt="Screenshot 2026-06-24 at 9 49 48 AM" src="https://github.com/user-attachments/assets/705bcd1c-1766-491a-9acc-f3ba9ed233bc" />
