### PR TITLE
PORTALS-4320:  use SynapseClient to bind the RAS account during app init

### DIFF
--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -113,6 +113,7 @@ import {
   SynapseClient as SynapseOpenAPIClient,
   DoiAssociation,
   EntityType,
+  OAuthValidationRequestProviderEnum,
   ViewEntityType,
   SearchIndexQuery,
   SearchQueryResults,
@@ -795,6 +796,27 @@ export const oAuthSessionRequest = (
       endpoint,
     ),
   )
+}
+
+/**
+ * Bind an OAuth identity to the authenticated user's account without an alias.
+ * Used for providers like NIH RAS that do not supply an alias.
+ * https://rest-docs.synapse.org/rest/POST/oauth2/identity.html
+ */
+export const oAuthIdentityRequest = (
+  provider: OAuthValidationRequestProviderEnum,
+  authenticationCode: string,
+  redirectUrl: string,
+): Promise<void> => {
+  return new SynapseOpenAPIClient({
+    basePath: getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+  }).authenticationServicesClient.postAuthV1Oauth2Identity({
+    oAuthValidationRequest: {
+      provider,
+      authenticationCode,
+      redirectUrl,
+    },
+  })
 }
 
 /**

--- a/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.test.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.test.ts
@@ -5,7 +5,6 @@ import {
   TwoFactorAuthErrorResponse,
 } from '@sage-bionetworks/synapse-types'
 import { renderHook as _renderHook, waitFor } from '@testing-library/react'
-import { MOCK_CONTEXT_VALUE } from '@/mocks/MockSynapseContext'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
 import { OAuth2State, SynapseClient } from '../../index'
 import { BackendDestinationEnum } from '../functions'
@@ -63,8 +62,8 @@ const mockBindOAuthProviderToAccount = vi.spyOn(
   'bindOAuthProviderToAccount',
 )
 const mockPostAuthV1Oauth2Identity = vi.spyOn(
-  MOCK_CONTEXT_VALUE.synapseClient.authenticationServicesClient,
-  'postAuthV1Oauth2Identity',
+  SynapseClient,
+  'oAuthIdentityRequest',
 )
 
 describe('useDetectSSOCode tests', () => {
@@ -224,13 +223,11 @@ describe('useDetectSSOCode tests', () => {
     expect(hookReturn.result.current.isLoading).toBe(true)
 
     await waitFor(() => {
-      expect(mockPostAuthV1Oauth2Identity).toHaveBeenCalledWith({
-        oAuthValidationRequest: {
-          provider: OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE,
-          authenticationCode: authorizationCode,
-          redirectUrl: `http://localhost:3000/?provider=${OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE}`,
-        },
-      })
+      expect(mockPostAuthV1Oauth2Identity).toHaveBeenCalledWith(
+        OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE,
+        authorizationCode,
+        `http://localhost:3000/?provider=${OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE}`,
+      )
       expect(mockBindOAuthProviderToAccount).not.toHaveBeenCalled()
       expect(mockSetAccessTokenCookie).not.toHaveBeenCalled()
       expect(onSignInComplete).toHaveBeenCalled()

--- a/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.test.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.test.ts
@@ -268,6 +268,83 @@ describe('useDetectSSOCode tests', () => {
     consoleSpy.mockReset()
   })
 
+  it('Logs in an unauthenticated user via NIH RAS if their RAS identity was previously bound', async () => {
+    const encodedState = encodeAndStoreState(buildOAuthState())
+    history.replaceState(
+      {},
+      '',
+      `/?code=${authorizationCode}&provider=${OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE}&state=${encodedState}`,
+    )
+    mockOAuthSessionRequest.mockResolvedValue(successfulLoginResponse)
+    mockSetAccessTokenCookie.mockResolvedValue(undefined)
+
+    const hookReturn = renderHook({
+      onSignInComplete,
+      isInitializingSession: false,
+      isAuthenticated: false,
+    })
+    expect(hookReturn.result.current.isLoading).toBe(true)
+
+    await waitFor(() => {
+      expect(mockOAuthSessionRequest).toHaveBeenCalledWith(
+        OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE,
+        authorizationCode,
+        `http://localhost:3000/?provider=${OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE}`,
+        BackendDestinationEnum.REPO_ENDPOINT,
+      )
+      expect(mockPostAuthV1Oauth2Identity).not.toHaveBeenCalled()
+      expect(mockSetAccessTokenCookie).toHaveBeenCalledWith(
+        successfulLoginResponse.accessToken,
+      )
+      expect(onSignInComplete).toHaveBeenCalled()
+      expect(hookReturn.result.current.isLoading).toBe(false)
+    })
+  })
+
+  it('Surfaces an explicit error (and does not redirect to registration) when unauthenticated NIH RAS login returns 404', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const encodedState = encodeAndStoreState(buildOAuthState())
+    history.replaceState(
+      {},
+      '',
+      `/?code=${authorizationCode}&provider=${OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE}&state=${encodedState}`,
+    )
+    const notFoundError = new SynapseClientError(
+      404,
+      'not found',
+      expect.getState().currentTestName!,
+    )
+    mockOAuthSessionRequest.mockRejectedValue(notFoundError)
+    const mockOnError = vi.fn()
+
+    const hookReturn = renderHook({
+      onSignInComplete,
+      onError: mockOnError,
+      isInitializingSession: false,
+      isAuthenticated: false,
+    })
+    expect(hookReturn.result.current.isLoading).toBe(true)
+
+    await waitFor(() => {
+      expect(mockOAuthSessionRequest).toHaveBeenCalledWith(
+        OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE,
+        authorizationCode,
+        `http://localhost:3000/?provider=${OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE}`,
+        BackendDestinationEnum.REPO_ENDPOINT,
+      )
+      // Must not redirect to registration — RAS cannot create a Synapse account.
+      // oxlint-disable-next-line @typescript-eslint/unbound-method
+      expect(window.location.replace).not.toHaveBeenCalled()
+      expect(mockOnError).toHaveBeenCalledWith(
+        expect.stringContaining('No Synapse account is linked'),
+      )
+      expect(mockSetAccessTokenCookie).not.toHaveBeenCalled()
+      expect(onSignInComplete).not.toHaveBeenCalled()
+      expect(hookReturn.result.current.isLoading).toBe(false)
+    })
+    consoleSpy.mockReset()
+  })
+
   const LOGIN_PROVIDERS = Object.values(OAUTH2_PROVIDERS).filter(
     p => p !== OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE,
   )

--- a/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.ts
@@ -187,7 +187,8 @@ export default function useDetectSSOCode(
           OAUTH2_PROVIDERS.GOOGLE == provider ||
           OAUTH2_PROVIDERS.ORCID == provider ||
           OAUTH2_PROVIDERS.ARCUS == provider ||
-          OAUTH2_PROVIDERS.SAGE_BIONETWORKS == provider
+          OAUTH2_PROVIDERS.SAGE_BIONETWORKS == provider ||
+          OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE == provider
         ) {
           const onSuccess = (
             response: LoginResponse | TwoFactorAuthErrorResponse | null,
@@ -219,6 +220,20 @@ export default function useDetectSSOCode(
           }
           const onFailure = (err: SynapseClientError) => {
             if (err.status === 404) {
+              if (OAUTH2_PROVIDERS.NIH_RESEARCHER_AUTH_SERVICE == provider) {
+                // RAS cannot create a Synapse account (no alias). Surface an
+                // explicit error instead of redirecting to registration.
+                console.error(
+                  'No Synapse account is linked to this NIH RAS identity: ',
+                  err,
+                )
+                if (onError) {
+                  onError(
+                    'No Synapse account is linked to this NIH RAS identity. Sign in to Synapse and link your NIH RAS identity from your account settings.',
+                  )
+                }
+                return
+              }
               // Synapse account not found, send to registration page
               window.location.replace(registerAccountUrl)
             }

--- a/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.ts
@@ -1,6 +1,7 @@
 import {
   bindOAuthProviderToAccount,
   getRootURL,
+  oAuthIdentityRequest,
   oAuthRegisterAccountStep2,
   oAuthSessionRequest,
   setAccessTokenCookie,
@@ -13,7 +14,6 @@ import { LoginResponse } from '@sage-bionetworks/synapse-types'
 import { useEffect, useMemo, useState } from 'react'
 import { BackendDestinationEnum } from '../functions'
 import { CSRF_TOKEN_STORAGE_KEY, OAUTH2_PROVIDERS } from '../SynapseConstants'
-import { useSynapseContext } from '../context/SynapseContext'
 import { useOneSageURL } from './useOneSageURL'
 
 function safeLocalStorageGetItem(key: string): string | null {
@@ -75,7 +75,6 @@ export default function useDetectSSOCode(
     isAuthenticated,
   } = opts
   const redirectURL = getRootURL()
-  const { synapseClient } = useSynapseContext()
   // 'code' handling (from SSO) should be preformed on the root page, and then redirect to original route.
   // Use 'http://localhost/' as a placeholder during SSR (no browser URL available).
   // Since there is no 'code' or 'provider' in this placeholder URL, the rest of the hook is a no-op.
@@ -176,14 +175,11 @@ export default function useDetectSSOCode(
               onError(err.reason)
             }
           }
-          synapseClient.authenticationServicesClient
-            .postAuthV1Oauth2Identity({
-              oAuthValidationRequest: {
-                provider: provider as OAuthValidationRequestProviderEnum,
-                authenticationCode: String(code),
-                redirectUrl,
-              },
-            })
+          oAuthIdentityRequest(
+            provider as OAuthValidationRequestProviderEnum,
+            String(code),
+            redirectUrl,
+          )
             .then(onSignInComplete)
             .catch(onFailure)
             .finally(() => setIsLoading(false))


### PR DESCRIPTION
See relevant comment here: https://sagebionetworks.jira.com/browse/PORTALS-4320?focusedCommentId=336500