### PR TITLE
PORTALS-4389: instruments and variables should be based on an entity …

### DIFF
--- a/apps/portals/classic/src/config/resources.ts
+++ b/apps/portals/classic/src/config/resources.ts
@@ -5,8 +5,6 @@ export const featuredResearchSql =
   'SELECT * FROM syn69806889 ORDER BY order ASC'
 export const publicationsSql = 'SELECT * FROM syn69806872 ORDER BY "Year" DESC'
 export const studiesSql = 'SELECT * FROM syn70760510'
-export const instrumentsSql = 'select * from syn75072123'
-export const variablesSql = 'select * from syn75072058'
 export const metadataSql = 'select * from syn75351203'
 
 export const publicationsSearchIndexId = 'syn75465147'

--- a/apps/portals/classic/src/config/synapseConfigs/instruments.ts
+++ b/apps/portals/classic/src/config/synapseConfigs/instruments.ts
@@ -1,9 +1,7 @@
 import type { QueryWrapperPlotNavProps } from 'synapse-react-client/components/QueryWrapperPlotNav/QueryWrapperPlotNav'
 import { TargetEnum } from 'synapse-react-client/utils/html/TargetEnum'
-import { instrumentsSql } from '../resources'
 
-const instrumentsPlotNavProps: QueryWrapperPlotNavProps = {
-  sql: instrumentsSql,
+const instrumentsPlotNavProps: Omit<QueryWrapperPlotNavProps, 'sql'> = {
   //   name: 'Instruments',
   fileIdColumnName: 'id',
   columnAliases: { study: 'On Synapse' },

--- a/apps/portals/classic/src/config/synapseConfigs/variables.ts
+++ b/apps/portals/classic/src/config/synapseConfigs/variables.ts
@@ -1,9 +1,7 @@
 import type { QueryWrapperPlotNavProps } from 'synapse-react-client/components/QueryWrapperPlotNav/QueryWrapperPlotNav'
 import { TargetEnum } from 'synapse-react-client/utils/html/TargetEnum'
-import { variablesSql } from '../resources'
 
-const variablesPlotNavProps: QueryWrapperPlotNavProps = {
-  sql: variablesSql,
+const variablesPlotNavProps: Omit<QueryWrapperPlotNavProps, 'sql'> = {
   //   name: 'Variables',
   fileIdColumnName: 'id',
   columnAliases: { study: 'On Synapse' },

--- a/apps/portals/classic/src/pages/StudyDetailsPage/StudyMetadataTab.tsx
+++ b/apps/portals/classic/src/pages/StudyDetailsPage/StudyMetadataTab.tsx
@@ -3,11 +3,11 @@ import { useDetailsPageContext } from '@sage-bionetworks/synapse-portal-framewor
 import { MarkdownSynapseFromColumnData } from '@sage-bionetworks/synapse-portal-framework/components/DetailsPage/markdown/MarkdownSynapseFromColumnData'
 import instrumentsPlotNavProps from '@/config/synapseConfigs/instruments'
 import variablesPlotNavProps from '@/config/synapseConfigs/variables'
-import { ColumnSingleValueFilterOperator } from '@sage-bionetworks/synapse-types'
 import QueryWrapperPlotNav from 'synapse-react-client/components/QueryWrapperPlotNav/QueryWrapperPlotNav'
 
 function StudyMetadataTab() {
-  const { value: study } = useDetailsPageContext('study')
+  const { value: instruments } = useDetailsPageContext('Instruments')
+  const { value: variables } = useDetailsPageContext('Variables')
 
   return (
     <DetailsPageContent
@@ -26,36 +26,40 @@ function StudyMetadataTab() {
             <MarkdownSynapseFromColumnData columnName={'studyMetadata'} />
           ),
         },
-        {
-          title: 'Instruments',
-          id: 'Instruments',
-          element: (
-            <QueryWrapperPlotNav
-              {...instrumentsPlotNavProps}
-              rgbIndex={8}
-              shouldDeepLink={false}
-              sqlOperator={ColumnSingleValueFilterOperator.EQUAL}
-              lockedColumn={{ columnName: 'study', value: study }}
-              searchParams={{ study }}
-              hideQueryCount
-            />
-          ),
-        },
-        {
-          title: 'Variables',
-          id: 'Variables',
-          element: (
-            <QueryWrapperPlotNav
-              {...variablesPlotNavProps}
-              rgbIndex={8}
-              shouldDeepLink={false}
-              sqlOperator={ColumnSingleValueFilterOperator.EQUAL}
-              lockedColumn={{ columnName: 'study', value: study }}
-              searchParams={{ study }}
-              hideQueryCount
-            />
-          ),
-        },
+        ...(instruments
+          ? [
+              {
+                title: 'Instruments',
+                id: 'Instruments',
+                element: (
+                  <QueryWrapperPlotNav
+                    {...instrumentsPlotNavProps}
+                    sql={`SELECT * FROM ${instruments}`}
+                    rgbIndex={8}
+                    shouldDeepLink={false}
+                    hideQueryCount
+                  />
+                ),
+              },
+            ]
+          : []),
+        ...(variables
+          ? [
+              {
+                title: 'Variables',
+                id: 'Variables',
+                element: (
+                  <QueryWrapperPlotNav
+                    {...variablesPlotNavProps}
+                    sql={`SELECT * FROM ${variables}`}
+                    rgbIndex={8}
+                    shouldDeepLink={false}
+                    hideQueryCount
+                  />
+                ),
+              },
+            ]
+          : []),
       ]}
     />
   )


### PR DESCRIPTION
…defined in the study table, not hard coded to the BCS study tables

<img width="1512" height="761" alt="Screenshot 2026-07-20 at 9 16 19 AM" src="https://github.com/user-attachments/assets/3dfc848d-6e35-40e0-bd9a-decf3231bcd6" />

Note, MAMBA study source tables for Instruments and Variables still need to be marked as OPEN_DATA:
See https://sagebionetworks.jira.com/browse/IT-5242
But the connection has been tested:
<img width="1511" height="745" alt="Screenshot 2026-07-20 at 9 16 36 AM" src="https://github.com/user-attachments/assets/b015333c-1da0-40f7-942c-ddf292a96bc2" />
