### PR TITLE
PORTALS-4337: add access column to ELITE portal datasets table

### DIFF
--- a/apps/portals/eliteportal/src/config/synapseConfigs/datasets.ts
+++ b/apps/portals/eliteportal/src/config/synapseConfigs/datasets.ts
@@ -24,6 +24,7 @@ export const datasetQueryWrapperPlotNavProps: QueryWrapperPlotNavProps = {
   defaultShowPlots: false,
   tableConfiguration: {
     columnLinks: datasetColumnLinks,
+    showAccessColumn: true,
   },
 }
 


### PR DESCRIPTION
<img width="1511" height="761" alt="Screenshot 2026-07-02 at 10 28 07 AM" src="https://github.com/user-attachments/assets/cdfd5ac3-526a-478c-8164-fc55bccaea48" />
