### PR TITLE
SWC-7872: Improve EntityPageTitleBar responsiveness

### DIFF
--- a/packages/synapse-react-client/src/components/entity/page/title_bar/EntityPageTitleBar.tsx
+++ b/packages/synapse-react-client/src/components/entity/page/title_bar/EntityPageTitleBar.tsx
@@ -55,7 +55,7 @@ export default function EntityPageTitleBar(props: EntityPageTitleBarProps) {
       >
         <Stack
           sx={{
-            flexDirection: { xs: 'column', sm: 'row' },
+            flexDirection: { xs: 'column', md: 'row' },
             alignItems: 'center',
           }}
         >

--- a/packages/synapse-react-client/src/components/menu/ComplexMenu.tsx
+++ b/packages/synapse-react-client/src/components/menu/ComplexMenu.tsx
@@ -47,7 +47,7 @@ export function ComplexMenu(props: ComplexMenuProps) {
         display: 'flex',
         alignItems: 'center',
         gap: '10px',
-        [theme.breakpoints.down('sm')]: {
+        [theme.breakpoints.down('md')]: {
           flexDirection: 'column',
           paddingTop: '10px',
         },
@@ -60,7 +60,7 @@ export function ComplexMenu(props: ComplexMenuProps) {
             <Box
               key={label}
               sx={theme => ({
-                [theme.breakpoints.down('sm')]: {
+                [theme.breakpoints.down('md')]: {
                   width: '100%',
                   '.MuiButton-root': { width: '100%' },
                 },
@@ -129,7 +129,7 @@ export function ComplexMenu(props: ComplexMenuProps) {
           menuProps.items.length > 0 && (
             <Box
               sx={theme => ({
-                [theme.breakpoints.down('sm')]: {
+                [theme.breakpoints.down('md')]: {
                   width: '100%',
                   '.MuiButton-root': { width: '100%' },
                 },

--- a/packages/synapse-react-client/src/components/menu/ComplexMenu.tsx
+++ b/packages/synapse-react-client/src/components/menu/ComplexMenu.tsx
@@ -47,6 +47,8 @@ export function ComplexMenu(props: ComplexMenuProps) {
         display: 'flex',
         alignItems: 'center',
         gap: '10px',
+        flexWrap: 'wrap',
+        justifyContent: 'flex-end',
         [theme.breakpoints.down('md')]: {
           flexDirection: 'column',
           paddingTop: '10px',


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/SWC-7872

<img width="1512" height="982" alt="Screenshot 2026-07-09 at 11 08 32 AM" src="https://github.com/user-attachments/assets/139f7c42-569c-42ab-992e-74b5f30c3804" />
<img width="1512" height="982" alt="Screenshot 2026-07-09 at 11 08 10 AM" src="https://github.com/user-attachments/assets/f21ebb4a-6c93-4980-84ec-eee5f0341a8a" />
bigger than tablet, smaller desktop, "slightly reduced width desktop" looks like this:
<img width="1512" height="982" alt="Screenshot 2026-07-09 at 11 08 02 AM" src="https://github.com/user-attachments/assets/1833b939-63ae-4e38-9572-e81e21acc097" />
