### PR TITLE
PORTALS-4330, PORTALS-4331: Fix NF dataset "On Synapse" link and remove survey banner

### DIFF
--- a/apps/portals-e2e/src/configs/bannersConfig.ts
+++ b/apps/portals-e2e/src/configs/bannersConfig.ts
@@ -1,6 +1,6 @@
 import { Portal } from './routesConfig'
 
-export type BannerType = 'cookies' | 'survey' | 'surveyDialog'
+export type BannerType = 'cookies' | 'surveyDialog'
 
 type BannerConfig = Record<Portal, BannerType[]>
 
@@ -15,7 +15,7 @@ const bannerConfig: BannerConfig = {
   digitalhealth: ['cookies'],
   eliteportal: ['cookies'],
   namhub: ['cookies'],
-  nf: ['cookies', 'survey'],
+  nf: ['cookies'],
   stopadportal: ['cookies'],
   genie: ['cookies'],
 }

--- a/apps/portals-e2e/src/helpers/banners.ts
+++ b/apps/portals-e2e/src/helpers/banners.ts
@@ -14,7 +14,6 @@ const dismissBannerConfig: Record<BannerType, DismissBannerConfig> = {
     bodyText: 'Our site uses cookies',
     closeButtonText: 'Disable All',
   },
-  survey: { bodyText: 'survey', closeButtonLabel: 'Close' },
   surveyDialog: {
     bodyText: 'survey',
     closeButtonLabel: 'Close survey dialog',

--- a/apps/portals/nf/src/pages/RootApp.tsx
+++ b/apps/portals/nf/src/pages/RootApp.tsx
@@ -1,18 +1,7 @@
 import App from '@sage-bionetworks/synapse-portal-framework/App'
-import SurveyToast from '@sage-bionetworks/synapse-portal-framework/components/SurveyToast'
 
 function RootApp() {
-  return (
-    <App>
-      <SurveyToast
-        localStorageKey={
-          'org.sagebionetworks.security.cookies.portal.nfsurvey.dismissed'
-        }
-        description="Help us improve the NF Data Portal by completing a data access survey!"
-        surveyURL="https://docs.google.com/forms/d/e/1FAIpQLSdSgkq66IoLHbvXNmMEjEg4nMELwM-_CaJK3rFkU9pn84gYuA/viewform"
-      />
-    </App>
-  )
+  return <App />
 }
 
 export default RootApp

--- a/apps/portals/nf/src/routes.ts
+++ b/apps/portals/nf/src/routes.ts
@@ -26,7 +26,7 @@ import {
 export default [
   // Top-level providers layout (ThemeProvider, QueryClientProvider, etc.)
   layout('pages/PortalRoot.tsx', [
-    // Root layout route — App shell (Navbar, Footer, SurveyToast, etc.)
+    // Root layout route — App shell (Navbar, Footer, etc.)
     route('/', 'pages/RootApp.tsx', [
       // sharedRoutes equivalents
       route('*', 'pages/ErrorPage.tsx'),

--- a/packages/synapse-react-client/src/components/GenericCard/SynapseCardLabel.test.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/SynapseCardLabel.test.tsx
@@ -70,6 +70,35 @@ describe('SynapseCardLabel tests', () => {
     )
   })
 
+  test('resolveEntityName links to the entity on Synapse.org', () => {
+    const value = 'syn1234567'
+    render(
+      <SynapseCardLabel
+        value={value}
+        labelLink={{
+          isMarkdown: false,
+          baseURL: 'Explore/Studies',
+          URLColumnName: 'studyId',
+          matchColumnName: 'studyId',
+          resolveEntityName: true,
+        }}
+        isHeader={false}
+        selectColumns={selectColumns}
+        columnModels={undefined}
+        columnName={'studyId'}
+        rowData={[]}
+      />,
+      { wrapper: createWrapper() },
+    )
+    const link = screen.getByTestId('EntityLink')
+    expect(link.getAttribute('href')).toEqual(
+      `https://www.synapse.org/Synapse:${value}`,
+    )
+    const entityLinkProps = mockEntityLink.mock.calls[0][0]
+    expect(entityLinkProps.entity).toEqual(value)
+    expect(entityLinkProps.link).toBeUndefined()
+  })
+
   test('works with a header', () => {
     const value = 'syn1234567'
     const { container } = render(

--- a/packages/synapse-react-client/src/components/GenericCard/SynapseCardLabel.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/SynapseCardLabel.tsx
@@ -153,9 +153,7 @@ export function SynapseCardLabel(props: SynapseCardLabelProps) {
   }
 
   if ('resolveEntityName' in labelLink && labelLink.resolveEntityName && str) {
-    const { baseURL, URLColumnName } = labelLink
-    const href = `/${baseURL}?${URLColumnName}=${str}`
-    return <EntityLink entity={str} link={href} showIcon={false} />
+    return <EntityLink entity={str} showIcon={false} />
   }
 
   let labelContent: ReactNode


### PR DESCRIPTION
## Summary

Resolves two NF Data Portal tickets:

### PORTALS-4330 — Dataset card "On Synapse" link misconfigured
Dataset cards render the `studyId` label via a `labelLinkConfig` entry with `resolveEntityName: true`. That branch in `SynapseCardLabel` ignored `urlParamStyle` and always built an **in-portal** URL (`/Explore/Studies?studyId=synXXX`), which has no matching route and falls back to the Explore page.

`EntityLink` already resolves the entity name for the link text and defaults to linking to `https://www.synapse.org/Synapse:{id}`. The fix stops overriding that default with the broken in-portal href.

`resolveEntityName` is used in exactly 3 places, all NF-only and all previously broken the same way, so this also fixes the study card's "Next/Previous Phase Project" links.

### PORTALS-4331 — Remove the data access survey banner
Removed the `SurveyToast` banner from the NF portal app shell (`RootApp.tsx`), mirroring the prior GENIE (PORTALS-3901) and AD Knowledge Portal (PORTALS-3899) removals. Also tidied a stale comment in `routes.ts`.

> Note on survey storage (ticket follow-up): the banner linked to a Google Form; responses live in that form's Responses tab (and any linked Google Sheet) under the owning Google account. The codebase only held the public form link.

## Test plan
- `SynapseCardLabel` unit tests pass (15/15), including a new test asserting the `resolveEntityName` branch links to Synapse.org and does not pass an in-portal `link` override.
- `synapse-react-client` type-check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)