### PR TITLE
docs: add code review norms to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,66 @@ All projects extend `shared/tsconfig.base.json` (strict mode). The root `tsconfi
 
 Husky runs ESLint + oxfmt (via lint-staged) on staged files before each commit.
 
+## Code review norms
+
+Recurring expectations from this repo's PR review history. Following them up front avoids review churn — reviewers ask for these repeatedly.
+
+### Tests
+
+- New components, hooks, and bug fixes get tests. A fix should include a test that captures the bug; a new behavior should include a test that exercises it (e.g. "add a test that the button is hidden when `canDelete` is false").
+- **Query priority (React Testing Library): prefer accessible queries — `getByRole`, `getByText`, `getByLabelText` — over `data-testid`.** Find banners, buttons, etc. by `role`; it's more robust and higher priority. Add a `data-testid` only when there's no accessible query, and delete test IDs that are no longer used.
+- For data-driven logic, prefer exhaustive tests that fail when a new case is added (e.g. iterate every `EntityType` and assert no throw) rather than spot-checking one value.
+- Don't stub `fetch` directly — mock at the network layer with MSW. Group Storybook MSW handlers as `Record<string, HttpHandler[]>` so a story can override one group.
+
+### Storybook
+
+- New components and new visual states get a Storybook story — do **not** commit throwaway demo HTML or one-off pages for visual testing. Demonstrate states (loading / empty / error, or different data like DUO values) with MSW mock responses.
+
+### React patterns
+
+- Prefer the `key` prop to reset component state instead of a `useEffect` that watches a prop and resets.
+- Run post-action logic in a callback, not an effect — e.g. a react-query mutation's `onSuccess`, not a `useEffect` watching the result.
+- Memoize objects passed to query hooks or children so references are stable across renders (`useMemo` for request objects) — don't build a new object inline on every render.
+- A `useQuery` result's `data` is possibly `undefined`; handle the loading/undefined state, don't assume it's always present.
+- `import React from 'react'` is unnecessary (automatic JSX runtime).
+
+### Types & the generated client
+
+- Use the generated type guards (e.g. `instanceOfOAuthIdentityProvider`) from `@sage-bionetworks/synapse-client` rather than hand-writing type-guard helpers.
+- Don't duplicate server-side enums/values that can drift out of sync (this caused a `FeatureFlagEnum` bug); keep one source of truth.
+
+### Reuse over duplication
+
+- Before adding a helper, component, or route, check whether one already exists and reuse it (e.g. `displayToast`, existing `parseX`/`href` helpers, shared routes). Reviewers frequently flag duplicated functions and components.
+- If a new component would closely duplicate an existing one (e.g. another plot like `SynapsePlot`), extend the existing component to cover the missing case rather than forking a near-copy.
+- Extract repeated style declarations into an SCSS module class or a shared `SxProps` constant instead of copy-pasting them.
+
+### Constants over hardcoded values
+
+- Pull magic numbers, repeated strings, and limits into named constants, and reference the **same** constant from both the component and its tests so they can't drift. Keep a single source of truth for repeated theme values.
+- Hardcoding is acceptable when there's genuinely no variation yet — don't over-parameterize prematurely. But hardcode _deliberately_: make the source obvious, and be wary of hardcoding data (counts, stats, page content) that a reader would expect to be query- or config-driven, and be ready to say where a value comes from.
+
+### Accessibility
+
+- Icon-only buttons need an `aria-label`; use MUI `IconButton` for interactive command-bar buttons.
+- Interactive non-button elements need `role` + `tabIndex={0}`.
+- For MUI `Select`, set/reference the `labelId` from the component (MUI a11y wants this direction).
+- Decorative images may use blank `alt`.
+
+### Module boundaries
+
+- No circular dependencies — the Vite (Rolldown) build is strict and will fail on cycles. Break a cycle by moving the shared constant/type into a neutral module.
+
+### PR hygiene
+
+- Reference the Jira ticket in the branch, PR title, and commit subject (`PORTALS-XXXX`, `SWC-XXXX`). Track follow-up or out-of-scope work in a new ticket instead of growing the PR.
+- When you fix something or adopt a convention, apply it consistently across every file the change touches — not just the first instance a reviewer points at.
+- Don't leave `console.*`, commented-out code, or other dead code in the diff.
+
+### Process & ownership
+
+- Whoever submits a change owns it going forward: maintainers will ask you to address future issues found in components you add or change, and to coordinate any required production updates. Factor this in before adding or expanding scope.
+
 ## Requirements
 
 - **Node:** >= 22, < 23

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,13 +133,13 @@ Recurring expectations from this repo's PR review history. Following them up fro
 ### Types & the generated client
 
 - Use the generated type guards (e.g. `instanceOfOAuthIdentityProvider`) from `@sage-bionetworks/synapse-client` rather than hand-writing type-guard helpers.
-- Don't duplicate server-side enums/values that can drift out of sync (this caused a `FeatureFlagEnum` bug); keep one source of truth.
+- Prefer using the generated enums/values when possible. Some components use the legacy manually-maintained types in `@sage-bionetworks/synapse-types`. Use these only when necessary for compatibility.
 
 ### Reuse over duplication
 
 - Before adding a helper, component, or route, check whether one already exists and reuse it (e.g. `displayToast`, existing `parseX`/`href` helpers, shared routes). Reviewers frequently flag duplicated functions and components.
 - If a new component would closely duplicate an existing one (e.g. another plot like `SynapsePlot`), extend the existing component to cover the missing case rather than forking a near-copy.
-- Extract repeated style declarations into an SCSS module class or a shared `SxProps` constant instead of copy-pasting them.
+- Extract repeated style declarations into an SCSS module class (preferred) or a shared `SxProps` constant (MUI-only) instead of copy-pasting them.
 
 ### Constants over hardcoded values
 
@@ -148,7 +148,7 @@ Recurring expectations from this repo's PR review history. Following them up fro
 
 ### Accessibility
 
-- Icon-only buttons need an `aria-label`; use MUI `IconButton` for interactive command-bar buttons.
+- Icon-only buttons need an `aria-label` or a MUI `Tooltip`; use MUI `IconButton` for interactive command-bar buttons.
 - Interactive non-button elements need `role` + `tabIndex={0}`.
 - For MUI `Select`, set/reference the `labelId` from the component (MUI a11y wants this direction).
 - Decorative images may use blank `alt`.
@@ -156,6 +156,7 @@ Recurring expectations from this repo's PR review history. Following them up fro
 ### Module boundaries
 
 - No circular dependencies — the Vite (Rolldown) build is strict and will fail on cycles. Break a cycle by moving the shared constant/type into a neutral module.
+- Avoid referencing, creating, or extending barrel files unless necessary.
 
 ### PR hygiene
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Recurring expectations from this repo's PR review history. Following them up fro
 - Prefer the `key` prop to reset component state instead of a `useEffect` that watches a prop and resets.
 - Run post-action logic in a callback, not an effect — e.g. a react-query mutation's `onSuccess`, not a `useEffect` watching the result.
 - Memoize objects passed to query hooks or children so references are stable across renders (`useMemo` for request objects) — don't build a new object inline on every render.
-- A `useQuery` result's `data` is possibly `undefined`; handle the loading/undefined state, don't assume it's always present.
+- A `useQuery` result's `data` is possibly `undefined`; handle the loading/undefined state, don't assume it's always present. Handle loading and error states explicitly by using the `isLoading`, and `error` values returned by `useQuery`.
 - `import React from 'react'` is unnecessary (automatic JSX runtime).
 
 ### Types & the generated client

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,11 @@ All projects extend `shared/tsconfig.base.json` (strict mode). The root `tsconfi
 
 Husky runs ESLint + oxfmt (via lint-staged) on staged files before each commit.
 
+## Comments
+
+Default to no comment. Code should be self-explanatory through clear naming and structure; a comment is a last resort for genuinely non-obvious intent — a subtle invariant, a workaround for external behavior, or a "why this and not the obvious thing" that the code can't express on its own. Never comment to restate what the code does, and don't narrate routine logic. It is always useful to document regex patterns - i.e. what they are intended to match. When in doubt, leave it out. 
+Never write "historical context" comments in a refactor — e.g. `// previously this used X`, `// changed from the old approach`, `// no longer does Y`. Once a PR merges, the old behavior is irrelevant and lives in git history. Comment what the code does now, not what it used to do.
+
 ## Code review norms
 
 Recurring expectations from this repo's PR review history. Following them up front avoids review churn — reviewers ask for these repeatedly.


### PR DESCRIPTION
## Summary

Adds a **Code review norms** section to the root `CLAUDE.md` so Claude (and anyone using it in this repo) follows the conventions reviewers enforce repeatedly, instead of rediscovering them in review.

The norms were distilled from this repo's PR review-comment history (the inline review corpus, dominated by @nickgros and @jay-hodgson, plus @hallieswan / @kianamcc / @afwillia), then de-duplicated against the existing root, `synapse-react-client/`, and `apps/portals/` CLAUDE.md files so nothing already documented is repeated.

## What's added

- **Tests** — fixes/new behavior need tests; React Testing Library query priority (`getByRole`/text/label over `data-testid`); exhaustive data-driven tests; no `fetch` stubs (mock with MSW); `Record`-grouped Storybook handlers
- **Storybook** — stories for new components/visual states; no throwaway demo HTML
- **React patterns** — `key` over state-resetting `useEffect`; mutation `onSuccess` over effects; `useMemo` for stable request objects; `useQuery` `data` is possibly undefined; no `import React`
- **Types & the generated client** — use generated `instanceOf*` guards; don't duplicate server-side enums that can drift
- **Reuse over duplication** — reuse existing helpers/components; extend a near-duplicate (e.g. `SynapsePlot`) rather than forking; extract repeated styles
- **Constants over hardcoded values** — name magic numbers and share constants with tests; hardcode deliberately and be wary of opaque hardcoded data
- **Accessibility** — `aria-label` on icon buttons, `IconButton`, `role`+`tabIndex`, MUI `Select` `labelId`
- **Module boundaries** — no circular deps (Rolldown is strict)
- **PR hygiene** — Jira ticket in branch/PR/commit; apply fixes consistently across the change; no dead code
- **Process & ownership** — whoever submits a change owns it going forward, including future issues and coordinating production updates

## Notes

- Deliberately excluded a hard "never hardcode portal stats" rule — reviewer signals on hardcoding are mixed (it's endorsed for simplicity in some threads), so this is framed as judgment rather than a rule.
- Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)