### PR TITLE
PORTALS-4320: during app init, explicitly get the access token.  Also…

### DIFF
--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -803,13 +803,17 @@ export const oAuthSessionRequest = (
  * Used for providers like NIH RAS that do not supply an alias.
  * https://rest-docs.synapse.org/rest/POST/oauth2/identity.html
  */
-export const oAuthIdentityRequest = (
+export const oAuthIdentityRequest = async (
   provider: OAuthValidationRequestProviderEnum,
   authenticationCode: string,
   redirectUrl: string,
 ): Promise<void> => {
+  // Web app may not have discovered the access token by this point in init.
+  // Look for the access token ourselves before binding.
+  const accessToken = await getAccessTokenFromCookie()
   return new SynapseOpenAPIClient({
     basePath: getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+    accessToken,
   }).authenticationServicesClient.postAuthV1Oauth2Identity({
     oAuthValidationRequest: {
       provider,

--- a/packages/synapse-react-client/src/utils/AppUtils/session/useSessionManager.ts
+++ b/packages/synapse-react-client/src/utils/AppUtils/session/useSessionManager.ts
@@ -9,6 +9,7 @@ import {
   useSyncExternalStore,
 } from 'react'
 import { useNavigate } from 'react-router'
+import { displayToast } from '../../../components/ToastMessage'
 import useDetectSSOCode from '../../hooks/useDetectSSOCode'
 import { restoreLastPlace } from '../AppUtils'
 import { ApplicationSessionContextType } from './ApplicationSessionContext'
@@ -138,8 +139,10 @@ export function useSessionManager(
       }
     },
     onError: (err: unknown) => {
-      // Throw the error so it propagates to an error boundary
-      throw err
+      // Surface SSO errors as a toast. Throwing here would only produce an
+      // unhandled promise rejection because onError is invoked from a .catch().
+      const message = err instanceof Error ? err.message : String(err)
+      displayToast(message, 'danger', { title: 'Sign-in error' })
     },
     isInitializingSession: !sessionState.hasInitializedSession,
     isAuthenticated: sessionState.isAuthenticated,


### PR DESCRIPTION
…, use displayToast on error to surface it to the user

This results in a successful call to `POST https://repo-dev.dev.sagebase.org/auth/v1/oauth2/identity`!
Also, errors during login are surfaces as a toast message.  Such as:
<img width="1448" height="558" alt="Screenshot 2026-07-22 at 5 20 25 PM" src="https://github.com/user-attachments/assets/64cb00a4-09a0-4d7a-96c3-9b7f7d114439" />
