### PR TITLE
PORTALS-4316: Download list icon in the main nav menu is hard to see

### DIFF
--- a/apps/synapse-portal-framework/src/style/_Navbar.scss
+++ b/apps/synapse-portal-framework/src/style/_Navbar.scss
@@ -18,6 +18,12 @@
   height: var(--synapse-header-height-with-sticky-search);
   box-shadow: none;
 
+  .Download-Link {
+    .SRC-primary-text-color svg {
+      color: var(--sticky-nav-color, #fff);
+    }
+  }
+
   .nav-logo-and-search-container {
     display: flex;
     width: 100%;


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/PORTALS-4316

<img width="1512" height="982" alt="Screenshot 2026-07-02 at 2 21 45 PM" src="https://github.com/user-attachments/assets/b8b5802d-3bc9-4dd1-8320-de325d2674cc" />

Unaffected:
<img width="1512" height="982" alt="Screenshot 2026-07-02 at 2 21 32 PM" src="https://github.com/user-attachments/assets/608d79ef-c542-4efb-8961-72b0c3a0a32a" />
