### PR TITLE
SWC-7900: Execute task and bug fixes

### DIFF
--- a/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboard.tsx
@@ -6,7 +6,6 @@ import Stack from '@mui/material/Stack'
 import { useMemo } from 'react'
 import CurationTaskCard from './components/CurationTaskCard'
 import sharedStyles from './components/shared.module.scss'
-import SWCPageLayout from '@/components/layout/SWCPageLayout'
 import { useSearchParams } from 'react-router'
 import { GRID_PAGE_TASK_ID_QUERY_PARAM } from '@/utils/SynapseConstants'
 
@@ -38,31 +37,27 @@ export default function CuratorDashboardContent() {
   }, [curationTasks])
 
   return (
-    <SWCPageLayout header={{ title: 'Curator Dashboard' }}>
-      <Stack className="pageContent" gap={4} mt={5}>
-        <Typography variant="headline1">On Your Radar</Typography>
-        <OpenInvitationsToUserCard
-          cardProps={{ className: sharedStyles.card }}
-        />
-        <InfiniteTableLayout
-          table={
-            <Stack gap={3}>
-              {tasks.map(taskBundle => (
-                <CurationTaskCard
-                  key={taskBundle.task?.taskId}
-                  taskBundle={taskBundle}
-                />
-              ))}
-            </Stack>
-          }
-          isLoading={isLoading}
-          isEmpty={tasks.length === 0}
-          hasNextPage={hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          onFetchNextPageClicked={() => void fetchNextPage()}
-          noResults={'There are currently no curation tasks assigned to you.'}
-        ></InfiniteTableLayout>
-      </Stack>
-    </SWCPageLayout>
+    <Stack gap={4}>
+      <Typography variant="headline1">On Your Radar</Typography>
+      <OpenInvitationsToUserCard cardProps={{ className: sharedStyles.card }} />
+      <InfiniteTableLayout
+        table={
+          <Stack gap={3}>
+            {tasks.map(taskBundle => (
+              <CurationTaskCard
+                key={taskBundle.task?.taskId}
+                taskBundle={taskBundle}
+              />
+            ))}
+          </Stack>
+        }
+        isLoading={isLoading}
+        isEmpty={tasks.length === 0}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        onFetchNextPageClicked={() => void fetchNextPage()}
+        noResults={'There are currently no curation tasks assigned to you.'}
+      ></InfiniteTableLayout>
+    </Stack>
   )
 }

--- a/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboardRouter.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboardRouter.tsx
@@ -1,6 +1,7 @@
 import EditCurationTaskPage from '@/features/entity/metadata-task/create-task/EditCurationTaskPage'
 import CuratorDashboardContent from './CuratorDashboard'
 import { PropsWithChildren, useMemo } from 'react'
+import { Outlet } from 'react-router'
 import {
   createBrowserRouter,
   createMemoryRouter,
@@ -8,6 +9,7 @@ import {
   RouterProvider,
 } from 'react-router'
 import { RouterProvider as DOMRouterProvider } from 'react-router/dom'
+import SWCPageLayout from '@/components/layout/SWCPageLayout'
 
 export type CuratorDashboardRouterProps = PropsWithChildren<{
   /** Used to determine the base path for the component. Default is CuratorDashboard:0 */
@@ -30,6 +32,13 @@ export default function CuratorDashboardRouter(
     () => [
       {
         path: '/',
+        element: (
+          <SWCPageLayout header={{ title: 'Curator Dashboard' }}>
+            <div className="pageContent" style={{ marginTop: '2rem' }}>
+              <Outlet />
+            </div>
+          </SWCPageLayout>
+        ),
         children: [
           { index: true, element: <CuratorDashboardContent /> },
           { path: 'edit/:taskId', element: <EditCurationTaskPage /> },

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.stories.tsx
@@ -1,7 +1,8 @@
 import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
+import { getExecuteCurationTaskHandlers } from '@/mocks/msw/handlers/curationTaskExecutionHandlers'
 import { TaskStatusStateEnum } from '@sage-bionetworks/synapse-client'
 import { Meta, StoryObj } from '@storybook/react-vite'
-import { http, HttpResponse } from 'msw'
+import { http, HttpHandler, HttpResponse } from 'msw'
 import CurationTaskCard, { CurationTaskCardProps } from './CurationTaskCard'
 
 const meta = {
@@ -13,6 +14,32 @@ export default meta
 
 const CAN_EDIT_PROJECT_ID = 'syn123'
 const CANNOT_EDIT_PROJECT_ID = 'syn456'
+const DESTINATION_TASK_ID = 456
+
+const bundleHandler = (canEditProjectId: string): HttpHandler =>
+  http.post(
+    `${MOCK_REPO_ORIGIN}/repo/v1/entity/:entityId/bundle2`,
+    ({ params }) => {
+      const canEdit = params.entityId === canEditProjectId
+      return HttpResponse.json({
+        entity: { name: 'Precision Drug Treatment Profiling' },
+        permissions: { canEdit },
+      })
+    },
+  )
+
+const executableTaskHandlers: Record<string, HttpHandler[]> = {
+  bundle: [bundleHandler(CAN_EDIT_PROJECT_ID)],
+  currentUserProfile: [
+    http.get(`${MOCK_REPO_ORIGIN}/repo/v1/userProfile`, () =>
+      HttpResponse.json({ ownerId: '273957' }),
+    ),
+    http.post(`${MOCK_REPO_ORIGIN}/repo/v1/userGroupHeaders/batch`, () =>
+      HttpResponse.json({ children: [] }),
+    ),
+  ],
+  execute: getExecuteCurationTaskHandlers(),
+}
 
 const baseTask = {
   dataType: 'metadata_clinical',
@@ -69,3 +96,55 @@ export const Demo: StoryObj<{ state: TaskStatusStateEnum; canEdit: boolean }> =
       />
     ),
   }
+
+const baseExecutableTask = {
+  dataType: 'sample_sheet',
+  taskId: 321,
+  instructions: 'Generate a sample sheet from the source annotations.',
+  assigneePrincipalId: '273957',
+  taskProperties: {
+    concreteType:
+      'org.sagebionetworks.repo.model.curation.execution.SampleSheetGenerationExecutionProperties' as const,
+    destinationTaskId: DESTINATION_TASK_ID,
+  },
+}
+
+export const ExecutableTask: StoryObj<{
+  state: TaskStatusStateEnum
+  canEdit: boolean
+  hasDestinationTask: boolean
+}> = {
+  argTypes: {
+    state: {
+      control: 'select',
+      options: Object.values(TaskStatusStateEnum),
+    },
+    canEdit: { control: 'boolean' },
+    hasDestinationTask: { control: 'boolean' },
+  },
+  args: {
+    state: TaskStatusStateEnum.NOT_STARTED,
+    canEdit: true,
+    hasDestinationTask: true,
+  },
+  parameters: {
+    msw: { handlers: executableTaskHandlers },
+  },
+  render: ({ state, canEdit, hasDestinationTask }) => (
+    <CurationTaskCard
+      taskBundle={{
+        task: {
+          ...baseExecutableTask,
+          projectId: canEdit ? CAN_EDIT_PROJECT_ID : CANNOT_EDIT_PROJECT_ID,
+          taskProperties: {
+            ...baseExecutableTask.taskProperties,
+            destinationTaskId: hasDestinationTask
+              ? DESTINATION_TASK_ID
+              : undefined,
+          },
+        },
+        status: { state },
+      }}
+    />
+  ),
+}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
@@ -24,6 +24,10 @@ vi.mock('./UserOrTeamChip', () => ({
   default: () => null,
 }))
 
+vi.mock('./ExecutableTaskCard', () => ({
+  default: () => <div data-testid="executable-task-card" />,
+}))
+
 vi.mock('@/synapse-queries/entity/useEntityBundle', () => ({
   default: vi.fn(),
 }))
@@ -88,10 +92,6 @@ describe('CurationTaskCard', () => {
       FileBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_FileBasedMetadataTaskProperties,
       RecordBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_RecordBasedMetadataTaskProperties,
     ]
-    const computeTypes = [
-      SampleSheetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_SampleSheetGenerationExecutionProperties,
-      RecordSetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_RecordSetGenerationExecutionProperties,
-    ]
 
     it.each(curateTypes)(
       'shows the "Curate Data" chip for curate type %s',
@@ -105,9 +105,16 @@ describe('CurationTaskCard', () => {
         expect(screen.getByText('Curate Data')).toBeInTheDocument()
       },
     )
+  })
+
+  describe('dispatch by task type', () => {
+    const computeTypes = [
+      SampleSheetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_SampleSheetGenerationExecutionProperties,
+      RecordSetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_RecordSetGenerationExecutionProperties,
+    ]
 
     it.each(computeTypes)(
-      'shows the "Compute" chip for compute type %s',
+      'renders the executable task card for compute type %s',
       concreteType => {
         renderComponent(
           createMockTaskBundle({
@@ -115,9 +122,24 @@ describe('CurationTaskCard', () => {
             taskProperties: { concreteType } as any,
           }),
         )
-        expect(screen.getByText('Compute')).toBeInTheDocument()
+        expect(screen.getByTestId('executable-task-card')).toBeInTheDocument()
       },
     )
+
+    it.each([
+      FileBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_FileBasedMetadataTaskProperties,
+      RecordBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_RecordBasedMetadataTaskProperties,
+    ])('renders the grid task card for curate type %s', concreteType => {
+      renderComponent(
+        createMockTaskBundle({
+          projectId: 'syn123',
+          taskProperties: { concreteType } as any,
+        }),
+      )
+      expect(
+        screen.getByRole('button', { name: /open curator/i }),
+      ).toBeInTheDocument()
+    })
   })
 
   describe('status chip', () => {

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.tsx
@@ -1,275 +1,60 @@
 import { displayToast } from '@/components'
-import { TASK_STATUS_CONFIG } from '@/features/entity/metadata-task/utils/constants'
-import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
-import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
-import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
-import {
-  Card,
-  Chip,
-  Collapse,
-  Divider,
-  IconButton,
-  Skeleton,
-  Typography,
-} from '@mui/material'
-import {
-  TaskBundle,
-  TaskStatusStateEnum,
-} from '@sage-bionetworks/synapse-client'
-import classNames from 'classnames'
-import { useNavigate } from 'react-router'
-import styles from './CurationTaskCard.module.scss'
+import { getComputeTaskConcreteType } from '@/features/entity/metadata-task/utils/types'
+import { TaskBundle } from '@sage-bionetworks/synapse-client'
+import CurationTaskCardLayout, {
+  deriveCardFields,
+} from './CurationTaskCardLayout'
+import ExecutableTaskCard from './ExecutableTaskCard'
+import GridTaskCard from './GridTaskCard'
 import NextStepButton from './NextStepButton'
-import sharedStyles from './shared.module.scss'
-import UserOrTeamChip from './UserOrTeamChip'
-import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
-import { useState } from 'react'
-import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
-import { parseDueDate } from '@/features/entity/metadata-task/utils/dueDate'
-
-dayjs.extend(utc)
+import styles from './CurationTaskCard.module.scss'
 
 export type CurationTaskCardProps = {
   taskBundle: TaskBundle
 }
 
-function useUiForTask(taskBundle: TaskBundle) {
-  const { onClick, isLoading, isPending, hasPermission } =
-    useOpenCuratorFromTaskButton(taskBundle)
+/**
+ * Card component for displaying a curation task on the curator dashboard. Dispatches to the card
+ * variant appropriate for the task's type: an executable (Compute Data) task, a grid-supported
+ * (Curate Data) task, or a fallback for unrecognized types.
+ */
+export default function CurationTaskCard(props: CurationTaskCardProps) {
+  const { taskBundle } = props
 
   if (!taskBundle.task || !taskBundle.status) {
     throw new Error('Task bundle is missing required properties')
   }
 
-  switch (taskBundle.task?.taskProperties?.concreteType) {
+  const concreteType = taskBundle.task.taskProperties?.concreteType
+
+  if (getComputeTaskConcreteType(taskBundle.task.taskProperties)) {
+    return <ExecutableTaskCard taskBundle={taskBundle} />
+  }
+
+  switch (concreteType) {
     case 'org.sagebionetworks.repo.model.curation.metadata.FileBasedMetadataTaskProperties':
     case 'org.sagebionetworks.repo.model.curation.metadata.RecordBasedMetadataTaskProperties':
-      return {
-        title: taskBundle.task.dataType,
-        description: taskBundle.task.instructions ?? '',
-        taskId: taskBundle.task.taskId,
-        principalIds: taskBundle.task.assigneePrincipalId
-          ? [taskBundle.task.assigneePrincipalId]
-          : [],
-        buttonText: 'Open Curator',
-        taskType: 'Curate Data',
-        statusState: taskBundle.status.state,
-        onClickNextStep: onClick,
-        isLoading,
-        isPending,
-        hasPermission,
-      }
-    case 'org.sagebionetworks.repo.model.curation.execution.RecordSetGenerationExecutionProperties':
-    case 'org.sagebionetworks.repo.model.curation.execution.SampleSheetGenerationExecutionProperties':
-      return {
-        title: taskBundle.task.dataType,
-        description: taskBundle.task.instructions ?? '',
-        taskId: taskBundle.task.taskId,
-        principalIds: taskBundle.task.assigneePrincipalId
-          ? [taskBundle.task.assigneePrincipalId]
-          : [],
-        buttonText: 'Start (Run Agent)',
-        taskType: 'Compute',
-        statusState: taskBundle.status.state,
-        onClickNextStep: () => {
-          displayToast('Coming soon!', 'info')
-        },
-        isLoading,
-        isPending,
-        hasPermission,
-      }
-    default: {
-      console.error(
-        'No UI implemented for task type: ' +
-          // @ts-expect-error - the switch should be exhaustive for known types
-          taskBundle.task?.taskProperties?.concreteType,
-      )
-    }
-  }
-
-  return {
-    title: taskBundle.task.dataType,
-    description: taskBundle.task.instructions ?? '',
-    taskId: taskBundle.task.taskId!,
-    principalIds: taskBundle.task.assigneePrincipalId
-      ? [taskBundle.task.assigneePrincipalId]
-      : [],
-    buttonText: 'Continue',
-    taskType: '',
-    statusState: taskBundle.status.state,
-    onClickNextStep: () => {
-      displayToast('No action defined for this task type', 'danger', {
-        title: 'Unexpected Error',
-      })
-    },
-    isLoading: false,
-    isPending: false,
-    hasPermission: undefined,
-  }
-}
-
-function TaskTypeChip(props: { label: string }) {
-  const { label } = props
-  return (
-    <Chip sx={{ fontWeight: 600, backgroundColor: '#BFD3ED' }} label={label} />
-  )
-}
-
-/**
- * A chip to display CurationTask status.
- *
- * See {@link https://www.figma.com/design/0oPm5lLSUva8kyfVNMS6FA/Sage-Style---Component-Library--SDS-?node-id=4942-1129&m=dev}
- */
-function TaskStatusChip(props: { state: TaskStatusStateEnum | undefined }) {
-  const { state } = props
-  if (!state) return null
-  const { label, backgroundColor } = TASK_STATUS_CONFIG[state]
-  return (
-    <Chip
-      size="small"
-      sx={{ fontWeight: 600, backgroundColor }}
-      label={label}
-    />
-  )
-}
-
-function DueDateChip(props: { dueDate: string | undefined }) {
-  const { dueDate } = props
-  const dueDateObj = parseDueDate(dueDate)
-  if (!dueDateObj) return null
-
-  const daysUntilDue = dueDateObj.diff(dayjs.utc().startOf('day'), 'day')
-  const formattedDate = dueDateObj.format('MM/DD/YY')
-
-  let backgroundColor = '#E0E0E0'
-  if (daysUntilDue < 0) {
-    backgroundColor = '#FFCDD2'
-  } else if (daysUntilDue < 30) {
-    backgroundColor = '#FFF9C4'
-  }
-
-  return (
-    <Chip
-      size="small"
-      sx={{ fontWeight: 600, backgroundColor }}
-      label={`Due ${formattedDate}`}
-    />
-  )
-}
-
-/**
- * Card component for displaying a curation task on the curator dashboard. Shows relevant information about the task and includes a button to proceed to the next step in the workflow.
- */
-export default function CurationTaskCard(props: CurationTaskCardProps) {
-  const { taskBundle } = props
-  const {
-    title,
-    description,
-    taskId,
-    taskType,
-    principalIds,
-    buttonText,
-    statusState,
-    onClickNextStep,
-    hasPermission: hasPermissionToOpenGrid,
-    isLoading,
-    isPending,
-  } = useUiForTask(taskBundle)
-
-  const navigate = useNavigate()
-  const [isExpanded, setIsExpanded] = useState(false)
-
-  const projectId = taskBundle.task?.projectId
-  const { data: bundle } = useGetEntityBundle(projectId, undefined, {
-    includeEntity: true,
-    includePermissions: true,
-  })
-  const canEdit = bundle?.permissions?.canEdit ?? false
-
-  function onClickAction() {
-    if (hasPermissionToOpenGrid) {
-      onClickNextStep()
-    } else {
-      displayToast(OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE, 'danger')
-    }
-  }
-
-  return (
-    <Card className={classNames(sharedStyles.card, styles.card)}>
-      <div className={styles.cardContent}>
-        <div className={styles.mainContent}>
-          <div className={styles.titleChipContainer}>
-            <Typography
-              variant="headline3"
-              className={styles.title}
-              onClick={() => setIsExpanded(!isExpanded)}
-            >
-              {title}
-            </Typography>
-            {taskType && <TaskTypeChip label={taskType} />}
-            {canEdit && (
-              <IconButton
-                onClick={() => void navigate(`edit/${taskId}`)}
-                aria-label="Task settings"
-              >
-                <SettingsOutlinedIcon />
-              </IconButton>
-            )}
-          </div>
-          <div className={styles.entityInfo}>
-            {bundle?.entity?.name ? (
-              <Typography variant="body1">{bundle.entity.name}</Typography>
-            ) : (
-              <Skeleton width={100} />
-            )}
-            {taskId && (
-              <Typography variant="body1">Task ID: {taskId}</Typography>
-            )}
-          </div>
-          <div className={styles.userChipContainer}>
-            {principalIds.map(principalId => (
-              <UserOrTeamChip key={principalId} principalId={principalId} />
-            ))}
-          </div>
-        </div>
-        <div className={styles.statusContainer}>
-          <TaskStatusChip state={statusState} />
-          <DueDateChip dueDate={taskBundle.status?.dueDate} />
-        </div>
-        {!isExpanded && (
-          <>
-            <Divider
-              orientation="vertical"
-              flexItem
-              sx={{ display: { xs: 'none', md: 'block' } }}
-            />
+      return <GridTaskCard taskBundle={taskBundle} />
+    default:
+      console.error('No UI implemented for task type: ' + concreteType)
+      return (
+        <CurationTaskCardLayout
+          taskBundle={taskBundle}
+          {...deriveCardFields(taskBundle.task)}
+          taskType=""
+          renderActionButton={({ expanded }) => (
             <NextStepButton
               className={styles.cardButton}
-              buttonText={buttonText}
-              onClick={onClickAction}
-              disabled={isLoading}
-              loading={isPending}
-              expanded={false}
+              buttonText="Continue"
+              onClick={() =>
+                displayToast('No action defined for this task type', 'danger', {
+                  title: 'Unexpected Error',
+                })
+              }
+              expanded={expanded}
             />
-          </>
-        )}
-      </div>
-      <Collapse in={isExpanded}>
-        <div className={styles.expandedContent}>
-          {description && (
-            <Typography variant="body1">{description}</Typography>
           )}
-          <NextStepButton
-            className={styles.cardButton}
-            buttonText={buttonText}
-            onClick={onClickAction}
-            disabled={isLoading}
-            loading={isPending}
-            expanded={true}
-          />
-        </div>
-      </Collapse>
-    </Card>
-  )
+        />
+      )
+  }
 }

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCardLayout.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCardLayout.tsx
@@ -1,0 +1,187 @@
+import {
+  Card,
+  Chip,
+  Collapse,
+  Divider,
+  IconButton,
+  Skeleton,
+  Typography,
+} from '@mui/material'
+import {
+  TaskBundle,
+  TaskStatusStateEnum,
+} from '@sage-bionetworks/synapse-client'
+import classNames from 'classnames'
+import { ReactNode, useState } from 'react'
+import { useNavigate } from 'react-router'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
+import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
+import { TASK_STATUS_CONFIG } from '@/features/entity/metadata-task/utils/constants'
+import { parseDueDate } from '@/features/entity/metadata-task/utils/dueDate'
+import styles from './CurationTaskCard.module.scss'
+import sharedStyles from './shared.module.scss'
+import UserOrTeamChip from './UserOrTeamChip'
+
+dayjs.extend(utc)
+
+function TaskTypeChip(props: { label: string }) {
+  const { label } = props
+  return (
+    <Chip sx={{ fontWeight: 600, backgroundColor: '#BFD3ED' }} label={label} />
+  )
+}
+
+/**
+ * A chip to display CurationTask status.
+ *
+ * See {@link https://www.figma.com/design/0oPm5lLSUva8kyfVNMS6FA/Sage-Style---Component-Library--SDS-?node-id=4942-1129&m=dev}
+ */
+function TaskStatusChip(props: { state: TaskStatusStateEnum | undefined }) {
+  const { state } = props
+  if (!state) return null
+  const { label, backgroundColor } = TASK_STATUS_CONFIG[state]
+  return (
+    <Chip
+      size="small"
+      sx={{ fontWeight: 600, backgroundColor }}
+      label={label}
+    />
+  )
+}
+
+function DueDateChip(props: { dueDate: string | undefined }) {
+  const { dueDate } = props
+  const dueDateObj = parseDueDate(dueDate)
+  if (!dueDateObj) return null
+
+  const daysUntilDue = dueDateObj.diff(dayjs.utc().startOf('day'), 'day')
+  const formattedDate = dueDateObj.format('MM/DD/YY')
+
+  let backgroundColor = '#E0E0E0'
+  if (daysUntilDue < 0) {
+    backgroundColor = '#FFCDD2'
+  } else if (daysUntilDue < 30) {
+    backgroundColor = '#FFF9C4'
+  }
+
+  return (
+    <Chip
+      size="small"
+      sx={{ fontWeight: 600, backgroundColor }}
+      label={`Due ${formattedDate}`}
+    />
+  )
+}
+
+export type CurationTaskCardLayoutProps = {
+  taskBundle: TaskBundle
+  title: string
+  description: string
+  taskType: string
+  principalIds: string[]
+  /** Renders the action button. `expanded` reflects whether the card is in its expanded layout. */
+  renderActionButton: (props: { expanded: boolean }) => ReactNode
+}
+
+/** Derives the fields shared by every card variant from a task's common properties. */
+export function deriveCardFields(task: TaskBundle['task']) {
+  return {
+    title: task?.dataType ?? '',
+    description: task?.instructions ?? '',
+    principalIds: task?.assigneePrincipalId ? [task.assigneePrincipalId] : [],
+  }
+}
+
+/**
+ * Shared presentational chrome for a curation task card: title, chips, entity info, assignees,
+ * status/due date, and an action button slot. Both the grid and executable task cards compose this.
+ */
+export default function CurationTaskCardLayout(
+  props: CurationTaskCardLayoutProps,
+) {
+  const {
+    taskBundle,
+    title,
+    description,
+    taskType,
+    principalIds,
+    renderActionButton,
+  } = props
+
+  const navigate = useNavigate()
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const taskId = taskBundle.task?.taskId
+  const projectId = taskBundle.task?.projectId
+  const { data: bundle } = useGetEntityBundle(projectId, undefined, {
+    includeEntity: true,
+    includePermissions: true,
+  })
+  const canEdit = bundle?.permissions?.canEdit ?? false
+
+  return (
+    <Card className={classNames(sharedStyles.card, styles.card)}>
+      <div className={styles.cardContent}>
+        <div className={styles.mainContent}>
+          <div className={styles.titleChipContainer}>
+            <Typography
+              variant="headline3"
+              className={styles.title}
+              onClick={() => setIsExpanded(!isExpanded)}
+            >
+              {title}
+            </Typography>
+            {taskType && <TaskTypeChip label={taskType} />}
+            {canEdit && (
+              <IconButton
+                onClick={() => void navigate(`edit/${taskId}`)}
+                aria-label="Task settings"
+              >
+                <SettingsOutlinedIcon />
+              </IconButton>
+            )}
+          </div>
+          <div className={styles.entityInfo}>
+            {bundle?.entity?.name ? (
+              <Typography variant="body1">{bundle.entity.name}</Typography>
+            ) : (
+              <Skeleton width={100} />
+            )}
+            {taskId && (
+              <Typography variant="body1">Task ID: {taskId}</Typography>
+            )}
+          </div>
+          <div className={styles.userChipContainer}>
+            {principalIds.map(principalId => (
+              <UserOrTeamChip key={principalId} principalId={principalId} />
+            ))}
+          </div>
+        </div>
+        <div className={styles.statusContainer}>
+          <TaskStatusChip state={taskBundle.status?.state} />
+          <DueDateChip dueDate={taskBundle.status?.dueDate} />
+        </div>
+        {!isExpanded && (
+          <>
+            <Divider
+              orientation="vertical"
+              flexItem
+              sx={{ display: { xs: 'none', md: 'block' } }}
+            />
+            {renderActionButton({ expanded: false })}
+          </>
+        )}
+      </div>
+      <Collapse in={isExpanded}>
+        <div className={styles.expandedContent}>
+          {description && (
+            <Typography variant="body1">{description}</Typography>
+          )}
+          {renderActionButton({ expanded: true })}
+        </div>
+      </Collapse>
+    </Card>
+  )
+}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/ExecutableTaskCard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/ExecutableTaskCard.test.tsx
@@ -1,0 +1,251 @@
+import {
+  createMockExecutableTaskBundle,
+  MOCK_CURATION_TASK_DESTINATION_TASK_ID,
+} from '@/mocks/curation/mockCurationTask'
+import { getExecuteCurationTaskHandlers } from '@/mocks/msw/handlers/curationTaskExecutionHandlers'
+import { server } from '@/mocks/msw/server'
+import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
+import { useGetCurrentUserProfile } from '@/synapse-queries/user/useUserBundle'
+import { useGetIsPrincipalIdUserOrMemberOfTeam } from '@/synapse-queries/team/useTeamMembers'
+import { GRID_PAGE_TASK_ID_QUERY_PARAM } from '@/utils/SynapseConstants'
+import { TaskBundle } from '@sage-bionetworks/synapse-client'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, useSearchParams } from 'react-router'
+import { http, HttpResponse } from 'msw'
+import { BackendDestinationEnum, getEndpoint } from '@/utils/functions'
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import {
+  DESTINATION_TASK_MISSING_MESSAGE,
+  EXECUTABLE_TASK_NO_PERMISSION_MESSAGE,
+  RUN_AGENT_BUTTON_TEXT,
+  RUNNING_BUTTON_TEXT,
+  VIEW_RESULT_BUTTON_TEXT,
+} from './getExecutableTaskButtonState'
+import ExecutableTaskCard from './ExecutableTaskCard'
+
+// Matches a button by its visible label as a substring, escaping regex-special characters
+// (RUN_AGENT_BUTTON_TEXT contains parentheses).
+function buttonByLabel(label: string) {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return { name: new RegExp(escaped) }
+}
+
+vi.mock('@/synapse-queries/entity/useEntityBundle', () => ({
+  default: vi.fn(),
+}))
+vi.mock('@/synapse-queries/user/useUserBundle', () => ({
+  useGetCurrentUserProfile: vi.fn(),
+}))
+vi.mock('@/synapse-queries/team/useTeamMembers', () => ({
+  useGetIsPrincipalIdUserOrMemberOfTeam: vi.fn(),
+}))
+vi.mock('./UserOrTeamChip', () => ({ default: () => null }))
+
+const mockUseGetEntityBundle = vi.mocked(useGetEntityBundle)
+const mockUseGetCurrentUserProfile = vi.mocked(useGetCurrentUserProfile)
+const mockUseIsUserOrTeamMember = vi.mocked(
+  useGetIsPrincipalIdUserOrMemberOfTeam,
+)
+
+function setCanEdit(canEdit: boolean) {
+  mockUseGetEntityBundle.mockReturnValue({
+    data: { entity: { name: 'Project' }, permissions: { canEdit } },
+  } as unknown as ReturnType<typeof useGetEntityBundle>)
+}
+
+function setIsAssigneeOrTeamMember(value: boolean) {
+  mockUseIsUserOrTeamMember.mockReturnValue({
+    data: value,
+  } as unknown as ReturnType<typeof useGetIsPrincipalIdUserOrMemberOfTeam>)
+}
+
+// Renders the card and exposes the current taskIds search param via a probe.
+let lastTaskIdsParam: string | null = null
+function SearchParamProbe() {
+  const [searchParams] = useSearchParams()
+  lastTaskIdsParam = searchParams.get(GRID_PAGE_TASK_ID_QUERY_PARAM)
+  return null
+}
+
+function renderCard(taskBundle: TaskBundle) {
+  return render(
+    <MemoryRouter>
+      <ExecutableTaskCard taskBundle={taskBundle} />
+      <SearchParamProbe />
+    </MemoryRouter>,
+    { wrapper: createWrapper({ accessToken: 'fake-token' }) },
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  lastTaskIdsParam = null
+  setCanEdit(true)
+  setIsAssigneeOrTeamMember(false)
+  mockUseGetCurrentUserProfile.mockReturnValue({
+    data: { ownerId: '999' },
+  } as unknown as ReturnType<typeof useGetCurrentUserProfile>)
+})
+
+describe('ExecutableTaskCard', () => {
+  describe('button state machine', () => {
+    it('offers to start the task when NOT_STARTED and the user can execute', () => {
+      renderCard(
+        createMockExecutableTaskBundle(
+          { projectId: 'syn1' },
+          { state: 'NOT_STARTED' },
+        ),
+      )
+      expect(
+        screen.getByRole('button', buttonByLabel(RUN_AGENT_BUTTON_TEXT)),
+      ).toBeEnabled()
+    })
+
+    it('shows a disabled Running button when EXECUTING', () => {
+      renderCard(
+        createMockExecutableTaskBundle(
+          { projectId: 'syn1' },
+          { state: 'EXECUTING' },
+        ),
+      )
+      expect(
+        screen.getByRole('button', buttonByLabel(RUNNING_BUTTON_TEXT)),
+      ).toBeDisabled()
+    })
+
+    it('offers to view the result when COMPLETED', () => {
+      renderCard(
+        createMockExecutableTaskBundle(
+          { projectId: 'syn1' },
+          { state: 'COMPLETED' },
+        ),
+      )
+      expect(
+        screen.getByRole('button', buttonByLabel(VIEW_RESULT_BUTTON_TEXT)),
+      ).toBeEnabled()
+    })
+  })
+
+  describe('permissions', () => {
+    it('disables Start with a tooltip when the user cannot execute', async () => {
+      const user = userEvent.setup()
+      setCanEdit(false)
+      setIsAssigneeOrTeamMember(false)
+      renderCard(
+        createMockExecutableTaskBundle(
+          { projectId: 'syn1' },
+          { state: 'NOT_STARTED' },
+        ),
+      )
+
+      const button = screen.getByRole(
+        'button',
+        buttonByLabel(RUN_AGENT_BUTTON_TEXT),
+      )
+      expect(button).toBeDisabled()
+
+      await user.hover(button)
+      expect(
+        await screen.findByRole('tooltip', {
+          name: EXECUTABLE_TASK_NO_PERMISSION_MESSAGE,
+        }),
+      ).toBeInTheDocument()
+    })
+
+    it('enables Start when the user is the assignee or a team member', () => {
+      setCanEdit(false)
+      setIsAssigneeOrTeamMember(true)
+      renderCard(
+        createMockExecutableTaskBundle(
+          { projectId: 'syn1' },
+          { state: 'NOT_STARTED' },
+        ),
+      )
+      expect(
+        screen.getByRole('button', buttonByLabel(RUN_AGENT_BUTTON_TEXT)),
+      ).toBeEnabled()
+    })
+  })
+
+  describe('destination task', () => {
+    it('sets the taskIds search param to the destination task when View Result is clicked', async () => {
+      const user = userEvent.setup()
+      renderCard(
+        createMockExecutableTaskBundle(
+          { projectId: 'syn1' },
+          { state: 'COMPLETED' },
+        ),
+      )
+
+      await user.click(
+        screen.getByRole('button', buttonByLabel(VIEW_RESULT_BUTTON_TEXT)),
+      )
+
+      expect(lastTaskIdsParam).toBe(
+        String(MOCK_CURATION_TASK_DESTINATION_TASK_ID),
+      )
+    })
+
+    it('disables View Result with a tooltip when the destination task is missing', async () => {
+      const user = userEvent.setup()
+      renderCard(
+        createMockExecutableTaskBundle(
+          {
+            projectId: 'syn1',
+            taskProperties: {
+              concreteType:
+                'org.sagebionetworks.repo.model.curation.execution.SampleSheetGenerationExecutionProperties',
+            } as never,
+          },
+          { state: 'COMPLETED' },
+        ),
+      )
+
+      const button = screen.getByRole(
+        'button',
+        buttonByLabel(VIEW_RESULT_BUTTON_TEXT),
+      )
+      expect(button).toBeDisabled()
+
+      await user.hover(button)
+      expect(
+        await screen.findByRole('tooltip', {
+          name: DESTINATION_TASK_MISSING_MESSAGE,
+        }),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('starting the task', () => {
+    beforeAll(() => server.listen())
+    afterAll(() => server.close())
+
+    it('calls the execute endpoint when Start is clicked', async () => {
+      const user = userEvent.setup()
+      let startCalled = false
+      server.use(
+        http.post(
+          `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}/repo/v1/curation/task/:taskId/execute/async/start`,
+          () => {
+            startCalled = true
+            return HttpResponse.json({ token: 'tok' }, { status: 201 })
+          },
+        ),
+        ...getExecuteCurationTaskHandlers(),
+      )
+      renderCard(
+        createMockExecutableTaskBundle(
+          { projectId: 'syn1' },
+          { state: 'NOT_STARTED' },
+        ),
+      )
+
+      await user.click(
+        screen.getByRole('button', buttonByLabel(RUN_AGENT_BUTTON_TEXT)),
+      )
+
+      await waitFor(() => expect(startCalled).toBe(true))
+    })
+  })
+})

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/ExecutableTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/ExecutableTaskCard.tsx
@@ -1,0 +1,96 @@
+import { displayToast } from '@/components'
+import { useExecuteCurationTask } from '@/synapse-queries/curation/task/useCurationTask'
+import useGetEntityBundle from '@/synapse-queries/entity/useEntityBundle'
+import { useGetIsPrincipalIdUserOrMemberOfTeam } from '@/synapse-queries/team/useTeamMembers'
+import { useGetCurrentUserProfile } from '@/synapse-queries/user/useUserBundle'
+import { GRID_PAGE_TASK_ID_QUERY_PARAM } from '@/utils/SynapseConstants'
+import { TaskBundle } from '@sage-bionetworks/synapse-client'
+import { useSearchParams } from 'react-router'
+import CurationTaskCardLayout, {
+  deriveCardFields,
+} from './CurationTaskCardLayout'
+import { getExecutableTaskButtonState } from './getExecutableTaskButtonState'
+import NextStepButton from './NextStepButton'
+import styles from './CurationTaskCard.module.scss'
+
+export type ExecutableTaskCardProps = {
+  taskBundle: TaskBundle
+}
+
+/**
+ * Card for an executable (Compute Data) curation task. Lets an authorized user run the task's agent
+ * and, once finished, navigate to the destination task where the generated output was written.
+ */
+export default function ExecutableTaskCard(props: ExecutableTaskCardProps) {
+  const { taskBundle } = props
+  const task = taskBundle.task!
+  const taskProperties = task.taskProperties
+  const destinationTaskId =
+    taskProperties && 'destinationTaskId' in taskProperties
+      ? taskProperties.destinationTaskId
+      : undefined
+
+  const [, setSearchParams] = useSearchParams()
+
+  const { data: bundle } = useGetEntityBundle(task.projectId, undefined, {
+    includeEntity: true,
+    includePermissions: true,
+  })
+  const canEdit = bundle?.permissions?.canEdit ?? false
+
+  const { data: currentUserProfile } = useGetCurrentUserProfile()
+  const { data: isAssigneeOrTeamMember } =
+    useGetIsPrincipalIdUserOrMemberOfTeam(
+      currentUserProfile?.ownerId ?? '',
+      task.assigneePrincipalId ?? '',
+      { enabled: !!currentUserProfile?.ownerId && !!task.assigneePrincipalId },
+    )
+
+  const canExecute = canEdit || Boolean(isAssigneeOrTeamMember)
+
+  const { mutate: executeTask, isPending } = useExecuteCurationTask({
+    onError: error => displayToast(error.message, 'danger'),
+  })
+
+  const buttonState = getExecutableTaskButtonState({
+    state: taskBundle.status?.state,
+    canExecute,
+    isExecutePending: isPending,
+    destinationTaskId,
+  })
+
+  const { title, description, principalIds } = deriveCardFields(task)
+
+  function onClickAction() {
+    if (buttonState.action === 'start') {
+      executeTask(task.taskId!)
+    } else if (buttonState.action === 'viewResult' && destinationTaskId) {
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev)
+        next.set(GRID_PAGE_TASK_ID_QUERY_PARAM, String(destinationTaskId))
+        return next
+      })
+    }
+  }
+
+  return (
+    <CurationTaskCardLayout
+      taskBundle={taskBundle}
+      title={title}
+      description={description}
+      taskType="Compute"
+      principalIds={principalIds}
+      renderActionButton={({ expanded }) => (
+        <NextStepButton
+          className={styles.cardButton}
+          buttonText={buttonState.buttonText}
+          onClick={onClickAction}
+          disabled={buttonState.disabled}
+          loading={buttonState.loading}
+          tooltip={buttonState.tooltip}
+          expanded={expanded}
+        />
+      )}
+    />
+  )
+}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/GridTaskCard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/GridTaskCard.tsx
@@ -1,0 +1,54 @@
+import { displayToast } from '@/components'
+import useOpenCuratorFromTaskButton from '@/features/entity/metadata-task/hooks/useOpenCuratorButton'
+import { OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE } from '@/features/entity/metadata-task/utils/constants'
+import { TaskBundle } from '@sage-bionetworks/synapse-client'
+import CurationTaskCardLayout, {
+  deriveCardFields,
+} from './CurationTaskCardLayout'
+import NextStepButton from './NextStepButton'
+import styles from './CurationTaskCard.module.scss'
+
+export type GridTaskCardProps = {
+  taskBundle: TaskBundle
+}
+
+/**
+ * Card for a grid-supported (Curate Data) curation task. The action button opens the task in
+ * Curator, gated on read access to the task's source entity.
+ */
+export default function GridTaskCard(props: GridTaskCardProps) {
+  const { taskBundle } = props
+
+  const { onClick, isLoading, isPending, hasPermission } =
+    useOpenCuratorFromTaskButton(taskBundle)
+
+  function onClickAction() {
+    if (hasPermission) {
+      onClick()
+    } else {
+      displayToast(OPEN_CURATOR_NO_PERMISSION_ON_SOURCE_ERROR_MESSAGE, 'danger')
+    }
+  }
+
+  const { title, description, principalIds } = deriveCardFields(taskBundle.task)
+
+  return (
+    <CurationTaskCardLayout
+      taskBundle={taskBundle}
+      title={title}
+      description={description}
+      taskType="Curate Data"
+      principalIds={principalIds}
+      renderActionButton={({ expanded }) => (
+        <NextStepButton
+          className={styles.cardButton}
+          buttonText="Open Curator"
+          onClick={onClickAction}
+          disabled={isLoading}
+          loading={isPending}
+          expanded={expanded}
+        />
+      )}
+    />
+  )
+}

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.test.tsx
@@ -54,6 +54,30 @@ describe('NextStepButton', () => {
     })
   })
 
+  describe('tooltip', () => {
+    it('shows the tooltip text on hover when a tooltip is provided', async () => {
+      const user = await import('@testing-library/user-event').then(m =>
+        m.default.setup(),
+      )
+      render(
+        <NextStepButton
+          buttonText="View Result"
+          onClick={mockOnClick}
+          disabled={true}
+          tooltip="Destination task is missing"
+        />,
+      )
+
+      await user.hover(screen.getByText('View Result'))
+
+      expect(
+        await screen.findByRole('tooltip', {
+          name: 'Destination task is missing',
+        }),
+      ).toBeInTheDocument()
+    })
+  })
+
   describe('expanded mode (expanded={true})', () => {
     it('renders the button text', () => {
       render(

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.tsx
@@ -3,7 +3,7 @@ import { Button, Tooltip, Typography } from '@mui/material'
 import { ArrowForwardIos, TableChartOutlined } from '@mui/icons-material'
 import { SynapseSpinner } from '@/components/LoadingScreen/LoadingScreen'
 import classNames from 'classnames'
-import { ReactElement } from 'react'
+import { PropsWithChildren } from 'react'
 
 type NextStepButtonProps = {
   className?: string
@@ -20,13 +20,16 @@ type NextStepButtonProps = {
  * Wraps the button in a Tooltip when tooltip text is provided. A disabled MUI button does not fire
  * pointer events, so the button is wrapped in a focusable span so the tooltip remains discoverable.
  */
-function withTooltip(button: ReactElement, tooltip: string | undefined) {
-  if (!tooltip) {
-    return button
+function OptionalButtonTooltip(
+  props: PropsWithChildren<{ title: string | undefined }>,
+) {
+  const { children, title } = props
+  if (!title) {
+    return children
   }
   return (
-    <Tooltip title={tooltip}>
-      <span style={{ display: 'inline-flex' }}>{button}</span>
+    <Tooltip title={title}>
+      <span style={{ display: 'inline-flex' }}>{children}</span>
     </Tooltip>
   )
 }
@@ -47,52 +50,54 @@ export default function NextStepButton(props: NextStepButtonProps) {
   } = props
 
   if (expanded) {
-    return withTooltip(
-      <Button
-        className={classNames(styles.expandedButton, className)}
-        onClick={onClick}
-        disabled={disabled || loading}
-        startIcon={<TableChartOutlined sx={{ fontSize: 20 }} />}
-        sx={{ width: '100%' }}
-      >
-        <Typography
-          variant="buttonLink"
-          sx={{ color: 'inherit', fontWeight: 700 }}
+    return (
+      <OptionalButtonTooltip title={tooltip}>
+        <Button
+          className={classNames(styles.expandedButton, className)}
+          onClick={onClick}
+          disabled={disabled || loading}
+          startIcon={<TableChartOutlined sx={{ fontSize: 20 }} />}
+          sx={{ width: '100%' }}
         >
-          {buttonText}
-        </Typography>
-      </Button>,
-      tooltip,
+          <Typography
+            variant="buttonLink"
+            sx={{ color: 'inherit', fontWeight: 700 }}
+          >
+            {buttonText}
+          </Typography>
+        </Button>
+      </OptionalButtonTooltip>
     )
   }
 
-  return withTooltip(
-    <button
-      type="button"
-      className={classNames(styles.button, className)}
-      onClick={onClick}
-      disabled={disabled || loading}
-    >
-      <div className={styles.buttonText}>
-        <Typography className={styles.buttonTextSub} variant="body1">
-          Next step
-        </Typography>
-        <Typography
-          className={styles.buttonTextMain}
-          variant="buttonLink"
-          color="primary"
-          fontWeight={700}
-          align="left"
-        >
-          {buttonText}
-        </Typography>
-      </div>
-      {loading ? (
-        <SynapseSpinner size={30} />
-      ) : (
-        <ArrowForwardIos className={styles.icon} />
-      )}
-    </button>,
-    tooltip,
+  return (
+    <OptionalButtonTooltip title={tooltip}>
+      <button
+        type="button"
+        className={classNames(styles.button, className)}
+        onClick={onClick}
+        disabled={disabled || loading}
+      >
+        <div className={styles.buttonText}>
+          <Typography className={styles.buttonTextSub} variant="body1">
+            Next step
+          </Typography>
+          <Typography
+            className={styles.buttonTextMain}
+            variant="buttonLink"
+            color="primary"
+            fontWeight={700}
+            align="left"
+          >
+            {buttonText}
+          </Typography>
+        </div>
+        {loading ? (
+          <SynapseSpinner size={30} />
+        ) : (
+          <ArrowForwardIos className={styles.icon} />
+        )}
+      </button>
+    </OptionalButtonTooltip>
   )
 }

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/NextStepButton.tsx
@@ -1,8 +1,9 @@
 import styles from './NextStepButton.module.scss'
-import { Button, Typography } from '@mui/material'
+import { Button, Tooltip, Typography } from '@mui/material'
 import { ArrowForwardIos, TableChartOutlined } from '@mui/icons-material'
 import { SynapseSpinner } from '@/components/LoadingScreen/LoadingScreen'
 import classNames from 'classnames'
+import { ReactElement } from 'react'
 
 type NextStepButtonProps = {
   className?: string
@@ -11,6 +12,23 @@ type NextStepButtonProps = {
   disabled?: boolean
   loading?: boolean
   expanded?: boolean
+  /** When provided, wraps the button in a tooltip. Useful to explain a disabled state. */
+  tooltip?: string
+}
+
+/**
+ * Wraps the button in a Tooltip when tooltip text is provided. A disabled MUI button does not fire
+ * pointer events, so the button is wrapped in a focusable span so the tooltip remains discoverable.
+ */
+function withTooltip(button: ReactElement, tooltip: string | undefined) {
+  if (!tooltip) {
+    return button
+  }
+  return (
+    <Tooltip title={tooltip}>
+      <span style={{ display: 'inline-flex' }}>{button}</span>
+    </Tooltip>
+  )
 }
 
 /**
@@ -18,10 +36,18 @@ type NextStepButtonProps = {
  * Displays an arrow icon or loading spinner when appropriate.
  */
 export default function NextStepButton(props: NextStepButtonProps) {
-  const { className, buttonText, onClick, disabled, loading, expanded } = props
+  const {
+    className,
+    buttonText,
+    onClick,
+    disabled,
+    loading,
+    expanded,
+    tooltip,
+  } = props
 
   if (expanded) {
-    return (
+    return withTooltip(
       <Button
         className={classNames(styles.expandedButton, className)}
         onClick={onClick}
@@ -35,11 +61,12 @@ export default function NextStepButton(props: NextStepButtonProps) {
         >
           {buttonText}
         </Typography>
-      </Button>
+      </Button>,
+      tooltip,
     )
   }
 
-  return (
+  return withTooltip(
     <button
       type="button"
       className={classNames(styles.button, className)}
@@ -65,6 +92,7 @@ export default function NextStepButton(props: NextStepButtonProps) {
       ) : (
         <ArrowForwardIos className={styles.icon} />
       )}
-    </button>
+    </button>,
+    tooltip,
   )
 }

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/getExecutableTaskButtonState.test.ts
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/getExecutableTaskButtonState.test.ts
@@ -1,0 +1,138 @@
+import { TaskStatusStateEnum } from '@sage-bionetworks/synapse-client'
+import { describe, expect, it } from 'vitest'
+import {
+  DESTINATION_TASK_MISSING_MESSAGE,
+  EXECUTABLE_TASK_NO_PERMISSION_MESSAGE,
+  getExecutableTaskButtonState,
+  RUN_AGENT_BUTTON_TEXT,
+  RUNNING_BUTTON_TEXT,
+  VIEW_RESULT_BUTTON_TEXT,
+} from './getExecutableTaskButtonState'
+
+describe('getExecutableTaskButtonState', () => {
+  describe('NOT_STARTED', () => {
+    it('offers to start the task when the user can execute', () => {
+      const result = getExecutableTaskButtonState({
+        state: TaskStatusStateEnum.NOT_STARTED,
+        canExecute: true,
+        isExecutePending: false,
+        destinationTaskId: 456,
+      })
+      expect(result).toEqual({
+        buttonText: RUN_AGENT_BUTTON_TEXT,
+        action: 'start',
+        disabled: false,
+        loading: false,
+        tooltip: undefined,
+      })
+    })
+
+    it('is disabled with a tooltip when the user cannot execute', () => {
+      const result = getExecutableTaskButtonState({
+        state: TaskStatusStateEnum.NOT_STARTED,
+        canExecute: false,
+        isExecutePending: false,
+        destinationTaskId: 456,
+      })
+      expect(result).toEqual({
+        buttonText: RUN_AGENT_BUTTON_TEXT,
+        action: 'none',
+        disabled: true,
+        loading: false,
+        tooltip: EXECUTABLE_TASK_NO_PERMISSION_MESSAGE,
+      })
+    })
+  })
+
+  describe('running', () => {
+    it('shows a loading Running button when the task is EXECUTING', () => {
+      const result = getExecutableTaskButtonState({
+        state: TaskStatusStateEnum.EXECUTING,
+        canExecute: true,
+        isExecutePending: false,
+        destinationTaskId: 456,
+      })
+      expect(result).toEqual({
+        buttonText: RUNNING_BUTTON_TEXT,
+        action: 'none',
+        disabled: true,
+        loading: true,
+        tooltip: undefined,
+      })
+    })
+
+    it('shows a loading Running button while the execute mutation is pending, even when NOT_STARTED', () => {
+      const result = getExecutableTaskButtonState({
+        state: TaskStatusStateEnum.NOT_STARTED,
+        canExecute: true,
+        isExecutePending: true,
+        destinationTaskId: 456,
+      })
+      expect(result).toEqual({
+        buttonText: RUNNING_BUTTON_TEXT,
+        action: 'none',
+        disabled: true,
+        loading: true,
+        tooltip: undefined,
+      })
+    })
+  })
+
+  describe('finished (lenient)', () => {
+    const finishedStates = [
+      TaskStatusStateEnum.IN_PROGRESS,
+      TaskStatusStateEnum.IN_REVIEW,
+      TaskStatusStateEnum.COMPLETED,
+      TaskStatusStateEnum.CANCELED,
+    ]
+
+    it.each(finishedStates)(
+      'offers to view the result for state %s when the destination task is present',
+      state => {
+        const result = getExecutableTaskButtonState({
+          state,
+          canExecute: true,
+          isExecutePending: false,
+          destinationTaskId: 456,
+        })
+        expect(result).toEqual({
+          buttonText: VIEW_RESULT_BUTTON_TEXT,
+          action: 'viewResult',
+          disabled: false,
+          loading: false,
+          tooltip: undefined,
+        })
+      },
+    )
+
+    it.each(finishedStates)(
+      'is disabled with a tooltip for state %s when the destination task is missing',
+      state => {
+        const result = getExecutableTaskButtonState({
+          state,
+          canExecute: true,
+          isExecutePending: false,
+          destinationTaskId: undefined,
+        })
+        expect(result).toEqual({
+          buttonText: VIEW_RESULT_BUTTON_TEXT,
+          action: 'none',
+          disabled: true,
+          loading: false,
+          tooltip: DESTINATION_TASK_MISSING_MESSAGE,
+        })
+      },
+    )
+
+    it('offers to view the result regardless of execute permission', () => {
+      const result = getExecutableTaskButtonState({
+        state: TaskStatusStateEnum.COMPLETED,
+        canExecute: false,
+        isExecutePending: false,
+        destinationTaskId: 456,
+      })
+      expect(result.action).toBe('viewResult')
+      expect(result.disabled).toBe(false)
+    })
+  })
+})

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/getExecutableTaskButtonState.ts
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/getExecutableTaskButtonState.ts
@@ -1,0 +1,71 @@
+import { TaskStatusStateEnum } from '@sage-bionetworks/synapse-client'
+
+export const RUN_AGENT_BUTTON_TEXT = 'Start (Run Agent)'
+export const RUNNING_BUTTON_TEXT = 'Running'
+export const VIEW_RESULT_BUTTON_TEXT = 'View Result'
+
+export const EXECUTABLE_TASK_NO_PERMISSION_MESSAGE =
+  'You do not have permission to run this task. Only the assignee or a data manager can run it.'
+export const DESTINATION_TASK_MISSING_MESSAGE = 'Destination task is missing'
+
+/** The action that clicking the button should perform. */
+export type ExecutableTaskButtonAction = 'start' | 'viewResult' | 'none'
+
+export type ExecutableTaskButtonState = {
+  buttonText: string
+  action: ExecutableTaskButtonAction
+  disabled: boolean
+  loading: boolean
+  tooltip: string | undefined
+}
+
+export type GetExecutableTaskButtonStateArgs = {
+  state: TaskStatusStateEnum | undefined
+  canExecute: boolean
+  isExecutePending: boolean
+  destinationTaskId: number | undefined
+}
+
+/**
+ * Pure state machine mapping a task's status, the user's execute permission, and the local
+ * mutation state to the props the action button should render with.
+ *
+ * "Running" is derived from the server state (`EXECUTING`) OR the in-flight local mutation, so it
+ * survives reloads and reflects a run started by another user. Any state past `NOT_STARTED`/
+ * `EXECUTING` is treated leniently as "finished" and offers to view the result.
+ */
+export function getExecutableTaskButtonState(
+  args: GetExecutableTaskButtonStateArgs,
+): ExecutableTaskButtonState {
+  const { state, canExecute, isExecutePending, destinationTaskId } = args
+
+  const isRunning = state === TaskStatusStateEnum.EXECUTING || isExecutePending
+  if (isRunning) {
+    return {
+      buttonText: RUNNING_BUTTON_TEXT,
+      action: 'none',
+      disabled: true,
+      loading: true,
+      tooltip: undefined,
+    }
+  }
+
+  if (state === undefined || state === TaskStatusStateEnum.NOT_STARTED) {
+    return {
+      buttonText: RUN_AGENT_BUTTON_TEXT,
+      action: canExecute ? 'start' : 'none',
+      disabled: !canExecute,
+      loading: false,
+      tooltip: canExecute ? undefined : EXECUTABLE_TASK_NO_PERMISSION_MESSAGE,
+    }
+  }
+
+  const hasDestination = destinationTaskId !== undefined
+  return {
+    buttonText: VIEW_RESULT_BUTTON_TEXT,
+    action: hasDestination ? 'viewResult' : 'none',
+    disabled: !hasDestination,
+    loading: false,
+    tooltip: hasDestination ? undefined : DESTINATION_TASK_MISSING_MESSAGE,
+  }
+}

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
@@ -88,7 +88,7 @@ import noop from 'lodash-es/noop'
 import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
 import { StyledFormControl } from '@/components/styled'
 import { instanceOfGridSupportedTaskProperties } from '../utils/types'
-import { dueDateInputToEpochMs, epochMsToDueDateInput } from '../utils/dueDate'
+import { dueDateInputToIso, isoToDueDateInput } from '../utils/dueDate'
 
 export type CreateOrUpdateCurationTaskDialogProps = {
   open: boolean
@@ -241,8 +241,8 @@ export default function CreateOrUpdateCurationTaskDialog(
   )
   const displayedDueDate =
     pendingDueDate ??
-    (isEditMode ? epochMsToDueDateInput(currentTaskStatus?.dueDate) : '')
-  const originalDueDateForComparison = epochMsToDueDateInput(
+    (isEditMode ? isoToDueDateInput(currentTaskStatus?.dueDate) : '')
+  const originalDueDateForComparison = isoToDueDateInput(
     currentTaskStatus?.dueDate,
   )
 
@@ -347,7 +347,7 @@ export default function CreateOrUpdateCurationTaskDialog(
           state: pendingStatusState ?? currentTaskStatus.state,
           dueDate:
             pendingDueDate !== undefined
-              ? dueDateInputToEpochMs(displayedDueDate)
+              ? dueDateInputToIso(displayedDueDate)
               : currentTaskStatus.dueDate,
           etag: latestTask.etag,
         })

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/MetadataTasksPage.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/MetadataTasksPage.test.tsx
@@ -149,10 +149,7 @@ describe('MetadataTasksPage', () => {
     })
     await user.click(newTaskButton)
 
-    const heading = await screen.findByRole('heading', {
-      name: /create new task/i,
-    })
-    expect(heading).toBeInTheDocument()
+    await screen.findByText('Select Category for New Task')
     expect(
       screen.getByRole('button', { name: /compute data/i }),
     ).toBeInTheDocument()

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/ComputeTaskForm.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/ComputeTaskForm.test.tsx
@@ -97,10 +97,10 @@ const SAMPLE_SHEET_TYPE =
 const RECORD_SET_TYPE =
   RecordSetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_RecordSetGenerationExecutionProperties
 
-// The date a user picks in the native date input, and its independently-computed UTC-midnight
-// epoch-ms encoding (Date.UTC(2030, 0, 1) === 1893456000000) as the backend stores it.
+// The date a user picks in the native date input, and its UTC-midnight ISO 8601 encoding as the
+// backend stores it.
 const DUE_DATE_INPUT = '2030-01-01'
-const DUE_DATE_EPOCH_MS = '1893456000000'
+const DUE_DATE_ISO = '2030-01-01T00:00:00.000Z'
 
 const mockCreateMutateAsync = vi.fn()
 const mockUpdateMutateAsync = vi.fn()
@@ -304,7 +304,7 @@ describe('ComputeTaskForm', () => {
       )
     })
 
-    it('applies the due date to the auto-created status as a UTC epoch-ms timestamp', async () => {
+    it('applies the due date to the auto-created status as a UTC ISO 8601 timestamp', async () => {
       mockCreateMutateAsync.mockResolvedValue({
         taskId: MOCK_CURATION_TASK_ID,
       } as CurationTask)
@@ -325,7 +325,7 @@ describe('ComputeTaskForm', () => {
       expect(mockUpdateStatusMutateAsync).toHaveBeenCalledWith(
         expect.objectContaining({
           taskId: MOCK_CURATION_TASK_ID,
-          dueDate: DUE_DATE_EPOCH_MS,
+          dueDate: DUE_DATE_ISO,
         }),
       )
     })
@@ -383,7 +383,7 @@ describe('ComputeTaskForm', () => {
         data: {
           taskId: editTask.taskId,
           state: 'NOT_STARTED',
-          dueDate: DUE_DATE_EPOCH_MS,
+          dueDate: DUE_DATE_ISO,
         },
         isFetching: false,
       } as any)
@@ -441,7 +441,7 @@ describe('ComputeTaskForm', () => {
         data: {
           taskId: editTask.taskId,
           state: 'NOT_STARTED',
-          dueDate: DUE_DATE_EPOCH_MS,
+          dueDate: DUE_DATE_ISO,
         },
         isFetching: false,
       } as any)
@@ -463,7 +463,7 @@ describe('ComputeTaskForm', () => {
         data: {
           taskId: editTask.taskId,
           state: 'NOT_STARTED',
-          dueDate: DUE_DATE_EPOCH_MS,
+          dueDate: DUE_DATE_ISO,
           etag: 'status-etag',
         },
         isFetching: false,
@@ -519,7 +519,7 @@ describe('ComputeTaskForm', () => {
         data: {
           taskId: editTask.taskId,
           state: 'NOT_STARTED',
-          dueDate: DUE_DATE_EPOCH_MS,
+          dueDate: DUE_DATE_ISO,
           etag: 'stale-etag',
         },
         isFetching: false,
@@ -536,12 +536,12 @@ describe('ComputeTaskForm', () => {
       await user.type(dueDateInput, '2031-02-02')
       await user.click(screen.getByRole('button', { name: /^save$/i }))
 
-      // The new due date is persisted as its UTC-midnight epoch-ms encoding
-      // (Date.UTC(2031, 1, 2) === 1927756800000), using the freshly bumped shared etag.
+      // The new due date is persisted as its UTC-midnight ISO 8601 encoding, using the freshly
+      // bumped shared etag.
       expect(mockUpdateStatusMutateAsync).toHaveBeenCalledWith(
         expect.objectContaining({
           etag: 'bumped-etag',
-          dueDate: '1927756800000',
+          dueDate: '2031-02-02T00:00:00.000Z',
         }),
       )
     })

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/CreateCurationTaskFlow.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/CreateCurationTaskFlow.test.tsx
@@ -164,6 +164,15 @@ describe('CreateCurationTaskFlow', () => {
     expect(screen.queryByText(/task list page/i)).not.toBeInTheDocument()
   })
 
+  it('shows a "Back to All Tasks" button on the category picker that calls onExit', async () => {
+    const user = userEvent.setup()
+    const { onExit } = renderFlow()
+
+    await user.click(screen.getByRole('button', { name: /back to all tasks/i }))
+
+    expect(onExit).toHaveBeenCalled()
+  })
+
   it('shows a "Back to All Tasks" button on the compute form that calls onExit', async () => {
     const user = userEvent.setup()
     const { onExit } = renderFlow()

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/CreateCurationTaskFlow.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/CreateCurationTaskFlow.tsx
@@ -1,5 +1,3 @@
-import { useGlobalIsEditingContext } from '@/utils/context/GlobalIsEditingContext'
-import { useEffect } from 'react'
 import {
   Navigate,
   Outlet,
@@ -9,13 +7,14 @@ import {
   useParams,
 } from 'react-router'
 import {
+  BACK_TO_ALL_TASKS_LABEL,
   CREATE_COMPUTE_TASK_PAGE_TITLE,
   CREATE_CURATE_TASK_PAGE_TITLE,
-  CREATE_CURATION_TASK_PAGE_TITLE,
   FILL_IN_COMPUTE_TASK_DETAILS_DESCRIPTION,
   FILL_IN_CURATE_TASK_DETAILS_DESCRIPTION,
 } from '../utils/constants'
-import { Typography } from '@mui/material'
+import { ArrowBack } from '@mui/icons-material'
+import { Button } from '@mui/material'
 import ComputeTaskForm from './ComputeTaskForm'
 import CreateTaskCategoryPicker from './CreateTaskCategoryPicker'
 import CreateTaskConfirmation from './CreateTaskConfirmation'
@@ -44,13 +43,24 @@ function ConfirmationRouteRenderer(props: { onExit: () => void }) {
  * Layout for the steps that share the generic "Create New Task" header (the category picker and the
  * confirmation screen). The compute form step renders its own more specific centered title/subtitle
  * instead (see `ComputeTaskForm`'s `pageTitle`/`pageDescription` props below), so it isn't nested here.
+ *
+ * When `onExit` is provided, a top-left "Back to All Tasks" button is shown above the title, matching
+ * the one on the form steps (see `TaskFormHeader`).
  */
-function CreateTaskLayout() {
+function CreateTaskLayout(props: { onExit?: () => void }) {
+  const { onExit } = props
   return (
     <>
-      <Typography variant="headline1" component="h1">
-        {CREATE_CURATION_TASK_PAGE_TITLE}
-      </Typography>
+      {onExit && (
+        <Button
+          variant="text"
+          startIcon={<ArrowBack />}
+          onClick={onExit}
+          sx={{ alignSelf: 'flex-start' }}
+        >
+          {BACK_TO_ALL_TASKS_LABEL}
+        </Button>
+      )}
       <Outlet />
     </>
   )
@@ -68,16 +78,10 @@ export default function CreateCurationTaskFlow(
 ) {
   const { projectId, onExit } = props
   const navigate = useNavigate()
-  const { setIsEditing } = useGlobalIsEditingContext()
-
-  useEffect(() => {
-    setIsEditing(true)
-    return () => setIsEditing(false)
-  }, [setIsEditing])
 
   return (
     <Routes>
-      <Route element={<CreateTaskLayout />}>
+      <Route element={<CreateTaskLayout onExit={onExit} />}>
         <Route
           index
           element={
@@ -87,6 +91,8 @@ export default function CreateCurationTaskFlow(
             />
           }
         />
+      </Route>
+      <Route element={<CreateTaskLayout />}>
         <Route
           path="confirmation/:taskId"
           element={<ConfirmationRouteRenderer onExit={onExit} />}

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/CurateTaskForm.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/CurateTaskForm.test.tsx
@@ -97,10 +97,10 @@ const FILE_BASED_TYPE =
 const RECORD_BASED_TYPE =
   RecordBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_RecordBasedMetadataTaskProperties
 
-// The date a user picks in the native date input, and its independently-computed UTC-midnight
-// epoch-ms encoding (Date.UTC(2030, 0, 1) === 1893456000000) as the backend stores it.
+// The date a user picks in the native date input, and its UTC-midnight ISO 8601 encoding as the
+// backend stores it.
 const DUE_DATE_INPUT = '2030-01-01'
-const DUE_DATE_EPOCH_MS = '1893456000000'
+const DUE_DATE_ISO = '2030-01-01T00:00:00.000Z'
 
 const mockCreateMutateAsync = vi.fn()
 const mockUpdateMutateAsync = vi.fn()
@@ -263,7 +263,7 @@ describe('CurateTaskForm', () => {
       )
     })
 
-    it('applies the due date to the auto-created status as a UTC epoch-ms timestamp', async () => {
+    it('applies the due date to the auto-created status as a UTC ISO 8601 timestamp', async () => {
       mockCreateMutateAsync.mockResolvedValue({
         taskId: MOCK_CURATION_TASK_ID,
       } as CurationTask)
@@ -284,7 +284,7 @@ describe('CurateTaskForm', () => {
       expect(mockUpdateStatusMutateAsync).toHaveBeenCalledWith(
         expect.objectContaining({
           taskId: MOCK_CURATION_TASK_ID,
-          dueDate: DUE_DATE_EPOCH_MS,
+          dueDate: DUE_DATE_ISO,
         }),
       )
     })
@@ -370,7 +370,7 @@ describe('CurateTaskForm', () => {
         data: {
           taskId: editTask.taskId,
           state: 'NOT_STARTED',
-          dueDate: DUE_DATE_EPOCH_MS,
+          dueDate: DUE_DATE_ISO,
         },
         isFetching: false,
       } as any)
@@ -417,7 +417,7 @@ describe('CurateTaskForm', () => {
         data: {
           taskId: editTask.taskId,
           state: 'NOT_STARTED',
-          dueDate: DUE_DATE_EPOCH_MS,
+          dueDate: DUE_DATE_ISO,
         },
         isFetching: false,
       } as any)
@@ -439,7 +439,7 @@ describe('CurateTaskForm', () => {
         data: {
           taskId: editTask.taskId,
           state: 'NOT_STARTED',
-          dueDate: DUE_DATE_EPOCH_MS,
+          dueDate: DUE_DATE_ISO,
           etag: 'status-etag',
         },
         isFetching: false,

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/EditCurationTaskPage.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/EditCurationTaskPage.tsx
@@ -1,8 +1,6 @@
 import { ErrorBanner } from '@/components/error/ErrorBanner'
 import { SynapseSpinner } from '@/components/LoadingScreen/LoadingScreen'
 import { useGetCurationTask } from '@/synapse-queries/curation/task/useCurationTask'
-import { useGlobalIsEditingContext } from '@/utils/context/GlobalIsEditingContext'
-import { useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import {
   EDIT_CURATION_TASK_PAGE_DESCRIPTION,
@@ -22,12 +20,6 @@ export default function EditCurationTaskPage() {
   const { taskId } = useParams<{ taskId: string }>()
   const parsedTaskId = taskId ? Number(taskId) : undefined
   const navigate = useNavigate()
-  const { setIsEditing } = useGlobalIsEditingContext()
-
-  useEffect(() => {
-    setIsEditing(true)
-    return () => setIsEditing(false)
-  }, [setIsEditing])
 
   const {
     data: task,

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/useCurationTaskFormState.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/useCurationTaskFormState.ts
@@ -18,7 +18,7 @@ import {
   DELETE_CURATION_TASK_ERROR_TOAST_PREFIX,
   DELETE_CURATION_TASK_SUCCESS_TOAST,
 } from '../utils/constants'
-import { dueDateInputToEpochMs, epochMsToDueDateInput } from '../utils/dueDate'
+import { dueDateInputToIso, isoToDueDateInput } from '../utils/dueDate'
 
 export type UseCurationTaskFormStateArgs = {
   /**
@@ -71,14 +71,14 @@ export function useCurationTaskFormState(args: UseCurationTaskFormStateArgs) {
   >(undefined)
   const displayedStatusState = pendingStatusState ?? currentTaskStatus?.state
   // `pendingDueDate` and `displayedDueDate` are always the native date input's `YYYY-MM-DD` string.
-  // The backend stores `TaskStatus.dueDate` as a unix-millisecond timestamp string, so the fetched
-  // value is converted for display and the entered value is converted back on write.
+  // The backend stores `TaskStatus.dueDate` as an ISO 8601 date-time string, so the fetched value is
+  // converted for display and the entered value is converted back on write.
   const [pendingDueDate, setPendingDueDate] = useState<string | undefined>(
     undefined,
   )
   const displayedDueDate =
     pendingDueDate ??
-    (isEditMode ? epochMsToDueDateInput(currentTaskStatus?.dueDate) : '')
+    (isEditMode ? isoToDueDateInput(currentTaskStatus?.dueDate) : '')
 
   const { data: permissions } = useGetEntityPermissions(effectiveProjectId, {
     enabled: !!effectiveProjectId,
@@ -141,7 +141,7 @@ export function useCurationTaskFormState(args: UseCurationTaskFormStateArgs) {
   async function submitTaskAndStatus(
     payload: CurationTask,
   ): Promise<CurationTask> {
-    const dueDateEpochMs = dueDateInputToEpochMs(displayedDueDate)
+    const dueDateIso = dueDateInputToIso(displayedDueDate)
 
     if (isEditMode) {
       const latestTask = await updateTask(payload)
@@ -151,7 +151,7 @@ export function useCurationTaskFormState(args: UseCurationTaskFormStateArgs) {
         pendingStatusState !== currentTaskStatus?.state
       const dueDateChanged =
         pendingDueDate !== undefined &&
-        dueDateEpochMs !== (currentTaskStatus?.dueDate ?? undefined)
+        dueDateIso !== (currentTaskStatus?.dueDate ?? undefined)
       if ((statusStateChanged || dueDateChanged) && currentTaskStatus != null) {
         // The task and its status share an etag, and the preceding `updateTask` bumped it; the
         // status update must use the etag returned by that update, not the stale fetched one. When
@@ -162,7 +162,7 @@ export function useCurationTaskFormState(args: UseCurationTaskFormStateArgs) {
           state: pendingStatusState ?? currentTaskStatus.state,
           dueDate:
             pendingDueDate !== undefined
-              ? dueDateEpochMs
+              ? dueDateIso
               : currentTaskStatus.dueDate,
           etag: latestTask.etag,
         })
@@ -173,7 +173,7 @@ export function useCurationTaskFormState(args: UseCurationTaskFormStateArgs) {
 
     const created = await createTask(payload)
 
-    if (dueDateEpochMs && created.taskId != null) {
+    if (dueDateIso && created.taskId != null) {
       // TODO(PLFM-9839): replace this best-effort status write with a single service that creates
       // the task and its status atomically. Until then, the task is created first and the due date
       // is applied to the auto-created status in a separate call; a failure there must not strand a
@@ -188,7 +188,7 @@ export function useCurationTaskFormState(args: UseCurationTaskFormStateArgs) {
         await updateTaskStatus({
           ...status,
           taskId: created.taskId,
-          dueDate: dueDateEpochMs,
+          dueDate: dueDateIso,
         })
       } catch {
         displayToast(CREATE_TASK_STATUS_NOT_SAVED_WARNING, 'warning')

--- a/packages/synapse-react-client/src/features/entity/metadata-task/utils/constants.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/utils/constants.ts
@@ -19,7 +19,6 @@ export const OPEN_CURATOR_LINK_TASK_CONFLICT_ERROR_MESSAGE =
 
 // Create/Edit Curation Task pages (see `create-task/`)
 
-export const CREATE_CURATION_TASK_PAGE_TITLE = 'Create New Task'
 export const EDIT_CURATION_TASK_PAGE_TITLE = 'Edit Task'
 export const EDIT_CURATION_TASK_PAGE_DESCRIPTION =
   'Update the details for this task.'

--- a/packages/synapse-react-client/src/features/entity/metadata-task/utils/dueDate.test.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/utils/dueDate.test.ts
@@ -1,48 +1,41 @@
 import { describe, it, expect } from 'vitest'
-import {
-  dueDateInputToEpochMs,
-  epochMsToDueDateInput,
-  parseDueDate,
-} from './dueDate'
+import { dueDateInputToIso, isoToDueDateInput, parseDueDate } from './dueDate'
 
-// Known-good literals computed independently via Date.UTC(...):
-//   Date.UTC(2030, 0, 1) === 1893456000000
-//   Date.UTC(2024, 4, 15) === 1715731200000
 const JAN_1_2030_INPUT = '2030-01-01'
-const JAN_1_2030_EPOCH_MS = '1893456000000'
+const JAN_1_2030_ISO = '2030-01-01T00:00:00.000Z'
 const MAY_15_2024_INPUT = '2024-05-15'
-const MAY_15_2024_EPOCH_MS = '1715731200000'
+const MAY_15_2024_ISO = '2024-05-15T00:00:00.000Z'
 
-describe('dueDateInputToEpochMs', () => {
-  it('converts a YYYY-MM-DD input to a UTC-midnight epoch-ms string', () => {
-    expect(dueDateInputToEpochMs(JAN_1_2030_INPUT)).toBe(JAN_1_2030_EPOCH_MS)
-    expect(dueDateInputToEpochMs(MAY_15_2024_INPUT)).toBe(MAY_15_2024_EPOCH_MS)
+describe('dueDateInputToIso', () => {
+  it('converts a YYYY-MM-DD input to a UTC-midnight ISO 8601 string', () => {
+    expect(dueDateInputToIso(JAN_1_2030_INPUT)).toBe(JAN_1_2030_ISO)
+    expect(dueDateInputToIso(MAY_15_2024_INPUT)).toBe(MAY_15_2024_ISO)
   })
 
   it('returns undefined for an empty string', () => {
-    expect(dueDateInputToEpochMs('')).toBeUndefined()
+    expect(dueDateInputToIso('')).toBeUndefined()
   })
 
   it('returns undefined for a malformed date string', () => {
-    expect(dueDateInputToEpochMs('not-a-date')).toBeUndefined()
-    expect(dueDateInputToEpochMs('2030-13-40')).toBeUndefined()
-    expect(dueDateInputToEpochMs('2030/01/01')).toBeUndefined()
+    expect(dueDateInputToIso('not-a-date')).toBeUndefined()
+    expect(dueDateInputToIso('2030-13-40')).toBeUndefined()
+    expect(dueDateInputToIso('2030/01/01')).toBeUndefined()
   })
 })
 
-describe('epochMsToDueDateInput', () => {
-  it('converts a UTC epoch-ms string back to a YYYY-MM-DD input value', () => {
-    expect(epochMsToDueDateInput(JAN_1_2030_EPOCH_MS)).toBe(JAN_1_2030_INPUT)
-    expect(epochMsToDueDateInput(MAY_15_2024_EPOCH_MS)).toBe(MAY_15_2024_INPUT)
+describe('isoToDueDateInput', () => {
+  it('converts a UTC ISO 8601 string back to a YYYY-MM-DD input value', () => {
+    expect(isoToDueDateInput(JAN_1_2030_ISO)).toBe(JAN_1_2030_INPUT)
+    expect(isoToDueDateInput(MAY_15_2024_ISO)).toBe(MAY_15_2024_INPUT)
   })
 
   it('returns an empty string when the due date is absent', () => {
-    expect(epochMsToDueDateInput(undefined)).toBe('')
-    expect(epochMsToDueDateInput('')).toBe('')
+    expect(isoToDueDateInput(undefined)).toBe('')
+    expect(isoToDueDateInput('')).toBe('')
   })
 
-  it('passes through a legacy YYYY-MM-DD value written under the old bug', () => {
-    expect(epochMsToDueDateInput(JAN_1_2030_INPUT)).toBe(JAN_1_2030_INPUT)
+  it('returns an empty string for an unparseable value', () => {
+    expect(isoToDueDateInput('not-a-date')).toBe('')
   })
 })
 
@@ -57,22 +50,16 @@ describe('dueDate round-trip is stable regardless of the host timezone', () => {
     'preserves the calendar date in %s',
     tz => {
       process.env.TZ = tz
-      const epochMs = dueDateInputToEpochMs(JAN_1_2030_INPUT)
-      expect(epochMs).toBe(JAN_1_2030_EPOCH_MS)
-      expect(epochMsToDueDateInput(epochMs)).toBe(JAN_1_2030_INPUT)
+      const iso = dueDateInputToIso(JAN_1_2030_INPUT)
+      expect(iso).toBe(JAN_1_2030_ISO)
+      expect(isoToDueDateInput(iso)).toBe(JAN_1_2030_INPUT)
     },
   )
 })
 
 describe('parseDueDate', () => {
-  it('parses the backend epoch-ms string to a UTC-anchored calendar date', () => {
-    const parsed = parseDueDate(JAN_1_2030_EPOCH_MS)
-    expect(parsed).not.toBeNull()
-    expect(parsed!.format('YYYY-MM-DD')).toBe(JAN_1_2030_INPUT)
-  })
-
-  it('parses a legacy YYYY-MM-DD value', () => {
-    const parsed = parseDueDate(JAN_1_2030_INPUT)
+  it('parses the backend ISO 8601 string to a UTC-anchored calendar date', () => {
+    const parsed = parseDueDate(JAN_1_2030_ISO)
     expect(parsed).not.toBeNull()
     expect(parsed!.format('YYYY-MM-DD')).toBe(JAN_1_2030_INPUT)
   })
@@ -87,9 +74,7 @@ describe('parseDueDate', () => {
     tz => {
       const originalTz = process.env.TZ
       process.env.TZ = tz
-      expect(parseDueDate(JAN_1_2030_EPOCH_MS)!.format('MM/DD/YY')).toBe(
-        '01/01/30',
-      )
+      expect(parseDueDate(JAN_1_2030_ISO)!.format('MM/DD/YY')).toBe('01/01/30')
       process.env.TZ = originalTz
     },
   )

--- a/packages/synapse-react-client/src/features/entity/metadata-task/utils/dueDate.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/utils/dueDate.ts
@@ -9,45 +9,41 @@ const DUE_DATE_INPUT_FORMAT = 'YYYY-MM-DD'
 
 /**
  * A native `<input type="date">` produces a bare `YYYY-MM-DD` calendar date with no timezone, but the
- * backend's `TaskStatus.dueDate` is a unix-millisecond timestamp serialized as a string. Both
- * conversions here anchor the calendar date to UTC midnight so the date a user picks is the date every
- * other user sees, regardless of their timezone. Returns `undefined` for an empty or malformed input so
- * the caller can persist an absent due date.
+ * backend's `TaskStatus.dueDate` is an ISO 8601 date-time string. Both conversions here anchor the
+ * calendar date to UTC midnight so the date a user picks is the date every other user sees, regardless
+ * of their timezone. Returns `undefined` for an empty or malformed input so the caller can persist an
+ * absent due date.
  */
-export function dueDateInputToEpochMs(yyyyMmDd: string): string | undefined {
+export function dueDateInputToIso(yyyyMmDd: string): string | undefined {
   if (!yyyyMmDd) {
     return undefined
   }
   const parsed = dayjs.utc(yyyyMmDd, DUE_DATE_INPUT_FORMAT, true)
-  return parsed.isValid() ? String(parsed.valueOf()) : undefined
+  return parsed.isValid() ? parsed.toISOString() : undefined
 }
 
 /**
- * Inverse of {@link dueDateInputToEpochMs}: formats the backend's unix-millisecond `dueDate` string
- * back to the `YYYY-MM-DD` value a native date input expects, in UTC. Tolerates a legacy `YYYY-MM-DD`
- * value so tasks whose due date was written before the timestamp fix still display. Returns `''` when
- * the due date is absent.
+ * Inverse of {@link dueDateInputToIso}: formats the backend's ISO 8601 `dueDate` string back to the
+ * `YYYY-MM-DD` value a native date input expects, in UTC. Returns `''` when the due date is absent or
+ * unparseable.
  */
-export function epochMsToDueDateInput(dueDate: string | undefined): string {
+export function isoToDueDateInput(dueDate: string | undefined): string {
   if (!dueDate) {
     return ''
   }
-  if (dayjs.utc(dueDate, DUE_DATE_INPUT_FORMAT, true).isValid()) {
-    return dueDate
-  }
-  return dayjs.utc(Number(dueDate)).format(DUE_DATE_INPUT_FORMAT)
+  const parsed = dayjs.utc(dueDate)
+  return parsed.isValid() ? parsed.format(DUE_DATE_INPUT_FORMAT) : ''
 }
 
 /**
  * The `dueDate` as a UTC-anchored dayjs, or `null` when absent/unparseable. Anchoring to UTC (the same
- * as {@link epochMsToDueDateInput}) means the calendar date shown matches the date the user picked,
- * regardless of the viewer's timezone. Accepts both the backend's unix-millisecond string and a legacy
- * `YYYY-MM-DD` value.
+ * as {@link isoToDueDateInput}) means the calendar date shown matches the date the user picked,
+ * regardless of the viewer's timezone.
  */
 export function parseDueDate(dueDate: string | undefined): Dayjs | null {
-  const asInput = epochMsToDueDateInput(dueDate)
-  if (!asInput) {
+  if (!dueDate) {
     return null
   }
-  return dayjs.utc(asInput, DUE_DATE_INPUT_FORMAT, true)
+  const parsed = dayjs.utc(dueDate)
+  return parsed.isValid() ? parsed : null
 }

--- a/packages/synapse-react-client/src/mocks/curation/mockCurationTask.ts
+++ b/packages/synapse-react-client/src/mocks/curation/mockCurationTask.ts
@@ -7,6 +7,7 @@ import {
 export const MOCK_CURATION_TASK_ID = 123
 export const MOCK_CURATION_TASK_ASSIGNEE_PRINCIPAL_ID = '456'
 export const MOCK_CURATION_TASK_FILE_VIEW_ID = 'syn999'
+export const MOCK_CURATION_TASK_DESTINATION_TASK_ID = 789
 
 /**
  * Creates a mock TaskBundle suitable for use in tests. Defaults to a
@@ -25,6 +26,32 @@ export function createMockTaskBundle(
           'org.sagebionetworks.repo.model.curation.metadata.FileBasedMetadataTaskProperties',
         fileViewId: MOCK_CURATION_TASK_FILE_VIEW_ID,
         suggestedAuthorizationMode: 'SESSION_OWNER',
+      },
+      ...taskOverrides,
+    },
+    status: {
+      taskId: MOCK_CURATION_TASK_ID,
+      ...statusOverrides,
+    },
+  } as TaskBundle
+}
+
+/**
+ * Creates a mock TaskBundle for an executable (Compute Data) task. Defaults to a
+ * SampleSheetGenerationExecutionProperties task with a destination task set.
+ */
+export function createMockExecutableTaskBundle(
+  taskOverrides: Partial<CurationTask> = {},
+  statusOverrides: Partial<TaskStatus> = {},
+): TaskBundle {
+  return {
+    task: {
+      taskId: MOCK_CURATION_TASK_ID,
+      assigneePrincipalId: MOCK_CURATION_TASK_ASSIGNEE_PRINCIPAL_ID,
+      taskProperties: {
+        concreteType:
+          'org.sagebionetworks.repo.model.curation.execution.SampleSheetGenerationExecutionProperties',
+        destinationTaskId: MOCK_CURATION_TASK_DESTINATION_TASK_ID,
       },
       ...taskOverrides,
     },

--- a/packages/synapse-react-client/src/mocks/msw/handlers/curationTaskExecutionHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/curationTaskExecutionHandlers.ts
@@ -1,0 +1,58 @@
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from '@/utils/functions/getEndpoint'
+import {
+  AsynchronousJobStatus,
+  ComputeTaskExecutionResponse,
+  ComputeTaskExecutionResponseConcreteTypeEnum,
+} from '@sage-bionetworks/synapse-client'
+import { http, HttpResponse } from 'msw'
+
+const EXECUTE_ASYNC_TOKEN = 'mock-execute-async-token'
+
+/**
+ * Handlers for executing a curation task. The start endpoint takes no request body (only a taskId
+ * path param), so the generic {@link generateAsyncJobHandlers} generator cannot be used.
+ *
+ * @param taskId the taskId the execution response should report
+ * @param jobState the terminal state the polled job should report. Use 'FAILED' to exercise the
+ *   error path.
+ * @param errorMessage the error message returned when jobState is 'FAILED'
+ */
+export function getExecuteCurationTaskHandlers({
+  taskId = 123,
+  jobState = 'COMPLETE',
+  errorMessage = 'Execution failed',
+  backendOrigin = getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+}: {
+  taskId?: number
+  jobState?: 'COMPLETE' | 'FAILED'
+  errorMessage?: string
+  backendOrigin?: string
+} = {}) {
+  const response: ComputeTaskExecutionResponse = {
+    concreteType:
+      ComputeTaskExecutionResponseConcreteTypeEnum.org_sagebionetworks_repo_model_curation_ComputeTaskExecutionResponse,
+    taskId,
+  }
+
+  return [
+    http.post(
+      `${backendOrigin}/repo/v1/curation/task/:taskId/execute/async/start`,
+      () => HttpResponse.json({ token: EXECUTE_ASYNC_TOKEN }, { status: 201 }),
+    ),
+    http.get(
+      `${backendOrigin}/repo/v1/asynchronous/job/:jobId`,
+      ({ params }) => {
+        const jobStatus: AsynchronousJobStatus = {
+          jobState,
+          jobId: params.jobId as string,
+          responseBody: jobState === 'COMPLETE' ? response : undefined,
+          errorMessage: jobState === 'FAILED' ? errorMessage : undefined,
+        }
+        return HttpResponse.json(jobStatus, { status: 200 })
+      },
+    ),
+  ]
+}

--- a/packages/synapse-react-client/src/synapse-queries/curation/task/useCurationTask.ts
+++ b/packages/synapse-react-client/src/synapse-queries/curation/task/useCurationTask.ts
@@ -1,10 +1,12 @@
 import { useSynapseContext } from '@/utils/index'
 import {
+  ComputeTaskExecutionResponse,
   CurationTask,
   ListCurationTaskRequest,
   ListCurationTaskResponse,
   SynapseClientError,
   TaskStatus,
+  waitForAsyncResult,
 } from '@sage-bionetworks/synapse-client'
 import {
   InfiniteData,
@@ -141,6 +143,47 @@ export function useDeleteCurationTask(
       synapseClient.curationTaskServicesClient.deleteRepoV1CurationTaskTaskId({
         taskId,
       }),
+    onSuccess: (data, taskId, context) => {
+      queryClient.invalidateQueries({
+        queryKey: keyFactory.getCurationTaskIdKey(taskId),
+      })
+      queryClient.invalidateQueries({
+        queryKey: keyFactory.getAllCurationTaskListKey(),
+      })
+      if (options?.onSuccess) {
+        options.onSuccess(data, taskId, context)
+      }
+    },
+  })
+}
+
+/**
+ * Starts an executable curation task (e.g. sample sheet or record set generation) and awaits its
+ * completion. Polls the generic asynchronous job endpoint so that in-progress and failed states are
+ * surfaced. On success, invalidates the task's queries and the task list so the dashboard reflects
+ * the new status.
+ */
+export function useExecuteCurationTask(
+  options?: Partial<
+    UseMutationOptions<ComputeTaskExecutionResponse, SynapseClientError, number>
+  >,
+) {
+  const { synapseClient, keyFactory } = useSynapseContext()
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...options,
+    mutationFn: async (taskId: number) => {
+      const asyncJobId =
+        await synapseClient.curationTaskServicesClient.postRepoV1CurationTaskTaskIdExecuteAsyncStart(
+          { taskId },
+        )
+      const asyncJobResponse = await waitForAsyncResult(() =>
+        synapseClient.asynchronousJobServicesClient.getRepoV1AsynchronousJobJobId(
+          { jobId: asyncJobId.token! },
+        ),
+      )
+      return asyncJobResponse.responseBody as ComputeTaskExecutionResponse
+    },
     onSuccess: (data, taskId, context) => {
       queryClient.invalidateQueries({
         queryKey: keyFactory.getCurationTaskIdKey(taskId),

--- a/packages/synapse-react-client/src/synapse-queries/curation/task/useExecuteCurationTask.test.ts
+++ b/packages/synapse-react-client/src/synapse-queries/curation/task/useExecuteCurationTask.test.ts
@@ -1,0 +1,48 @@
+import { server } from '@/mocks/msw/server'
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { ComputeTaskExecutionResponseConcreteTypeEnum } from '@sage-bionetworks/synapse-client'
+import { renderHook, waitFor } from '@testing-library/react'
+import { MOCK_CURATION_TASK_ID } from '@/mocks/curation/mockCurationTask'
+import { getExecuteCurationTaskHandlers } from '@/mocks/msw/handlers/curationTaskExecutionHandlers'
+import { useExecuteCurationTask } from './useCurationTask'
+
+describe('useExecuteCurationTask', () => {
+  beforeAll(() => server.listen())
+  afterAll(() => server.close())
+
+  it('starts the execution, polls to completion, and resolves with the response', async () => {
+    server.use(
+      ...getExecuteCurationTaskHandlers({ taskId: MOCK_CURATION_TASK_ID }),
+    )
+
+    const { result } = renderHook(() => useExecuteCurationTask(), {
+      wrapper: createWrapper({ accessToken: 'fake-token' }),
+    })
+
+    result.current.mutate(MOCK_CURATION_TASK_ID)
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual({
+      concreteType:
+        ComputeTaskExecutionResponseConcreteTypeEnum.org_sagebionetworks_repo_model_curation_ComputeTaskExecutionResponse,
+      taskId: MOCK_CURATION_TASK_ID,
+    })
+  })
+
+  it('surfaces an error when the job fails', async () => {
+    server.use(
+      ...getExecuteCurationTaskHandlers({
+        taskId: MOCK_CURATION_TASK_ID,
+        jobState: 'FAILED',
+      }),
+    )
+
+    const { result } = renderHook(() => useExecuteCurationTask(), {
+      wrapper: createWrapper({ accessToken: 'fake-token' }),
+    })
+
+    result.current.mutate(MOCK_CURATION_TASK_ID)
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})


### PR DESCRIPTION
Split CurationTaskCard into a dispatcher that routes to a new ExecutableTaskCard (SampleSheet/RecordSet generation) or the existing grid card. Executable cards can Start (Run Agent) via an async execute job, show a server-derived Running state, and navigate to the destination task's result by updating the taskIds URL filter. Adds useExecuteCurationTask, a NextStepButton tooltip, MSW handlers, tests, and a Storybook story.