### PR TITLE
SWC-7905

### DIFF
--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/ComputeTaskForm.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/ComputeTaskForm.test.tsx
@@ -167,7 +167,7 @@ describe('ComputeTaskForm', () => {
       ).toHaveTextContent(/sample sheet generation/i)
     })
 
-    it('shows Sample Sheet fields by default, and switches to Record Set fields when the type is changed', async () => {
+    it('shows Sample Sheet fields by default, and switches to Record Set fields when the type is changed, resetting the value when switched back', async () => {
       const user = userEvent.setup()
       render(<ComputeTaskForm projectId="syn123" />)
 
@@ -175,6 +175,8 @@ describe('ComputeTaskForm', () => {
       expect(
         screen.queryByLabelText(/agent instructions/i),
       ).not.toBeInTheDocument()
+
+      await user.type(screen.getByLabelText(/input task id/i), '1')
 
       await user.click(
         screen.getByRole('combobox', { name: /compute task type/i }),
@@ -190,6 +192,18 @@ describe('ComputeTaskForm', () => {
 
       expect(screen.queryByLabelText(/input task id/i)).not.toBeInTheDocument()
       expect(screen.getByLabelText(/agent instructions/i)).toBeInTheDocument()
+
+      // Switching back to Sample Sheet Generation resets its value rather than retaining what was
+      // previously entered -- the form only owns one active concrete-type value at a time.
+      await user.click(
+        screen.getByRole('combobox', { name: /compute task type/i }),
+      )
+      await user.click(
+        await screen.findByRole('option', {
+          name: COMPUTE_TASK_TYPE_CONFIG[SAMPLE_SHEET_TYPE].label,
+        }),
+      )
+      expect(screen.getByLabelText(/input task id/i)).toHaveValue('')
     })
 
     it('shows the project selector only when no projectId is supplied', () => {
@@ -252,10 +266,15 @@ describe('ComputeTaskForm', () => {
       expect(screen.getByRole('button', { name: /create/i })).toBeEnabled()
     })
 
-    it('does not touch task status when created without a due date', async () => {
+    it('sets executionDetails on the auto-created status even without a due date, since a Compute task always needs it to route execution', async () => {
       mockCreateMutateAsync.mockResolvedValue({
         taskId: MOCK_CURATION_TASK_ID,
       } as CurationTask)
+      mockGetStatus.mockResolvedValue({
+        taskId: MOCK_CURATION_TASK_ID,
+        state: 'NOT_STARTED',
+        etag: 'status-etag',
+      })
       const user = userEvent.setup()
       render(<ComputeTaskForm projectId="syn123" />)
 
@@ -267,7 +286,15 @@ describe('ComputeTaskForm', () => {
       await user.click(screen.getByRole('button', { name: /create/i }))
 
       expect(mockCreateMutateAsync).toHaveBeenCalled()
-      expect(mockUpdateStatusMutateAsync).not.toHaveBeenCalled()
+      expect(mockUpdateStatusMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dueDate: undefined,
+          executionDetails: {
+            concreteType:
+              'org.sagebionetworks.repo.model.curation.execution.SampleSheetGenerationExecutionDetails',
+          },
+        }),
+      )
     })
 
     it('keeps Create disabled when a task ID field is not a positive integer', async () => {
@@ -312,7 +339,7 @@ describe('ComputeTaskForm', () => {
       )
     })
 
-    it('applies the due date to the auto-created status as a UTC ISO 8601 timestamp', async () => {
+    it('applies the due date to the auto-created status as a UTC ISO 8601 timestamp, alongside executionDetails', async () => {
       mockCreateMutateAsync.mockResolvedValue({
         taskId: MOCK_CURATION_TASK_ID,
       } as CurationTask)
@@ -334,6 +361,49 @@ describe('ComputeTaskForm', () => {
         expect.objectContaining({
           taskId: MOCK_CURATION_TASK_ID,
           dueDate: DUE_DATE_ISO,
+          executionDetails: {
+            concreteType:
+              'org.sagebionetworks.repo.model.curation.execution.SampleSheetGenerationExecutionDetails',
+          },
+        }),
+      )
+    })
+
+    it('sets a RecordSetGenerationExecutionDetails executionDetails when creating a Record Set Generation task', async () => {
+      mockCreateMutateAsync.mockResolvedValue({
+        taskId: MOCK_CURATION_TASK_ID,
+      } as CurationTask)
+      mockGetStatus.mockResolvedValue({
+        taskId: MOCK_CURATION_TASK_ID,
+        state: 'NOT_STARTED',
+        etag: 'status-etag',
+      })
+      const user = userEvent.setup()
+      render(<ComputeTaskForm projectId="syn123" />)
+
+      await user.click(
+        screen.getByRole('combobox', { name: /compute task type/i }),
+      )
+      await user.click(
+        await screen.findByRole('option', {
+          name: COMPUTE_TASK_TYPE_CONFIG[RECORD_SET_TYPE].label,
+        }),
+      )
+
+      await user.type(screen.getByLabelText(/task name/i), 'My Task')
+      await user.type(screen.getByLabelText(/^instructions/i), 'Do it')
+      await user.click(screen.getByTestId('user-search-box'))
+      await user.type(screen.getByLabelText(/source folder/i), 'syn999')
+      await user.type(screen.getByLabelText(/agent instructions/i), 'Do it')
+      await user.type(screen.getByLabelText(/destination task id/i), '2')
+      await user.click(screen.getByRole('button', { name: /create/i }))
+
+      expect(mockUpdateStatusMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          executionDetails: {
+            concreteType:
+              'org.sagebionetworks.repo.model.curation.execution.RecordSetGenerationExecutionDetails',
+          },
         }),
       )
     })
@@ -414,6 +484,24 @@ describe('ComputeTaskForm', () => {
       render(<ComputeTaskForm task={editTask} />)
       expect(
         screen.getByRole('combobox', { name: /compute task type/i }),
+      ).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('disables the EXECUTING and CANCELED status options, since a user must not be able to manually select into either', async () => {
+      mockUseGetCurationTaskStatus.mockReturnValue({
+        data: { taskId: editTask.taskId, state: 'NOT_STARTED' },
+        isFetching: false,
+      } as any)
+      const user = userEvent.setup()
+      render(<ComputeTaskForm task={editTask} />)
+
+      await user.click(screen.getByRole('combobox', { name: /^status$/i }))
+
+      expect(
+        await screen.findByRole('option', { name: /^executing$/i }),
+      ).toHaveAttribute('aria-disabled', 'true')
+      expect(
+        screen.getByRole('option', { name: /^canceled$/i }),
       ).toHaveAttribute('aria-disabled', 'true')
     })
 

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/ComputeTaskForm.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/ComputeTaskForm.tsx
@@ -2,48 +2,28 @@ import { StyledFormControl } from '@/components/styled'
 import { Alert, InputLabel, MenuItem, Select, Stack } from '@mui/material'
 import {
   CurationTask,
-  TaskStatusStateEnum,
+  SampleSheetGenerationExecutionPropertiesConcreteTypeEnum,
 } from '@sage-bionetworks/synapse-client'
 import noop from 'lodash-es/noop'
-import { useState } from 'react'
 import {
+  COMPUTE_TASK_DISABLED_STATUS_STATES,
+  COMPUTE_TASK_EXECUTION_DETAILS,
   COMPUTE_TASK_TYPE_CONFIG,
   COMPUTE_TASK_TYPE_INPUT_LABEL,
   COMPUTE_TASK_TYPE_OPTIONS,
-  DEFAULT_COMPUTE_TASK_TYPE,
   EDIT_TASK_UNRECOGNIZED_TYPE_MESSAGE,
   GENERIC_SAVE_ERROR_MESSAGE,
-  TASK_STATUS_CONFIG,
-  TASK_STATUS_INPUT_LABEL,
 } from '../utils/constants'
-import {
-  ComputeTaskConcreteType,
-  getComputeTaskConcreteType,
-  instanceOfGridSupportedTaskProperties,
-} from '../utils/types'
 import CommonTaskFields from './CommonTaskFields'
 import ProjectSelectorField from './ProjectSelectorField'
 import RecordSetFields from './RecordSetFields'
 import SampleSheetFields from './SampleSheetFields'
 import TaskFormActions from './TaskFormActions'
 import TaskFormHeader from './TaskFormHeader'
+import TaskStatusField from './TaskStatusField'
+import { useComputeTypeFields } from './useComputeTypeFields'
 import { useCurationTaskFormState } from './useCurationTaskFormState'
-import {
-  buildComputeTaskPayload,
-  RecordSetFieldsValue,
-  SampleSheetFieldsValue,
-} from './utils/buildComputeTaskPayload'
-import { isValidTaskIdInput } from './utils/taskIdValidation'
-
-const EMPTY_SAMPLE_SHEET_VALUE: SampleSheetFieldsValue = {
-  inputTaskId: '',
-  destinationTaskId: '',
-}
-const EMPTY_RECORD_SET_VALUE: RecordSetFieldsValue = {
-  folderId: '',
-  instructions: '',
-  destinationTaskId: '',
-}
+import { buildComputeTaskPayload } from './utils/buildComputeTaskPayload'
 
 export type ComputeTaskFormProps = {
   /**
@@ -101,59 +81,13 @@ export default function ComputeTaskForm(props: ComputeTaskFormProps) {
   const form = useCurationTaskFormState({ projectId, task, onDeleted })
   const { isEditMode } = form
 
-  const existingComputeConcreteType = getComputeTaskConcreteType(
-    task?.taskProperties,
-  )
+  const typeFields = useComputeTypeFields({
+    taskProperties: task?.taskProperties,
+    isEditMode,
+  })
 
-  // Whether the type-specific fields (and type selector) should render at all. False when editing a task
-  // whose category isn't one of the two Compute Data types (e.g. a legacy Curate Data task).
-  const showTypeSection =
-    !isEditMode || existingComputeConcreteType !== undefined
-  const showUnrecognizedTypeWarning =
-    isEditMode &&
-    existingComputeConcreteType === undefined &&
-    !instanceOfGridSupportedTaskProperties(task?.taskProperties)
-
-  const [selectedConcreteType, setSelectedConcreteType] =
-    useState<ComputeTaskConcreteType>(
-      () => existingComputeConcreteType ?? DEFAULT_COMPUTE_TASK_TYPE,
-    )
-
-  const [sampleSheetValue, setSampleSheetValue] =
-    useState<SampleSheetFieldsValue>(() => {
-      const tp = task?.taskProperties
-      if (tp?.concreteType === COMPUTE_TASK_TYPE_OPTIONS[0]) {
-        return {
-          inputTaskId: tp.inputTaskId?.toString() ?? '',
-          destinationTaskId: tp.destinationTaskId?.toString() ?? '',
-        }
-      }
-      return EMPTY_SAMPLE_SHEET_VALUE
-    })
-  const [recordSetValue, setRecordSetValue] = useState<RecordSetFieldsValue>(
-    () => {
-      const tp = task?.taskProperties
-      if (tp?.concreteType === COMPUTE_TASK_TYPE_OPTIONS[1]) {
-        return {
-          folderId: tp.folderId ?? '',
-          instructions: tp.instructions ?? '',
-          destinationTaskId: tp.destinationTaskId?.toString() ?? '',
-        }
-      }
-      return EMPTY_RECORD_SET_VALUE
-    },
-  )
-
-  const isTypeSpecificValid =
-    !showTypeSection ||
-    (selectedConcreteType === COMPUTE_TASK_TYPE_OPTIONS[0]
-      ? isValidTaskIdInput(sampleSheetValue.inputTaskId) &&
-        isValidTaskIdInput(sampleSheetValue.destinationTaskId)
-      : !!recordSetValue.folderId.trim() &&
-        !!recordSetValue.instructions.trim() &&
-        isValidTaskIdInput(recordSetValue.destinationTaskId))
   const isValid =
-    form.isCommonFieldsValid && form.isProjectValid && isTypeSpecificValid
+    form.isCommonFieldsValid && form.isProjectValid && typeFields.isValid
 
   async function handleSubmit() {
     const payload = buildComputeTaskPayload({
@@ -162,16 +96,15 @@ export default function ComputeTaskForm(props: ComputeTaskFormProps) {
       dataType: form.dataType,
       instructions: form.instructions,
       assigneePrincipalId: form.assigneePrincipalId,
-      computeTypeFields: showTypeSection
-        ? {
-            concreteType: selectedConcreteType,
-            sampleSheet: sampleSheetValue,
-            recordSet: recordSetValue,
-          }
+      computeTypeFields: typeFields.showTypeSection
+        ? typeFields.state
         : undefined,
     })
 
-    const result = await form.submitTaskAndStatus(payload)
+    const result = await form.submitTaskAndStatus(payload, {
+      initialExecutionDetails:
+        COMPUTE_TASK_EXECUTION_DETAILS[typeFields.state.concreteType],
+    })
     if (isEditMode) {
       onSaved?.(result)
     } else {
@@ -188,7 +121,7 @@ export default function ComputeTaskForm(props: ComputeTaskFormProps) {
       />
 
       <Stack gap={3} sx={{ width: '100%', maxWidth: 700, mx: 'auto' }}>
-        {showTypeSection && (
+        {typeFields.showTypeSection && (
           <StyledFormControl fullWidth>
             <InputLabel id="compute-task-type-label">
               {COMPUTE_TASK_TYPE_INPUT_LABEL}
@@ -196,9 +129,9 @@ export default function ComputeTaskForm(props: ComputeTaskFormProps) {
             <Select
               labelId="compute-task-type-label"
               label={COMPUTE_TASK_TYPE_INPUT_LABEL}
-              value={selectedConcreteType}
+              value={typeFields.state.concreteType}
               disabled={isEditMode}
-              onChange={e => setSelectedConcreteType(e.target.value)}
+              onChange={e => typeFields.setConcreteType(e.target.value)}
             >
               {COMPUTE_TASK_TYPE_OPTIONS.map(concreteType => (
                 <MenuItem key={concreteType} value={concreteType}>
@@ -228,44 +161,30 @@ export default function ComputeTaskForm(props: ComputeTaskFormProps) {
         />
 
         {isEditMode && (
-          <StyledFormControl fullWidth>
-            <InputLabel id="compute-task-status-label">
-              {TASK_STATUS_INPUT_LABEL}
-            </InputLabel>
-            <Select
-              labelId="compute-task-status-label"
-              value={form.displayedStatusState ?? ''}
-              label={TASK_STATUS_INPUT_LABEL}
-              disabled={form.isStatusFetching || form.currentTaskStatus == null}
-              onChange={e =>
-                form.setPendingStatusState(
-                  e.target.value as TaskStatusStateEnum,
-                )
-              }
-            >
-              {Object.values(TaskStatusStateEnum).map(state => (
-                <MenuItem key={state} value={state}>
-                  {TASK_STATUS_CONFIG[state].label}
-                </MenuItem>
-              ))}
-            </Select>
-          </StyledFormControl>
+          <TaskStatusField
+            labelId="compute-task-status-label"
+            value={form.displayedStatusState}
+            onChange={form.setPendingStatusState}
+            disabled={form.isStatusFetching || form.currentTaskStatus == null}
+            disabledStates={COMPUTE_TASK_DISABLED_STATUS_STATES}
+          />
         )}
 
-        {showTypeSection &&
-          (selectedConcreteType === COMPUTE_TASK_TYPE_OPTIONS[0] ? (
+        {typeFields.showTypeSection &&
+          (typeFields.state.concreteType ===
+          SampleSheetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_SampleSheetGenerationExecutionProperties ? (
             <SampleSheetFields
-              value={sampleSheetValue}
-              onChange={setSampleSheetValue}
+              value={typeFields.state.value}
+              onChange={typeFields.setValue}
             />
           ) : (
             <RecordSetFields
-              value={recordSetValue}
-              onChange={setRecordSetValue}
+              value={typeFields.state.value}
+              onChange={typeFields.setValue}
             />
           ))}
 
-        {showUnrecognizedTypeWarning && (
+        {typeFields.showUnrecognizedTypeWarning && (
           <Alert severity="warning">
             {EDIT_TASK_UNRECOGNIZED_TYPE_MESSAGE}
           </Alert>

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/CurateTaskForm.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/CurateTaskForm.test.tsx
@@ -164,12 +164,14 @@ describe('CurateTaskForm', () => {
       ).toHaveTextContent(/file-based data/i)
     })
 
-    it('shows File-Based fields by default, and switches to Records-Based fields when the type is changed', async () => {
+    it('shows File-Based fields by default, and switches to Records-Based fields when the type is changed, resetting the value when switched back', async () => {
       const user = userEvent.setup()
       render(<CurateTaskForm projectId="syn123" />)
 
       expect(screen.getByLabelText(/upload folder id/i)).toBeInTheDocument()
       expect(screen.queryByLabelText(/record set id/i)).not.toBeInTheDocument()
+
+      await user.type(screen.getByLabelText(/upload folder id/i), 'syn1')
 
       await user.click(
         screen.getByRole('combobox', { name: /curate task type/i }),
@@ -182,6 +184,16 @@ describe('CurateTaskForm', () => {
         screen.queryByLabelText(/upload folder id/i),
       ).not.toBeInTheDocument()
       expect(screen.getByLabelText(/record set id/i)).toBeInTheDocument()
+
+      // Switching back to File-Based Data resets its value rather than retaining what was previously
+      // entered -- the form only owns one active concrete-type value at a time.
+      await user.click(
+        screen.getByRole('combobox', { name: /curate task type/i }),
+      )
+      await user.click(
+        await screen.findByRole('option', { name: /file-based data/i }),
+      )
+      expect(screen.getByLabelText(/upload folder id/i)).toHaveValue('')
     })
 
     it('shows the project selector only when no projectId is supplied', () => {
@@ -395,6 +407,24 @@ describe('CurateTaskForm', () => {
       expect(
         screen.getByRole('combobox', { name: /curate task type/i }),
       ).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('disables the EXECUTING status option, but leaves CANCELED selectable', async () => {
+      mockUseGetCurationTaskStatus.mockReturnValue({
+        data: { taskId: editTask.taskId, state: 'NOT_STARTED' },
+        isFetching: false,
+      } as any)
+      const user = userEvent.setup()
+      render(<CurateTaskForm task={editTask} />)
+
+      await user.click(screen.getByRole('combobox', { name: /^status$/i }))
+
+      expect(
+        await screen.findByRole('option', { name: /^executing$/i }),
+      ).toHaveAttribute('aria-disabled', 'true')
+      expect(
+        screen.getByRole('option', { name: /^canceled$/i }),
+      ).not.toHaveAttribute('aria-disabled', 'true')
     })
 
     it('shows a Delete button when the user has permission, and deletes on confirmation', async () => {

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/CurateTaskForm.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/CurateTaskForm.tsx
@@ -14,57 +14,33 @@ import {
 import {
   CurationTask,
   FileBasedMetadataTaskPropertiesConcreteTypeEnum,
-  TaskStatusStateEnum,
 } from '@sage-bionetworks/synapse-client'
 import noop from 'lodash-es/noop'
-import { useState } from 'react'
 import {
   AUTH_MODE_CHANGED_WARNING,
   AUTH_MODE_CONFIG,
   AUTH_MODE_INPUT_DESCRIPTION,
   AUTH_MODE_INPUT_LABEL,
   AUTH_MODE_OPTIONS,
+  CURATE_TASK_DISABLED_STATUS_STATES,
   CURATE_TASK_TYPE_CONFIG,
   CURATE_TASK_TYPE_INPUT_LABEL,
   CURATE_TASK_TYPE_OPTIONS,
-  DEFAULT_CURATE_TASK_TYPE,
   GENERIC_SAVE_ERROR_MESSAGE,
-  TASK_STATUS_CONFIG,
-  TASK_STATUS_INPUT_LABEL,
 } from '../utils/constants'
-import {
-  CurateTaskConcreteType,
-  getCurateTaskConcreteType,
-  instanceOfGridSupportedTaskProperties,
-} from '../utils/types'
 import CommonTaskFields from './CommonTaskFields'
 import FileBasedFields from './FileBasedFields'
 import ProjectSelectorField from './ProjectSelectorField'
 import RecordBasedFields from './RecordBasedFields'
 import TaskFormActions from './TaskFormActions'
 import TaskFormHeader from './TaskFormHeader'
+import TaskStatusField from './TaskStatusField'
+import { useCurateTypeFields } from './useCurateTypeFields'
 import { useCurationTaskFormState } from './useCurationTaskFormState'
 import {
   AuthorizationModeOption,
   buildCurateTaskPayload,
-  FileBasedFieldsValue,
-  RecordBasedFieldsValue,
 } from './utils/buildCurateTaskPayload'
-
-const EMPTY_FILE_BASED_VALUE: FileBasedFieldsValue = {
-  uploadFolderId: '',
-  fileViewId: '',
-}
-const EMPTY_RECORD_BASED_VALUE: RecordBasedFieldsValue = {
-  recordSetId: '',
-}
-
-function toAuthorizationModeOption(
-  value: string | undefined,
-): AuthorizationModeOption {
-  if (value === 'SESSION_OWNER' || value === 'SOURCE_BENEFACTOR') return value
-  return 'NONE'
-}
 
 export type CurateTaskFormProps = {
   /**
@@ -122,55 +98,13 @@ export default function CurateTaskForm(props: CurateTaskFormProps) {
   const form = useCurationTaskFormState({ projectId, task, onDeleted })
   const { isEditMode } = form
 
-  const existingCurateConcreteType = getCurateTaskConcreteType(
-    task?.taskProperties,
-  )
+  const typeFields = useCurateTypeFields({
+    taskProperties: task?.taskProperties,
+    isEditMode,
+  })
 
-  const [selectedConcreteType, setSelectedConcreteType] =
-    useState<CurateTaskConcreteType>(
-      () => existingCurateConcreteType ?? DEFAULT_CURATE_TASK_TYPE,
-    )
-
-  const [fileBasedValue, setFileBasedValue] = useState<FileBasedFieldsValue>(
-    () => {
-      const tp = task?.taskProperties
-      if (tp?.concreteType === CURATE_TASK_TYPE_OPTIONS[0]) {
-        return {
-          uploadFolderId: tp.uploadFolderId ?? '',
-          fileViewId: tp.fileViewId ?? '',
-        }
-      }
-      return EMPTY_FILE_BASED_VALUE
-    },
-  )
-  const [recordBasedValue, setRecordBasedValue] =
-    useState<RecordBasedFieldsValue>(() => {
-      const tp = task?.taskProperties
-      if (tp?.concreteType === CURATE_TASK_TYPE_OPTIONS[1]) {
-        return { recordSetId: tp.recordSetId ?? '' }
-      }
-      return EMPTY_RECORD_BASED_VALUE
-    })
-
-  const initialAuthorizationMode = toAuthorizationModeOption(
-    instanceOfGridSupportedTaskProperties(task?.taskProperties)
-      ? task.taskProperties.suggestedAuthorizationMode
-      : undefined,
-  )
-  const [authorizationMode, setAuthorizationMode] = useState(
-    initialAuthorizationMode,
-  )
-
-  const isTypeSpecificValid =
-    selectedConcreteType === CURATE_TASK_TYPE_OPTIONS[0]
-      ? !!fileBasedValue.uploadFolderId.trim() &&
-        !!fileBasedValue.fileViewId.trim()
-      : !!recordBasedValue.recordSetId.trim()
   const isValid =
-    form.isCommonFieldsValid && form.isProjectValid && isTypeSpecificValid
-
-  const authModeChanged =
-    isEditMode && authorizationMode !== initialAuthorizationMode
+    form.isCommonFieldsValid && form.isProjectValid && typeFields.isValid
 
   async function handleSubmit() {
     const payload = buildCurateTaskPayload({
@@ -180,10 +114,8 @@ export default function CurateTaskForm(props: CurateTaskFormProps) {
       instructions: form.instructions,
       assigneePrincipalId: form.assigneePrincipalId,
       curateTypeFields: {
-        concreteType: selectedConcreteType,
-        authorizationMode,
-        fileBased: fileBasedValue,
-        recordBased: recordBasedValue,
+        ...typeFields.state,
+        authorizationMode: typeFields.authorizationMode,
       },
     })
 
@@ -211,9 +143,9 @@ export default function CurateTaskForm(props: CurateTaskFormProps) {
           <Select
             labelId="curate-task-type-label"
             label={CURATE_TASK_TYPE_INPUT_LABEL}
-            value={selectedConcreteType}
+            value={typeFields.state.concreteType}
             disabled={isEditMode}
-            onChange={e => setSelectedConcreteType(e.target.value)}
+            onChange={e => typeFields.setConcreteType(e.target.value)}
           >
             {CURATE_TASK_TYPE_OPTIONS.map(concreteType => (
               <MenuItem key={concreteType} value={concreteType}>
@@ -242,41 +174,26 @@ export default function CurateTaskForm(props: CurateTaskFormProps) {
         />
 
         {isEditMode && (
-          <StyledFormControl fullWidth>
-            <InputLabel id="curate-task-status-label">
-              {TASK_STATUS_INPUT_LABEL}
-            </InputLabel>
-            <Select
-              labelId="curate-task-status-label"
-              value={form.displayedStatusState ?? ''}
-              label={TASK_STATUS_INPUT_LABEL}
-              disabled={form.isStatusFetching || form.currentTaskStatus == null}
-              onChange={e =>
-                form.setPendingStatusState(
-                  e.target.value as TaskStatusStateEnum,
-                )
-              }
-            >
-              {Object.values(TaskStatusStateEnum).map(state => (
-                <MenuItem key={state} value={state}>
-                  {TASK_STATUS_CONFIG[state].label}
-                </MenuItem>
-              ))}
-            </Select>
-          </StyledFormControl>
+          <TaskStatusField
+            labelId="curate-task-status-label"
+            value={form.displayedStatusState}
+            onChange={form.setPendingStatusState}
+            disabled={form.isStatusFetching || form.currentTaskStatus == null}
+            disabledStates={CURATE_TASK_DISABLED_STATUS_STATES}
+          />
         )}
 
-        {selectedConcreteType ===
+        {typeFields.state.concreteType ===
         FileBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_FileBasedMetadataTaskProperties ? (
           <FileBasedFields
-            value={fileBasedValue}
-            onChange={setFileBasedValue}
+            value={typeFields.state.value}
+            onChange={typeFields.setValue}
             disabled={isEditMode}
           />
         ) : (
           <RecordBasedFields
-            value={recordBasedValue}
-            onChange={setRecordBasedValue}
+            value={typeFields.state.value}
+            onChange={typeFields.setValue}
             disabled={isEditMode}
           />
         )}
@@ -289,9 +206,11 @@ export default function CurateTaskForm(props: CurateTaskFormProps) {
           <Select
             labelId="curate-task-auth-mode-label"
             label={AUTH_MODE_INPUT_LABEL}
-            value={authorizationMode}
+            value={typeFields.authorizationMode}
             onChange={e =>
-              setAuthorizationMode(e.target.value as AuthorizationModeOption)
+              typeFields.setAuthorizationMode(
+                e.target.value as AuthorizationModeOption,
+              )
             }
           >
             {AUTH_MODE_OPTIONS.map(mode => (
@@ -309,7 +228,7 @@ export default function CurateTaskForm(props: CurateTaskFormProps) {
           </Select>
         </StyledFormControl>
 
-        {authModeChanged && (
+        {typeFields.authModeChanged && (
           <Alert severity="warning">{AUTH_MODE_CHANGED_WARNING}</Alert>
         )}
         {form.error && (

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/FileBasedFields.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/FileBasedFields.tsx
@@ -11,7 +11,22 @@ import {
   UPLOAD_FOLDER_FINDER_PROMPT,
   UPLOAD_FOLDER_FINDER_TITLE,
 } from '../utils/constants'
-import { FileBasedFieldsValue } from './utils/buildCurateTaskPayload'
+
+export type FileBasedFieldsValue = {
+  uploadFolderId: string
+  fileViewId: string
+}
+
+export const EMPTY_FILE_BASED_VALUE: FileBasedFieldsValue = {
+  uploadFolderId: '',
+  fileViewId: '',
+}
+
+export function isFileBasedFieldsValueValid(
+  value: FileBasedFieldsValue,
+): boolean {
+  return !!value.uploadFolderId.trim() && !!value.fileViewId.trim()
+}
 
 export type FileBasedFieldsProps = {
   value: FileBasedFieldsValue

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/RecordBasedFields.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/RecordBasedFields.tsx
@@ -7,7 +7,20 @@ import {
   RECORD_SET_FINDER_PROMPT,
   RECORD_SET_FINDER_TITLE,
 } from '../utils/constants'
-import { RecordBasedFieldsValue } from './utils/buildCurateTaskPayload'
+
+export type RecordBasedFieldsValue = {
+  recordSetId: string
+}
+
+export const EMPTY_RECORD_BASED_VALUE: RecordBasedFieldsValue = {
+  recordSetId: '',
+}
+
+export function isRecordBasedFieldsValueValid(
+  value: RecordBasedFieldsValue,
+): boolean {
+  return !!value.recordSetId.trim()
+}
 
 export type RecordBasedFieldsProps = {
   value: RecordBasedFieldsValue

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/RecordSetFields.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/RecordSetFields.tsx
@@ -15,8 +15,29 @@ import {
   RECORD_SET_INSTRUCTIONS_LABEL,
   TASK_ID_FIELD_INVALID_ERROR_MESSAGE,
 } from '../utils/constants'
-import { RecordSetFieldsValue } from './utils/buildComputeTaskPayload'
 import { isValidTaskIdInput } from './utils/taskIdValidation'
+
+export type RecordSetFieldsValue = {
+  folderId: string
+  instructions: string
+  destinationTaskId: string
+}
+
+export const EMPTY_RECORD_SET_VALUE: RecordSetFieldsValue = {
+  folderId: '',
+  instructions: '',
+  destinationTaskId: '',
+}
+
+export function isRecordSetFieldsValueValid(
+  value: RecordSetFieldsValue,
+): boolean {
+  return (
+    !!value.folderId.trim() &&
+    !!value.instructions.trim() &&
+    isValidTaskIdInput(value.destinationTaskId)
+  )
+}
 
 export type RecordSetFieldsProps = {
   value: RecordSetFieldsValue

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/SampleSheetFields.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/SampleSheetFields.tsx
@@ -7,8 +7,26 @@ import {
   SAMPLE_SHEET_INPUT_TASK_ID_LABEL,
   TASK_ID_FIELD_INVALID_ERROR_MESSAGE,
 } from '../utils/constants'
-import { SampleSheetFieldsValue } from './utils/buildComputeTaskPayload'
 import { isValidTaskIdInput } from './utils/taskIdValidation'
+
+export type SampleSheetFieldsValue = {
+  inputTaskId: string
+  destinationTaskId: string
+}
+
+export const EMPTY_SAMPLE_SHEET_VALUE: SampleSheetFieldsValue = {
+  inputTaskId: '',
+  destinationTaskId: '',
+}
+
+export function isSampleSheetFieldsValueValid(
+  value: SampleSheetFieldsValue,
+): boolean {
+  return (
+    isValidTaskIdInput(value.inputTaskId) &&
+    isValidTaskIdInput(value.destinationTaskId)
+  )
+}
 
 export type SampleSheetFieldsProps = {
   value: SampleSheetFieldsValue

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/TaskStatusField.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/TaskStatusField.tsx
@@ -1,0 +1,48 @@
+import { StyledFormControl } from '@/components/styled'
+import { InputLabel, MenuItem, Select } from '@mui/material'
+import { TaskStatusStateEnum } from '@sage-bionetworks/synapse-client'
+import { TASK_STATUS_CONFIG, TASK_STATUS_INPUT_LABEL } from '../utils/constants'
+
+export type TaskStatusFieldProps = {
+  value: TaskStatusStateEnum | undefined
+  onChange: (state: TaskStatusStateEnum) => void
+  disabled: boolean
+  /**
+   * States the user must not be able to manually select into (e.g. EXECUTING, which a compute task
+   * enters automatically). These still render as `MenuItem`s -- so a task already in one of these
+   * states continues to display it correctly -- but are disabled.
+   */
+  disabledStates: TaskStatusStateEnum[]
+  /** Must be unique per rendered instance; passed through to both the `InputLabel` and the `Select`. */
+  labelId: string
+}
+
+/**
+ * The task status `<Select>` shown in edit mode by both `ComputeTaskForm` and `CurateTaskForm`.
+ */
+export default function TaskStatusField(props: TaskStatusFieldProps) {
+  const { value, onChange, disabled, disabledStates, labelId } = props
+
+  return (
+    <StyledFormControl fullWidth>
+      <InputLabel id={labelId}>{TASK_STATUS_INPUT_LABEL}</InputLabel>
+      <Select
+        labelId={labelId}
+        value={value ?? ''}
+        label={TASK_STATUS_INPUT_LABEL}
+        disabled={disabled}
+        onChange={e => onChange(e.target.value as TaskStatusStateEnum)}
+      >
+        {Object.values(TaskStatusStateEnum).map(state => (
+          <MenuItem
+            key={state}
+            value={state}
+            disabled={disabledStates.includes(state)}
+          >
+            {TASK_STATUS_CONFIG[state].label}
+          </MenuItem>
+        ))}
+      </Select>
+    </StyledFormControl>
+  )
+}

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/useComputeTypeFields.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/useComputeTypeFields.ts
@@ -1,0 +1,119 @@
+import {
+  CurationTaskProperties,
+  RecordSetGenerationExecutionPropertiesConcreteTypeEnum,
+  SampleSheetGenerationExecutionPropertiesConcreteTypeEnum,
+} from '@sage-bionetworks/synapse-client'
+import { useState } from 'react'
+import { DEFAULT_COMPUTE_TASK_TYPE } from '../utils/constants'
+import {
+  ComputeTaskConcreteType,
+  getComputeTaskConcreteType,
+  instanceOfGridSupportedTaskProperties,
+} from '../utils/types'
+import {
+  EMPTY_RECORD_SET_VALUE,
+  isRecordSetFieldsValueValid,
+  RecordSetFieldsValue,
+} from './RecordSetFields'
+import {
+  EMPTY_SAMPLE_SHEET_VALUE,
+  isSampleSheetFieldsValueValid,
+  SampleSheetFieldsValue,
+} from './SampleSheetFields'
+import { ComputeTypeFields } from './utils/buildComputeTaskPayload'
+
+function emptyValueForConcreteType(
+  concreteType: ComputeTaskConcreteType,
+): ComputeTypeFields {
+  if (
+    concreteType ===
+    RecordSetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_RecordSetGenerationExecutionProperties
+  ) {
+    return { concreteType, value: EMPTY_RECORD_SET_VALUE }
+  }
+  return { concreteType, value: EMPTY_SAMPLE_SHEET_VALUE }
+}
+
+function initialStateFor(
+  taskProperties: CurationTaskProperties | undefined,
+): ComputeTypeFields {
+  if (
+    taskProperties?.concreteType ===
+    SampleSheetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_SampleSheetGenerationExecutionProperties
+  ) {
+    return {
+      concreteType: taskProperties.concreteType,
+      value: {
+        inputTaskId: taskProperties.inputTaskId?.toString() ?? '',
+        destinationTaskId: taskProperties.destinationTaskId?.toString() ?? '',
+      },
+    }
+  }
+  if (
+    taskProperties?.concreteType ===
+    RecordSetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_RecordSetGenerationExecutionProperties
+  ) {
+    return {
+      concreteType: taskProperties.concreteType,
+      value: {
+        folderId: taskProperties.folderId ?? '',
+        instructions: taskProperties.instructions ?? '',
+        destinationTaskId: taskProperties.destinationTaskId?.toString() ?? '',
+      },
+    }
+  }
+  return emptyValueForConcreteType(DEFAULT_COMPUTE_TASK_TYPE)
+}
+
+export type UseComputeTypeFieldsArgs = {
+  /** The existing task's `taskProperties`, for edit-mode initialization. Undefined when creating. */
+  taskProperties: CurationTaskProperties | undefined
+  isEditMode: boolean
+}
+
+/**
+ * Owns the single active Compute Data type-specific value (`ComputeTypeFields`) for `ComputeTaskForm`:
+ * which concrete type is selected, its field values, and whether that value is currently valid.
+ * Switching the concrete type resets the value to that type's empty default.
+ */
+export function useComputeTypeFields(args: UseComputeTypeFieldsArgs) {
+  const { taskProperties, isEditMode } = args
+
+  const existingComputeConcreteType = getComputeTaskConcreteType(taskProperties)
+  // Whether the type-specific fields (and type selector) should render at all. False when editing a
+  // task whose category isn't one of the two Compute Data types (e.g. a legacy Curate Data task).
+  const showTypeSection =
+    !isEditMode || existingComputeConcreteType !== undefined
+  const showUnrecognizedTypeWarning =
+    isEditMode &&
+    existingComputeConcreteType === undefined &&
+    !instanceOfGridSupportedTaskProperties(taskProperties)
+
+  const [state, setState] = useState<ComputeTypeFields>(() =>
+    initialStateFor(taskProperties),
+  )
+
+  function setConcreteType(concreteType: ComputeTaskConcreteType) {
+    setState(emptyValueForConcreteType(concreteType))
+  }
+
+  function setValue(value: SampleSheetFieldsValue | RecordSetFieldsValue) {
+    setState(prev => ({ ...prev, value }) as ComputeTypeFields)
+  }
+
+  const isValid =
+    !showTypeSection ||
+    (state.concreteType ===
+    SampleSheetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_SampleSheetGenerationExecutionProperties
+      ? isSampleSheetFieldsValueValid(state.value)
+      : isRecordSetFieldsValueValid(state.value))
+
+  return {
+    state,
+    setConcreteType,
+    setValue,
+    isValid,
+    showTypeSection,
+    showUnrecognizedTypeWarning,
+  }
+}

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/useCurateTypeFields.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/useCurateTypeFields.ts
@@ -1,0 +1,126 @@
+import {
+  CurationTaskProperties,
+  FileBasedMetadataTaskPropertiesConcreteTypeEnum,
+  RecordBasedMetadataTaskPropertiesConcreteTypeEnum,
+} from '@sage-bionetworks/synapse-client'
+import { useState } from 'react'
+import { DEFAULT_CURATE_TASK_TYPE } from '../utils/constants'
+import {
+  CurateTaskConcreteType,
+  instanceOfGridSupportedTaskProperties,
+} from '../utils/types'
+import {
+  EMPTY_FILE_BASED_VALUE,
+  FileBasedFieldsValue,
+  isFileBasedFieldsValueValid,
+} from './FileBasedFields'
+import {
+  EMPTY_RECORD_BASED_VALUE,
+  isRecordBasedFieldsValueValid,
+  RecordBasedFieldsValue,
+} from './RecordBasedFields'
+import {
+  AuthorizationModeOption,
+  CurateTypeState,
+} from './utils/buildCurateTaskPayload'
+
+function toAuthorizationModeOption(
+  value: string | undefined,
+): AuthorizationModeOption {
+  if (value === 'SESSION_OWNER' || value === 'SOURCE_BENEFACTOR') return value
+  return 'NONE'
+}
+
+function emptyValueForConcreteType(
+  concreteType: CurateTaskConcreteType,
+): CurateTypeState {
+  if (
+    concreteType ===
+    RecordBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_RecordBasedMetadataTaskProperties
+  ) {
+    return { concreteType, value: EMPTY_RECORD_BASED_VALUE }
+  }
+  return { concreteType, value: EMPTY_FILE_BASED_VALUE }
+}
+
+function initialStateFor(
+  taskProperties: CurationTaskProperties | undefined,
+): CurateTypeState {
+  if (
+    taskProperties?.concreteType ===
+    FileBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_FileBasedMetadataTaskProperties
+  ) {
+    return {
+      concreteType: taskProperties.concreteType,
+      value: {
+        uploadFolderId: taskProperties.uploadFolderId ?? '',
+        fileViewId: taskProperties.fileViewId ?? '',
+      },
+    }
+  }
+  if (
+    taskProperties?.concreteType ===
+    RecordBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_RecordBasedMetadataTaskProperties
+  ) {
+    return {
+      concreteType: taskProperties.concreteType,
+      value: { recordSetId: taskProperties.recordSetId ?? '' },
+    }
+  }
+  return emptyValueForConcreteType(DEFAULT_CURATE_TASK_TYPE)
+}
+
+export type UseCurateTypeFieldsArgs = {
+  /** The existing task's `taskProperties`, for edit-mode initialization. Undefined when creating. */
+  taskProperties: CurationTaskProperties | undefined
+  isEditMode: boolean
+}
+
+/**
+ * Owns the single active Curate Data type-specific value (`CurateTypeState`) for `CurateTaskForm` --
+ * which concrete type is selected, its field values, and whether that value is currently valid -- plus
+ * the Authorization Mode selection and whether it has changed from the task's existing value.
+ * Switching the concrete type resets the value to that type's empty default.
+ */
+export function useCurateTypeFields(args: UseCurateTypeFieldsArgs) {
+  const { taskProperties, isEditMode } = args
+
+  const [state, setState] = useState<CurateTypeState>(() =>
+    initialStateFor(taskProperties),
+  )
+
+  function setConcreteType(concreteType: CurateTaskConcreteType) {
+    setState(emptyValueForConcreteType(concreteType))
+  }
+
+  function setValue(value: FileBasedFieldsValue | RecordBasedFieldsValue) {
+    setState(prev => ({ ...prev, value }) as CurateTypeState)
+  }
+
+  const isValid =
+    state.concreteType ===
+    FileBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_FileBasedMetadataTaskProperties
+      ? isFileBasedFieldsValueValid(state.value)
+      : isRecordBasedFieldsValueValid(state.value)
+
+  const initialAuthorizationMode = toAuthorizationModeOption(
+    instanceOfGridSupportedTaskProperties(taskProperties)
+      ? taskProperties.suggestedAuthorizationMode
+      : undefined,
+  )
+  const [authorizationMode, setAuthorizationMode] = useState(
+    initialAuthorizationMode,
+  )
+  const authModeChanged =
+    isEditMode && authorizationMode !== initialAuthorizationMode
+
+  return {
+    state,
+    setConcreteType,
+    setValue,
+    isValid,
+    authorizationMode,
+    setAuthorizationMode,
+    authModeChanged,
+  }
+}

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/useCurationTaskFormState.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/useCurationTaskFormState.ts
@@ -10,6 +10,7 @@ import { displayToast } from '@/components/ToastMessage'
 import { useSynapseContext } from '@/utils/index'
 import {
   CurationTask,
+  TaskExecutionDetails,
   TaskStatusStateEnum,
 } from '@sage-bionetworks/synapse-client'
 import { useState } from 'react'
@@ -133,13 +134,15 @@ export function useCurationTaskFormState(args: UseCurationTaskFormStateArgs) {
 
   /**
    * Persists `payload` as either a create or an update (based on edit mode), then reconciles the
-   * task's `TaskStatus` (state + due date). Returns the persisted task. On create, the status is
-   * fetched (it is created server-side automatically) and patched only when a due date was entered.
-   * On update, the status is written only when the state or due date changed; clearing the due date
-   * (empty string) is a valid change and persists as an absent due date.
+   * task's `TaskStatus` (state + due date + `options.initialExecutionDetails`). Returns the persisted
+   * task. On create, the status is fetched (it is created server-side automatically) and patched when
+   * a due date was entered or `options.initialExecutionDetails` was supplied. On update, the status is
+   * written only when the state or due date changed; clearing the due date (empty string) is a valid
+   * change and persists as an absent due date. `initialExecutionDetails` is never backfilled on edit.
    */
   async function submitTaskAndStatus(
     payload: CurationTask,
+    options?: { initialExecutionDetails?: TaskExecutionDetails },
   ): Promise<CurationTask> {
     const dueDateIso = dueDateInputToIso(displayedDueDate)
 
@@ -173,7 +176,10 @@ export function useCurationTaskFormState(args: UseCurationTaskFormStateArgs) {
 
     const created = await createTask(payload)
 
-    if (dueDateIso && created.taskId != null) {
+    if (
+      (dueDateIso || options?.initialExecutionDetails) &&
+      created.taskId != null
+    ) {
       // TODO(PLFM-9839): replace this best-effort status write with a single service that creates
       // the task and its status atomically. Until then, the task is created first and the due date
       // is applied to the auto-created status in a separate call; a failure there must not strand a
@@ -189,6 +195,7 @@ export function useCurationTaskFormState(args: UseCurationTaskFormStateArgs) {
           ...status,
           taskId: created.taskId,
           dueDate: dueDateIso,
+          executionDetails: options?.initialExecutionDetails,
         })
       } catch {
         displayToast(CREATE_TASK_STATUS_NOT_SAVED_WARNING, 'warning')

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/utils/buildComputeTaskPayload.test.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/utils/buildComputeTaskPayload.test.ts
@@ -18,8 +18,7 @@ describe('buildComputeTaskPayload', () => {
       assigneePrincipalId: '456',
       computeTypeFields: {
         concreteType: SAMPLE_SHEET_TYPE,
-        sampleSheet: { inputTaskId: '1', destinationTaskId: '2' },
-        recordSet: { folderId: '', instructions: '', destinationTaskId: '' },
+        value: { inputTaskId: '1', destinationTaskId: '2' },
       },
     })
 
@@ -44,8 +43,7 @@ describe('buildComputeTaskPayload', () => {
       assigneePrincipalId: '456',
       computeTypeFields: {
         concreteType: RECORD_SET_TYPE,
-        sampleSheet: { inputTaskId: '', destinationTaskId: '' },
-        recordSet: {
+        value: {
           folderId: 'syn999',
           instructions: 'Transform the files',
           destinationTaskId: '3',
@@ -69,8 +67,7 @@ describe('buildComputeTaskPayload', () => {
       assigneePrincipalId: undefined,
       computeTypeFields: {
         concreteType: SAMPLE_SHEET_TYPE,
-        sampleSheet: { inputTaskId: '', destinationTaskId: 'not-a-number' },
-        recordSet: { folderId: '', instructions: '', destinationTaskId: '' },
+        value: { inputTaskId: '', destinationTaskId: 'not-a-number' },
       },
     })
 

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/utils/buildComputeTaskPayload.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/utils/buildComputeTaskPayload.ts
@@ -2,26 +2,22 @@ import {
   CurationTask,
   CurationTaskProperties,
   RecordSetGenerationExecutionPropertiesConcreteTypeEnum,
+  SampleSheetGenerationExecutionPropertiesConcreteTypeEnum,
 } from '@sage-bionetworks/synapse-client'
-import { ComputeTaskConcreteType } from '../../utils/types'
+import { RecordSetFieldsValue } from '../RecordSetFields'
+import { SampleSheetFieldsValue } from '../SampleSheetFields'
 import { parseTaskIdInput } from './taskIdValidation'
 
-export type SampleSheetFieldsValue = {
-  inputTaskId: string
-  destinationTaskId: string
-}
-
-export type RecordSetFieldsValue = {
-  folderId: string
-  instructions: string
-  destinationTaskId: string
-}
-
-export type ComputeTypeFields = {
-  concreteType: ComputeTaskConcreteType
-  sampleSheet: SampleSheetFieldsValue
-  recordSet: RecordSetFieldsValue
-}
+/** A form's active Compute Data type-specific value, as a discriminated union keyed by `concreteType`. */
+export type ComputeTypeFields =
+  | {
+      concreteType: SampleSheetGenerationExecutionPropertiesConcreteTypeEnum
+      value: SampleSheetFieldsValue
+    }
+  | {
+      concreteType: RecordSetGenerationExecutionPropertiesConcreteTypeEnum
+      value: RecordSetFieldsValue
+    }
 
 export type BuildComputeTaskPayloadArgs = {
   /** The task being edited, if any. Server-managed fields (taskId, etag, etc.) are carried over. */
@@ -71,23 +67,23 @@ export function buildComputeTaskPayload(
 function buildComputeTaskProperties(
   fields: ComputeTypeFields,
 ): CurationTaskProperties {
-  const { concreteType, sampleSheet, recordSet } = fields
-
   if (
-    concreteType ===
+    fields.concreteType ===
     RecordSetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_RecordSetGenerationExecutionProperties
   ) {
+    const { concreteType, value } = fields
     return {
       concreteType,
-      folderId: recordSet.folderId.trim() || undefined,
-      instructions: recordSet.instructions.trim() || undefined,
-      destinationTaskId: parseTaskIdInput(recordSet.destinationTaskId),
+      folderId: value.folderId.trim() || undefined,
+      instructions: value.instructions.trim() || undefined,
+      destinationTaskId: parseTaskIdInput(value.destinationTaskId),
     }
   }
 
+  const { concreteType, value } = fields
   return {
     concreteType,
-    inputTaskId: parseTaskIdInput(sampleSheet.inputTaskId),
-    destinationTaskId: parseTaskIdInput(sampleSheet.destinationTaskId),
+    inputTaskId: parseTaskIdInput(value.inputTaskId),
+    destinationTaskId: parseTaskIdInput(value.destinationTaskId),
   }
 }

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/utils/buildCurateTaskPayload.test.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/utils/buildCurateTaskPayload.test.ts
@@ -19,8 +19,7 @@ describe('buildCurateTaskPayload', () => {
       curateTypeFields: {
         concreteType: FILE_BASED_TYPE,
         authorizationMode: 'NONE',
-        fileBased: { uploadFolderId: 'syn1', fileViewId: 'syn2' },
-        recordBased: { recordSetId: '' },
+        value: { uploadFolderId: 'syn1', fileViewId: 'syn2' },
       },
     })
 
@@ -48,8 +47,7 @@ describe('buildCurateTaskPayload', () => {
       curateTypeFields: {
         concreteType: RECORD_BASED_TYPE,
         authorizationMode: 'NONE',
-        fileBased: { uploadFolderId: '', fileViewId: '' },
-        recordBased: { recordSetId: 'syn3' },
+        value: { recordSetId: 'syn3' },
       },
     })
 
@@ -70,8 +68,7 @@ describe('buildCurateTaskPayload', () => {
       curateTypeFields: {
         concreteType: FILE_BASED_TYPE,
         authorizationMode: 'SESSION_OWNER',
-        fileBased: { uploadFolderId: 'syn1', fileViewId: 'syn2' },
-        recordBased: { recordSetId: '' },
+        value: { uploadFolderId: 'syn1', fileViewId: 'syn2' },
       },
     })
 
@@ -100,8 +97,7 @@ describe('buildCurateTaskPayload', () => {
       curateTypeFields: {
         concreteType: FILE_BASED_TYPE,
         authorizationMode: 'NONE',
-        fileBased: { uploadFolderId: 'syn1', fileViewId: 'syn2' },
-        recordBased: { recordSetId: '' },
+        value: { uploadFolderId: 'syn1', fileViewId: 'syn2' },
       },
     })
 
@@ -119,8 +115,7 @@ describe('buildCurateTaskPayload', () => {
       curateTypeFields: {
         concreteType: FILE_BASED_TYPE,
         authorizationMode: 'NONE',
-        fileBased: { uploadFolderId: '  ', fileViewId: '' },
-        recordBased: { recordSetId: '' },
+        value: { uploadFolderId: '  ', fileViewId: '' },
       },
     })
 

--- a/packages/synapse-react-client/src/features/entity/metadata-task/create-task/utils/buildCurateTaskPayload.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/create-task/utils/buildCurateTaskPayload.ts
@@ -3,31 +3,30 @@ import {
   CurationTaskProperties,
   FileBasedMetadataTaskPropertiesConcreteTypeEnum,
   FileBasedMetadataTaskPropertiesSuggestedAuthorizationModeEnum,
+  RecordBasedMetadataTaskPropertiesConcreteTypeEnum,
 } from '@sage-bionetworks/synapse-client'
-import {
-  CurateTaskConcreteType,
-  instanceOfGridSupportedTaskProperties,
-} from '../../utils/types'
+import { instanceOfGridSupportedTaskProperties } from '../../utils/types'
+import { FileBasedFieldsValue } from '../FileBasedFields'
+import { RecordBasedFieldsValue } from '../RecordBasedFields'
 
 /** Null represents the "Legacy" / unset option for suggestedAuthorizationMode. */
 export type AuthorizationModeOption =
   | FileBasedMetadataTaskPropertiesSuggestedAuthorizationModeEnum
   | 'NONE'
 
-export type FileBasedFieldsValue = {
-  uploadFolderId: string
-  fileViewId: string
-}
+/** A form's active Curate Data type-specific value, as a discriminated union keyed by `concreteType`. */
+export type CurateTypeState =
+  | {
+      concreteType: FileBasedMetadataTaskPropertiesConcreteTypeEnum
+      value: FileBasedFieldsValue
+    }
+  | {
+      concreteType: RecordBasedMetadataTaskPropertiesConcreteTypeEnum
+      value: RecordBasedFieldsValue
+    }
 
-export type RecordBasedFieldsValue = {
-  recordSetId: string
-}
-
-export type CurateTypeFields = {
-  concreteType: CurateTaskConcreteType
+export type CurateTypeFields = CurateTypeState & {
   authorizationMode: AuthorizationModeOption
-  fileBased: FileBasedFieldsValue
-  recordBased: RecordBasedFieldsValue
 }
 
 export type BuildCurateTaskPayloadArgs = {
@@ -80,26 +79,28 @@ function buildCurateTaskProperties(
   fields: CurateTypeFields,
   collaboratorPrincipalIds: string[] | undefined,
 ): CurationTaskProperties {
-  const { concreteType, authorizationMode, fileBased, recordBased } = fields
+  const { authorizationMode } = fields
   const suggestedAuthorizationMode =
     authorizationMode === 'NONE' ? undefined : authorizationMode
 
   if (
-    concreteType ===
-    FileBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_FileBasedMetadataTaskProperties
+    fields.concreteType ===
+    RecordBasedMetadataTaskPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_metadata_RecordBasedMetadataTaskProperties
   ) {
+    const { concreteType, value } = fields
     return {
       concreteType,
-      uploadFolderId: fileBased.uploadFolderId.trim() || undefined,
-      fileViewId: fileBased.fileViewId.trim() || undefined,
+      recordSetId: value.recordSetId.trim() || undefined,
       suggestedAuthorizationMode,
       collaboratorPrincipalIds,
     }
   }
 
+  const { concreteType, value } = fields
   return {
     concreteType,
-    recordSetId: recordBased.recordSetId.trim() || undefined,
+    uploadFolderId: value.uploadFolderId.trim() || undefined,
+    fileViewId: value.fileViewId.trim() || undefined,
     suggestedAuthorizationMode,
     collaboratorPrincipalIds,
   }

--- a/packages/synapse-react-client/src/features/entity/metadata-task/utils/constants.ts
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/utils/constants.ts
@@ -1,10 +1,14 @@
 import {
   FileBasedMetadataTaskPropertiesConcreteTypeEnum,
   RecordBasedMetadataTaskPropertiesConcreteTypeEnum,
+  RecordSetGenerationExecutionDetailsConcreteTypeEnum,
   RecordSetGenerationExecutionPropertiesConcreteTypeEnum,
+  SampleSheetGenerationExecutionDetailsConcreteTypeEnum,
   SampleSheetGenerationExecutionPropertiesConcreteTypeEnum,
+  TaskExecutionDetails,
   TaskStatusStateEnum,
 } from '@sage-bionetworks/synapse-client'
+import { ComputeTaskConcreteType } from './types'
 
 export const OPEN_CURATOR_ERROR_TITLE =
   'An error occurred while trying to open Curator'
@@ -237,6 +241,19 @@ export const TASK_STATUS_CONFIG: Record<
   CANCELED: { label: 'Canceled', backgroundColor: '#FFCCBC' },
 }
 
+/**
+ * Do not allow users to manually set task state to one of these values (controlled by the system)
+ */
+export const COMPUTE_TASK_DISABLED_STATUS_STATES = [
+  TaskStatusStateEnum.EXECUTING,
+  TaskStatusStateEnum.CANCELED,
+]
+
+/** Curate tasks have no automatic EXECUTING transition, but it remains a system-controlled state. */
+export const CURATE_TASK_DISABLED_STATUS_STATES = [
+  TaskStatusStateEnum.EXECUTING,
+]
+
 export const DELETE_CURATION_TASK_DIALOG_TITLE = 'Delete Task'
 export const DELETE_CURATION_TASK_CONFIRMATION_PROMPT =
   'Are you sure you want to delete this task? This action cannot be undone.'
@@ -258,3 +275,24 @@ export const COLLABORATORS_TOOLTIP =
   'Collaborators can contribute to the grid session alongside the assignee. For "Session Owner" authorization mode, collaborators are added as additional owners of the session.'
 export const UNRECOGNIZED_TASK_TYPE_ERROR =
   'This task has an unrecognized task type and cannot be edited here.'
+
+/**
+ * The `TaskStatus.executionDetails` value to set when creating a Compute task of each concrete type.
+ * Both concrete `TaskExecutionDetails` types require only `concreteType` -- the remaining fields
+ * (`asyncJobId`, `startedBy`, `startedOn`, `errorMessage`, `errorDetails`) are server-managed.
+ */
+export const COMPUTE_TASK_EXECUTION_DETAILS: Record<
+  ComputeTaskConcreteType,
+  TaskExecutionDetails
+> = {
+  [SampleSheetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_SampleSheetGenerationExecutionProperties]:
+    {
+      concreteType:
+        SampleSheetGenerationExecutionDetailsConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_SampleSheetGenerationExecutionDetails,
+    },
+  [RecordSetGenerationExecutionPropertiesConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_RecordSetGenerationExecutionProperties]:
+    {
+      concreteType:
+        RecordSetGenerationExecutionDetailsConcreteTypeEnum.org_sagebionetworks_repo_model_curation_execution_RecordSetGenerationExecutionDetails,
+    },
+}


### PR DESCRIPTION
Restrict Compute/Curate task status options, refactor type-specific field state, and set executionDetails on Compute task create

- ComputeTaskForm disables EXECUTING/CANCELED in the status select; CurateTaskForm disables EXECUTING only (via new shared TaskStatusField)
- Co-locate each concrete type's Value/EMPTY/isValid with its Fields component; ComputeTypeFields/CurateTypeFields become discriminated unions
- Extract useComputeTypeFields/useCurateTypeFields hooks, removing dual-type state/validity/payload branching from the form components
- Always set TaskStatus.executionDetails when creating a Compute task, regardless of due date