### PR TITLE
SWC-7875 - Expandable content in CurationTaskCard

### DIFF
--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.module.scss
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.module.scss
@@ -19,6 +19,7 @@
   flex-direction: column;
   gap: 16px;
   flex-grow: 1;
+  flex: 1;
 }
 
 .titleChipContainer {
@@ -31,6 +32,34 @@
     flex-direction: column;
     align-items: flex-start;
   }
+}
+
+.title {
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.entityInfo {
+  display: flex;
+  gap: 16px;
+}
+
+.statusContainer {
+  display: flex;
+  align-items: center;
+}
+
+.expandedContent {
+  background-color: #fff;
+  padding: 16px;
+  margin: 16px;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .userChipContainer {

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
@@ -186,4 +186,54 @@ describe('CurationTaskCard', () => {
       ).not.toBeInTheDocument()
     })
   })
+
+  describe('expanded state', () => {
+    it('hides instructions by default', () => {
+      const taskWithInstructions = createMockTaskBundle({
+        projectId: 'syn123',
+        dataType: 'Test Data Type',
+        instructions: 'Test instructions',
+      })
+      renderComponent(taskWithInstructions)
+      expect(screen.queryByText('Test instructions')).not.toBeInTheDocument()
+    })
+
+    it('shows instructions when title is clicked', async () => {
+      const user = userEvent.setup()
+      const taskWithInstructions = createMockTaskBundle({
+        projectId: 'syn123',
+        dataType: 'Test Data Type',
+        instructions: 'Test instructions',
+      })
+      renderComponent(taskWithInstructions)
+
+      const title = screen.getByText('Test Data Type')
+      await user.click(title)
+
+      expect(screen.getByText('Test instructions')).toBeInTheDocument()
+    })
+
+    it('toggles expanded state when title is clicked', async () => {
+      const user = userEvent.setup()
+      const taskWithInstructions = createMockTaskBundle({
+        projectId: 'syn123',
+        dataType: 'Test Data Type',
+        instructions: 'Test instructions',
+      })
+      renderComponent(taskWithInstructions)
+
+      const title = screen.getByText('Test Data Type')
+
+      // Initially collapsed
+      expect(screen.queryByText('Test instructions')).not.toBeInTheDocument()
+
+      // Click to expand
+      await user.click(title)
+      expect(screen.getByText('Test instructions')).toBeInTheDocument()
+
+      // Click to collapse
+      await user.click(title)
+      expect(screen.queryByText('Test instructions')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
@@ -3,7 +3,7 @@ import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/
 import { createMockTaskBundle } from '@/mocks/curation/mockCurationTask'
 import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
 import { CurationTask, TaskBundle } from '@sage-bionetworks/synapse-client'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach } from 'vitest'
 import CurationTaskCard from './CurationTaskCard'
@@ -195,7 +195,8 @@ describe('CurationTaskCard', () => {
         instructions: 'Test instructions',
       })
       renderComponent(taskWithInstructions)
-      expect(screen.queryByText('Test instructions')).not.toBeInTheDocument()
+      const instructions = screen.queryByText('Test instructions')
+      expect(instructions).not.toBeVisible()
     })
 
     it('shows instructions when title is clicked', async () => {
@@ -210,7 +211,8 @@ describe('CurationTaskCard', () => {
       const title = screen.getByText('Test Data Type')
       await user.click(title)
 
-      expect(screen.getByText('Test instructions')).toBeInTheDocument()
+      const instructions = screen.getByText('Test instructions')
+      expect(instructions).toBeVisible()
     })
 
     it('toggles expanded state when title is clicked', async () => {
@@ -223,17 +225,20 @@ describe('CurationTaskCard', () => {
       renderComponent(taskWithInstructions)
 
       const title = screen.getByText('Test Data Type')
+      const instructions = screen.getByText('Test instructions')
 
       // Initially collapsed
-      expect(screen.queryByText('Test instructions')).not.toBeInTheDocument()
+      expect(instructions).not.toBeVisible()
 
       // Click to expand
       await user.click(title)
-      expect(screen.getByText('Test instructions')).toBeInTheDocument()
+      expect(instructions).toBeVisible()
 
       // Click to collapse
       await user.click(title)
-      expect(screen.queryByText('Test instructions')).not.toBeInTheDocument()
+      await waitFor(() => {
+        expect(instructions).not.toBeVisible()
+      })
     })
   })
 })

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -125,6 +125,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
   } = useUiForTask(taskBundle)
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(false)
 
   const projectId = taskBundle.task?.projectId
   const { data: bundle } = useGetEntityBundle(projectId, undefined, {
@@ -144,9 +145,21 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
   return (
     <Card className={classNames(sharedStyles.card, styles.card)}>
       <div className={styles.cardContent}>
-        <div className={styles.mainContent}>
+        <div className={styles.mainContent} style={{ flex: 1 }}>
           <div className={styles.titleChipContainer}>
-            <Typography variant="headline3">{title}</Typography>
+            <Typography
+              variant="headline3"
+              onClick={() => setIsExpanded(!isExpanded)}
+              sx={{
+                cursor: 'pointer',
+                color: 'primary.main',
+                '&:hover': {
+                  textDecoration: 'underline',
+                },
+              }}
+            >
+              {title}
+            </Typography>
             {taskType && <TaskTypeChip label={taskType} />}
             {canEdit && (
               <IconButton
@@ -167,9 +180,6 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
               <Typography variant="body1">Task ID: {taskId}</Typography>
             )}
           </Box>
-          {description && (
-            <Typography variant="body1">{description}</Typography>
-          )}
           <div className={styles.userChipContainer}>
             {principalIds.map(principalId => (
               <UserOrTeamChip key={principalId} principalId={principalId} />
@@ -179,19 +189,42 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
           <TaskStatusChip state={statusState} />
         </Box>
-        <Divider
-          orientation="vertical"
-          flexItem
-          sx={{ display: { xs: 'none', md: 'block' } }}
-        />
-        <NextStepButton
-          className={styles.cardButton}
-          buttonText={buttonText}
-          onClick={onClickAction}
-          disabled={isLoading}
-          loading={isPending}
-        />
+        {!isExpanded && (
+          <NextStepButton
+            className={styles.cardButton}
+            buttonText={buttonText}
+            onClick={onClickAction}
+            disabled={isLoading}
+            loading={isPending}
+            expanded={false}
+          />
+        )}
       </div>
+      {isExpanded && (
+        <Box
+          sx={{
+            backgroundColor: '#fff',
+            padding: 2,
+            margin: 2,
+            borderRadius: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          {description && (
+            <Typography variant="body1">{description}</Typography>
+          )}
+          <NextStepButton
+            className={styles.cardButton}
+            buttonText={buttonText}
+            onClick={onClickAction}
+            disabled={isLoading}
+            loading={isPending}
+            expanded={true}
+          />
+        </Box>
+      )}
       <CreateOrUpdateCurationTaskDialog
         key={String(isSettingsOpen)}
         open={isSettingsOpen}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -190,14 +190,21 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
           <TaskStatusChip state={statusState} />
         </Box>
         {!isExpanded && (
-          <NextStepButton
-            className={styles.cardButton}
-            buttonText={buttonText}
-            onClick={onClickAction}
-            disabled={isLoading}
-            loading={isPending}
-            expanded={false}
-          />
+          <>
+            <Divider
+              orientation="vertical"
+              flexItem
+              sx={{ display: { xs: 'none', md: 'block' } }}
+            />
+            <NextStepButton
+              className={styles.cardButton}
+              buttonText={buttonText}
+              onClick={onClickAction}
+              disabled={isLoading}
+              loading={isPending}
+              expanded={false}
+            />
+          </>
         )}
       </div>
       {isExpanded && (

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -5,9 +5,9 @@ import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/
 import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
 import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
 import {
-  Box,
   Card,
   Chip,
+  Collapse,
   Divider,
   IconButton,
   Skeleton,
@@ -145,18 +145,12 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
   return (
     <Card className={classNames(sharedStyles.card, styles.card)}>
       <div className={styles.cardContent}>
-        <div className={styles.mainContent} style={{ flex: 1 }}>
+        <div className={styles.mainContent}>
           <div className={styles.titleChipContainer}>
             <Typography
               variant="headline3"
+              className={styles.title}
               onClick={() => setIsExpanded(!isExpanded)}
-              sx={{
-                cursor: 'pointer',
-                color: 'primary.main',
-                '&:hover': {
-                  textDecoration: 'underline',
-                },
-              }}
             >
               {title}
             </Typography>
@@ -170,7 +164,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
               </IconButton>
             )}
           </div>
-          <Box sx={{ display: 'flex', gap: 4 }}>
+          <div className={styles.entityInfo}>
             {bundle?.entity?.name ? (
               <Typography variant="body1">{bundle.entity.name}</Typography>
             ) : (
@@ -179,16 +173,16 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
             {taskId && (
               <Typography variant="body1">Task ID: {taskId}</Typography>
             )}
-          </Box>
+          </div>
           <div className={styles.userChipContainer}>
             {principalIds.map(principalId => (
               <UserOrTeamChip key={principalId} principalId={principalId} />
             ))}
           </div>
         </div>
-        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <div className={styles.statusContainer}>
           <TaskStatusChip state={statusState} />
-        </Box>
+        </div>
         {!isExpanded && (
           <>
             <Divider
@@ -207,18 +201,8 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
           </>
         )}
       </div>
-      {isExpanded && (
-        <Box
-          sx={{
-            backgroundColor: '#fff',
-            padding: 2,
-            margin: 2,
-            borderRadius: 1,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 2,
-          }}
-        >
+      <Collapse in={isExpanded}>
+        <div className={styles.expandedContent}>
           {description && (
             <Typography variant="body1">{description}</Typography>
           )}
@@ -230,8 +214,8 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
             loading={isPending}
             expanded={true}
           />
-        </Box>
-      )}
+        </div>
+      </Collapse>
       <CreateOrUpdateCurationTaskDialog
         key={String(isSettingsOpen)}
         open={isSettingsOpen}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.module.scss
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.module.scss
@@ -55,3 +55,31 @@
     }
   }
 }
+
+.expandedButton {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 24px;
+  background-color: var(--synapse-primary-action-color);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+
+  &:disabled {
+    pointer-events: all;
+    opacity: 0.5;
+  }
+
+  &:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  &:active:not(:disabled) {
+    opacity: 0.8;
+  }
+}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from '@testing-library/react'
+import NextStepButton from './NextStepButton'
+
+describe('NextStepButton', () => {
+  const mockOnClick = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('default mode (expanded={false})', () => {
+    it('renders the button text', () => {
+      render(<NextStepButton buttonText="Open Curator" onClick={mockOnClick} />)
+      expect(screen.getByText('Open Curator')).toBeInTheDocument()
+    })
+
+    it('renders the "Next step" label', () => {
+      render(<NextStepButton buttonText="Open Curator" onClick={mockOnClick} />)
+      expect(screen.getByText('Next step')).toBeInTheDocument()
+    })
+
+    it('renders the arrow icon', () => {
+      render(<NextStepButton buttonText="Open Curator" onClick={mockOnClick} />)
+      expect(screen.getByTestId('ArrowForwardIosIcon')).toBeInTheDocument()
+    })
+
+    it('calls onClick when clicked', async () => {
+      const user = await import('@testing-library/user-event').then(m =>
+        m.default.setup(),
+      )
+      render(<NextStepButton buttonText="Open Curator" onClick={mockOnClick} />)
+
+      const button = screen.getByRole('button', { name: /next step/i })
+      await user.click(button)
+
+      expect(mockOnClick).toHaveBeenCalledOnce()
+    })
+
+    it('is disabled when disabled prop is true', () => {
+      render(
+        <NextStepButton
+          buttonText="Open Curator"
+          onClick={mockOnClick}
+          disabled={true}
+        />,
+      )
+
+      const button = screen.getByRole('button')
+      expect(button).toBeDisabled()
+    })
+
+    it('is disabled when loading is true', () => {
+      render(
+        <NextStepButton
+          buttonText="Open Curator"
+          onClick={mockOnClick}
+          loading={true}
+        />,
+      )
+
+      const button = screen.getByRole('button')
+      expect(button).toBeDisabled()
+    })
+  })
+
+  describe('expanded mode (expanded={true})', () => {
+    it('renders the button text', () => {
+      render(
+        <NextStepButton
+          buttonText="Open Curator"
+          onClick={mockOnClick}
+          expanded={true}
+        />,
+      )
+      expect(screen.getByText('Open Curator')).toBeInTheDocument()
+    })
+
+    it('does not render the "Next step" label', () => {
+      render(
+        <NextStepButton
+          buttonText="Open Curator"
+          onClick={mockOnClick}
+          expanded={true}
+        />,
+      )
+      expect(screen.queryByText('Next step')).not.toBeInTheDocument()
+    })
+
+    it('renders the spreadsheet icon', () => {
+      render(
+        <NextStepButton
+          buttonText="Open Curator"
+          onClick={mockOnClick}
+          expanded={true}
+        />,
+      )
+      expect(screen.getByTestId('TableChartOutlinedIcon')).toBeInTheDocument()
+    })
+
+    it('does not render the arrow icon', () => {
+      render(
+        <NextStepButton
+          buttonText="Open Curator"
+          onClick={mockOnClick}
+          expanded={true}
+        />,
+      )
+      expect(
+        screen.queryByTestId('ArrowForwardIosIcon'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('calls onClick when clicked', async () => {
+      const user = await import('@testing-library/user-event').then(m =>
+        m.default.setup(),
+      )
+      render(
+        <NextStepButton
+          buttonText="Open Curator"
+          onClick={mockOnClick}
+          expanded={true}
+        />,
+      )
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+
+      expect(mockOnClick).toHaveBeenCalledOnce()
+    })
+
+    it('is disabled when disabled prop is true', () => {
+      render(
+        <NextStepButton
+          buttonText="Open Curator"
+          onClick={mockOnClick}
+          disabled={true}
+          expanded={true}
+        />,
+      )
+
+      const button = screen.getByRole('button')
+      expect(button).toBeDisabled()
+    })
+
+    it('is disabled when loading is true', () => {
+      render(
+        <NextStepButton
+          buttonText="Open Curator"
+          onClick={mockOnClick}
+          loading={true}
+          expanded={true}
+        />,
+      )
+
+      const button = screen.getByRole('button')
+      expect(button).toBeDisabled()
+    })
+  })
+})

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import NextStepButton from './NextStepButton'
 
 describe('NextStepButton', () => {

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.test.tsx
@@ -15,16 +15,6 @@ describe('NextStepButton', () => {
       expect(screen.getByText('Open Curator')).toBeInTheDocument()
     })
 
-    it('renders the "Next step" label', () => {
-      render(<NextStepButton buttonText="Open Curator" onClick={mockOnClick} />)
-      expect(screen.getByText('Next step')).toBeInTheDocument()
-    })
-
-    it('renders the arrow icon', () => {
-      render(<NextStepButton buttonText="Open Curator" onClick={mockOnClick} />)
-      expect(screen.getByTestId('ArrowForwardIosIcon')).toBeInTheDocument()
-    })
-
     it('calls onClick when clicked', async () => {
       const user = await import('@testing-library/user-event').then(m =>
         m.default.setup(),
@@ -85,30 +75,6 @@ describe('NextStepButton', () => {
         />,
       )
       expect(screen.queryByText('Next step')).not.toBeInTheDocument()
-    })
-
-    it('renders the spreadsheet icon', () => {
-      render(
-        <NextStepButton
-          buttonText="Open Curator"
-          onClick={mockOnClick}
-          expanded={true}
-        />,
-      )
-      expect(screen.getByTestId('TableChartOutlinedIcon')).toBeInTheDocument()
-    })
-
-    it('does not render the arrow icon', () => {
-      render(
-        <NextStepButton
-          buttonText="Open Curator"
-          onClick={mockOnClick}
-          expanded={true}
-        />,
-      )
-      expect(
-        screen.queryByTestId('ArrowForwardIosIcon'),
-      ).not.toBeInTheDocument()
     })
 
     it('calls onClick when clicked', async () => {

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.tsx
@@ -1,5 +1,5 @@
 import styles from './NextStepButton.module.scss'
-import { Typography, useTheme } from '@mui/material'
+import { Button, Typography } from '@mui/material'
 import { ArrowForwardIos, TableChartOutlined } from '@mui/icons-material'
 import { SynapseSpinner } from '@/components/LoadingScreen/LoadingScreen'
 import classNames from 'classnames'
@@ -19,37 +19,23 @@ type NextStepButtonProps = {
  */
 export default function NextStepButton(props: NextStepButtonProps) {
   const { className, buttonText, onClick, disabled, loading, expanded } = props
-  const theme = useTheme()
 
   if (expanded) {
     return (
-      <button
-        type="button"
-        className={classNames(styles.button, className)}
+      <Button
+        className={classNames(styles.expandedButton, className)}
         onClick={onClick}
         disabled={disabled || loading}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: '8px',
-          width: '100%',
-          backgroundColor: theme.palette.primary.main,
-          color: 'white',
-          border: 'none',
-          padding: '12px 24px',
-          borderRadius: '4px',
-          cursor: 'pointer',
-        }}
+        startIcon={<TableChartOutlined sx={{ fontSize: 20 }} />}
+        sx={{ width: '100%' }}
       >
-        <TableChartOutlined sx={{ fontSize: 20 }} />
         <Typography
           variant="buttonLink"
           sx={{ color: 'inherit', fontWeight: 700 }}
         >
           {buttonText}
         </Typography>
-      </button>
+      </Button>
     )
   }
 

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.tsx
@@ -1,6 +1,6 @@
 import styles from './NextStepButton.module.scss'
-import { Typography } from '@mui/material'
-import { ArrowForwardIos } from '@mui/icons-material'
+import { Typography, useTheme } from '@mui/material'
+import { ArrowForwardIos, TableChartOutlined } from '@mui/icons-material'
 import { SynapseSpinner } from '@/components/LoadingScreen/LoadingScreen'
 import classNames from 'classnames'
 
@@ -10,6 +10,7 @@ type NextStepButtonProps = {
   onClick: () => void
   disabled?: boolean
   loading?: boolean
+  expanded?: boolean
 }
 
 /**
@@ -17,7 +18,41 @@ type NextStepButtonProps = {
  * Displays an arrow icon or loading spinner when appropriate.
  */
 export default function NextStepButton(props: NextStepButtonProps) {
-  const { className, buttonText, onClick, disabled, loading } = props
+  const { className, buttonText, onClick, disabled, loading, expanded } = props
+  const theme = useTheme()
+
+  if (expanded) {
+    return (
+      <button
+        type="button"
+        className={classNames(styles.button, className)}
+        onClick={onClick}
+        disabled={disabled || loading}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '8px',
+          width: '100%',
+          backgroundColor: theme.palette.primary.main,
+          color: 'white',
+          border: 'none',
+          padding: '12px 24px',
+          borderRadius: '4px',
+          cursor: 'pointer',
+        }}
+      >
+        <TableChartOutlined sx={{ fontSize: 20 }} />
+        <Typography
+          variant="buttonLink"
+          sx={{ color: 'inherit', fontWeight: 700 }}
+        >
+          {buttonText}
+        </Typography>
+      </button>
+    )
+  }
+
   return (
     <button
       type="button"


### PR DESCRIPTION
Update the curation task card to match designs. Header toggles project instructions and card size.

Collapsed state - hide project instructions and display side button.
<img width="1243" height="203" alt="collapsed" src="https://github.com/user-attachments/assets/5d122144-082e-4c18-8163-bfc508b27112" />

Expanded - display project instructions and move next step button to bottom.
<img width="1249" height="333" alt="expanded" src="https://github.com/user-attachments/assets/ab5d99c7-9a13-41ce-a6ec-ea9bbaff6097" />
