### PR TITLE
PORTALS-4282: label DUO card row with the column display name (match the facet)

### DIFF
--- a/packages/synapse-react-client/src/components/GenericCard/DuoTermTags/DuoTermTags.stories.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/DuoTermTags/DuoTermTags.stories.tsx
@@ -95,8 +95,9 @@ export const TruncatedForFacetSidebar: Story = {
 }
 
 /**
- * On a dataset card, DUO terms appear as a "Data Usage Restrictions" row in the
- * metadata section, with full term names.
+ * On a dataset card, DUO terms appear as a metadata row labeled with the DUO
+ * column's display name (e.g. "Data Use Modifiers", matching the facet), with
+ * full term names.
  */
 export const OnADatasetCard: Story = {
   args: { terms: [] },
@@ -109,7 +110,7 @@ export const OnADatasetCard: Story = {
         icon={<GenericCardIcon type="DATASET" useTypeForIcon />}
         labels={[
           {
-            columnDisplayName: 'Data Usage Restrictions',
+            columnDisplayName: 'Data Use Modifiers',
             value: (
               <DuoTermTags terms={['DUO:0000006', 'DUO:0000046', 'DUOplus7']} />
             ),
@@ -125,7 +126,7 @@ export const OnADatasetCard: Story = {
         icon={<GenericCardIcon type="DATASET" useTypeForIcon />}
         labels={[
           {
-            columnDisplayName: 'Data Usage Restrictions',
+            columnDisplayName: 'Data Use Modifiers',
             value: (
               <DuoTermTags
                 terms={[

--- a/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
@@ -230,6 +230,25 @@ describe('TableRowGenericCard tests', () => {
     screen.getByTestId('CardFooter')
   })
 
+  test('labels the DUO row with the column display name so it matches the facet', async () => {
+    // The card row for DUO tags must be labeled with the dataUseModifiers column's
+    // display name (unCamelCase / any alias) — the same source the facet uses —
+    // rather than a hardcoded string, so the two never diverge.
+    renderComponent(
+      {
+        ...propsForNonHeaderMode,
+        schema: { ...schema, dataUseModifiers: 13 },
+        data: [...data, 'DUO:0000046'],
+        genericCardSchema: {
+          ...genericCardSchema,
+          dataUseModifiersColumnName: 'dataUseModifiers',
+        },
+      },
+      'TableEntity',
+    )
+    expect(await screen.findByText('Data Use Modifiers')).toBeInTheDocument()
+  })
+
   describe('Renders UserCards when a UserId_List column is present', () => {
     const columnModelWithUserIdList = [
       {

--- a/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.tsx
@@ -152,7 +152,8 @@ export type TableToGenericCardMapping = {
   /**
    * Column name of a STRING_LIST of Data Use Ontology (DUO) values (ontology
    * codes or term names). When set, the values are rendered as DUO tags in a
-   * "Data Usage Restrictions" row in the card's metadata section.
+   * metadata row labeled with the column's display name, so the card matches the
+   * corresponding facet.
    */
   dataUseModifiersColumnName?: string
 }
@@ -303,7 +304,7 @@ export function TableRowGenericCard(props: TableRowGenericCardProps) {
   )
 
   // DUO (Data Use Ontology) tags, when a dataUseModifiers column is configured.
-  // Rendered as a "Data Usage Restrictions" row in the metadata section.
+  // Rendered as a metadata row labeled with the column's display name.
   const duoContent = useMemo(() => {
     const col = genericCardSchema.dataUseModifiersColumnName
     if (!col) {
@@ -412,9 +413,14 @@ export function TableRowGenericCard(props: TableRowGenericCardProps) {
   const customLabelConfig = genericCardSchema.customSecondaryLabelConfig
 
   // DUO tags rendered as a metadata row (alongside "How to download", size, …).
-  if (duoContent) {
+  // Label it with the DUO column's display name so the card row matches the
+  // facet exactly (respecting any column alias) rather than a hardcoded string.
+  if (duoContent && genericCardSchema.dataUseModifiersColumnName) {
     values.push({
-      columnDisplayName: 'Data Usage Restrictions',
+      columnName: genericCardSchema.dataUseModifiersColumnName,
+      columnDisplayName: getColumnDisplayName(
+        genericCardSchema.dataUseModifiersColumnName,
+      ),
       value: duoContent,
     })
   }


### PR DESCRIPTION
Follow-up to #2930 addressing Ashley's review comment: the dataset card row was hardcoded as "Data Usage Restrictions" while the DUO facet showed the column's display name ("Data Use Modifiers"), which is confusing.

The card now derives the row label from the `dataUseModifiers` column's display name via `getColumnDisplayName` — the same source the facet uses — so the two always match (and follow any column alias). With NF's config both read **"Data Use Modifiers"**.

Added a guard test asserting the DUO card row is labeled with the column's display name, so it can't silently drift back to a hardcoded string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)