### PR TITLE
SWC-7890 - Upload components support chat attachment limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We're using [pnpm workspaces](https://pnpm.io/workspaces) to manage multiple pro
 │  ├── ./portals - Generates sites for data portals. Contains configurations for each maintained portal.
 │  ├── ./SageAccountWeb - Standalone client-only React application for managing a Sage Bionetworks user account
 │  └── ./synapse-oauth-signin - Standalone client-only React application used to authenticate and consent to an app that uses Synapse OAuth2+OIDC services
-├── ./projects - Libraries and utilities that may or may not be published to NPM
+├── ./packages - Libraries and utilities that may or may not be published to NPM
 │  ├── ./synapse-react-client - React components and utilities used in Synapse.org and portals
 │  ├── ./synapse-types - TypeScript definitions and utility functions for Synapse REST API objects
 │  └── ./vite-config - Shared configuration files for Vite used by apps

--- a/packages/synapse-react-client/src/components/file/upload/BasicFileHandleUpload.tsx
+++ b/packages/synapse-react-client/src/components/file/upload/BasicFileHandleUpload.tsx
@@ -1,5 +1,6 @@
 import MultiFileUploadProgress from '@/components/file/upload/MultiFileUploadProgress'
 import UploadFilePanel from '@/components/file/upload/UploadFilePanel'
+import { FileSelectionConstraints } from '@/components/file/upload/validateFileSelection'
 import {
   UploaderState,
   useUploadFiles,
@@ -9,10 +10,16 @@ import { ForwardedRef, forwardRef, useEffect, useImperativeHandle } from 'react'
 
 export type BasicFileHandleUploadProps = {
   /**
-   * Whether to allow uploading multiple files.
-   * Currently, only single file upload is supported by this UI component.
+   * Whether to allow uploading multiple files at once.
    */
-  allowMultipleUpload: false
+  allowMultipleUpload: boolean
+  /**
+   * When `allowMultipleUpload` is true, whether to skip the Files/Folder menu and open the
+   * (multi-select) file browser directly, rather than offering a folder upload option.
+   * Has no effect when `allowMultipleUpload` is false.
+   * @default false
+   */
+  disableFolderUpload?: boolean
   /**
    * Whether to disable "drag-and-drop to upload" functionality.
    * Currently, drag-and-drop cannot be enabled.
@@ -23,7 +30,31 @@ export type BasicFileHandleUploadProps = {
   /** Callback that is invoked when component is ready to upload */
   onUploadReady?: () => void
   /** Callback that is invoked when an individual upload is complete */
-  onFileUploadComplete?: (fileHandleIds: string) => void
+  onFileUploadComplete?: (fileHandleId: string, file: File) => void
+  /**
+   * If provided, files whose type is not included in this list are rejected before upload.
+   */
+  acceptedContentTypes?: FileSelectionConstraints['acceptedContentTypes']
+  /**
+   * If provided, files larger than this are rejected before upload.
+   */
+  maxFileSizeBytes?: FileSelectionConstraints['maxFileSizeBytes']
+  /**
+   * If provided, a selection that would bring the total file count (see `currentFileCount`)
+   * above this value is rejected before upload.
+   */
+  maxFiles?: FileSelectionConstraints['maxFiles']
+  /**
+   * The number of files already selected/uploaded prior to this selection. Used with `maxFiles`.
+   * @default 0
+   */
+  currentFileCount?: FileSelectionConstraints['currentFileCount']
+  /**
+   * Invoked when a file selection is rejected due to `acceptedContentTypes`, `maxFileSizeBytes`,
+   * or `maxFiles`. Invoked with `null` when a subsequent selection is valid, so the caller can
+   * clear a previously displayed error.
+   */
+  onValidationError?: (message: string | null) => void
 }
 
 export type FileUploadHandle = {
@@ -41,14 +72,20 @@ export const BasicFileHandleUpload = forwardRef(function FileHandleUpload(
 ) {
   const {
     allowMultipleUpload,
+    disableFolderUpload = false,
     onStateChange = noop,
     onUploadReady = noop,
     onFileUploadComplete = noop,
+    acceptedContentTypes,
+    maxFileSizeBytes,
+    maxFiles,
+    currentFileCount,
+    onValidationError,
   } = props
 
   const { startUpload, state, uploadProgress } = useUploadFiles({
-    onUploadComplete: (_, fileHandleId) => {
-      onFileUploadComplete(fileHandleId)
+    onUploadComplete: (preparedFile, fileHandleId) => {
+      onFileUploadComplete(fileHandleId, preparedFile.file)
       return Promise.resolve()
     },
   })
@@ -79,7 +116,13 @@ export const BasicFileHandleUpload = forwardRef(function FileHandleUpload(
       <UploadFilePanel
         onUploadFileList={uploadFileList}
         allowMultipleFiles={allowMultipleUpload}
+        hideFolderOption={disableFolderUpload}
         disableDragAndDrop={true}
+        acceptedContentTypes={acceptedContentTypes}
+        maxFileSizeBytes={maxFileSizeBytes}
+        maxFiles={maxFiles}
+        currentFileCount={currentFileCount}
+        onValidationError={onValidationError}
       />
       <MultiFileUploadProgress
         uploaderState={state}

--- a/packages/synapse-react-client/src/components/file/upload/UploadFilePanel.test.tsx
+++ b/packages/synapse-react-client/src/components/file/upload/UploadFilePanel.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import UploadFilePanel, { UploadFilePanelProps } from './UploadFilePanel'
+
+function renderComponent(propOverrides: Partial<UploadFilePanelProps> = {}) {
+  const user = userEvent.setup()
+  const onUploadFileList = vi.fn()
+  const onValidationError = vi.fn()
+  const result = render(
+    <UploadFilePanel
+      onUploadFileList={onUploadFileList}
+      allowMultipleFiles={true}
+      onValidationError={onValidationError}
+      {...propOverrides}
+    />,
+  )
+  const fileInput = result.container.querySelector<HTMLInputElement>(
+    'input[type="file"][id=filesToUpload]',
+  )!
+  return { user, onUploadFileList, onValidationError, fileInput, result }
+}
+
+describe('UploadFilePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uploads a selection that satisfies all constraints', async () => {
+    const { user, onUploadFileList, onValidationError, fileInput } =
+      renderComponent({
+        acceptedContentTypes: ['text/plain'],
+        maxFileSizeBytes: 1024,
+        maxFiles: 2,
+      })
+
+    const file = new File(['contents'], 'file.txt', { type: 'text/plain' })
+    await user.upload(fileInput, file)
+
+    expect(onUploadFileList).toHaveBeenCalledTimes(1)
+    expect(onUploadFileList.mock.calls[0][0][0]).toBe(file)
+    expect(onValidationError).toHaveBeenCalledWith(null)
+  })
+
+  it('sets the accept attribute from acceptedContentTypes', () => {
+    const { fileInput } = renderComponent({
+      acceptedContentTypes: ['text/plain', 'application/pdf'],
+    })
+    expect(fileInput).toHaveAttribute('accept', 'text/plain,application/pdf')
+  })
+
+  it('rejects a file that exceeds maxFileSizeBytes without uploading', async () => {
+    const { user, onUploadFileList, onValidationError, fileInput } =
+      renderComponent({
+        maxFileSizeBytes: 10,
+      })
+
+    const file = new File(['this content is over ten bytes'], 'big.txt', {
+      type: 'text/plain',
+    })
+    await user.upload(fileInput, file)
+
+    expect(onUploadFileList).not.toHaveBeenCalled()
+    expect(onValidationError).toHaveBeenCalledWith(
+      'Each file must be 0 MB or less.',
+    )
+  })
+
+  it('rejects an unsupported content type without uploading', () => {
+    // Uses fireEvent (rather than userEvent.upload) because userEvent.upload simulates the
+    // browser's own filtering against the `accept` attribute, which is advisory only in real
+    // browsers -- our JS-side validation is the actual enforcement being tested here.
+    const { onUploadFileList, onValidationError, fileInput } = renderComponent({
+      acceptedContentTypes: ['text/plain'],
+    })
+
+    const file = new File(['contents'], 'file.exe', {
+      type: 'application/x-msdownload',
+    })
+    Object.defineProperty(fileInput, 'files', { value: [file] })
+    fireEvent.change(fileInput)
+
+    expect(onUploadFileList).not.toHaveBeenCalled()
+    expect(onValidationError).toHaveBeenCalledWith(
+      'Unsupported file type: file.exe.',
+    )
+  })
+
+  it('rejects a selection that would exceed maxFiles, counting currentFileCount', async () => {
+    const { user, onUploadFileList, onValidationError, fileInput } =
+      renderComponent({
+        maxFiles: 2,
+        currentFileCount: 2,
+      })
+
+    const file = new File(['contents'], 'file.txt', { type: 'text/plain' })
+    await user.upload(fileInput, file)
+
+    expect(onUploadFileList).not.toHaveBeenCalled()
+    expect(onValidationError).toHaveBeenCalledWith(
+      'You can attach up to 2 files.',
+    )
+  })
+
+  it('opens the file browser directly when hideFolderOption is true, even when allowMultipleFiles is true', async () => {
+    const { user } = renderComponent({
+      allowMultipleFiles: true,
+      hideFolderOption: true,
+    })
+
+    await user.click(await screen.findByText('Click to upload'))
+
+    expect(
+      screen.queryByRole('menuitem', { name: 'Files' }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('menuitem', { name: 'Folder' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('still shows the Files/Folder menu when hideFolderOption is false (default)', async () => {
+    const { user } = renderComponent({ allowMultipleFiles: true })
+
+    await user.click(await screen.findByText('Click to upload'))
+
+    expect(
+      await screen.findByRole('menuitem', { name: 'Files' }),
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByRole('menuitem', { name: 'Folder' }),
+    ).toBeInTheDocument()
+  })
+
+  it('behaves the same as before when no constraint props are provided', async () => {
+    const { user, onUploadFileList, onValidationError, fileInput } =
+      renderComponent({ onValidationError: undefined })
+
+    const file = new File(['contents'], 'file.txt', { type: 'text/plain' })
+    await user.upload(fileInput, file)
+
+    expect(onUploadFileList).toHaveBeenCalledTimes(1)
+    expect(onValidationError).not.toHaveBeenCalled()
+  })
+})

--- a/packages/synapse-react-client/src/components/file/upload/UploadFilePanel.tsx
+++ b/packages/synapse-react-client/src/components/file/upload/UploadFilePanel.tsx
@@ -1,12 +1,17 @@
+import Fade from '@mui/material/Fade'
 import Link from '@mui/material/Link'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
 import { SxProps } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
+import { noop } from 'lodash-es'
 import { MouseEvent, ReactNode, useRef, useState } from 'react'
 import { SynapseSpinner } from '../../LoadingScreen/LoadingScreen'
-import Menu from '@mui/material/Menu'
-import Fade from '@mui/material/Fade'
-import MenuItem from '@mui/material/MenuItem'
+import {
+  FileSelectionConstraints,
+  validateFileSelection,
+} from './validateFileSelection'
 
 const disabledUploadPaneSx: SxProps = {
   pointerEvents: 'none',
@@ -46,6 +51,37 @@ export type UploadFilePanelProps = {
    * @default false
    */
   disableDragAndDrop?: boolean
+  /**
+   * When `allowMultipleFiles` is true, whether to skip the Files/Folder menu and open the
+   * (multi-select) file browser directly. Has no effect when `allowMultipleFiles` is false.
+   * @default false
+   */
+  hideFolderOption?: boolean
+  /**
+   * If provided, files whose `type` is not included in this list are rejected before upload,
+   * and used to constrain the file picker via the input's `accept` attribute.
+   */
+  acceptedContentTypes?: FileSelectionConstraints['acceptedContentTypes']
+  /**
+   * If provided, files larger than this are rejected before upload.
+   */
+  maxFileSizeBytes?: FileSelectionConstraints['maxFileSizeBytes']
+  /**
+   * If provided, a selection that would bring the total file count (see `currentFileCount`)
+   * above this value is rejected before upload.
+   */
+  maxFiles?: FileSelectionConstraints['maxFiles']
+  /**
+   * The number of files already selected/uploaded prior to this selection. Used with `maxFiles`.
+   * @default 0
+   */
+  currentFileCount?: FileSelectionConstraints['currentFileCount']
+  /**
+   * Invoked when a file selection is rejected due to `acceptedContentTypes`, `maxFileSizeBytes`,
+   * or `maxFiles`, with a human-readable description of the violation. Invoked with `null` when
+   * a subsequent selection is valid, so the caller can clear a previously displayed error.
+   */
+  onValidationError?: (message: string | null) => void
 }
 
 /**
@@ -62,6 +98,12 @@ export default function UploadFilePanel(props: UploadFilePanelProps) {
     disabled = false,
     message,
     disableDragAndDrop = false,
+    hideFolderOption = false,
+    acceptedContentTypes,
+    maxFileSizeBytes,
+    maxFiles,
+    currentFileCount = 0,
+    onValidationError = noop,
   } = props
   const fileInputRef = useRef<HTMLInputElement>(null)
   const folderInputRef = useRef<HTMLInputElement>(null)
@@ -69,7 +111,7 @@ export default function UploadFilePanel(props: UploadFilePanelProps) {
   const open = Boolean(anchorEl)
 
   const handleClick = (event: MouseEvent<HTMLElement>) => {
-    if (!allowMultipleFiles) {
+    if (!allowMultipleFiles || hideFolderOption) {
       fileInputRef.current!.click()
     } else {
       setAnchorEl(event.currentTarget)
@@ -77,6 +119,22 @@ export default function UploadFilePanel(props: UploadFilePanelProps) {
   }
   const handleClose = () => {
     setAnchorEl(null)
+  }
+
+  function handleFileListSelected(fileList: FileList) {
+    const files = Array.from(fileList)
+    const validationError = validateFileSelection(files, {
+      acceptedContentTypes,
+      maxFileSizeBytes,
+      maxFiles,
+      currentFileCount,
+    })
+    if (validationError) {
+      onValidationError(validationError)
+      return
+    }
+    onValidationError(null)
+    onUploadFileList(fileList)
   }
 
   return (
@@ -123,10 +181,13 @@ export default function UploadFilePanel(props: UploadFilePanelProps) {
             style={{ display: 'none' }}
             aria-hidden="true"
             multiple={allowMultipleFiles}
+            accept={acceptedContentTypes?.join(',')}
             ref={fileInputRef}
             onChange={e => {
               if (e.target.files != null) {
-                onUploadFileList(e.target.files)
+                handleFileListSelected(e.target.files)
+                // Reset so the same file(s) can be reselected after fixing a validation error.
+                e.target.value = ''
               }
             }}
           />
@@ -140,7 +201,8 @@ export default function UploadFilePanel(props: UploadFilePanelProps) {
             ref={folderInputRef}
             onChange={e => {
               if (e.target.files != null) {
-                onUploadFileList(e.target.files)
+                handleFileListSelected(e.target.files)
+                e.target.value = ''
               }
             }}
             // @ts-expect-error - webkitdirectory is not included in the InputHTMLAttributes type

--- a/packages/synapse-react-client/src/components/file/upload/validateFileSelection.test.ts
+++ b/packages/synapse-react-client/src/components/file/upload/validateFileSelection.test.ts
@@ -1,0 +1,83 @@
+import { validateFileSelection } from './validateFileSelection'
+
+describe('validateFileSelection', () => {
+  const txtFile = (name: string, sizeBytes = 10) => {
+    const file = new File(['x'.repeat(sizeBytes)], name, {
+      type: 'text/plain',
+    })
+    return file
+  }
+
+  it('returns null when there are no constraints', () => {
+    expect(validateFileSelection([txtFile('a.txt')], {})).toBeNull()
+  })
+
+  it('returns null when the selection satisfies all constraints', () => {
+    expect(
+      validateFileSelection([txtFile('a.txt')], {
+        acceptedContentTypes: ['text/plain'],
+        maxFileSizeBytes: 1000,
+        maxFiles: 5,
+        currentFileCount: 1,
+      }),
+    ).toBeNull()
+  })
+
+  it('rejects a selection that would exceed maxFiles, counting currentFileCount', () => {
+    const result = validateFileSelection([txtFile('a.txt'), txtFile('b.txt')], {
+      maxFiles: 2,
+      currentFileCount: 1,
+    })
+    expect(result).toEqual('You can attach up to 2 files.')
+  })
+
+  it('allows a selection that exactly meets maxFiles', () => {
+    const result = validateFileSelection([txtFile('a.txt'), txtFile('b.txt')], {
+      maxFiles: 2,
+      currentFileCount: 0,
+    })
+    expect(result).toBeNull()
+  })
+
+  it('rejects a file exceeding maxFileSizeBytes', () => {
+    const oneMb = 1024 * 1024
+    const result = validateFileSelection([txtFile('big.txt', oneMb * 2)], {
+      maxFileSizeBytes: oneMb,
+    })
+    expect(result).toEqual('Each file must be 1 MB or less.')
+  })
+
+  it('rejects an unsupported content type', () => {
+    const exeFile = new File(['x'], 'virus.exe', {
+      type: 'application/x-msdownload',
+    })
+    const result = validateFileSelection([exeFile], {
+      acceptedContentTypes: ['text/plain', 'application/pdf'],
+    })
+    expect(result).toEqual('Unsupported file type: virus.exe.')
+  })
+
+  it('lists every unsupported file by name', () => {
+    const exeFile = new File(['x'], 'virus.exe', {
+      type: 'application/x-msdownload',
+    })
+    const batFile = new File(['x'], 'script.bat', { type: '' })
+    const result = validateFileSelection([exeFile, batFile], {
+      acceptedContentTypes: ['text/plain'],
+    })
+    expect(result).toEqual('Unsupported file type: virus.exe, script.bat.')
+  })
+
+  it('checks maxFiles before file size or type', () => {
+    const bigUnsupportedFile = new File(['x'.repeat(2000)], 'big.exe', {
+      type: 'application/x-msdownload',
+    })
+    const result = validateFileSelection([bigUnsupportedFile], {
+      acceptedContentTypes: ['text/plain'],
+      maxFileSizeBytes: 1000,
+      maxFiles: 0,
+      currentFileCount: 0,
+    })
+    expect(result).toEqual('You can attach up to 0 files.')
+  })
+})

--- a/packages/synapse-react-client/src/components/file/upload/validateFileSelection.ts
+++ b/packages/synapse-react-client/src/components/file/upload/validateFileSelection.ts
@@ -1,0 +1,63 @@
+export type FileSelectionConstraints = {
+  /**
+   * If provided, files whose `type` is not included in this list will be rejected.
+   */
+  acceptedContentTypes?: readonly string[]
+  /**
+   * If provided, files larger than this will be rejected.
+   */
+  maxFileSizeBytes?: number
+  /**
+   * If provided, the total number of files (this selection plus `currentFileCount`) may not exceed this value.
+   */
+  maxFiles?: number
+  /**
+   * The number of files already selected/uploaded prior to this selection. Used with `maxFiles`.
+   * @default 0
+   */
+  currentFileCount?: number
+}
+
+function formatMegabytes(bytes: number): string {
+  return `${Math.round(bytes / (1024 * 1024))} MB`
+}
+
+/**
+ * Validates a file selection against the given constraints, returning a human-readable error
+ * message describing the first violation encountered, or null if the selection is valid.
+ */
+export function validateFileSelection(
+  files: File[],
+  constraints: FileSelectionConstraints,
+): string | null {
+  const {
+    acceptedContentTypes,
+    maxFileSizeBytes,
+    maxFiles,
+    currentFileCount = 0,
+  } = constraints
+
+  if (maxFiles != null && currentFileCount + files.length > maxFiles) {
+    return `You can attach up to ${maxFiles} files.`
+  }
+
+  if (
+    maxFileSizeBytes != null &&
+    files.some(file => file.size > maxFileSizeBytes)
+  ) {
+    return `Each file must be ${formatMegabytes(maxFileSizeBytes)} or less.`
+  }
+
+  if (acceptedContentTypes != null) {
+    const unsupportedFiles = files.filter(
+      file => !acceptedContentTypes.includes(file.type),
+    )
+    if (unsupportedFiles.length > 0) {
+      return `Unsupported file type: ${unsupportedFiles
+        .map(file => file.name)
+        .join(', ')}.`
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
Extend existing upload components to support limitations on file size and file type. These limitations will be applied for the scenario where attachments can be uploaded to agent chat.