### PR TITLE
SWC-7895: Wire edit task flow into the Curator Dashboard

### DIFF
--- a/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboard.test.tsx
@@ -1,4 +1,4 @@
-import { CuratorDashboardContent } from './CuratorDashboard'
+import CuratorDashboardContent from './CuratorDashboard'
 import { useGetCurationTasksInfinite } from '@/synapse-queries/curation/task/useCurationTask'
 import { createMockTaskBundle } from '@/mocks/curation/mockCurationTask'
 import { render, screen, waitFor } from '@testing-library/react'

--- a/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboard.tsx
@@ -10,7 +10,7 @@ import SWCPageLayout from '@/components/layout/SWCPageLayout'
 import { useSearchParams } from 'react-router'
 import { GRID_PAGE_TASK_ID_QUERY_PARAM } from '@/utils/SynapseConstants'
 
-export function CuratorDashboardContent() {
+export default function CuratorDashboardContent() {
   const [searchParams] = useSearchParams()
   const taskIdParam = searchParams.get(GRID_PAGE_TASK_ID_QUERY_PARAM)
 

--- a/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboardRouter.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboardRouter.tsx
@@ -1,3 +1,5 @@
+import EditCurationTaskPage from '@/features/entity/metadata-task/create-task/EditCurationTaskPage'
+import CuratorDashboardContent from './CuratorDashboard'
 import { PropsWithChildren, useMemo } from 'react'
 import {
   createBrowserRouter,
@@ -6,10 +8,9 @@ import {
   RouterProvider,
 } from 'react-router'
 import { RouterProvider as DOMRouterProvider } from 'react-router/dom'
-import { CuratorDashboardContent } from './CuratorDashboard'
 
 export type CuratorDashboardRouterProps = PropsWithChildren<{
-  /** Used to determine the base path for the component. Default is /curator/dashboard */
+  /** Used to determine the base path for the component. Default is CuratorDashboard:0 */
   routerBaseName?: string
   /** If true use a MemoryRouter, which prevents the browser URL from updating. For testing purposes only. */
   useMemoryRouter?: boolean
@@ -22,14 +23,17 @@ export type CuratorDashboardRouterProps = PropsWithChildren<{
 export default function CuratorDashboardRouter(
   props: CuratorDashboardRouterProps,
 ) {
-  const { routerBaseName = '/curator/dashboard:0', useMemoryRouter = false } =
+  const { routerBaseName = '/CuratorDashboard:0', useMemoryRouter = false } =
     props
 
   const routes: RouteObject[] = useMemo(
     () => [
       {
         path: '/',
-        element: <CuratorDashboardContent />,
+        children: [
+          { index: true, element: <CuratorDashboardContent /> },
+          { path: 'edit/:taskId', element: <EditCurationTaskPage /> },
+        ],
       },
     ],
     [],

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
@@ -7,7 +7,7 @@ import CurationTaskCard, { CurationTaskCardProps } from './CurationTaskCard'
 const meta = {
   title: 'Curator/Dashboard/CurationTaskCard',
   component: CurationTaskCard,
-  parameters: { stack: 'mock' },
+  parameters: { stack: 'mock', withRouter: true },
 } satisfies Meta<CurationTaskCardProps>
 export default meta
 

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
@@ -1,42 +1,24 @@
-import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { createMockTaskBundle } from '@/mocks/curation/mockCurationTask'
 import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
-import { CurationTask, TaskBundle } from '@sage-bionetworks/synapse-client'
+import {
+  FileBasedMetadataTaskPropertiesConcreteTypeEnum,
+  RecordBasedMetadataTaskPropertiesConcreteTypeEnum,
+  RecordSetGenerationExecutionPropertiesConcreteTypeEnum,
+  SampleSheetGenerationExecutionPropertiesConcreteTypeEnum,
+  TaskBundle,
+} from '@sage-bionetworks/synapse-client'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useNavigate } from 'react-router'
 import { beforeEach } from 'vitest'
 import CurationTaskCard from './CurationTaskCard'
+
+vi.mock('react-router')
 
 vi.mock('@/features/entity/metadata-task/hooks/useOpenCuratorButton', () => ({
   default: vi.fn(),
 }))
-
-vi.mock(
-  '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog',
-  () => ({
-    default: vi.fn(
-      ({
-        open,
-        onCancel,
-        onSuccess,
-        onDeleteSuccess,
-      }: {
-        open: boolean
-        onCancel: () => void
-        onSuccess: (task: CurationTask) => void
-        onDeleteSuccess: () => void
-      }) =>
-        open ? (
-          <div data-testid="settings-dialog">
-            <button onClick={onCancel}>Cancel</button>
-            <button onClick={() => onSuccess({} as CurationTask)}>Save</button>
-            <button onClick={onDeleteSuccess}>Delete</button>
-          </div>
-        ) : null,
-    ),
-  }),
-)
 
 vi.mock('./UserOrTeamChip', () => ({
   default: () => null,
@@ -47,10 +29,8 @@ vi.mock('@/synapse-queries/entity/useEntityBundle', () => ({
 }))
 
 const mockUseOpenCuratorFromTaskButton = vi.mocked(useOpenCuratorFromTaskButton)
-const mockCreateOrUpdateCurationTaskDialog = vi.mocked(
-  CreateOrUpdateCurationTaskDialog,
-)
 const mockUseGetEntityBundle = vi.mocked(useGetEntityBundle)
+const mockNavigate = vi.fn()
 
 const mockTaskBundle = createMockTaskBundle({
   projectId: 'syn123',
@@ -62,6 +42,7 @@ const renderComponent = (taskBundle: TaskBundle = mockTaskBundle) =>
 
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.mocked(useNavigate).mockReturnValue(mockNavigate)
   mockUseOpenCuratorFromTaskButton.mockReturnValue({
     hasPermission: true,
     isLoading: false,
@@ -91,63 +72,52 @@ describe('CurationTaskCard', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('does not show the settings dialog on initial render', () => {
-    renderComponent()
-    expect(screen.queryByTestId('settings-dialog')).not.toBeInTheDocument()
-  })
-
-  it('opens the settings dialog when the settings button is clicked', async () => {
+  it('navigates to the edit route for the task when the settings button is clicked', async () => {
     const user = userEvent.setup()
     renderComponent()
 
     await user.click(screen.getByRole('button', { name: /task settings/i }))
 
-    expect(screen.getByTestId('settings-dialog')).toBeInTheDocument()
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `edit/${mockTaskBundle.task!.taskId}`,
+    )
   })
 
-  it('passes the task to the dialog so it opens in edit mode', () => {
-    renderComponent()
+  describe('task type chip', () => {
+    const curateTypes = [
+      FileBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_FileBasedMetadataTaskProperties,
+      RecordBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_RecordBasedMetadataTaskProperties,
+    ]
+    const computeTypes = [
+      SampleSheetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_SampleSheetGenerationExecutionProperties,
+      RecordSetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_RecordSetGenerationExecutionProperties,
+    ]
 
-    const props = mockCreateOrUpdateCurationTaskDialog.mock.calls[0][0]
-    expect(props.task).toEqual(mockTaskBundle.task)
-  })
+    it.each(curateTypes)(
+      'shows the "Curate Data" chip for curate type %s',
+      concreteType => {
+        renderComponent(
+          createMockTaskBundle({
+            projectId: 'syn123',
+            taskProperties: { concreteType } as any,
+          }),
+        )
+        expect(screen.getByText('Curate Data')).toBeInTheDocument()
+      },
+    )
 
-  it('passes the projectId from the task to the dialog', () => {
-    renderComponent()
-
-    const props = mockCreateOrUpdateCurationTaskDialog.mock.calls[0][0]
-    expect(props.projectId).toBe('syn123')
-  })
-
-  it('closes the settings dialog when onCancel is called', async () => {
-    const user = userEvent.setup()
-    renderComponent()
-
-    await user.click(screen.getByRole('button', { name: /task settings/i }))
-    expect(screen.getByTestId('settings-dialog')).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /cancel/i }))
-    expect(screen.queryByTestId('settings-dialog')).not.toBeInTheDocument()
-  })
-
-  it('closes the settings dialog when onSuccess is called', async () => {
-    const user = userEvent.setup()
-    renderComponent()
-
-    await user.click(screen.getByRole('button', { name: /task settings/i }))
-    await user.click(screen.getByRole('button', { name: /save/i }))
-
-    expect(screen.queryByTestId('settings-dialog')).not.toBeInTheDocument()
-  })
-
-  it('closes the settings dialog when onDeleteSuccess is called', async () => {
-    const user = userEvent.setup()
-    renderComponent()
-
-    await user.click(screen.getByRole('button', { name: /task settings/i }))
-    await user.click(screen.getByRole('button', { name: /delete/i }))
-
-    expect(screen.queryByTestId('settings-dialog')).not.toBeInTheDocument()
+    it.each(computeTypes)(
+      'shows the "Compute" chip for compute type %s',
+      concreteType => {
+        renderComponent(
+          createMockTaskBundle({
+            projectId: 'syn123',
+            taskProperties: { concreteType } as any,
+          }),
+        )
+        expect(screen.getByText('Compute')).toBeInTheDocument()
+      },
+    )
   })
 
   describe('status chip', () => {

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -1,5 +1,4 @@
 import { displayToast } from '@/components'
-import CreateOrUpdateCurationTaskDialog from '@/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog'
 import { TASK_STATUS_CONFIG } from '@/features/entity/metadata-task/utils/constants'
 import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
 import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
@@ -18,6 +17,7 @@ import {
   TaskStatusStateEnum,
 } from '@sage-bionetworks/synapse-client'
 import classNames from 'classnames'
+import { useNavigate } from 'react-router'
 import styles from './CurationTaskCard.module.scss'
 import NextStepButton from './NextStepButton'
 import sharedStyles from './shared.module.scss'
@@ -55,8 +55,8 @@ function useUiForTask(taskBundle: TaskBundle) {
         isPending,
         hasPermission,
       }
-    case 'org.sagebionetworks.repo.model.curation.execution.SampleSheetGenerationExecutionProperties':
     case 'org.sagebionetworks.repo.model.curation.execution.RecordSetGenerationExecutionProperties':
+    case 'org.sagebionetworks.repo.model.curation.execution.SampleSheetGenerationExecutionProperties':
       return {
         title: taskBundle.task.dataType,
         description: taskBundle.task.instructions ?? '',
@@ -148,7 +148,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
     isPending,
   } = useUiForTask(taskBundle)
 
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const navigate = useNavigate()
   const [isExpanded, setIsExpanded] = useState(false)
 
   const projectId = taskBundle.task?.projectId
@@ -181,7 +181,7 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
             {taskType && <TaskTypeChip label={taskType} />}
             {canEdit && (
               <IconButton
-                onClick={() => setIsSettingsOpen(true)}
+                onClick={() => void navigate(`edit/${taskId}`)}
                 aria-label="Task settings"
               >
                 <SettingsOutlinedIcon />
@@ -240,15 +240,6 @@ export default function CurationTaskCard(props: CurationTaskCardProps) {
           />
         </div>
       </Collapse>
-      <CreateOrUpdateCurationTaskDialog
-        key={String(isSettingsOpen)}
-        open={isSettingsOpen}
-        onCancel={() => setIsSettingsOpen(false)}
-        onSuccess={() => setIsSettingsOpen(false)}
-        onDeleteSuccess={() => setIsSettingsOpen(false)}
-        projectId={projectId ?? ''}
-        task={taskBundle.task}
-      />
     </Card>
   )
 }


### PR DESCRIPTION
## Depends on #3012 (which depends on #3011)

> **Note:** Base is `main`, so until #3012 and #3011 merge this PR's diff also shows their changes. Review/merge order: #3011 → #3012 → this PR. Reviews in parallel with #3013 (both stack only on #3012). The files owned by *this* PR are the Curator Dashboard + task card + router listed below.

## Summary

Wires the edit curation task flow (added in #3012) into the **Curator Dashboard**.

## What's here

- **`CuratorDashboardRouter`** (new) — router wrapper mirroring `GridPageRouter`: `index` → the dashboard cards, `edit/:taskId` → `EditCurationTaskPage`. Supports `useMemoryRouter` / `routerBaseName` for tests/Storybook.
- **`CuratorDashboard`** — split into `CuratorDashboardInternal` (the cards) and a router-wrapped default export. Default export identity is preserved, so `SWC.index.ts` needs no change.
- **`CurationTaskCard`** — the settings gear now navigates to `edit/:taskId` instead of opening the (soon-to-be-removed) dialog. Also replaces the hardcoded `concreteType` string literals in its type switch with the generated `*ConcreteTypeEnum` values (addresses a review finding).

## Testing

- `tsc --noEmit` clean.
- `curator/dashboard` tests pass (24 tests).
