### PR TITLE
PORTALS-4358

### DIFF
--- a/packages/synapse-react-client/src/components/HeaderCard.tsx
+++ b/packages/synapse-react-client/src/components/HeaderCard.tsx
@@ -174,7 +174,14 @@ const HeaderCardClassic = forwardRef(function HeaderCardClassic(
                   {icon}
                 </Box>
               )}
-              {subTitle && <div className="SRC-author">{subTitle}</div>}
+              {subTitle && (
+                <div
+                  className="SRC-author"
+                  style={{ fontStyle: 'italic', marginBottom: '10px' }}
+                >
+                  {subTitle}
+                </div>
+              )}
               <CollapsibleDescription
                 description={description}
                 descriptionSubTitle={descriptionSubTitle}


### PR DESCRIPTION
Before:
<img width="1493" height="704" alt="Screenshot 2026-07-13 at 2 25 47 PM" src="https://github.com/user-attachments/assets/609390c3-81dc-4729-80f5-4eb4280a0933" />

After: 
<img width="1496" height="748" alt="Screenshot 2026-07-13 at 2 23 00 PM" src="https://github.com/user-attachments/assets/eab0fd8e-38bc-457b-a68a-8f2b8e17661c" />
