### PR TITLE
SWC-7907 - Support taskIds filter on MetadataTasksPage

### DIFF
--- a/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboard.test.tsx
@@ -2,6 +2,7 @@ import CuratorDashboardContent from './CuratorDashboard'
 import { useGetCurationTasksInfinite } from '@/synapse-queries/curation/task/useCurationTask'
 import { createMockTaskBundle } from '@/mocks/curation/mockCurationTask'
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { RouterProvider, createMemoryRouter, RouteObject } from 'react-router'
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 
@@ -150,6 +151,102 @@ describe('CuratorDashboard', () => {
             taskIds: [123, 456],
             assignedToMe: true,
           }),
+        )
+      })
+    })
+  })
+
+  describe('assignedToMe search parameter', () => {
+    it('defaults to assignedToMe: true when not set in the URL', async () => {
+      mockUseGetCurationTasksInfinite.mockReturnValue({
+        data: { pages: [] },
+        isLoading: false,
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        fetchNextPage: vi.fn(),
+      } as any)
+
+      renderWithRouter({ initialEntry: '/' })
+
+      await waitFor(() => {
+        expect(mockUseGetCurationTasksInfinite).toHaveBeenCalledWith(
+          expect.objectContaining({ assignedToMe: true }),
+        )
+      })
+    })
+
+    it('respects assignedToMe: false when explicitly set in the URL', async () => {
+      mockUseGetCurationTasksInfinite.mockReturnValue({
+        data: { pages: [] },
+        isLoading: false,
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        fetchNextPage: vi.fn(),
+      } as any)
+
+      renderWithRouter({ initialEntry: '/?assignedToMe=false' })
+
+      await waitFor(() => {
+        expect(mockUseGetCurationTasksInfinite).toHaveBeenCalledWith(
+          expect.objectContaining({ assignedToMe: false }),
+        )
+      })
+    })
+  })
+
+  describe('filtered task banner', () => {
+    it('shows the banner when taskIds are present in the URL', async () => {
+      mockUseGetCurationTasksInfinite.mockReturnValue({
+        data: { pages: [{ bundlePage: [mockTaskBundle1] }] },
+        isLoading: false,
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        fetchNextPage: vi.fn(),
+      } as any)
+
+      renderWithRouter({ initialEntry: '/?taskIds=123' })
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(
+        'Showing 1 filtered task',
+      )
+    })
+
+    it('does not show the banner when taskIds are not present in the URL', () => {
+      mockUseGetCurationTasksInfinite.mockReturnValue({
+        data: { pages: [] },
+        isLoading: false,
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        fetchNextPage: vi.fn(),
+      } as any)
+
+      renderWithRouter({ initialEntry: '/' })
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('removes the taskIds filter and hides the banner when "Clear filter" is clicked', async () => {
+      const user = userEvent.setup()
+      mockUseGetCurationTasksInfinite.mockReturnValue({
+        data: { pages: [{ bundlePage: [mockTaskBundle1] }] },
+        isLoading: false,
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        fetchNextPage: vi.fn(),
+      } as any)
+
+      renderWithRouter({ initialEntry: '/?taskIds=123' })
+
+      await user.click(
+        await screen.findByRole('button', { name: /clear filter/i }),
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(mockUseGetCurationTasksInfinite).toHaveBeenLastCalledWith(
+          expect.objectContaining({ taskIds: undefined }),
         )
       })
     })

--- a/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboard.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/CuratorDashboard.tsx
@@ -1,25 +1,18 @@
 import InfiniteTableLayout from '@/components/layout/InfiniteTableLayout'
 import OpenInvitationsToUserCard from '@/features/team/invitation/components/OpenInvitationsToUserCard'
 import { useGetCurationTasksInfinite } from '@/synapse-queries/curation/task/useCurationTask'
+import { useCurationTaskListFilters } from '@/utils/hooks/useCurationTaskListFilters'
 import { Typography } from '@mui/material'
 import Stack from '@mui/material/Stack'
 import { useMemo } from 'react'
 import CurationTaskCard from './components/CurationTaskCard'
+import FilteredByTaskIdsBanner from './components/FilteredByTaskIdsBanner'
 import sharedStyles from './components/shared.module.scss'
-import { useSearchParams } from 'react-router'
-import { GRID_PAGE_TASK_ID_QUERY_PARAM } from '@/utils/SynapseConstants'
 
 export default function CuratorDashboardContent() {
-  const [searchParams] = useSearchParams()
-  const taskIdParam = searchParams.get(GRID_PAGE_TASK_ID_QUERY_PARAM)
-
-  const taskIds = useMemo(() => {
-    if (!taskIdParam) return undefined
-    return taskIdParam
-      .split(',')
-      .map(id => parseInt(id, 10))
-      .filter(id => !isNaN(id))
-  }, [taskIdParam])
+  const { request, taskIds, clearTaskIdsFilter } = useCurationTaskListFilters({
+    defaultAssignedToMe: true,
+  })
 
   const {
     data: curationTasks,
@@ -27,10 +20,7 @@ export default function CuratorDashboardContent() {
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
-  } = useGetCurationTasksInfinite({
-    assignedToMe: true,
-    taskIds,
-  })
+  } = useGetCurationTasksInfinite(request)
 
   const tasks = useMemo(() => {
     return curationTasks?.pages.flatMap(page => page.bundlePage ?? []) ?? []
@@ -40,6 +30,7 @@ export default function CuratorDashboardContent() {
     <Stack gap={4}>
       <Typography variant="headline1">On Your Radar</Typography>
       <OpenInvitationsToUserCard cardProps={{ className: sharedStyles.card }} />
+      <FilteredByTaskIdsBanner taskIds={taskIds} onClear={clearTaskIdsFilter} />
       <InfiniteTableLayout
         table={
           <Stack gap={3}>

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/FilteredByTaskIdsBanner.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/FilteredByTaskIdsBanner.test.tsx
@@ -1,0 +1,46 @@
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import FilteredByTaskIdsBanner from './FilteredByTaskIdsBanner'
+
+function renderComponent(taskIds: number[] | undefined, onClear = vi.fn()) {
+  render(<FilteredByTaskIdsBanner taskIds={taskIds} onClear={onClear} />, {
+    wrapper: createWrapper(),
+  })
+  return { onClear }
+}
+
+describe('FilteredByTaskIdsBanner', () => {
+  it('renders nothing when taskIds is undefined', () => {
+    renderComponent(undefined)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when taskIds is an empty array', () => {
+    renderComponent([])
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('shows the singular count when there is one task ID', () => {
+    renderComponent([123])
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Showing 1 filtered task',
+    )
+  })
+
+  it('shows the plural count when there are multiple task IDs', () => {
+    renderComponent([123, 456])
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Showing 2 filtered tasks',
+    )
+  })
+
+  it('calls onClear when the "Clear filter" button is clicked', async () => {
+    const user = userEvent.setup()
+    const { onClear } = renderComponent([123])
+
+    await user.click(screen.getByRole('button', { name: /clear filter/i }))
+
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/FilteredByTaskIdsBanner.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/FilteredByTaskIdsBanner.tsx
@@ -1,0 +1,34 @@
+import FullWidthAlert from '@/components/FullWidthAlert/FullWidthAlert'
+
+export type FilteredByTaskIdsBannerProps = {
+  taskIds: number[] | undefined
+  onClear: () => void
+}
+
+/**
+ * Displayed above a curation task list when it is filtered down to a specific set of task IDs (via
+ * the `taskIds` URL search param), with an action to clear the filter and return to the unfiltered list.
+ */
+export default function FilteredByTaskIdsBanner(
+  props: FilteredByTaskIdsBannerProps,
+) {
+  const { taskIds, onClear } = props
+
+  if (!taskIds || taskIds.length === 0) {
+    return null
+  }
+
+  return (
+    <FullWidthAlert
+      isGlobal={false}
+      variant="info"
+      description={`Showing ${taskIds.length} filtered task${
+        taskIds.length === 1 ? '' : 's'
+      }`}
+      primaryButtonConfig={{
+        text: 'Clear filter',
+        onClick: onClear,
+      }}
+    />
+  )
+}

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/MetadataTasksPage.test.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/MetadataTasksPage.test.tsx
@@ -1,8 +1,11 @@
 import { createMockTaskBundle } from '@/mocks/curation/mockCurationTask'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import MetadataTasksPage from './MetadataTasksPage'
+import { RouteObject, RouterProvider, createMemoryRouter } from 'react-router'
+import MetadataTasksPage, {
+  MetadataTasksPageInternal,
+} from './MetadataTasksPage'
 
 import { useGetCurationTasksInfinite } from '@/synapse-queries/curation/task/useCurationTask'
 import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
@@ -131,6 +134,23 @@ function renderComponent() {
   )
 }
 
+function renderInternalWithRouter(initialEntry = '/') {
+  const routes: RouteObject[] = [
+    {
+      path: '/',
+      element: <MetadataTasksPageInternal projectId={MOCK_PROJECT_ID} />,
+    },
+  ]
+
+  const router = createMemoryRouter(routes, {
+    initialEntries: [initialEntry],
+  })
+
+  return render(<RouterProvider router={router} />, {
+    wrapper: createWrapper(),
+  })
+}
+
 describe('MetadataTasksPage', () => {
   it('renders a card for each task in the list', async () => {
     renderComponent()
@@ -211,5 +231,90 @@ describe('MetadataTasksPage', () => {
     renderComponent()
 
     expect(await screen.findByText('No Results')).toBeInTheDocument()
+  })
+
+  describe('taskIds search parameter', () => {
+    it('passes taskIds parsed from the URL to the task query', async () => {
+      renderInternalWithRouter('/?taskIds=123,456')
+
+      await waitFor(() => {
+        expect(mockUseGetCurationTasksInfinite).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            projectId: MOCK_PROJECT_ID,
+            taskIds: [123, 456],
+          }),
+        )
+      })
+    })
+
+    it('shows the filtered task banner when taskIds are present', async () => {
+      renderInternalWithRouter('/?taskIds=123')
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(
+        'Showing 1 filtered task',
+      )
+    })
+
+    it('does not show the filtered task banner when taskIds are absent', async () => {
+      renderInternalWithRouter('/')
+
+      await screen.findByText('Test Data Type')
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('removes the taskIds filter and hides the banner when "Clear filter" is clicked', async () => {
+      const user = userEvent.setup()
+      renderInternalWithRouter('/?taskIds=123')
+
+      await user.click(
+        await screen.findByRole('button', { name: /clear filter/i }),
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(mockUseGetCurationTasksInfinite).toHaveBeenLastCalledWith(
+          expect.objectContaining({ taskIds: undefined }),
+        )
+      })
+    })
+  })
+
+  describe('assignedToMe search parameter', () => {
+    it('pre-checks the switch and passes assignedToMe: true when set in the URL', async () => {
+      renderInternalWithRouter('/?assignedToMe=true')
+
+      expect(
+        await screen.findByRole('switch', {
+          name: /view only tasks assigned to me/i,
+        }),
+      ).toBeChecked()
+      expect(mockUseGetCurationTasksInfinite).toHaveBeenLastCalledWith(
+        expect.objectContaining({ assignedToMe: true }),
+      )
+    })
+
+    it('adds assignedToMe=true to the URL when the switch is toggled on', async () => {
+      const user = userEvent.setup()
+      renderInternalWithRouter('/')
+
+      await screen.findByText('Test Data Type')
+      await user.click(
+        screen.getByRole('switch', { name: /view only tasks assigned to me/i }),
+      )
+
+      expect(mockUseGetCurationTasksInfinite).toHaveBeenLastCalledWith(
+        expect.objectContaining({ assignedToMe: true }),
+      )
+
+      await user.click(
+        screen.getByRole('switch', { name: /view only tasks assigned to me/i }),
+      )
+
+      expect(mockUseGetCurationTasksInfinite).toHaveBeenLastCalledWith(
+        expect.objectContaining({ assignedToMe: false }),
+      )
+    })
   })
 })

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/MetadataTasksPage.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/MetadataTasksPage.tsx
@@ -1,11 +1,12 @@
 import InfiniteTableLayout from '@/components/layout/InfiniteTableLayout'
 import CurationTaskCard from '@/features/curator/dashboard/components/CurationTaskCard'
+import FilteredByTaskIdsBanner from '@/features/curator/dashboard/components/FilteredByTaskIdsBanner'
 import { useGetCurationTasksInfinite } from '@/synapse-queries/curation/task/useCurationTask'
 import { useGetFeatureFlag } from '@/synapse-queries/index'
 import { useGetEntityPermissions } from '@/synapse-queries/entity/useEntity'
+import { useCurationTaskListFilters } from '@/utils/hooks/useCurationTaskListFilters'
 import { Button, FormControlLabel, Stack, Switch } from '@mui/material'
-import { useMemo, useState } from 'react'
-import { ListCurationTaskRequest } from '@sage-bionetworks/synapse-client'
+import { useMemo } from 'react'
 import { AddCircleTwoTone } from '@mui/icons-material'
 import { FeatureFlagEnum } from '@/utils/featureflag/FeatureFlags'
 import { useNavigate } from 'react-router'
@@ -23,16 +24,18 @@ export type MetadataTaskTableProps = {
 function MetadataTasksPageInternal(props: MetadataTaskTableProps) {
   const { projectId } = props
   const navigate = useNavigate()
-  const [listCurationTaskRequest, setListCurationTaskRequest] =
-    useState<ListCurationTaskRequest>({
-      projectId,
-      assignedToMe: false,
-    })
+  const {
+    request,
+    taskIds,
+    assignedToMe,
+    setAssignedToMe,
+    clearTaskIdsFilter,
+  } = useCurationTaskListFilters({ projectId })
 
   const { data: permissions } = useGetEntityPermissions(projectId)
 
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
-    useGetCurationTasksInfinite(listCurationTaskRequest)
+    useGetCurationTasksInfinite(request)
 
   const tasks = useMemo(
     () => data?.pages.flatMap(page => page.bundlePage ?? []) ?? [],
@@ -49,12 +52,9 @@ function MetadataTasksPageInternal(props: MetadataTaskTableProps) {
         <FormControlLabel
           control={
             <Switch
-              checked={!!listCurationTaskRequest.assignedToMe}
+              checked={assignedToMe}
               onChange={(_e, checked) => {
-                setListCurationTaskRequest(prev => ({
-                  ...prev,
-                  assignedToMe: checked,
-                }))
+                setAssignedToMe(checked)
               }}
             />
           }
@@ -70,6 +70,7 @@ function MetadataTasksPageInternal(props: MetadataTaskTableProps) {
           </Button>
         )}
       </Stack>
+      <FilteredByTaskIdsBanner taskIds={taskIds} onClear={clearTaskIdsFilter} />
       <InfiniteTableLayout
         table={
           <Stack gap={3} sx={{ my: 2 }}>

--- a/packages/synapse-react-client/src/utils/SynapseConstants.ts
+++ b/packages/synapse-react-client/src/utils/SynapseConstants.ts
@@ -223,6 +223,9 @@ export const GRID_PAGE_SESSION_ID_QUERY_PARAM = 'sessionId'
 export const GRID_PAGE_AGENT_REGISTRATION_ID_QUERY_PARAM = 'agentRegistrationId'
 export const GRID_PAGE_TASK_ID_QUERY_PARAM = 'taskIds'
 
+// Curation Task List URL Query Parameters
+export const CURATION_TASK_LIST_ASSIGNED_TO_ME_QUERY_PARAM = 'assignedToMe'
+
 // Search Page URL Query Parameters
 export const SEARCH_PAGE_QUERY_PARAM = 'query'
 

--- a/packages/synapse-react-client/src/utils/hooks/useCurationTaskListFilters.test.tsx
+++ b/packages/synapse-react-client/src/utils/hooks/useCurationTaskListFilters.test.tsx
@@ -1,0 +1,129 @@
+import { act, renderHook } from '@testing-library/react'
+import { PropsWithChildren } from 'react'
+import { MemoryRouter, useLocation } from 'react-router'
+import {
+  parseTaskIdsSearchParam,
+  useCurationTaskListFilters,
+} from './useCurationTaskListFilters'
+
+function renderWithRouter(
+  init?: Parameters<typeof useCurationTaskListFilters>[0],
+  initialEntry = '/',
+) {
+  return renderHook(
+    () => ({
+      ...useCurationTaskListFilters(init),
+      search: useLocation().search,
+    }),
+    {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <MemoryRouter initialEntries={[initialEntry]}>{children}</MemoryRouter>
+      ),
+    },
+  )
+}
+
+describe('parseTaskIdsSearchParam', () => {
+  it('returns undefined when the value is null', () => {
+    expect(parseTaskIdsSearchParam(null)).toBeUndefined()
+  })
+
+  it('returns undefined when the value is an empty string', () => {
+    expect(parseTaskIdsSearchParam('')).toBeUndefined()
+  })
+
+  it('parses a single numeric ID', () => {
+    expect(parseTaskIdsSearchParam('123')).toEqual([123])
+  })
+
+  it('parses comma-separated numeric IDs', () => {
+    expect(parseTaskIdsSearchParam('123,456')).toEqual([123, 456])
+  })
+
+  it('filters out non-numeric entries', () => {
+    expect(parseTaskIdsSearchParam('123,abc,456')).toEqual([123, 456])
+  })
+})
+
+describe('useCurationTaskListFilters', () => {
+  it('defaults assignedToMe to false and taskIds to undefined', () => {
+    const { result } = renderWithRouter({ projectId: 'syn123' })
+
+    expect(result.current.request).toEqual({
+      projectId: 'syn123',
+      assignedToMe: false,
+      taskIds: undefined,
+    })
+    expect(result.current.taskIds).toBeUndefined()
+    expect(result.current.assignedToMe).toBe(false)
+  })
+
+  it('seeds assignedToMe from defaultAssignedToMe', () => {
+    const { result } = renderWithRouter({ defaultAssignedToMe: true })
+
+    expect(result.current.assignedToMe).toBe(true)
+    expect(result.current.request).toEqual({
+      projectId: undefined,
+      assignedToMe: true,
+      taskIds: undefined,
+    })
+  })
+
+  it('reads assignedToMe from the URL, overriding the default', () => {
+    const { result } = renderWithRouter(
+      { defaultAssignedToMe: true },
+      '/?assignedToMe=false',
+    )
+
+    expect(result.current.assignedToMe).toBe(false)
+    expect(result.current.request.assignedToMe).toBe(false)
+  })
+
+  it('sets the assignedToMe URL param via setAssignedToMe when it differs from the default', () => {
+    const { result } = renderWithRouter({ defaultAssignedToMe: false })
+
+    act(() => {
+      result.current.setAssignedToMe(true)
+    })
+
+    expect(result.current.assignedToMe).toBe(true)
+    expect(result.current.request.assignedToMe).toBe(true)
+    expect(result.current.search).toBe('?assignedToMe=true')
+  })
+
+  it('removes the assignedToMe URL param via setAssignedToMe when it matches the default', () => {
+    const { result } = renderWithRouter(
+      { defaultAssignedToMe: false },
+      '/?assignedToMe=true',
+    )
+    expect(result.current.assignedToMe).toBe(true)
+
+    act(() => {
+      result.current.setAssignedToMe(false)
+    })
+
+    expect(result.current.assignedToMe).toBe(false)
+    expect(result.current.request.assignedToMe).toBe(false)
+    expect(result.current.search).toBe('')
+  })
+
+  it('parses taskIds from the URL search params into the request', () => {
+    const { result } = renderWithRouter({}, '/?taskIds=123,456')
+
+    expect(result.current.taskIds).toEqual([123, 456])
+    expect(result.current.request.taskIds).toEqual([123, 456])
+  })
+
+  it('clears the taskIds filter via clearTaskIdsFilter', () => {
+    const { result } = renderWithRouter({}, '/?taskIds=123,456')
+
+    expect(result.current.taskIds).toEqual([123, 456])
+
+    act(() => {
+      result.current.clearTaskIdsFilter()
+    })
+
+    expect(result.current.taskIds).toBeUndefined()
+    expect(result.current.request.taskIds).toBeUndefined()
+  })
+})

--- a/packages/synapse-react-client/src/utils/hooks/useCurationTaskListFilters.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useCurationTaskListFilters.ts
@@ -1,0 +1,120 @@
+import {
+  CURATION_TASK_LIST_ASSIGNED_TO_ME_QUERY_PARAM,
+  GRID_PAGE_TASK_ID_QUERY_PARAM,
+} from '@/utils/SynapseConstants'
+import { ListCurationTaskRequest } from '@sage-bionetworks/synapse-client'
+import { useCallback, useMemo } from 'react'
+import { useSearchParams } from 'react-router'
+
+/**
+ * Parses the `taskIds` URL search param value (a comma-separated list of numeric IDs) into an array
+ * of numbers, filtering out any non-numeric entries. Returns `undefined` if the value is empty/absent.
+ */
+export function parseTaskIdsSearchParam(
+  rawValue: string | null,
+): number[] | undefined {
+  if (!rawValue) {
+    return undefined
+  }
+  return rawValue
+    .split(',')
+    .map(id => parseInt(id, 10))
+    .filter(id => !isNaN(id))
+}
+
+/**
+ * Parses the `assignedToMe` URL search param value ('true' | 'false'), falling back to
+ * `defaultValue` if the param is absent.
+ */
+export function parseAssignedToMeSearchParam(
+  rawValue: string | null,
+  defaultValue: boolean,
+): boolean {
+  return rawValue === null ? defaultValue : rawValue === 'true'
+}
+
+export type UseCurationTaskListFiltersInit = {
+  /** The project to scope the task list to. If omitted, results are aggregated across projects. */
+  projectId?: string
+  /** The value of the `assignedToMe` filter used when the URL does not specify one. Defaults to `false`. */
+  defaultAssignedToMe?: boolean
+}
+
+export type UseCurationTaskListFiltersResult = {
+  /** A `ListCurationTaskRequest`, ready to pass to `useGetCurationTasksInfinite`. */
+  request: ListCurationTaskRequest
+  /** The task IDs parsed from the `taskIds` URL search param, or `undefined` if not present. */
+  taskIds: number[] | undefined
+  assignedToMe: boolean
+  /** Sets the `assignedToMe` URL search param, removing it if it matches `defaultAssignedToMe`. */
+  setAssignedToMe: (assignedToMe: boolean) => void
+  /** Removes the `taskIds` filter from the URL. */
+  clearTaskIdsFilter: () => void
+}
+
+/**
+ * Builds a `ListCurationTaskRequest` from a combination of caller-provided filters (`projectId`,
+ * `assignedToMe`) and the `taskIds`/`assignedToMe` URL search params. Shared by any page that lists
+ * curation tasks (e.g. `CuratorDashboard`, `MetadataTasksPage`) so these URL-driven filters behave
+ * consistently.
+ */
+export function useCurationTaskListFilters(
+  init: UseCurationTaskListFiltersInit = {},
+): UseCurationTaskListFiltersResult {
+  const { projectId, defaultAssignedToMe = false } = init
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const taskIdParam = searchParams.get(GRID_PAGE_TASK_ID_QUERY_PARAM)
+  const taskIds = useMemo(
+    () => parseTaskIdsSearchParam(taskIdParam),
+    [taskIdParam],
+  )
+
+  const assignedToMeParam = searchParams.get(
+    CURATION_TASK_LIST_ASSIGNED_TO_ME_QUERY_PARAM,
+  )
+  const assignedToMe = useMemo(
+    () => parseAssignedToMeSearchParam(assignedToMeParam, defaultAssignedToMe),
+    [assignedToMeParam, defaultAssignedToMe],
+  )
+
+  const setAssignedToMe = useCallback(
+    (value: boolean) => {
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev)
+        if (value === defaultAssignedToMe) {
+          next.delete(CURATION_TASK_LIST_ASSIGNED_TO_ME_QUERY_PARAM)
+        } else {
+          next.set(CURATION_TASK_LIST_ASSIGNED_TO_ME_QUERY_PARAM, String(value))
+        }
+        return next
+      })
+    },
+    [setSearchParams, defaultAssignedToMe],
+  )
+
+  const clearTaskIdsFilter = useCallback(() => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      next.delete(GRID_PAGE_TASK_ID_QUERY_PARAM)
+      return next
+    })
+  }, [setSearchParams])
+
+  const request = useMemo<ListCurationTaskRequest>(
+    () => ({
+      projectId,
+      assignedToMe,
+      taskIds,
+    }),
+    [projectId, assignedToMe, taskIds],
+  )
+
+  return {
+    request,
+    taskIds,
+    assignedToMe,
+    setAssignedToMe,
+    clearTaskIdsFilter,
+  }
+}


### PR DESCRIPTION
Extract the taskIds URL-search-param filtering from CuratorDashboard into a shared useCurationTaskListFilters hook, and reuse it in MetadataTasksPage. Both pages now show a FilteredByTaskIdsBanner with a "Clear filter" action when the filter is active, since ExecutableTaskCard's "View Result" link can set taskIds from either page's task list.

Also moved `assignedToMe` state to the URL for consistency.