### PR TITLE
PORTALS-4359: Release chat co-pilot on NF only. Move isChatEnabled lo…

### DIFF
--- a/apps/portals/b2ai.standards/src/components/StandardsHeader.tsx
+++ b/apps/portals/b2ai.standards/src/components/StandardsHeader.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Box, Typography, Button } from '@mui/material'
 import HeaderSearchBox from '@sage-bionetworks/synapse-portal-framework/components/HeaderSearchBox'
+import { FeatureFlagEnum } from 'synapse-react-client/utils/featureflag/FeatureFlags'
+import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/index'
 import { FTSConfig } from 'synapse-react-client/components/SynapseTable/SearchV2'
 import { standardsSearchIndexConfig } from '@/config/synapseConfigs/searchConfig'
 
@@ -100,6 +102,7 @@ const StandardsHeader = (props: StandardsHeaderProps): React.ReactNode => {
           searchPlaceholder={searchPlaceholder}
           path="/Search"
           searchIndexConfig={standardsSearchIndexConfig}
+          isChatEnabled={useGetFeatureFlag(FeatureFlagEnum.PORTAL_CHAT)}
           sx={{
             flex: 1,
             '& > :first-child': {

--- a/apps/portals/demoportal/src/components/DemoPortalHeader.tsx
+++ b/apps/portals/demoportal/src/components/DemoPortalHeader.tsx
@@ -3,6 +3,8 @@ import { Box, Typography } from '@mui/material'
 import { TypeAnimation } from 'react-type-animation'
 import { visuallyHidden } from 'synapse-react-client'
 import HeaderSearchBox from '@sage-bionetworks/synapse-portal-framework/components/HeaderSearchBox'
+import { FeatureFlagEnum } from 'synapse-react-client/utils/featureflag/FeatureFlags'
+import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/index'
 import { usePortalContext } from '@sage-bionetworks/synapse-portal-framework/components/PortalContext'
 
 type DemoPortalHeaderProps = {
@@ -105,6 +107,7 @@ const DemoPortalHeader = (props: DemoPortalHeaderProps): React.ReactNode => {
           searchExampleTerms={searchExampleTerms}
           searchPlaceholder={searchPlaceholder}
           path="/Search"
+          isChatEnabled={useGetFeatureFlag(FeatureFlagEnum.PORTAL_CHAT)}
           sx={{
             flex: 1,
             '& > :first-child': {

--- a/apps/synapse-portal-framework/src/components/HeaderSearchBox.tsx
+++ b/apps/synapse-portal-framework/src/components/HeaderSearchBox.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlagEnum } from 'synapse-react-client/utils/featureflag/FeatureFlags'
 import {
   Box,
   Stack,
@@ -26,7 +25,6 @@ import {
 } from 'synapse-react-client/utils/functions/SqlFunctions'
 import { useChatDialogContext } from './ChatDialogContext'
 import { useSynapseContext } from 'synapse-react-client'
-import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/index'
 import { useGetSuggestionsForSearchIndex } from 'synapse-react-client/components/SearchQueryWrapper/SearchQueryUseQueryOptions'
 import { SearchIndexConfig } from '../types/portal-util-types'
 
@@ -34,6 +32,7 @@ type HeaderSearchBoxProps = {
   searchPlaceholder?: string
   searchExampleTerms?: string[]
   hideChatOption?: boolean
+  isChatEnabled?: boolean
   // in practice, either set the path or callback.
   path?: string // redirect to this path with the search term in the search params
   callback?: (searchString: string) => void // call back this function with the search term
@@ -53,6 +52,7 @@ const HeaderSearchBox = ({
   variant = 'default',
   searchIndexConfig,
   hideChatOption = false,
+  isChatEnabled = false,
 }: HeaderSearchBoxProps): React.ReactNode => {
   const styles = {
     ...defaultStyles,
@@ -67,7 +67,6 @@ const HeaderSearchBox = ({
   const { isAuthenticated } = useSynapseContext()
   const chatDialogContext = useChatDialogContext()
   const isChatAvailable = chatDialogContext?.isChatAvailable
-  const isChatEnabled = useGetFeatureFlag(FeatureFlagEnum.PORTAL_CHAT)
   const showChatOption =
     isAuthenticated &&
     chatDialogContext &&

--- a/apps/synapse-portal-framework/src/components/adknowledge/AdknowledgeHeader/AdknowledgeHeader.tsx
+++ b/apps/synapse-portal-framework/src/components/adknowledge/AdknowledgeHeader/AdknowledgeHeader.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Box, Stack, Typography } from '@mui/material'
 import HeaderSearchBox from '@/components/HeaderSearchBox'
+import { FeatureFlagEnum } from 'synapse-react-client/utils/featureflag/FeatureFlags'
+import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/index'
 import { TypeAnimation } from 'react-type-animation'
 import styles from './AdknowledgeHeader.module.scss'
 import { WordPressLatestPostChip } from 'synapse-react-client/components/WordPress/WordPressLatestPostChip'
@@ -68,6 +70,7 @@ const AdknowledgeHeader = (): React.ReactNode => {
           searchPlaceholder={searchPlaceholder}
           path="/Search"
           variant="v2"
+          isChatEnabled={useGetFeatureFlag(FeatureFlagEnum.PORTAL_CHAT)}
         />
       </Stack>
     </header>

--- a/apps/synapse-portal-framework/src/components/ampals/AMPALSHeader.tsx
+++ b/apps/synapse-portal-framework/src/components/ampals/AMPALSHeader.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Box, Typography } from '@mui/material'
 import HeaderSearchBox from '../HeaderSearchBox'
 import { usePortalContext } from '@/components/PortalContext'
+import { FeatureFlagEnum } from 'synapse-react-client/utils/featureflag/FeatureFlags'
+import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/index'
 
 type AMPALSHeaderProps = {
   headerSvgURL: string
@@ -86,6 +88,7 @@ const AMPALSHeader = (props: AMPALSHeaderProps): React.ReactNode => {
           searchExampleTerms={searchExampleTerms}
           searchPlaceholder={searchPlaceholder}
           path="/Search"
+          isChatEnabled={useGetFeatureFlag(FeatureFlagEnum.PORTAL_CHAT)}
           sx={{
             flex: 1,
             '& > :first-child': {

--- a/apps/synapse-portal-framework/src/components/cancercomplexity/CancerComplexityHeader.tsx
+++ b/apps/synapse-portal-framework/src/components/cancercomplexity/CancerComplexityHeader.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Box, Typography, Link } from '@mui/material'
 import HeaderSearchBox from '../HeaderSearchBox'
 import { AddAlertTwoTone } from '@mui/icons-material'
+import { FeatureFlagEnum } from 'synapse-react-client/utils/featureflag/FeatureFlags'
+import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/index'
 import { TypeAnimation } from 'react-type-animation'
 import headerBackground from '../assets/cckp-header-background.jpeg'
 import { visuallyHidden } from 'synapse-react-client'
@@ -173,6 +175,7 @@ const CancerComplexityHeader = (): React.ReactNode => {
             searchPlaceholder={searchPlaceholder}
             path="/Search"
             roles={roles}
+            isChatEnabled={useGetFeatureFlag(FeatureFlagEnum.PORTAL_CHAT)}
             sx={{
               flex: 1,
               '& > :first-child': {

--- a/apps/synapse-portal-framework/src/components/eliteportal/ELITEHeader.tsx
+++ b/apps/synapse-portal-framework/src/components/eliteportal/ELITEHeader.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Box, Typography } from '@mui/material'
 import HeaderSearchBox from '../HeaderSearchBox'
+import { FeatureFlagEnum } from 'synapse-react-client/utils/featureflag/FeatureFlags'
+import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/index'
 
 type ELITEHeaderProps = {
   backgroundCss: string
@@ -102,6 +104,7 @@ const ELITEHeader = ({
           ]}
           searchPlaceholder="Search for longevity and aging data and resources"
           path="/Search"
+          isChatEnabled={useGetFeatureFlag(FeatureFlagEnum.PORTAL_CHAT)}
           sx={{
             flex: 1,
             zIndex: 2,

--- a/apps/synapse-portal-framework/src/components/nf/NFHeader.tsx
+++ b/apps/synapse-portal-framework/src/components/nf/NFHeader.tsx
@@ -89,6 +89,7 @@ const NFHeader = (): React.ReactNode => {
           searchExampleTerms={searchExampleTerms}
           searchPlaceholder={searchPlaceholder}
           path="/Search"
+          isChatEnabled={true}
           sx={{
             flex: 1,
             '& > :first-child': {


### PR DESCRIPTION
…gic out from the reusable HeaderSearchBox

Always available on NF:
<img width="1339" height="702" alt="Screenshot 2026-07-14 at 4 33 19 PM" src="https://github.com/user-attachments/assets/94001dd3-0b4c-47b7-b03a-e5b224594232" />



Not shown on other portals unless Experimental Mode is turned on:
<img width="1316" height="679" alt="Screenshot 2026-07-14 at 4 34 31 PM" src="https://github.com/user-attachments/assets/64fa1392-6ced-4ddc-b45d-f559b5711f0e" />
