### PR TITLE
PORTALS-4334: resize & restyle v3 navbar search box

### DIFF
--- a/apps/synapse-portal-framework/src/components/HeaderSearchBoxV3.module.scss
+++ b/apps/synapse-portal-framework/src/components/HeaderSearchBoxV3.module.scss
@@ -34,6 +34,7 @@
   :global(.MuiInputBase-root) {
     border-radius: 30px;
     background: #fcfcfc;
+    height: 44px;
   }
 
   :global(.MuiInputBase-input)::placeholder {

--- a/apps/synapse-portal-framework/src/components/HeaderSearchBoxV3.module.scss
+++ b/apps/synapse-portal-framework/src/components/HeaderSearchBoxV3.module.scss
@@ -34,10 +34,6 @@
   :global(.MuiInputBase-root) {
     border-radius: 30px;
     background: #fcfcfc;
-    // The default MUI small input (~40px) looks short against the navbar strip.
-    // Fixed rather than derived from --synapse-nav-top-height, which doubles at
-    // the mobile breakpoint and would overflow the mobile navbar grid.
-    height: 44px;
   }
 
   :global(.MuiInputBase-input)::placeholder {

--- a/apps/synapse-portal-framework/src/components/HeaderSearchBoxV3.module.scss
+++ b/apps/synapse-portal-framework/src/components/HeaderSearchBoxV3.module.scss
@@ -27,11 +27,16 @@
 
 .searchField {
   border-radius: 30px;
-  border: 1px solid #eee;
+  // Resting border: a clear grey so the field reads against the near-white
+  // navbar (was #eee, which was too low-contrast). Focus stays primary blue.
+  border: 1px solid var(--synapse-gray-500);
 
   :global(.MuiInputBase-root) {
     border-radius: 30px;
     background: #fcfcfc;
+    // Size to half the navbar strip height (the v3 box lives in the sticky-search
+    // navbar). The default MUI small input (~40px) looks short against the strip.
+    height: calc(var(--synapse-nav-top-height) / 2);
   }
 
   :global(.MuiInputBase-input)::placeholder {

--- a/apps/synapse-portal-framework/src/components/HeaderSearchBoxV3.module.scss
+++ b/apps/synapse-portal-framework/src/components/HeaderSearchBoxV3.module.scss
@@ -34,9 +34,10 @@
   :global(.MuiInputBase-root) {
     border-radius: 30px;
     background: #fcfcfc;
-    // Size to half the navbar strip height (the v3 box lives in the sticky-search
-    // navbar). The default MUI small input (~40px) looks short against the strip.
-    height: calc(var(--synapse-nav-top-height) / 2);
+    // The default MUI small input (~40px) looks short against the navbar strip.
+    // Fixed rather than derived from --synapse-nav-top-height, which doubles at
+    // the mobile breakpoint and would overflow the mobile navbar grid.
+    height: 44px;
   }
 
   :global(.MuiInputBase-input)::placeholder {

--- a/apps/synapse-portal-framework/src/style/_Navbar.scss
+++ b/apps/synapse-portal-framework/src/style/_Navbar.scss
@@ -36,13 +36,6 @@
       justify-content: space-between;
       align-items: center;
       padding: 16px 40px;
-
-      // The default MUI small input (~40px) looks short against the desktop
-      // strip. Only tall here: on mobile the box is stacked above the MENU
-      // link, where a taller box would push MENU down.
-      .MuiInputBase-root {
-        height: 44px;
-      }
     }
 
     .nav-link-container {
@@ -85,11 +78,14 @@
       flex-direction: row;
       flex-wrap: wrap;
       align-items: stretch;
+      // Pack the logo/search and MENU lines to the top instead of stretching
+      // free space between them, so the search box and MENU stay close.
+      align-content: flex-start;
       height: var(--synapse-header-height-with-sticky-search);
 
       .mb-open,
       .mb-close {
-        padding: 24px 18px 0 18px;
+        padding: 12px 18px 0 18px;
       }
     }
 

--- a/apps/synapse-portal-framework/src/style/_Navbar.scss
+++ b/apps/synapse-portal-framework/src/style/_Navbar.scss
@@ -36,6 +36,13 @@
       justify-content: space-between;
       align-items: center;
       padding: 16px 40px;
+
+      // The default MUI small input (~40px) looks short against the desktop
+      // strip. Only tall here: on mobile the box is stacked above the MENU
+      // link, where a taller box would push MENU down.
+      .MuiInputBase-root {
+        height: 44px;
+      }
     }
 
     .nav-link-container {


### PR DESCRIPTION
## Summary

Adjusts the sticky-search navbar search box (`HeaderSearchBox variant="v3"`) to approximately match the NF Research Tools Database design in Figma, with one deliberate deviation for legibility.

**Figma reference:** https://www.figma.com/design/aSr8SUVMX0EETgF3Qxvyrw/NF-Research-Tools-Database?node-id=2577-3277

## Changes

In the shared `HeaderSearchBoxV3.module.scss` and `_Navbar.scss`:

- **Height** — the box used the default small MUI input (~24–40px), which looked disproportionately short against the navbar strip. Set to a fixed `44px` on all breakpoints.
- **Mobile MENU spacing** — the mobile sticky-search navbar is a fixed-height `flex-wrap` container, so its default `align-content: stretch` injected free vertical space *between* the search box and the "MENU" link. When the box grew taller, that stretch (not padding) is what pushed MENU down. Fixed by packing the wrapped lines to the top (`align-content: flex-start`) and reducing the MENU top padding, so the taller box and MENU stay close and MENU is no longer displaced.
- **Resting border** — changed from `#eee` to `--synapse-gray-500`. This is a slight, intentional departure from the Figma: at `#eee` the unhighlighted (unfocused) search bar was very low-contrast against the near-white navbar and hard to see. The focused state stays primary blue.

## Scope

This is a shared v3-navbar change, so it applies to the portals that use the `with-sticky-search` navbar layout:

- **NF** (always)
- **ELITE** (always)
- **AD Knowledge Portal** (V2 layout only)

All other portals use the `default` navbar layout and are unaffected.

## Test plan

- [x] Ran NF locally and verified the desktop navbar search box height and resting/focused border against the design.
- [x] Verified on mobile widths that the taller box is preserved and the "MENU" link sits directly below it without being pushed down (compared against a pre-PR build side by side).
- [x] Spot-checked ELITE (shares the v3 box) at desktop and mobile widths.
- [ ] ADKP (V2) uses the same shared navbar component; its V2 layout is behind the `ADKP_HOMEPAGE_V2` feature flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)