### PR TITLE
PORTALS-4399

### DIFF
--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
@@ -1584,3 +1584,94 @@ describe('toSearchIndexQuery – searchQueryConfig', () => {
     expect(clause.multi_match.fields).not.toContain('description^1')
   })
 })
+
+// ---------------------------------------------------------------------------
+// toSearchIndexQuery – exact phrase matching (double-quoted queries)
+// ---------------------------------------------------------------------------
+
+describe('toSearchIndexQuery – exact phrase matching', () => {
+  function makeQueryBundleWithText(searchExpression: string) {
+    return makeQueryBundleRequest({
+      additionalFilters: [
+        {
+          concreteType: TEXT_MATCHES_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+          searchExpression,
+        },
+      ],
+    })
+  }
+
+  it('a fully-quoted phrase always emits simple_query_string regardless of strategy', () => {
+    const strategies = [
+      undefined,
+      'MULTI_MATCH',
+      'MULTI_MATCH_BEST_FIELDS',
+      'MULTI_MATCH_CROSS_FIELDS',
+      'PHRASE_PREFIX',
+      'BOOSTED_FUZZY',
+      'SIMPLE_QUERY_STRING',
+    ] as const
+
+    for (const queryStrategy of strategies) {
+      const result = toSearchIndexQuery(
+        makeQueryBundleWithText('"cancer genomics"'),
+        SEARCH_INDEX_ID,
+        undefined,
+        queryStrategy ? { queryStrategy } : undefined,
+      )
+      expect(result.searchQuery?.query).toEqual({
+        simple_query_string: { query: '"cancer genomics"' },
+      })
+    }
+  })
+
+  it('a mixed phrase+term query emits simple_query_string', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('"cancer genomics" atlas'),
+      SEARCH_INDEX_ID,
+    )
+    expect(result.searchQuery?.query).toEqual({
+      simple_query_string: { query: '"cancer genomics" atlas' },
+    })
+  })
+
+  it('field boosts are preserved when routing to simple_query_string for a phrase query', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('"exact phrase"'),
+      SEARCH_INDEX_ID,
+      undefined,
+      {
+        queryStrategy: 'BOOSTED_FUZZY',
+        fieldBoosts: { resourceName: 5, synonyms: 4 },
+      },
+    )
+    expect(result.searchQuery?.query).toEqual({
+      simple_query_string: {
+        query: '"exact phrase"',
+        fields: ['resourceName^5', 'synonyms^4'],
+      },
+    })
+  })
+
+  it('an unquoted query is NOT routed to simple_query_string by the phrase-detection path', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('cancer genomics'),
+      SEARCH_INDEX_ID,
+    )
+    // Should use the default MULTI_MATCH path, not simple_query_string
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: { query: 'cancer genomics', fuzziness: 'AUTO' },
+    })
+  })
+
+  it('a query with only an empty pair of double-quotes is NOT treated as a phrase', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('""'),
+      SEARCH_INDEX_ID,
+    )
+    // "" contains no inner characters → falls through to the normal strategy
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: { query: '""', fuzziness: 'AUTO' },
+    })
+  })
+})

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -117,12 +117,36 @@ function resolveFields(
   )
 }
 
+/**
+ * Returns true if the query text contains at least one double-quoted phrase
+ * (e.g. `"cancer genomics"`). OpenSearch `multi_match` does not understand the
+ * `"phrase"` operator — only `simple_query_string` does — so callers use this
+ * to route quoted queries appropriately.
+ */
+function containsQuotedPhrase(text: string): boolean {
+  // Match a pair of double-quotes enclosing at least one non-quote character.
+  return /"[^"]+"/u.test(text)
+}
+
 function buildQueryClause(
   queryText: string,
   config: SearchQueryConfig = {},
 ): MultiMatchClause | SimpleQueryStringClause {
   const { queryStrategy = 'MULTI_MATCH', fieldBoosts, fuzziness } = config
   const fields = resolveFields(fieldBoosts)
+
+  // When the query text contains a double-quoted phrase (e.g. "cancer genomics"),
+  // multi_match cannot honour the phrase operator — only simple_query_string can.
+  // Route directly to simple_query_string so phrase matching works regardless of
+  // the configured strategy.
+  if (containsQuotedPhrase(queryText)) {
+    return {
+      simple_query_string: {
+        query: queryText,
+        ...(fields ? { fields } : {}),
+      },
+    }
+  }
 
   switch (queryStrategy) {
     case 'SIMPLE_QUERY_STRING':


### PR DESCRIPTION
## Fix: Exact phrase matching with double quotes in SearchQueryWrapper

### Problem
When a user surrounded a search term in double quotes (e.g. `"cancer genomics"`), the
exact phrase match was silently ignored. All non-`SIMPLE_QUERY_STRING` strategies route
to OpenSearch `multi_match`, which does not understand the `"phrase"` operator — it treats
the quotes as literal characters. The default `MULTI_MATCH` and `BOOSTED_FUZZY` strategies
also apply `fuzziness: AUTO`, which is fundamentally incompatible with phrase matching.

### Fix (`SearchQueryUseQueryOptions.ts`)
- Added `containsQuotedPhrase(text)` — a one-line regex helper that returns `true` when
  the query contains at least one `"…"` substring (one or more non-quote characters between
  a pair of double quotes).
- Added an early-return branch at the top of `buildQueryClause`: if `containsQuotedPhrase`
  returns `true`, the function immediately emits a `simple_query_string` clause (preserving
  any configured `fieldBoosts`) regardless of the configured `queryStrategy`.
  `simple_query_string` is the only OpenSearch query type that natively handles the
  `"phrase"` operator.
- Queries without double-quoted phrases continue through the existing strategy `switch`
  unchanged — no behaviour change for non-phrase queries.

### Tests added (`SearchQueryUseQueryOptions.test.ts`)
New `describe` block: **"toSearchIndexQuery – exact phrase matching"**

| Test | What it asserts |
|---|---|
| A fully-quoted phrase always emits `simple_query_string` | All six strategies + the default (no config) all produce `simple_query_string` when the query is `"cancer genomics"` |
| Mixed phrase + term | `"cancer genomics" atlas` also routes to `simple_query_string` |
| Field boosts preserved | `fieldBoosts` are forwarded to `simple_query_string` even when the original strategy was `BOOSTED_FUZZY` |
| Unquoted query unchanged | `cancer genomics` (no quotes) still produces `multi_match` with `fuzziness: AUTO` |
| Empty double-quotes not treated as phrase | `""` contains no inner characters and falls through to the normal strategy |