### PR TITLE
PORTALS-4319

### DIFF
--- a/apps/portals/nf/src/config/resources.ts
+++ b/apps/portals/nf/src/config/resources.ts
@@ -1,4 +1,5 @@
 import { ExternalAnalysisPlatform } from 'synapse-react-client/components/SynapseTable/export/ExternalAnalysisPlatformsConstants'
+import type { SearchQueryConfig } from 'synapse-react-client/components'
 
 export const SYNAPSE_PORTAL_ID = '1005'
 
@@ -40,6 +41,17 @@ export const publicationsSearchIndexId = 'syn75081631'
 export const studiesSearchIndexId = 'syn75081633'
 export const initiativesSearchIndexId = 'syn75081635'
 export const toolsSearchIndexId = 'syn75081636'
+export const toolsSearchQueryConfig: SearchQueryConfig = {
+  queryStrategy: 'MULTI_MATCH_BEST_FIELDS',
+  fieldBoosts: {
+    resourceName: 5,
+    synonyms: 4,
+    rrid: 4,
+    targetAntigen: 2,
+    diseaseType: 1,
+    description: 1,
+  },
+}
 export const peopleSearchIndexId = 'syn75081637'
 export const fundersSearchIndexId = 'syn75081638'
 export const hackathonsSearchIndexId = 'syn75081639'

--- a/apps/portals/nf/src/config/resources.ts
+++ b/apps/portals/nf/src/config/resources.ts
@@ -1,5 +1,5 @@
 import { ExternalAnalysisPlatform } from 'synapse-react-client/components/SynapseTable/export/ExternalAnalysisPlatformsConstants'
-import type { SearchQueryConfig } from 'synapse-react-client/components'
+import type { SearchQueryConfig } from 'synapse-react-client/components/SearchQueryWrapper/SearchQueryUseQueryOptions'
 
 export const SYNAPSE_PORTAL_ID = '1005'
 

--- a/apps/portals/nf/src/config/synapseConfigs/tools.tsx
+++ b/apps/portals/nf/src/config/synapseConfigs/tools.tsx
@@ -2,7 +2,11 @@ import type { CardConfiguration } from 'synapse-react-client/components/CardCont
 import type { QueryWrapperPlotNavProps } from 'synapse-react-client/components/QueryWrapperPlotNav/QueryWrapperPlotNav'
 import * as SynapseConstants from 'synapse-react-client/utils/SynapseConstants'
 import { TableToGenericCardMapping } from 'synapse-react-client/components/GenericCard/TableRowGenericCard'
-import { toolsSearchIndexId, toolsSql } from '../resources'
+import {
+  toolsSearchIndexId,
+  toolsSearchQueryConfig,
+  toolsSql,
+} from '../resources'
 import { columnAliases } from './commonProps'
 import { SearchQueryWrapperPlotNavProps } from 'synapse-react-client/components/SearchQueryWrapperPlotNav/SearchQueryWrapperPlotNav'
 
@@ -86,17 +90,7 @@ export const toolsSearch: SearchQueryWrapperPlotNavProps = {
   autocompleteFieldName: 'resourceName',
   hideTopLevelControls: false,
   hideQueryCount: false,
-  searchQueryConfig: {
-    queryStrategy: 'MULTI_MATCH_BEST_FIELDS',
-    fieldBoosts: {
-      resourceName: 5,
-      synonyms: 4,
-      rrid: 4,
-      targetAntigen: 2,
-      diseaseType: 1,
-      description: 1,
-    },
-  },
+  searchQueryConfig: toolsSearchQueryConfig,
 }
 
 export default tools

--- a/apps/portals/nf/src/config/synapseConfigs/tools.tsx
+++ b/apps/portals/nf/src/config/synapseConfigs/tools.tsx
@@ -86,6 +86,17 @@ export const toolsSearch: SearchQueryWrapperPlotNavProps = {
   autocompleteFieldName: 'resourceName',
   hideTopLevelControls: false,
   hideQueryCount: false,
+  searchQueryConfig: {
+    queryStrategy: 'MULTI_MATCH_BEST_FIELDS',
+    fieldBoosts: {
+      resourceName: 5,
+      synonyms: 4,
+      rrid: 4,
+      targetAntigen: 2,
+      diseaseType: 1,
+      description: 1,
+    },
+  },
 }
 
 export default tools

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
@@ -17,6 +17,7 @@ import {
   getNextPageParamForSearchQueryResults,
   searchQueryResultsToQueryResultBundle,
   toSearchIndexQuery,
+  type SearchQueryConfig,
 } from './SearchQueryUseQueryOptions'
 
 const SEARCH_INDEX_ID = 'syn60001'
@@ -1279,5 +1280,191 @@ describe('searchQueryResultsToQueryResultBundle', () => {
     const facet = result.facets![0] as FacetColumnResultRange
     expect(facet.selectedMin).toBeUndefined()
     expect(facet.selectedMax).toBe('2021-12-31')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// toSearchIndexQuery – searchQueryConfig
+// ---------------------------------------------------------------------------
+
+describe('toSearchIndexQuery – searchQueryConfig', () => {
+  const queryBundleWithText = makeQueryBundleRequest({
+    additionalFilters: [
+      {
+        concreteType: TEXT_MATCHES_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        searchExpression: 'schwann',
+      },
+    ],
+  })
+
+  it('omitting searchQueryConfig keeps the default MULTI_MATCH behavior (fuzziness AUTO, no fields)', () => {
+    const result = toSearchIndexQuery(queryBundleWithText, SEARCH_INDEX_ID)
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: { query: 'schwann', fuzziness: 'AUTO' },
+    })
+  })
+
+  it('MULTI_MATCH strategy is identical to the default', () => {
+    const result = toSearchIndexQuery(
+      queryBundleWithText,
+      SEARCH_INDEX_ID,
+      undefined,
+      {
+        queryStrategy: 'MULTI_MATCH',
+      },
+    )
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: { query: 'schwann', fuzziness: 'AUTO' },
+    })
+  })
+
+  it('MULTI_MATCH_BEST_FIELDS with field boosts emits type best_fields and fields array', () => {
+    const config: SearchQueryConfig = {
+      queryStrategy: 'MULTI_MATCH_BEST_FIELDS',
+      fieldBoosts: { resourceName: 5, synonyms: 4, rrid: 4 },
+    }
+    const result = toSearchIndexQuery(
+      queryBundleWithText,
+      SEARCH_INDEX_ID,
+      undefined,
+      config,
+    )
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: {
+        query: 'schwann',
+        type: 'best_fields',
+        fields: ['resourceName^5', 'synonyms^4', 'rrid^4'],
+      },
+    })
+  })
+
+  it('MULTI_MATCH_BEST_FIELDS without field boosts emits no fields key', () => {
+    const result = toSearchIndexQuery(
+      queryBundleWithText,
+      SEARCH_INDEX_ID,
+      undefined,
+      {
+        queryStrategy: 'MULTI_MATCH_BEST_FIELDS',
+      },
+    )
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: { query: 'schwann', type: 'best_fields' },
+    })
+  })
+
+  it('MULTI_MATCH_CROSS_FIELDS with field boosts emits type cross_fields', () => {
+    const result = toSearchIndexQuery(
+      queryBundleWithText,
+      SEARCH_INDEX_ID,
+      undefined,
+      {
+        queryStrategy: 'MULTI_MATCH_CROSS_FIELDS',
+        fieldBoosts: { resourceName: 5, description: 1 },
+      },
+    )
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: {
+        query: 'schwann',
+        type: 'cross_fields',
+        fields: ['resourceName^5', 'description'],
+      },
+    })
+  })
+
+  it('SIMPLE_QUERY_STRING emits a simple_query_string clause with field boosts', () => {
+    const result = toSearchIndexQuery(
+      queryBundleWithText,
+      SEARCH_INDEX_ID,
+      undefined,
+      {
+        queryStrategy: 'SIMPLE_QUERY_STRING',
+        fieldBoosts: { resourceName: 5, synonyms: 4 },
+      },
+    )
+    expect(result.searchQuery?.query).toEqual({
+      simple_query_string: {
+        query: 'schwann',
+        fields: ['resourceName^5', 'synonyms^4'],
+      },
+    })
+  })
+
+  it('SIMPLE_QUERY_STRING without field boosts emits no fields key', () => {
+    const result = toSearchIndexQuery(
+      queryBundleWithText,
+      SEARCH_INDEX_ID,
+      undefined,
+      {
+        queryStrategy: 'SIMPLE_QUERY_STRING',
+      },
+    )
+    expect(result.searchQuery?.query).toEqual({
+      simple_query_string: { query: 'schwann' },
+    })
+  })
+
+  it('PHRASE_PREFIX emits type phrase_prefix', () => {
+    const result = toSearchIndexQuery(
+      queryBundleWithText,
+      SEARCH_INDEX_ID,
+      undefined,
+      {
+        queryStrategy: 'PHRASE_PREFIX',
+      },
+    )
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: { query: 'schwann', type: 'phrase_prefix' },
+    })
+  })
+
+  it('BOOSTED_FUZZY with field boosts emits fuzziness AUTO', () => {
+    const result = toSearchIndexQuery(
+      queryBundleWithText,
+      SEARCH_INDEX_ID,
+      undefined,
+      {
+        queryStrategy: 'BOOSTED_FUZZY',
+        fieldBoosts: { resourceName: 5, synonyms: 4 },
+      },
+    )
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: {
+        query: 'schwann',
+        fields: ['resourceName^5', 'synonyms^4'],
+        fuzziness: 'AUTO',
+      },
+    })
+  })
+
+  it('explicit fuzziness overrides the per-strategy default', () => {
+    const result = toSearchIndexQuery(
+      queryBundleWithText,
+      SEARCH_INDEX_ID,
+      undefined,
+      {
+        queryStrategy: 'MULTI_MATCH',
+        fuzziness: '1',
+      },
+    )
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: { query: 'schwann', fuzziness: '1' },
+    })
+  })
+
+  it('a boost of 1 renders as the bare field name with no ^ suffix', () => {
+    const result = toSearchIndexQuery(
+      queryBundleWithText,
+      SEARCH_INDEX_ID,
+      undefined,
+      {
+        queryStrategy: 'MULTI_MATCH_BEST_FIELDS',
+        fieldBoosts: { resourceName: 5, description: 1 },
+      },
+    )
+    const clause = result.searchQuery?.query as {
+      multi_match: { fields: string[] }
+    }
+    expect(clause.multi_match.fields).toContain('description')
+    expect(clause.multi_match.fields).not.toContain('description^1')
   })
 })

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -44,11 +44,50 @@ import { KeyFactory } from '@/synapse-queries/KeyFactory'
 // we actually produce/consume are declared. Aggregation types use the generated
 // Aggregation/TermsAggregation types from @sage-bionetworks/synapse-client.
 
+export type SearchQueryStrategy =
+  | 'MULTI_MATCH'
+  | 'MULTI_MATCH_BEST_FIELDS'
+  | 'MULTI_MATCH_CROSS_FIELDS'
+  | 'SIMPLE_QUERY_STRING'
+  | 'PHRASE_PREFIX'
+  | 'BOOSTED_FUZZY'
+
+export type SearchQueryConfig = {
+  /**
+   * Which OpenSearch query clause to emit when the user has typed a search term.
+   * Defaults to 'MULTI_MATCH' (all fields, fuzziness AUTO — today's behavior).
+   */
+  queryStrategy?: SearchQueryStrategy
+  /**
+   * Per-field relevance multipliers. Serialized to the OpenSearch `fields` array
+   * as e.g. `["resourceName^5", "synonyms^4"]`. When omitted, all fields are
+   * queried at equal weight.
+   */
+  fieldBoosts?: Record<string, number>
+  /**
+   * Fuzziness override. Overrides the per-strategy default. Leave undefined to
+   * use each strategy's natural default (AUTO for MULTI_MATCH/BOOSTED_FUZZY,
+   * none for the rest).
+   */
+  fuzziness?: string
+}
+
 type FilterClause =
   | { terms: Record<string, string[]> }
   | { range: Record<string, { gte?: string; lte?: string }> }
 
-type MultiMatchClause = { multi_match: { query: string; fuzziness: string } }
+type MultiMatchClause = {
+  multi_match: {
+    query: string
+    fuzziness?: string
+    type?: 'best_fields' | 'cross_fields' | 'phrase_prefix'
+    fields?: string[]
+  }
+}
+
+type SimpleQueryStringClause = {
+  simple_query_string: { query: string; fields?: string[] }
+}
 
 type BoolQuery = {
   bool: {
@@ -65,8 +104,77 @@ type SelectionFilter =
 
 type SearchQueryDSL =
   | MultiMatchClause
+  | SimpleQueryStringClause
   | { match_all: Record<never, never> }
   | BoolQuery
+
+function resolveFields(
+  fieldBoosts: Record<string, number> | undefined,
+): string[] | undefined {
+  if (!fieldBoosts) return undefined
+  return Object.entries(fieldBoosts).map(([field, boost]) =>
+    boost === 1 ? field : `${field}^${boost}`,
+  )
+}
+
+function buildQueryClause(
+  queryText: string,
+  config: SearchQueryConfig = {},
+): MultiMatchClause | SimpleQueryStringClause {
+  const { queryStrategy = 'MULTI_MATCH', fieldBoosts, fuzziness } = config
+  const fields = resolveFields(fieldBoosts)
+
+  switch (queryStrategy) {
+    case 'SIMPLE_QUERY_STRING':
+      return {
+        simple_query_string: {
+          query: queryText,
+          ...(fields ? { fields } : {}),
+        },
+      }
+    case 'MULTI_MATCH_BEST_FIELDS':
+      return {
+        multi_match: {
+          query: queryText,
+          type: 'best_fields',
+          ...(fields ? { fields } : {}),
+          ...(fuzziness ? { fuzziness } : {}),
+        },
+      }
+    case 'MULTI_MATCH_CROSS_FIELDS':
+      return {
+        multi_match: {
+          query: queryText,
+          type: 'cross_fields',
+          ...(fields ? { fields } : {}),
+          ...(fuzziness ? { fuzziness } : {}),
+        },
+      }
+    case 'PHRASE_PREFIX':
+      return {
+        multi_match: {
+          query: queryText,
+          type: 'phrase_prefix',
+          ...(fields ? { fields } : {}),
+        },
+      }
+    case 'BOOSTED_FUZZY':
+      return {
+        multi_match: {
+          query: queryText,
+          ...(fields ? { fields } : {}),
+          fuzziness: fuzziness ?? 'AUTO',
+        },
+      }
+    default: // 'MULTI_MATCH'
+      return {
+        multi_match: {
+          query: queryText,
+          fuzziness: fuzziness ?? 'AUTO',
+        },
+      }
+  }
+}
 
 type OpenSearchBucket = { key: unknown; doc_count: number }
 type OpenSearchTermsAgg = { buckets?: OpenSearchBucket[] }
@@ -152,6 +260,7 @@ export function toSearchIndexQuery(
   queryBundleRequest: QueryBundleRequest,
   searchIndexId: string,
   columnModels?: ColumnModel[],
+  searchQueryConfig?: SearchQueryConfig,
 ): SearchIndexQuery {
   // Build aggregations from ColumnModels that have facetType 'enumeration'.
   // Range columns are excluded: we synthesize FacetColumnResultRange entries client-side.
@@ -214,7 +323,7 @@ export function toSearchIndexQuery(
   // Build the OpenSearch query DSL (text search only; facet selections go to post_filter).
   let query: SearchQueryDSL
   if (queryText) {
-    query = { multi_match: { query: queryText, fuzziness: 'AUTO' } }
+    query = buildQueryClause(queryText, searchQueryConfig)
   } else {
     query = { match_all: {} }
   }
@@ -481,11 +590,13 @@ export function getSearchQueryUseQueryOptions(
   accessToken: string | undefined,
   searchIndexId: string,
   columnModels?: ColumnModel[],
+  searchQueryConfig?: SearchQueryConfig,
 ): SearchTableQueryUseQueryOptions {
   const baseQuery: SearchIndexQuery = toSearchIndexQuery(
     queryBundleRequest,
     searchIndexId,
     columnModels,
+    searchQueryConfig,
   )
   const rowDataQuery: SearchIndexQuery = {
     ...baseQuery,
@@ -679,6 +790,7 @@ export function useSearchQueryUseQueryOptions(
   queryBundleRequest: QueryBundleRequest,
   searchIndexId: string,
   synapseId?: string,
+  searchQueryConfig?: SearchQueryConfig,
 ): SearchTableQueryUseQueryOptions {
   const { keyFactory, accessToken } = useSynapseContext()
 
@@ -695,7 +807,15 @@ export function useSearchQueryUseQueryOptions(
         accessToken,
         searchIndexId,
         columnModels,
+        searchQueryConfig,
       ),
-    [keyFactory, accessToken, queryBundleRequest, searchIndexId, columnModels],
+    [
+      keyFactory,
+      accessToken,
+      queryBundleRequest,
+      searchIndexId,
+      columnModels,
+      searchQueryConfig,
+    ],
   )
 }

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryWrapper.tsx
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryWrapper.tsx
@@ -24,6 +24,7 @@ import {
 import {
   getSearchQueryUseQueryOptions,
   useSearchQueryUseQueryOptions,
+  SearchQueryConfig,
 } from './SearchQueryUseQueryOptions'
 import { TableQueryUseQueryOptions } from '../QueryWrapper/TableQueryUseQueryOptions'
 import useHasFacetedSelectColumn from '../QueryWrapper/useHasFacetedSelectColumn'
@@ -69,6 +70,8 @@ export type SearchQueryWrapperProps = PropsWithChildren<{
   isInfinite?: boolean
   /** Whether the URL should update when the query is modified (deep linking). */
   shouldDeepLink?: boolean
+  /** OpenSearch query strategy and field-boost configuration. */
+  searchQueryConfig?: SearchQueryConfig
 }>
 
 /**
@@ -120,6 +123,7 @@ function SearchQueryWrapperInternalWithSession(props: SearchQueryWrapperProps) {
     isInfinite = false,
     searchIndexId,
     shouldDeepLink = false,
+    searchQueryConfig,
   } = props
 
   const { keyFactory, accessToken } = useSynapseContext()
@@ -201,6 +205,7 @@ function SearchQueryWrapperInternalWithSession(props: SearchQueryWrapperProps) {
     currentQueryRequest as QueryBundleRequest,
     searchIndexId,
     synapseId,
+    searchQueryConfig,
   ) as unknown as TableQueryUseQueryOptions
 
   const hasFacetedSelectColumn = useHasFacetedSelectColumn(
@@ -228,6 +233,7 @@ function SearchQueryWrapperInternalWithSession(props: SearchQueryWrapperProps) {
           accessToken,
           searchIndexId,
           columnModels,
+          searchQueryConfig,
         ) as unknown as TableQueryUseQueryOptions
       ).rowDataQueryOptions
     },
@@ -237,6 +243,7 @@ function SearchQueryWrapperInternalWithSession(props: SearchQueryWrapperProps) {
       accessToken,
       searchIndexId,
       columnModels,
+      searchQueryConfig,
     ],
   )
 

--- a/packages/synapse-react-client/src/components/SearchQueryWrapperPlotNav/SearchQueryWrapperPlotNav.tsx
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapperPlotNav/SearchQueryWrapperPlotNav.tsx
@@ -68,6 +68,8 @@ export type SearchQueryWrapperPlotNavProps = SearchQueryWrapperPlotNavOwnProps &
     onQueryResultBundleChange?: SearchQueryWrapperProps['onQueryResultBundleChange']
     /** Whether the URL should update when the query is modified (deep linking). */
     shouldDeepLink?: SearchQueryWrapperProps['shouldDeepLink']
+    /** OpenSearch query strategy and field-boost configuration. Forwarded to SearchQueryWrapper. */
+    searchQueryConfig?: SearchQueryWrapperProps['searchQueryConfig']
   }
 
 /**
@@ -143,6 +145,7 @@ export default function SearchQueryWrapperPlotNav(
       isInfinite={isInfinite}
       onQueryResultBundleChange={onQueryResultBundleChange}
       shouldDeepLink={shouldDeepLink}
+      searchQueryConfig={props.searchQueryConfig}
     >
       <Suspense fallback={<QueryWrapperLoadingScreen />}>
         <QueryVisualizationWrapper

--- a/packages/synapse-react-client/src/components/index.ts
+++ b/packages/synapse-react-client/src/components/index.ts
@@ -63,6 +63,10 @@ export * from './QueryWrapper'
 export * from './QueryWrapperPlotNav'
 export { SearchQueryWrapper } from './SearchQueryWrapper/SearchQueryWrapper'
 export type { SearchQueryWrapperProps } from './SearchQueryWrapper/SearchQueryWrapper'
+export type {
+  SearchQueryConfig,
+  SearchQueryStrategy,
+} from './SearchQueryWrapper/SearchQueryUseQueryOptions'
 export {
   default as SearchQueryWrapperPlotNav,
   isSearchQueryWrapperPlotNavProps,


### PR DESCRIPTION
Verified most requests are not impacted by the change:
<img width="1310" height="762" alt="Screenshot 2026-07-01 at 2 02 24 PM" src="https://github.com/user-attachments/assets/33c21960-1a5a-45b9-a6bd-d6b628daf346" />

Verified test configuration with multi-match and field boosting for NF tools:
<img width="1303" height="698" alt="Screenshot 2026-07-01 at 1 59 48 PM" src="https://github.com/user-attachments/assets/876b7c90-d507-49c3-98f7-609a35504c7d" />


