### PR TITLE
Clarity for agents

### DIFF
--- a/.claude/skills/pnpm-security-audit/SKILL.md
+++ b/.claude/skills/pnpm-security-audit/SKILL.md
@@ -108,7 +108,7 @@ pnpm info <parent> versions --json
 pnpm info <parent>@latest dependencies --json | grep <vulnerable-package>
 ```
 
-**Before applying a parent update, check for breaking changes** — especially for major version bumps or core tools (eslint, vite, storybook, typescript-eslint):
+**Before applying a parent update, check for breaking changes** — especially for major version bumps or core tools (typescript, oxlint, vite, storybook):
 
 ```bash
 # Check the changelog or release notes
@@ -206,7 +206,7 @@ Document:
 Scope tests to the impact:
 
 - **Production dep changed** → `pnpm nx run <affected-package>:test`
-- **Dev tooling dep** (eslint, vitest, rollup, storybook) → `pnpm lint` and/or a quick test run
+- **Dev tooling dep** (oxlint, vitest, rollup, storybook) → `pnpm lint` and/or a quick test run
 - **CLI tool dep** (openapi-generator-cli, etc.) → run the relevant generate/build command
 
 If tests fail, check: API breaking change in the updated package, accidentally too-broad override bumping a major version, or pre-existing failure on `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,23 +73,9 @@ pnpm build
 
 ### Test Setup
 
-Tests use **Vitest** with jsdom. Each package has a `vite.config.ts` that uses the shared `ConfigBuilder` from `packages/vite-config`. Test setup files are at `src/testutils/vitest.setup.ts` (synapse-react-client) and `src/vitest.setup.ts` (synapse-client).
+Tests use **Vitest** with jsdom. Each package has a `vite.config.ts`. When possible, the config uses shared utilities from `packages/vite-config`. Test setup files are at `src/testutils/vitest.setup.ts` (synapse-react-client) and `src/vitest.setup.ts` (synapse-client).
 
 Coverage reports are written to `./coverage/report/index.html`.
-
-### Vite Config Pattern
-
-All packages compose their Vite config using `ConfigBuilder`:
-
-```typescript
-import { ConfigBuilder } from '@sage-bionetworks/vite-config'
-
-const config = new ConfigBuilder()
-  .setIncludeVitestConfig(true)
-  .setIncludeReactConfig(true)
-  .setIncludeLibraryConfig(true, { except: ['...external deps...'] })
-  .build()
-```
 
 ### CSS/Theming
 
@@ -105,11 +91,23 @@ All projects extend `shared/tsconfig.base.json` (strict mode). The root `tsconfi
 
 ### Pre-commit Hooks
 
-Husky runs ESLint + oxfmt (via lint-staged) on staged files before each commit.
+Husky runs oxlint + oxfmt (via lint-staged) on staged files before each commit.
+
+## Tools and Technologies
+
+These are the standard tools and technologies that are used by multiple packages in this repository. For each of these tools, you can check `package.json` to verify the version of the tool that is running.
+
+- TypeScript
+- Vite
+- vitest
+- oxlint
+- oxfmt
+- react-router
+- MUI
 
 ## Comments
 
-Default to no comment. Code should be self-explanatory through clear naming and structure; a comment is a last resort for genuinely non-obvious intent — a subtle invariant, a workaround for external behavior, or a "why this and not the obvious thing" that the code can't express on its own. Never comment to restate what the code does, and don't narrate routine logic. It is always useful to document regex patterns - i.e. what they are intended to match. When in doubt, leave it out. 
+Default to no comment. Code should be self-explanatory through clear naming and structure; a comment is a last resort for genuinely non-obvious intent — a subtle invariant, a workaround for external behavior, or a "why this and not the obvious thing" that the code can't express on its own. Never comment to restate what the code does, and don't narrate routine logic. It is always useful to document regex patterns - i.e. what they are intended to match. When in doubt, leave it out.
 Never write "historical context" comments in a refactor — e.g. `// previously this used X`, `// changed from the old approach`, `// no longer does Y`. Once a PR merges, the old behavior is irrelevant and lives in git history. Comment what the code does now, not what it used to do.
 
 ## Code review norms

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![npm version](https://badge.fury.io/js/synapse-react-client.svg)](https://badge.fury.io/js/synapse-react-client)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
 # synapse-web-monorepo
 

--- a/apps/SageAccountWeb/src/pages/RegisterAccount1.tsx
+++ b/apps/SageAccountWeb/src/pages/RegisterAccount1.tsx
@@ -117,7 +117,7 @@ const RegisterAccount1 = (): React.ReactNode => {
       setPage(Pages.EMAIL_REGISTRATION)
     }
     // Initialize the email address field with the email query parameter, but allow the user to change it or register using OAuth
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // If this is the Arcus app, skip the "choose registration" page and go straight to OAuth registration

--- a/apps/synapse-portal-framework/src/components/AppInitializer.tsx
+++ b/apps/synapse-portal-framework/src/components/AppInitializer.tsx
@@ -62,7 +62,7 @@ function AppInitializer(props: AppInitializerProps) {
     return () => {
       window.removeEventListener('click', globalClickHandler)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- run only on mount
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- run only on mount
   }, [cookiePreferences])
 
   return (

--- a/apps/synapse-portal-framework/src/components/DetailsPage/utils.ts
+++ b/apps/synapse-portal-framework/src/components/DetailsPage/utils.ts
@@ -21,6 +21,6 @@ export function useScrollOnMount() {
       clearTimeout(timer)
     }
     // Empty dependency array to intentionally run only on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 }

--- a/packages/markdown-it-container/test/api.mjs
+++ b/packages/markdown-it-container/test/api.mjs
@@ -3,8 +3,6 @@ import markdownit from 'markdown-it'
 
 import container from '../index.mjs'
 
-/* eslint-env mocha */
-
 describe('api', function () {
   it('renderer', function () {
     const res = markdownit()

--- a/packages/markdown-it-container/test/default.mjs
+++ b/packages/markdown-it-container/test/default.mjs
@@ -4,8 +4,6 @@ import generate from 'markdown-it-testgen'
 
 import container from '../index.mjs'
 
-/* eslint-env mocha */
-
 describe('default container', function () {
   const md = markdownit().use(container, 'name')
 

--- a/packages/markdown-it-synapse/src/index.ts
+++ b/packages/markdown-it-synapse/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-useless-escape */
+/* oxlint-disable no-useless-escape */
 
 // Process ${widgetname?param1=1&param2=2}
 
@@ -642,7 +642,7 @@ function init_markdown_it(
         token: state.tokens.length - 1,
 
         // Token level.
-        // @ts-ignore
+        // @ts-expect-error
         level: state.level,
 
         // If this delimiter is matched as a valid opener, `end` will be

--- a/packages/synapse-client/src/util/promiseWithRetry.test.ts
+++ b/packages/synapse-client/src/util/promiseWithRetry.test.ts
@@ -46,7 +46,7 @@ describe('promiseWithRetry', () => {
       .mockRejectedValue(lastError)
 
     const resultPromise = promiseWithRetry(fn, 2, 100)
-    // eslint-disable-next-line vitest/valid-expect -- We need to capture the promise rejection before advancing timers
+    // oxlint-disable-next-line vitest/valid-expect -- We need to capture the promise rejection before advancing timers
     const assertionPromise = expect(resultPromise).rejects.toThrow(lastError)
 
     await vi.runAllTimersAsync()

--- a/packages/synapse-react-client/CLAUDE.md
+++ b/packages/synapse-react-client/CLAUDE.md
@@ -14,7 +14,7 @@ pnpm test run src/features/entity/metadata-task  # Run all tests under a directo
 pnpm test --reporter=verbose                     # Run with verbose output (watch mode)
 pnpm build                                       # Build the library (Vite + tsc + copy assets)
 pnpm start                                       # Run Storybook dev server on port 6060
-pnpm lint                                        # ESLint
+pnpm lint                                        # Oxlint
 pnpm type-check                                  # TypeScript type check
 ```
 

--- a/packages/synapse-react-client/CONTRIBUTING.md
+++ b/packages/synapse-react-client/CONTRIBUTING.md
@@ -4,10 +4,7 @@
 
 ### Setup
 
-You may use any IDE you like. If you use [Visual Studio Code](https://code.visualstudio.com/), you can load the [workspace file](../../synapse-web-monorepo.code-workspace), which preconfigures and recommends some extensions, such as:
-
-- The [eslint](https://github.com/Microsoft/vscode-eslint) extension, which is a js linter and rough style guide.
-- The [prettier](https://github.com/prettier/prettier) extension, which is a more opinionated js linter. You will need to ensure you have vscode configured to format on saving by modifying ,.vscode/setting.json to include the line `"editor.formatOnSave": true`. See [here](https://code.visualstudio.com/updates/v1_6#_format-on-save) for more details.
+You may use any IDE you like. If you use [Visual Studio Code](https://code.visualstudio.com/), you can load the [workspace file](../../synapse-web-monorepo.code-workspace), which preconfigures and recommends relevant extensions.
 
 ### Git Workflow
 

--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.test.tsx
@@ -28,7 +28,7 @@ describe('AccessRequirementList tests', () => {
 
   async function init(props: AccessRequirementListProps) {
     // We must await asynchronous events for our assertions to pass
-    // eslint-disable-next-line @typescript-eslint/require-await
+    // oxlint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
       render(<AccessRequirementList {...props} />, {
         wrapper: createWrapper(),

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
@@ -270,7 +270,7 @@ export default function DataAccessRequestAccessorsFilesForm(
       }
     }
     // Intentionally only re-synchronize state when server state changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [dataAccessRequest])
 
   function getDataAccessRequestWithLocalState(): Request | Renewal {

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManagedACTAccessRequirementItem.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManagedACTAccessRequirementItem.test.tsx
@@ -30,7 +30,7 @@ async function renderComponent(
 ) {
   let renderReturn
   // We must await asynchronous events for our assertions to pass
-  // eslint-disable-next-line @typescript-eslint/require-await
+  // oxlint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     renderReturn = render(<ManagedACTAccessRequirementItem {...props} />, {
       wrapper: createWrapper(wrapperProps),

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.test.tsx
@@ -74,7 +74,7 @@ const defaultProps: ResearchProjectFormProps = {
 async function renderComponent(props: ResearchProjectFormProps) {
   let component
   // We must await asynchronous events for our assertions to pass
-  // eslint-disable-next-line @typescript-eslint/require-await
+  // oxlint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     component = render(<ResearchProjectForm {...props} />, {
       wrapper: createWrapper(),

--- a/packages/synapse-react-client/src/components/AclEditor/useUpdateAcl.ts
+++ b/packages/synapse-react-client/src/components/AclEditor/useUpdateAcl.ts
@@ -85,7 +85,7 @@ export default function useUpdateAcl(
 
   useEffect(() => {
     onChange(resourceAccessList)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [resourceAccessList])
 
   const addResourceAccessItem = useCallback(

--- a/packages/synapse-react-client/src/components/Authentication/TwoFactorBackupCodes.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/TwoFactorBackupCodes.tsx
@@ -56,7 +56,7 @@ export default function TwoFactorBackupCodes(props: TwoFactorBackupCodesProps) {
       generateCodes()
     }
     // Run on mount only
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const { visibleOnPrintClassName, hiddenOnPrintClassName } =

--- a/packages/synapse-react-client/src/components/Authentication/TwoFactorEnrollmentForm.tsx
+++ b/packages/synapse-react-client/src/components/Authentication/TwoFactorEnrollmentForm.tsx
@@ -140,7 +140,7 @@ export default function TwoFactorEnrollmentForm(
             After setting up 2FA, you’ll use an authenticator app as part of
             your login process, in addition to your existing password. If you
             log in using your Google
-            {/* eslint-disable-next-line no-constant-binary-expression -- Remove conditionality when NIH RAS login is supported */}
+            {/* oxlint-disable-next-line no-constant-binary-expression -- Remove conditionality when NIH RAS login is supported */}
             {false && ', NIH RAS,'} or ORCiD account, you may need to use 2FA as
             part of
             {/*those processes*/}

--- a/packages/synapse-react-client/src/components/CannedRejectionDialog/CannedRejectionDialog.tsx
+++ b/packages/synapse-react-client/src/components/CannedRejectionDialog/CannedRejectionDialog.tsx
@@ -335,7 +335,7 @@ export function CannedRejectionDialog(props: CannedRejectionDialogProps) {
       setEmailText(defaultEmailMessage)
     }
     // Specifically fire on update to just selectedRowIds
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedRowIds])
 
   // If fetching/processing the table fails, gracefully fall back to just show the email template

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/SubmissionDirectoryList.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/SubmissionDirectoryList.tsx
@@ -105,7 +105,7 @@ function SubmissionDirectoryList({
     }
     // TODO: Temporary useEffect hook to remove onSuccess QueryOption for @tanstack/react-query v5
     // Refactor this component to remove this effect.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [headerResults])
 
   function getPageHeaders() {
@@ -125,7 +125,7 @@ function SubmissionDirectoryList({
 
   useEffect(() => {
     reset()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [entityType, pageSize])
 
   const queries = useGetEntities(getPageHeaders())

--- a/packages/synapse-react-client/src/components/CreateProjectModal/CreateProjectModal.test.tsx
+++ b/packages/synapse-react-client/src/components/CreateProjectModal/CreateProjectModal.test.tsx
@@ -204,7 +204,7 @@ describe('CreateProjectModal tests', () => {
 
       expect(mockUpdateEntityACL).toHaveBeenCalledWith(
         expect.objectContaining({
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment
           resourceAccess: expect.arrayContaining([
             expect.objectContaining({
               principalId: MOCK_PUBLIC_PRINCIPAL_ID,
@@ -235,7 +235,7 @@ describe('CreateProjectModal tests', () => {
 
       expect(mockUpdateEntityACL).toHaveBeenCalledWith(
         expect.objectContaining({
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment
           resourceAccess: expect.arrayContaining([
             expect.objectContaining({
               principalId: MOCK_PUBLIC_PRINCIPAL_ID,

--- a/packages/synapse-react-client/src/components/DataGrid/StartGridSession.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/StartGridSession.test.tsx
@@ -417,7 +417,7 @@ describe('StartGridSession - useImperativeHandle methods', () => {
     })
 
     it('should call onSessionChange with null when deleting session', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       let capturedDeleteOptions: any
 
       mockUseDeleteGridSession.mockImplementation(options => {
@@ -446,9 +446,9 @@ describe('StartGridSession - useImperativeHandle methods', () => {
 
       // Simulate successful deletion
       mockDeleteSession.mockImplementation(sessionId => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        // oxlint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (capturedDeleteOptions?.onSuccess) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          // oxlint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
           capturedDeleteOptions.onSuccess(undefined, sessionId, undefined)
         }
       })

--- a/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.test.ts
@@ -266,11 +266,11 @@ describe('useDataGridWebSocket', () => {
       expect(result.current.websocketInstance).not.toBe(firstInstance)
     })
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line @typescript-eslint/unbound-method
     expect(firstInstance.disconnect).toHaveBeenCalled()
     expect(result.current.websocketInstance).not.toBe(firstInstance)
     // Second instance should not be disconnected yet
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line @typescript-eslint/unbound-method
     expect(result.current.websocketInstance?.disconnect).not.toHaveBeenCalled()
   })
 
@@ -608,7 +608,7 @@ describe('useDataGridWebSocket', () => {
     })
 
     await waitFor(() => {
-      // eslint-disable-next-line @typescript-eslint/unbound-method
+      // oxlint-disable-next-line @typescript-eslint/unbound-method
       expect(result.current.websocketInstance?.disconnect).toHaveBeenCalled()
     })
   })

--- a/packages/synapse-react-client/src/components/EntityFinder/tree/EntityTree.tsx
+++ b/packages/synapse-react-client/src/components/EntityFinder/tree/EntityTree.tsx
@@ -142,7 +142,7 @@ export function EntityTree(props: EntityTreeProps) {
     if (setDetailsViewConfiguration) {
       setDetailsViewConfiguration(DEFAULT_CONFIGURATION)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const setSelectedId = useCallback(

--- a/packages/synapse-react-client/src/components/EntityFinder/tree/VirtualizedTree.tsx
+++ b/packages/synapse-react-client/src/components/EntityFinder/tree/VirtualizedTree.tsx
@@ -281,7 +281,7 @@ export function Node(
       toggleExpand()
     }
     // Intentionally only toggle the expanded state when isSelected changes, otherwise the node cannot be un-expanded
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [isSelected])
 
   /**

--- a/packages/synapse-react-client/src/components/EntityTreeTable/components/IdColumnHeader.test.tsx
+++ b/packages/synapse-react-client/src/components/EntityTreeTable/components/IdColumnHeader.test.tsx
@@ -118,11 +118,11 @@ const createMockHeaderContext = (): HeaderContext<
   EntityBundleRow,
   unknown
 > => ({
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
   table: mockTable as any,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
   header: { id: 'test-header', colSpan: 1, isPlaceholder: false } as any,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
   column: { id: 'test-column', columnDef: {} } as any,
 })
 
@@ -164,7 +164,7 @@ describe('IdColumnHeader', () => {
 
     const headerContext = {
       ...createMockHeaderContext(),
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
       table: emptyTable as any,
     }
 
@@ -198,7 +198,7 @@ describe('IdColumnHeader', () => {
 
     const headerContext = {
       ...createMockHeaderContext(),
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
       table: loadMoreTable as any,
     }
 
@@ -226,7 +226,7 @@ describe('IdColumnHeader', () => {
 
     const headerContext = {
       ...createMockHeaderContext(),
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
       table: mixedTable as any,
     }
 

--- a/packages/synapse-react-client/src/components/Evaluation/EvaluationRoundEditorList.tsx
+++ b/packages/synapse-react-client/src/components/Evaluation/EvaluationRoundEditorList.tsx
@@ -85,7 +85,7 @@ export function EvaluationRoundEditorList({
     },
     // we explicitly dont want to list setEvaluationRoundInputList nor setError as a dependency
     // if we do, the fetchEvaluationList will re-fetch from the backend on every new render
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
     [accessToken, evaluationId],
   )
 

--- a/packages/synapse-react-client/src/components/FeaturedToolsList/FeaturedToolsList.test.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedToolsList/FeaturedToolsList.test.tsx
@@ -37,7 +37,7 @@ describe('basic tests', () => {
 
   it('displays featured tool cards from a Synapse Table', async () => {
     // We must await asynchronous events for our assertions to pass
-    // eslint-disable-next-line @typescript-eslint/require-await
+    // oxlint-disable-next-line @typescript-eslint/require-await
     const { container } = await act(async () => init())
     await waitFor(() => {
       expect(container.querySelector('.FeaturedToolCard')).toBeDefined()

--- a/packages/synapse-react-client/src/components/GenericCard/BioregistryRules.ts
+++ b/packages/synapse-react-client/src/components/GenericCard/BioregistryRules.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-useless-escape */
+/* oxlint-disable no-useless-escape */
 // This file is auto-generated. Do not edit manually.
 // Generated from bioregistry.io API based on collection.yaml
 

--- a/packages/synapse-react-client/src/components/Plot/StatisticsPlot.test.tsx
+++ b/packages/synapse-react-client/src/components/Plot/StatisticsPlot.test.tsx
@@ -79,7 +79,7 @@ const projectFilesStatsResponse: ProjectFilesStatisticsResponse = {
 async function renderComponent(props: StatisticsPlotProps) {
   let renderReturn: RenderResult<Queries, HTMLElement, HTMLElement> | undefined
   // We must await asynchronous events for our assertions to pass
-  // eslint-disable-next-line @typescript-eslint/require-await
+  // oxlint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     renderReturn = render(<StatisticsPlot {...props} />, {
       wrapper: createWrapper(),

--- a/packages/synapse-react-client/src/components/Plot/SynapsePlot.test.tsx
+++ b/packages/synapse-react-client/src/components/Plot/SynapsePlot.test.tsx
@@ -29,7 +29,7 @@ const defaultProps: SynapsePlotProps = {
 async function renderComponent(props: SynapsePlotProps) {
   let renderReturn: RenderResult<Queries, HTMLElement, HTMLElement> | undefined
   // We must await asynchronous events for our assertions to pass
-  // eslint-disable-next-line @typescript-eslint/require-await
+  // oxlint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     renderReturn = render(<SynapsePlot {...props} />, {
       wrapper: createWrapper(),

--- a/packages/synapse-react-client/src/components/Plot/UpsetPlot.tsx
+++ b/packages/synapse-react-client/src/components/Plot/UpsetPlot.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* oxlint-disable @typescript-eslint/no-explicit-any */
 import LargeButton from '@/components/styled/LargeButton'
 import SynapseClient from '@/synapse-client'
 import { SynapseConstants } from '@/utils'
@@ -17,8 +17,8 @@ import UpSetJS, {
   UpSetFontSizes,
   UpSetSelectionProps,
 } from '@upsetjs/react'
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* oxlint-disable @typescript-eslint/no-unsafe-member-access */
+/* oxlint-disable @typescript-eslint/no-unsafe-assignment */
 import { useEffect, useState } from 'react'
 import { getColorPalette } from '../ColorGradient/ColorGradient'
 import { ErrorBanner } from '../error/ErrorBanner'

--- a/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/SchemaDrivenAnnotationsEditor.test.tsx
+++ b/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/SchemaDrivenAnnotationsEditor.test.tsx
@@ -56,7 +56,7 @@ const defaultProps: SchemaDrivenAnnotationEditorProps = {
 async function renderComponent(wrapperProps?: SynapseContextType) {
   let result: RenderResult
   // We must await asynchronous events for our assertions to pass
-  // eslint-disable-next-line @typescript-eslint/require-await
+  // oxlint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     result = render(<SchemaDrivenAnnotationEditor {...defaultProps} />, {
       wrapper: createWrapper(wrapperProps),

--- a/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/field/AdditionalPropertiesSchemaField.tsx
+++ b/packages/synapse-react-client/src/components/SchemaDrivenAnnotationEditor/field/AdditionalPropertiesSchemaField.tsx
@@ -173,7 +173,7 @@ export function AdditionalPropertiesSchemaField<
     }
 
     onNextPropertyTypeUpdate()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [nextPropertyType])
 
   /**
@@ -201,7 +201,7 @@ export function AdditionalPropertiesSchemaField<
     coerceDataAndUpdateWidget()
     // Don't add other properties to dependency array because we don't want to automatically coerce input
     // i.e. Only coerce data when the type changes, which should only be on mount or when the user explicitly chooses a new type.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [propertyType])
 
   const itemsSchema = getSchemaForPropertyType(propertyType)

--- a/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
+++ b/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
@@ -77,9 +77,9 @@ export function StorybookComponentWrapper(props: {
   // Subscribe to the framework-agnostic SynapseSessionManager for token/auth state
   // These methods are bound in the SynapseSessionManager constructor, so they are safe to pass directly.
   const sessionState: SessionState = useSyncExternalStore(
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line @typescript-eslint/unbound-method
     sessionManager.subscribe,
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line @typescript-eslint/unbound-method
     sessionManager.getSnapshot,
   )
 

--- a/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.test.tsx
@@ -72,11 +72,11 @@ describe('SynapseChat - suggestedPrompts', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     mockUseCreateAgentSession.mockReturnValue(idleMutation as any)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     mockUseUpdateAgentSession.mockReturnValue(idleMutation as any)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     mockUseGetChatAgentTraceEvents.mockReturnValue({ data: undefined } as any)
     mockUseChatState.mockReturnValue(defaultMockChatState)
   })

--- a/packages/synapse-react-client/src/components/SynapseForm/SynapseFormSubmissionGrid.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseForm/SynapseFormSubmissionGrid.test.tsx
@@ -27,7 +27,7 @@ const renderComponent = async (
   contextOverrides?: Partial<SynapseContextType>,
 ) => {
   // We must await asynchronous events for our assertions to pass
-  // eslint-disable-next-line @typescript-eslint/require-await
+  // oxlint-disable-next-line @typescript-eslint/require-await
   return await act(async () => {
     render(<UserFileGrid {...props} />, {
       wrapper: createWrapper(contextOverrides),

--- a/packages/synapse-react-client/src/components/SynapsePortalBanners/SynapsePortalBanners.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapsePortalBanners/SynapsePortalBanners.test.tsx
@@ -93,7 +93,7 @@ async function renderComponent(
 ) {
   let renderReturn
   // We must await asynchronous events for our assertions to pass
-  // eslint-disable-next-line @typescript-eslint/require-await
+  // oxlint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     renderReturn = render(<SynapsePortalBanners {...props} />, {
       wrapper: createWrapper(wrapperProps),

--- a/packages/synapse-react-client/src/components/SynapseTable/TablePagination.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/TablePagination.tsx
@@ -70,7 +70,7 @@ export const TablePagination = (): React.ReactNode => {
   // A custom `renderItem` implementation for the MUI Pagination component that prefetches a page's data when the page number button is hovered over
   const renderPaginationItem = useCallback(
     (params: PaginationRenderItemParams) => {
-      // eslint-disable-next-line react/no-unstable-nested-components -- this declaration is within a useCallback itself, so it is stable (enough)
+      // oxlint-disable-next-line react/no-unstable-nested-components -- this declaration is within a useCallback itself, so it is stable (enough)
       const ButtonWithPagePrefetchOnHover = forwardRef(
         function PaginationItemButton(
           props: ComponentProps<'button'>,

--- a/packages/synapse-react-client/src/components/SynapseTable/datasets/DatasetItemsEditor.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/datasets/DatasetItemsEditor.tsx
@@ -531,7 +531,7 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
     }
     setPreviousDatasetToUpdate(datasetToUpdate)
     // Only run when datasetToUpdate changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [datasetToUpdate])
 
   const tableData = useMemo(

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaForm.tsx
@@ -177,7 +177,7 @@ function TableColumnSchemaFormInternal(
       })
     }
     // Don't re-run if initial data changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoadingDefaultColumns])
 
   const validateInternal = useCallback(() => {

--- a/packages/synapse-react-client/src/components/TableFeedCards/TableFeedCards.test.tsx
+++ b/packages/synapse-react-client/src/components/TableFeedCards/TableFeedCards.test.tsx
@@ -30,7 +30,7 @@ describe('basic tests', () => {
 
   it('displays news cards from a Synapse Table', async () => {
     // We must await asynchronous events for our assertions to pass
-    // eslint-disable-next-line @typescript-eslint/require-await
+    // oxlint-disable-next-line @typescript-eslint/require-await
     await act(async () => init())
     expect(container.querySelector('.FeedItem')).toBeDefined()
     expect(container.querySelectorAll('.FeedItem')).toHaveLength(3)

--- a/packages/synapse-react-client/src/components/TanStackTable/StyledTanStackTable.tsx
+++ b/packages/synapse-react-client/src/components/TanStackTable/StyledTanStackTable.tsx
@@ -142,7 +142,7 @@ export default function StyledTanStackTable<
     }
     return colSizes
     // Intentionally limit the dependencies to only recompute when the column sizes change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [
     table.getState().columnSizingInfo,
     table.getState().columnSizing,

--- a/packages/synapse-react-client/src/components/TimelinePlot/TimelinePlot.test.tsx
+++ b/packages/synapse-react-client/src/components/TimelinePlot/TimelinePlot.test.tsx
@@ -17,7 +17,7 @@ const timelineProps: TimelinePlotProps = {
 
 async function renderTimeline(props: TimelinePlotProps = timelineProps) {
   let component
-  // eslint-disable-next-line @typescript-eslint/require-await
+  // oxlint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     component = render(<TimelinePlot {...props} />, {
       wrapper: createWrapper(),

--- a/packages/synapse-react-client/src/components/TimelinePlot/TimelinePlotSpeciesSelector.test.tsx
+++ b/packages/synapse-react-client/src/components/TimelinePlot/TimelinePlotSpeciesSelector.test.tsx
@@ -35,7 +35,7 @@ async function renderTimelineSelector(
   props: TimelinePlotSpeciesSelectorProps = timelineSpeciesSelectorProps,
 ) {
   let component
-  // eslint-disable-next-line @typescript-eslint/require-await
+  // oxlint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     component = render(<TimelinePlotSpeciesSelector {...props} />, {
       wrapper: createWrapper(),

--- a/packages/synapse-react-client/src/components/download_list/DownloadConfirmationUI.test.tsx
+++ b/packages/synapse-react-client/src/components/download_list/DownloadConfirmationUI.test.tsx
@@ -20,7 +20,7 @@ async function setUp(
   const user = userEvent.setup()
   let component
   // We must await asynchronous events for our assertions to pass
-  // eslint-disable-next-line @typescript-eslint/require-await
+  // oxlint-disable-next-line @typescript-eslint/require-await
   await act(async () => {
     component = render(<DownloadConfirmationUI {...componentProps} />, {
       wrapper: createWrapper(wrapperProps),

--- a/packages/synapse-react-client/src/components/download_list/DownloadDetails.test.tsx
+++ b/packages/synapse-react-client/src/components/download_list/DownloadDetails.test.tsx
@@ -8,7 +8,7 @@ vi.mock('../../../src/utils/functions/testDownloadSpeed', () => ({
 
 const renderComponent = async (props: DownloadDetailsProps) => {
   // We must await asynchronous events for our assertions to pass
-  // eslint-disable-next-line @typescript-eslint/require-await
+  // oxlint-disable-next-line @typescript-eslint/require-await
   return await act(async () => {
     render(<DownloadDetails {...props} />, {
       wrapper: createWrapper(),

--- a/packages/synapse-react-client/src/features/team/invitation/components/OpenInvitationsToUserCard.test.tsx
+++ b/packages/synapse-react-client/src/features/team/invitation/components/OpenInvitationsToUserCard.test.tsx
@@ -52,9 +52,9 @@ const mockAcceptMutate = vi.fn()
 const mockDeclineMutate = vi.fn()
 
 // Captured options so tests can invoke onSuccess/onError callbacks directly.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any
 let capturedAddMemberOptions: any
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any
 let capturedDeleteInvitationOptions: any
 
 const MOCK_INVITATION_WITH_MESSAGE: MembershipInvitation = {

--- a/packages/synapse-react-client/src/testutils/ReactQueryMockUtils.ts
+++ b/packages/synapse-react-client/src/testutils/ReactQueryMockUtils.ts
@@ -625,11 +625,11 @@ export function getUseMutationMock<
  * @deprecated Use {@link getUseMutationMock} instead, which provides utilities to dynamically change the state of the mock hook.
  */
 export function getUseMutationIdleMock<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   TData = any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   TError = any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   TVariables = any,
 >(data?: TData) {
   return {
@@ -656,11 +656,11 @@ export function getUseMutationIdleMock<
  * @deprecated Use {@link getUseMutationMock} instead, which provides utilities to dynamically change the state of the mock hook.
  */
 export function getUseMutationPendingMock<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   TData = any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   TError = any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   TVariables = any,
 >(data?: TData, variables?: TVariables) {
   return {

--- a/packages/synapse-react-client/src/testutils/vitest.d.ts
+++ b/packages/synapse-react-client/src/testutils/vitest.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type,@typescript-eslint/no-empty-interface */
+/* oxlint-disable @typescript-eslint/no-empty-object-type,@typescript-eslint/no-empty-interface */
 import 'vitest'
 
 interface CustomMatchers<R = unknown> {

--- a/packages/synapse-react-client/src/theme/ThemeTypes.d.ts
+++ b/packages/synapse-react-client/src/theme/ThemeTypes.d.ts
@@ -1,5 +1,5 @@
-/* eslint-disable @typescript-eslint/no-empty-interface  */
-/* eslint-disable @typescript-eslint/no-empty-object-type */
+/* oxlint-disable @typescript-eslint/no-empty-interface  */
+/* oxlint-disable @typescript-eslint/no-empty-object-type */
 
 import '@mui/material/styles'
 

--- a/packages/synapse-react-client/src/types/ThemeTypes.d.ts
+++ b/packages/synapse-react-client/src/types/ThemeTypes.d.ts
@@ -1,5 +1,5 @@
-/* eslint-disable @typescript-eslint/no-empty-interface  */
-/* eslint-disable @typescript-eslint/no-empty-object-type */
+/* oxlint-disable @typescript-eslint/no-empty-interface  */
+/* oxlint-disable @typescript-eslint/no-empty-object-type */
 import '@mui/material/styles'
 
 // If creating a new Typography variant, add it to this list.

--- a/packages/synapse-react-client/src/utils/AppUtils/session/AuthenticationGuard.test.tsx
+++ b/packages/synapse-react-client/src/utils/AppUtils/session/AuthenticationGuard.test.tsx
@@ -60,9 +60,9 @@ function createMockSynapseContext(
     utcTime: false,
     withErrorBoundary: false,
     downloadCartPageUrl: '/DownloadCart',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     keyFactory: {} as any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     synapseClient: {} as any,
     ...overrides,
   }

--- a/packages/synapse-react-client/src/utils/functions/IsEqualTreatUndefinedAsMissing.ts
+++ b/packages/synapse-react-client/src/utils/functions/IsEqualTreatUndefinedAsMissing.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* oxlint-disable @typescript-eslint/no-explicit-any */
 // `any` is safe for these comparison functions
 import { isArray, isObject, includes, isEqualWith, omitBy } from 'lodash-es'
 

--- a/packages/synapse-react-client/src/utils/functions/deepLinkingUtils.test.ts
+++ b/packages/synapse-react-client/src/utils/functions/deepLinkingUtils.test.ts
@@ -19,20 +19,20 @@ describe('deepLinkingUtils', () => {
     })
 
     // Mock window.location
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     delete (window as any).location
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment
     window.location = {
       ...originalLocation,
       pathname: '/test',
       search: '',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     } as any
   })
 
   afterEach(() => {
     vi.clearAllMocks()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
     window.location = originalLocation as any
   })
 

--- a/packages/synapse-react-client/src/utils/hooks/useDebouncedEffect.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useDebouncedEffect.ts
@@ -16,6 +16,6 @@ export const useDebouncedEffect = (
     const handler = setTimeout(() => effect(), delay)
 
     return () => clearTimeout(handler)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [...(deps || []), delay])
 }

--- a/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.test.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.test.ts
@@ -348,7 +348,7 @@ describe('useDetectSSOCode tests', () => {
         )
         expect(mockSetAccessTokenCookie).not.toHaveBeenCalled()
         expect(onSignInComplete).not.toHaveBeenCalled()
-        // eslint-disable-next-line @typescript-eslint/unbound-method
+        // oxlint-disable-next-line @typescript-eslint/unbound-method
         expect(window.location.replace).toHaveBeenCalledWith(
           'http://localhost:3000/register1',
         )

--- a/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.ts
@@ -241,7 +241,7 @@ export default function useDetectSSOCode(
       }
     }
     // Intentionally only monitoring initialization of the session -- only running on mount after the session detection has completed since this uses URL params that come from a redirect
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [isInitializingSession])
 
   return { isLoading }

--- a/packages/synapse-react-client/src/utils/hooks/useImmutableTableQuery/useImmutableTableQuery.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useImmutableTableQuery/useImmutableTableQuery.ts
@@ -143,7 +143,7 @@ function useSynchronizeQueryWithUrl(
       })
     }
     // should only run on mount, or if the component index changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [componentIndex])
 
   // If `shouldDeepLink` is true, synchronize the URL

--- a/packages/synapse-react-client/src/utils/hooks/useLogin.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useLogin.ts
@@ -129,7 +129,7 @@ export default function useLogin(opts: UseLoginOptions): UseLoginReturn {
       }
     }
     // We do NOT want to rerun this effect on step change. It should only run once, when we get the error.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [twoFaErrorResponse])
 
   /**

--- a/packages/synapse-types/src/Table/View.ts
+++ b/packages/synapse-types/src/Table/View.ts
@@ -3,8 +3,6 @@ import { Table } from './Table'
 
 // https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/View.html
 
-// The View interface only exists in
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface View extends Table {
   concreteType: VIEW_CONCRETE_TYPE
 }


### PR DESCRIPTION
I noticed agents kept trying to use `eslint` for linting, but we use oxlint now. I tried to scrub 'eslint' from our codebase (as much as I could, we still rely on `@typescript-eslint` for type-aware rules) and add some basic explicit info to CLAUDE.md to make this less likely

- Update CLAUDE.md to get it up-to-date
- Drop as many references to `eslint` as possible