### PR TITLE
PORTALS-4397

### DIFF
--- a/apps/synapse-portal-framework/src/components/PortalSearch/PortalSearchPage.tsx
+++ b/apps/synapse-portal-framework/src/components/PortalSearch/PortalSearchPage.tsx
@@ -28,6 +28,13 @@ function getQueryCount(queryResultBundleJSON: string) {
   return queryCount
 }
 
+function getMaxScore(queryResultBundleJSON: string): number | undefined {
+  const bundle = JSON.parse(queryResultBundleJSON) as QueryResultBundle & {
+    maxScore?: number
+  }
+  return bundle.maxScore
+}
+
 export function PortalSearchPage(props: PortalSearchPageProps) {
   const {
     selectedTabIndex,
@@ -51,8 +58,17 @@ export function PortalSearchPage(props: PortalSearchPageProps) {
       selectedTabIndex?: number,
     ) => {
       const newCount = getQueryCount(newQueryResultBundleJSON)
+      const newScore = getMaxScore(newQueryResultBundleJSON)
+      let didChange = false
       if (searchPageTabsState[tabIndex].count !== newCount) {
         searchPageTabsState[tabIndex].count = newCount
+        didChange = true
+      }
+      if (searchPageTabsState[tabIndex].score !== newScore) {
+        searchPageTabsState[tabIndex].score = newScore
+        didChange = true
+      }
+      if (didChange) {
         setSearchPageTabsState([...searchPageTabsState])
       }
       // PORTALS-3382: If no tab is selected and all counts have been set, then redirect to the item with the highest count
@@ -69,14 +85,17 @@ export function PortalSearchPage(props: PortalSearchPageProps) {
             search: location.search,
           })
         } else {
-          // Navigate to the tab that has the highest count.
-          // Explicitly initialize the accumulator ("max") to the first element (searchPageTabs[0]). "max" will never be null
-          const maxCountTab = searchPageTabs.reduce(
-            (max, tab) => (tab.count! > max.count! ? tab : max),
-            searchPageTabs[0],
-          )
+          // Navigate to the tab with the highest relevance score.
+          // Fall back to the first tab if no tab has a score (e.g. no results or search not yet performed).
+          const maxScoreTab = searchPageTabs.reduce<
+            PortalSearchTabConfig | undefined
+          >((best, tab) => {
+            if (tab.score === undefined) return best
+            if (best === undefined || best.score === undefined) return tab
+            return tab.score > best.score ? tab : best
+          }, undefined)
           navigate({
-            pathname: `/Search/${maxCountTab.path}`,
+            pathname: `/Search/${(maxScoreTab ?? searchPageTabs[0]).path}`,
             search: location.search,
           })
         }

--- a/apps/synapse-portal-framework/src/components/PortalSearch/PortalSearchTabs.tsx
+++ b/apps/synapse-portal-framework/src/components/PortalSearch/PortalSearchTabs.tsx
@@ -5,6 +5,7 @@ export type PortalSearchTabConfig = {
   path: string
   title: string
   count?: number
+  score?: number
 }
 
 export type PortalSearchTabUIProps = {

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -585,13 +585,15 @@ export function searchQueryResultsToQueryResultBundle(
       ]
     : allFacets
 
+  const maxScore = results.hits?.[0]?.score
   return {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
     queryCount: results.totalHits,
     selectColumns: headers,
     queryResult,
     facets: orderedFacets,
-  }
+    ...(maxScore !== undefined && { maxScore }),
+  } as QueryResultBundle
 }
 
 export function getSearchQueryUseQueryOptions(
@@ -624,11 +626,18 @@ export function getSearchQueryUseQueryOptions(
   }
   const metadataQuery: SearchIndexQuery = {
     ...baseQuery,
+    searchQuery: {
+      ...baseQuery.searchQuery,
+      // Fetch only 1 hit: we need just the top hit's score for tab auto-selection.
+      // Aggregation counts are independent of size.
+      size: 1,
+    },
     // Request all opt-in parts needed for the metadata response:
+    // HITS → exposes the top hit's relevance score for tab auto-selection
     // TOTAL_HITS → queryCount (drives tab count / spinner resolution)
     // SELECT_COLUMNS → column headers for the table
     // Aggregation results are returned automatically when aggregations is set on the query.
-    responseParts: new Set(['TOTAL_HITS', 'SELECT_COLUMNS'] as const),
+    responseParts: new Set(['HITS', 'TOTAL_HITS', 'SELECT_COLUMNS'] as const),
   }
 
   // Convert responseParts Set → sorted array for query key building.


### PR DESCRIPTION
## Score-based tab auto-selection for Portal Search

### Problem
The portal search page previously auto-navigated to the tab with the **highest result count**.
This doesn't reflect relevance — a tab with many low-quality matches could win over a tab with
fewer but highly relevant results.

### Solution
Auto-navigate to the tab whose **top search hit has the highest relevance score** instead.
Fall back to the first tab when no tab has a score.

### Changes

#### `SearchQueryUseQueryOptions.ts`
- **`searchQueryResultsToQueryResultBundle`**: includes `maxScore` (the relevance score of the
  first/top-ranked hit) as a non-standard field in the returned `QueryResultBundle` object.
- **`metadataQuery`** (inside `getSearchQueryUseQueryOptions`): now requests `HITS` with
  `size: 1` so the top hit's score is available in the metadata response. Previously `HITS` was
  omitted, making the score unreachable. Fetching only 1 hit keeps the overhead minimal; facet
  aggregation counts and `totalHits` are unaffected by `size`.

#### `PortalSearchTabs.tsx`
- Adds `score?: number` to `PortalSearchTabConfig` — tracked alongside the existing `count`.

#### `PortalSearchPage.tsx`
- Adds a `getMaxScore` helper that reads the `maxScore` field from the serialized bundle JSON.
- `onQueryResultBundleChange` now mutates and tracks `score` per tab in addition to `count`,
  using the same pattern already used for counts.
- The auto-navigation `reduce` now finds the tab with the **highest `score`** rather than the
  highest `count`. If no tab has a score, `maxScoreTab` is `undefined` and `searchPageTabs[0]`
  is used as the fallback. The existing `roleMapping` override is preserved.