### PR TITLE
SWC-7890 - Restyle chat input and add components for attachments

### DIFF
--- a/packages/synapse-react-client/src/components/SynapseChat/AccessLevelMenu.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/AccessLevelMenu.tsx
@@ -45,6 +45,7 @@ export function AccessLevelMenu({
       </Typography>
       <DropdownSelect
         variant={'outlined'}
+        buttonGroupAriaLabel={'Access Level Menu'}
         options={options}
         selectedIndex={selectedIndex}
         setSelectedIndex={index => {

--- a/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.tsx
@@ -4,29 +4,18 @@ import {
   useUpdateAgentSession,
 } from '@/synapse-queries/chat/useChat'
 import { useSynapseContext } from '@/utils'
-import { ArrowUpward } from '@mui/icons-material'
-import {
-  Alert,
-  Box,
-  Chip,
-  IconButton,
-  List,
-  Stack,
-  TextField,
-  Typography,
-  useTheme,
-} from '@mui/material'
-import { Color } from '@mui/material/styles'
+import { Alert, Box, Chip, List, Stack, Typography } from '@mui/material'
 import { GridAgentSessionContext } from '@sage-bionetworks/synapse-client'
 import {
   AgentAccessLevel,
   AgentSession,
   TraceEvent,
 } from '@sage-bionetworks/synapse-types'
-import { KeyboardEventHandler, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { SkeletonParagraph } from '../Skeleton'
 import { displayToast } from '../ToastMessage'
 import AccessLevelMenu from './AccessLevelMenu'
+import { ChatInputArea } from './components/ChatInputArea/ChatInputArea'
 import SynapseChatInteraction from './SynapseChatInteraction'
 import SynapseChatMessage from './SynapseChatMessage'
 
@@ -101,7 +90,6 @@ export function SynapseChat({
         'danger',
       ),
   })
-  const theme = useTheme()
   const [agentAccessLevel, setAgentAccessLevel] = useState<AgentAccessLevel>(
     sessionContext
       ? AgentAccessLevel.WRITE_YOUR_PRIVATE_DATA
@@ -165,26 +153,11 @@ export function SynapseChat({
     }
   }, [agentSession, initialMessage, initialMessageProcessed, sendChat])
 
-  const handleSendMessage = () => {
-    if (userChatTextfieldValue.trim()) {
-      sendChat(userChatTextfieldValue.trim())
-      setUserChatTextfieldValue('')
-    }
+  const handleSend = (message: string) => {
+    sendChat(message)
+    setUserChatTextfieldValue('')
   }
 
-  const isDisabled =
-    !agentSession || !userChatTextfieldValue || !!pendingMessage
-
-  const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = event => {
-    if (!isDisabled && event.key === 'Enter' && !event.shiftKey) {
-      event.preventDefault()
-      handleSendMessage()
-    }
-  }
-
-  const sendMessageButtonColor = (
-    theme.palette.secondary as unknown as Color
-  )[300]
   if (createAgentSessionError) {
     return (
       <Alert severity={'error'} sx={{ my: 2 }}>
@@ -303,54 +276,19 @@ export function SynapseChat({
               ))}
             </Stack>
           )}
-        <Box
-          component="form"
-          sx={{
-            pt: '8px',
-            mt: '5px',
-            pb: '10px',
-            position: 'sticky',
-            borderTop: '1px solid',
-            borderColor: 'grey.400',
-          }}
-          onSubmit={handleSendMessage}
-        >
-          <TextField
-            fullWidth
+        <Box sx={{ mt: '5px' }}>
+          <ChatInputArea
             value={userChatTextfieldValue}
-            onChange={e => setUserChatTextfieldValue(e.target.value)}
-            onKeyDown={handleKeyDown}
+            onValueChange={setUserChatTextfieldValue}
+            onSend={handleSend}
             placeholder={`Message ${chatbotName}`}
-            slotProps={{
-              input: {
-                sx: { borderRadius: 96.6 },
-                endAdornment: (
-                  <IconButton
-                    disabled={isDisabled}
-                    onClick={handleSendMessage}
-                    sx={{
-                      ml: '7px',
-                      mr: '-8px',
-                      color: sendMessageButtonColor,
-                      borderStyle: 'solid',
-                      borderWidth: isDisabled ? '1px' : '2px',
-                      borderColor: isDisabled ? 'gray' : sendMessageButtonColor,
-                    }}
-                  >
-                    <ArrowUpward />
-                  </IconButton>
-                ),
-              },
-            }}
+            disabled={!agentSession || !!pendingMessage}
           />
-          <Typography
-            variant="smallText1"
-            sx={{ pt: '8px', textAlign: 'center' }}
-          >
-            {chatbotName} can make mistakes.
-          </Typography>
         </Box>
       </Box>
+      <Typography variant="smallText1" sx={{ pt: '8px', textAlign: 'center' }}>
+        {chatbotName} can make mistakes.
+      </Typography>
     </Box>
   )
 }

--- a/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.module.scss
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.module.scss
@@ -1,0 +1,16 @@
+.chip {
+  position: relative;
+}
+
+.removeBadge:global(.MuiButtonBase-root) {
+  position: absolute;
+  top: -6px;
+  left: -6px;
+  opacity: 0;
+  transition: opacity 100ms;
+}
+
+.chip:hover .removeBadge,
+.chip:focus-within .removeBadge {
+  opacity: 1;
+}

--- a/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.stories.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.stories.tsx
@@ -1,0 +1,40 @@
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { fn } from 'storybook/test'
+import { AttachmentChip } from './AttachmentChip'
+
+const meta = {
+  title: 'Synapse/Chat/AttachmentChip',
+  component: AttachmentChip,
+} satisfies Meta<typeof AttachmentChip>
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    label: 'PCA_Lung_Cancer_Feature_Reduction_Classification.pdf',
+    contentType: 'application/pdf',
+  },
+}
+
+export const Removable: Story = {
+  args: {
+    label: 'report.csv',
+    contentType: 'text/csv',
+    onRemove: fn(),
+  },
+}
+
+export const GenericRestoredAttachment: Story = {
+  args: {
+    // A restored/polled turn only has the fileHandleId that was sent to the server.
+    label: '9999999',
+  },
+}
+
+export const Failed: Story = {
+  args: {
+    label: 'unsupported-file.exe',
+    status: 'failed',
+    errorMessage: 'This file type is not supported.',
+  },
+}

--- a/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AttachmentChip } from './AttachmentChip'
+
+describe('AttachmentChip', () => {
+  it('renders the filename and a type label derived from contentType', () => {
+    render(<AttachmentChip label="report.pdf" contentType="application/pdf" />)
+
+    expect(screen.getByText('report.pdf')).toBeInTheDocument()
+    expect(screen.getByText('PDF')).toBeInTheDocument()
+  })
+
+  it('renders a generic "FILE" type label when contentType is omitted', () => {
+    render(<AttachmentChip label="9999999" />)
+
+    expect(screen.getByText('9999999')).toBeInTheDocument()
+    expect(screen.getByText('FILE')).toBeInTheDocument()
+  })
+
+  it('does not render a remove button when onRemove is omitted', () => {
+    render(<AttachmentChip label="report.pdf" contentType="application/pdf" />)
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('renders an accessible remove button that invokes onRemove when clicked', async () => {
+    const user = userEvent.setup()
+    const onRemove = vi.fn()
+    render(
+      <AttachmentChip
+        label="report.pdf"
+        contentType="application/pdf"
+        onRemove={onRemove}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Remove report.pdf' }))
+
+    expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+
+  it('supports a custom accessible label for the remove button', () => {
+    render(
+      <AttachmentChip
+        label="report.pdf"
+        onRemove={vi.fn()}
+        removeButtonLabel="Remove attachment report.pdf"
+      />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Remove attachment report.pdf' }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows a "Failed" label instead of the content type label when status is failed', () => {
+    render(
+      <AttachmentChip
+        label="report.pdf"
+        contentType="application/pdf"
+        status="failed"
+      />,
+    )
+
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.queryByText('PDF')).not.toBeInTheDocument()
+  })
+
+  it('shows the failure message in a tooltip when status is failed', async () => {
+    const user = userEvent.setup()
+    render(
+      <AttachmentChip
+        label="report.pdf"
+        status="failed"
+        errorMessage="The file could not be found."
+      />,
+    )
+
+    await user.hover(screen.getByText('report.pdf'))
+
+    expect(
+      await screen.findByText('The file could not be found.'),
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.tsx
@@ -1,0 +1,123 @@
+import CloseIcon from '@mui/icons-material/Close'
+import { Box, IconButton, Tooltip, Typography } from '@mui/material'
+import styles from './AttachmentChip.module.scss'
+
+export type AttachmentChipStatus = 'default' | 'failed'
+
+export type AttachmentChipProps = {
+  /**
+   * Display name for the attachment. For a pending/just-uploaded attachment this is the real
+   * filename; for a restored/polled turn where file metadata isn't available, pass the
+   * fileHandleId instead.
+   */
+  label: string
+  /**
+   * MIME content type, used to derive a short type label (e.g. "PDF"). Omit when the type is
+   * unknown (e.g. a restored turn).
+   */
+  contentType?: string
+  /**
+   * @default 'default'
+   */
+  status?: AttachmentChipStatus
+  /** Shown in a tooltip on the chip when `status` is 'failed'. */
+  errorMessage?: string
+  /** If provided, renders a remove ("x") button; invoked when clicked. */
+  onRemove?: () => void
+  /** Accessible label for the remove button. @default `Remove ${label}` */
+  removeButtonLabel?: string
+}
+
+const CONTENT_TYPE_LABELS: Record<string, string> = {
+  'application/pdf': 'PDF',
+  'text/plain': 'TXT',
+  'text/csv': 'CSV',
+  'application/json': 'JSON',
+  'text/tab-separated-values': 'TSV',
+}
+
+export function getContentTypeLabel(contentType?: string): string {
+  if (!contentType) {
+    return 'FILE'
+  }
+  return CONTENT_TYPE_LABELS[contentType] ?? 'FILE'
+}
+
+/**
+ * Displays a single chat attachment as a chip with a filename and type label. Used both for
+ * attachments still pending send (with a remove button) and for attachments on a sent/restored
+ * chat turn (read-only, optionally showing a server-reported failure).
+ */
+export function AttachmentChip({
+  label,
+  contentType,
+  status = 'default',
+  errorMessage,
+  onRemove,
+  removeButtonLabel = `Remove ${label}`,
+}: AttachmentChipProps) {
+  const isFailed = status === 'failed'
+
+  const chip = (
+    <Box
+      className={styles.chip}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '10px',
+        border: '1px solid',
+        borderColor: isFailed ? 'error.main' : 'grey.300',
+        borderRadius: '8px',
+        boxShadow: '0px 1px 1px rgba(0,0,0,0.05)',
+        p: '10px',
+      }}
+    >
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography
+          variant="body1"
+          sx={{
+            fontWeight: 700,
+            fontSize: '14px',
+            color: isFailed ? 'error.main' : 'grey.900',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {label}
+        </Typography>
+        <Typography
+          variant="body1"
+          sx={{ fontSize: '12px', color: 'grey.600' }}
+        >
+          {isFailed ? 'Failed' : getContentTypeLabel(contentType)}
+        </Typography>
+      </Box>
+      {onRemove && (
+        <IconButton
+          type="button"
+          aria-label={removeButtonLabel}
+          onClick={onRemove}
+          size="small"
+          className={styles.removeBadge}
+          sx={{
+            border: '1px solid',
+            borderColor: 'grey.300',
+            backgroundColor: 'white',
+            width: '16px',
+            height: '16px',
+          }}
+        >
+          <CloseIcon sx={{ fontSize: '10px' }} />
+        </IconButton>
+      )}
+    </Box>
+  )
+
+  if (isFailed && errorMessage) {
+    return <Tooltip title={errorMessage}>{chip}</Tooltip>
+  }
+  return chip
+}
+
+export default AttachmentChip

--- a/packages/synapse-react-client/src/components/SynapseChat/components/ChatAttachmentStrip/ChatAttachmentStrip.module.scss
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/ChatAttachmentStrip/ChatAttachmentStrip.module.scss
@@ -1,0 +1,19 @@
+// Minimum width for each chip so 3 attachments are visible and a 4th is partially offscreen
+// in the 480px-wide composer. Kept as a SCSS variable since CSS is its only consumer.
+$chip-min-width: 140px;
+
+.strip {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+}
+
+.wrap {
+  flex-wrap: wrap;
+  overflow-x: visible;
+}
+
+.item {
+  flex: 1 1 0;
+  min-width: $chip-min-width;
+}

--- a/packages/synapse-react-client/src/components/SynapseChat/components/ChatAttachmentStrip/ChatAttachmentStrip.stories.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/ChatAttachmentStrip/ChatAttachmentStrip.stories.tsx
@@ -1,0 +1,84 @@
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { fn } from 'storybook/test'
+import { AttachmentStripItem, ChatAttachmentStrip } from './ChatAttachmentStrip'
+
+const meta = {
+  title: 'Synapse/Chat/ChatAttachmentStrip',
+  component: ChatAttachmentStrip,
+  args: {
+    onRemove: fn(),
+  },
+} satisfies Meta<typeof ChatAttachmentStrip>
+export default meta
+type Story = StoryObj<typeof meta>
+
+function attachmentItem(
+  fileHandleId: string,
+  overrides: Partial<AttachmentStripItem> = {},
+): AttachmentStripItem {
+  return {
+    fileHandleId,
+    label: `file-${fileHandleId}.txt`,
+    contentType: 'text/plain',
+    ...overrides,
+  }
+}
+
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+}
+
+export const WithAttachments: Story = {
+  args: {
+    items: [
+      attachmentItem('1', {
+        label: 'PCA_Lung_Cancer_Feature_Reduction_Classification.pdf',
+        contentType: 'application/pdf',
+      }),
+      attachmentItem('2', { label: 'Adams cool text file.txt' }),
+      attachmentItem('3', {
+        label: 'Another file.csv',
+        contentType: 'text/csv',
+      }),
+    ],
+  },
+}
+
+/**
+ * In the composer (nowrap), a 4th chip is intentionally left partially offscreen -- the
+ * container relies on default browser horizontal-scroll behavior rather than a custom
+ * scrollbar.
+ */
+export const FourthChipOverflows: Story = {
+  args: {
+    items: Array.from({ length: 4 }, (_, i) => attachmentItem(`${i + 1}`)),
+  },
+  parameters: {
+    // Matches the composer card's inner content width (480px).
+    chromatic: { viewports: [480] },
+  },
+  decorators: [
+    Story => (
+      <div style={{ width: '480px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const Wrapping: Story = {
+  args: {
+    wrap: true,
+    onRemove: undefined,
+    items: Array.from({ length: 5 }, (_, i) => attachmentItem(`${i + 1}`)),
+  },
+  decorators: [
+    Story => (
+      <div style={{ width: '512px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/packages/synapse-react-client/src/components/SynapseChat/components/ChatAttachmentStrip/ChatAttachmentStrip.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/ChatAttachmentStrip/ChatAttachmentStrip.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AttachmentStripItem, ChatAttachmentStrip } from './ChatAttachmentStrip'
+
+describe('ChatAttachmentStrip', () => {
+  it('renders nothing when there are no items', () => {
+    const { container } = render(<ChatAttachmentStrip items={[]} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders a chip for each item', () => {
+    const items: AttachmentStripItem[] = [
+      { fileHandleId: '1', label: 'a.txt', contentType: 'text/plain' },
+      { fileHandleId: '2', label: 'b.pdf', contentType: 'application/pdf' },
+    ]
+
+    render(<ChatAttachmentStrip items={items} />)
+
+    expect(screen.getByText('a.txt')).toBeInTheDocument()
+    expect(screen.getByText('b.pdf')).toBeInTheDocument()
+  })
+
+  it('does not render a remove button on any chip when onRemove is omitted', () => {
+    render(
+      <ChatAttachmentStrip items={[{ fileHandleId: '1', label: 'a.txt' }]} />,
+    )
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('invokes onRemove with the fileHandleId when a chip is removed', async () => {
+    const user = userEvent.setup()
+    const onRemove = vi.fn()
+
+    render(
+      <ChatAttachmentStrip
+        items={[{ fileHandleId: '1', label: 'a.txt' }]}
+        onRemove={onRemove}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Remove a.txt' }))
+
+    expect(onRemove).toHaveBeenCalledExactlyOnceWith('1')
+  })
+
+  it('shows a failed chip with its error message in a tooltip', async () => {
+    const user = userEvent.setup()
+    render(
+      <ChatAttachmentStrip
+        items={[
+          {
+            fileHandleId: '1',
+            label: 'a.txt',
+            status: 'failed',
+            errorMessage: 'The file could not be found.',
+          },
+        ]}
+      />,
+    )
+
+    await user.hover(screen.getByText('a.txt'))
+
+    expect(
+      await screen.findByText('The file could not be found.'),
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/synapse-react-client/src/components/SynapseChat/components/ChatAttachmentStrip/ChatAttachmentStrip.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/ChatAttachmentStrip/ChatAttachmentStrip.tsx
@@ -1,0 +1,55 @@
+import classNames from 'classnames'
+import {
+  AttachmentChip,
+  AttachmentChipStatus,
+} from '../AttachmentChip/AttachmentChip'
+import styles from './ChatAttachmentStrip.module.scss'
+
+export type AttachmentStripItem = {
+  fileHandleId: string
+  label: string
+  contentType?: string
+  status?: AttachmentChipStatus
+  errorMessage?: string
+}
+
+export type ChatAttachmentStripProps = {
+  items: AttachmentStripItem[]
+  /** Wrap to multiple rows instead of overflowing horizontally. @default false */
+  wrap?: boolean
+  /** If provided, each chip gets a remove badge. Invoked with the fileHandleId of the attachment to remove. */
+  onRemove?: (fileHandleId: string) => void
+}
+
+/**
+ * A strip of attachment chips. Used both above the chat text input for attachments pending
+ * send (horizontally-scrolling, with a remove control on each chip) and below a sent message
+ * in the chat transcript (wrapping, read-only).
+ */
+export function ChatAttachmentStrip({
+  items,
+  wrap = false,
+  onRemove,
+}: ChatAttachmentStripProps) {
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={classNames(styles.strip, wrap && styles.wrap)}>
+      {items.map(item => (
+        <div key={item.fileHandleId} className={styles.item}>
+          <AttachmentChip
+            label={item.label}
+            contentType={item.contentType}
+            status={item.status}
+            errorMessage={item.errorMessage}
+            onRemove={onRemove ? () => onRemove(item.fileHandleId) : undefined}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default ChatAttachmentStrip

--- a/packages/synapse-react-client/src/components/SynapseChat/components/ChatInputArea/ChatInputArea.module.scss
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/ChatInputArea/ChatInputArea.module.scss
@@ -1,0 +1,39 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  background: var(--synapse-white);
+  border: 1px solid var(--synapse-gray-300);
+  border-radius: 8px;
+  box-shadow:
+    0 6px 6px rgb(0 0 0 / 3%),
+    0 1px 1px rgb(0 0 0 / 3%);
+
+  &:has(textarea:focus) {
+    border-color: var(--synapse-primary-focus-border);
+    box-shadow:
+      0 6px 6px rgb(0 0 0 / 3%),
+      0 1px 1px rgb(0 0 0 / 3%),
+      0 0 0 0.1rem var(--synapse-primary-focus-shadow);
+  }
+}
+
+.textarea {
+  width: 100%;
+  min-height: 44px;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  box-shadow: none;
+  resize: none;
+  background: transparent;
+  font: inherit;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+}

--- a/packages/synapse-react-client/src/components/SynapseChat/components/ChatInputArea/ChatInputArea.stories.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/ChatInputArea/ChatInputArea.stories.tsx
@@ -1,0 +1,43 @@
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import { fn } from 'storybook/test'
+import { ChatInputArea } from './ChatInputArea'
+
+const meta = {
+  title: 'Synapse/Chat/ChatInputArea',
+  component: ChatInputArea,
+  args: {
+    onValueChange: fn(),
+    onSend: fn(),
+    placeholder: 'Message SynapseChat',
+  },
+  render: function Render(args) {
+    // ChatInputArea controls its text value externally -- a trivial useState wrapper is enough
+    // to demo it in isolation, without an agent session or chat MSW handlers.
+    const [value, setValue] = useState(args.value)
+    return (
+      <ChatInputArea
+        {...args}
+        value={value}
+        onValueChange={newValue => {
+          setValue(newValue)
+          args.onValueChange(newValue)
+        }}
+      />
+    )
+  },
+} satisfies Meta<typeof ChatInputArea>
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Empty: Story = {
+  args: { value: '' },
+}
+
+export const Typed: Story = {
+  args: { value: 'What files are attached to this project?' },
+}
+
+export const Disabled: Story = {
+  args: { value: 'Waiting for a session...', disabled: true },
+}

--- a/packages/synapse-react-client/src/components/SynapseChat/components/ChatInputArea/ChatInputArea.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/ChatInputArea/ChatInputArea.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { ChatInputArea, ChatInputAreaProps } from './ChatInputArea'
+
+function renderChatInputArea(
+  props: Partial<Omit<ChatInputAreaProps, 'value' | 'onValueChange'>> & {
+    initialValue?: string
+  } = {},
+) {
+  const user = userEvent.setup()
+  const onSend = props.onSend ?? vi.fn()
+
+  function Harness() {
+    const [value, setValue] = useState(props.initialValue ?? '')
+    return (
+      <ChatInputArea
+        value={value}
+        onValueChange={setValue}
+        onSend={onSend}
+        placeholder={props.placeholder}
+        disabled={props.disabled}
+      />
+    )
+  }
+
+  render(<Harness />)
+  return { user, onSend }
+}
+
+describe('ChatInputArea', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sends the trimmed message when Enter is pressed without Shift', async () => {
+    const { user, onSend } = renderChatInputArea()
+
+    await user.type(screen.getByRole('textbox'), '  hello  {Enter}')
+
+    expect(onSend).toHaveBeenCalledExactlyOnceWith('hello')
+  })
+
+  it('does not send when Shift+Enter is pressed', async () => {
+    const { user, onSend } = renderChatInputArea()
+
+    await user.type(screen.getByRole('textbox'), 'hello')
+    await user.keyboard('{Shift>}{Enter}{/Shift}')
+
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('disables the send button when the input is empty or whitespace-only', () => {
+    renderChatInputArea({ initialValue: '   ' })
+
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled()
+  })
+
+  it('disables the send button when disabled', () => {
+    renderChatInputArea({ initialValue: 'hello', disabled: true })
+
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled()
+  })
+
+  it('prevents the default form submission when the send button is clicked', async () => {
+    const { user, onSend } = renderChatInputArea({ initialValue: 'hello' })
+    const form = screen.getByRole('textbox').closest('form')!
+    let capturedEvent: Event | undefined
+    form.addEventListener('submit', event => {
+      capturedEvent = event
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Send message' }))
+
+    expect(capturedEvent?.defaultPrevented).toBe(true)
+    expect(onSend).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/synapse-react-client/src/components/SynapseChat/components/ChatInputArea/ChatInputArea.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/ChatInputArea/ChatInputArea.tsx
@@ -1,0 +1,89 @@
+import ArrowUpward from '@mui/icons-material/ArrowUpward'
+import { Box, IconButton, TextareaAutosize } from '@mui/material'
+import { FormEventHandler, KeyboardEventHandler } from 'react'
+import styles from './ChatInputArea.module.scss'
+
+/** Max number of visible rows the textarea grows to before it scrolls internally. */
+export const MAX_CHAT_INPUT_ROWS = 6
+
+export type ChatInputAreaProps = {
+  value: string
+  onValueChange: (value: string) => void
+  onSend: (message: string) => void
+  placeholder?: string
+  /** No session yet, or a response is in flight. */
+  disabled?: boolean
+}
+
+const actionButtonSx = {
+  height: '36px',
+  px: '12px',
+  border: '1px solid',
+  borderColor: 'grey.300',
+  borderRadius: '1px',
+}
+
+/**
+ * The chat composer: a bordered card containing a conditional attachment strip, an
+ * auto-growing borderless text input, and a right-aligned row of actions (attach + send).
+ * Owns attachment upload state end-to-end; the message text itself is controlled by the
+ * caller since it can also be set from outside the card (e.g. suggested-prompt pills).
+ */
+export function ChatInputArea({
+  value,
+  onValueChange,
+  onSend,
+  placeholder,
+  disabled = false,
+}: ChatInputAreaProps) {
+  const isSendDisabled = disabled || !value.trim()
+
+  const submit = () => {
+    if (isSendDisabled) {
+      return
+    }
+    onSend(value.trim())
+  }
+
+  const handleFormSubmit: FormEventHandler<HTMLFormElement> = event => {
+    event.preventDefault()
+    submit()
+  }
+
+  const handleTextareaKeyDown: KeyboardEventHandler<
+    HTMLTextAreaElement
+  > = event => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
+      submit()
+    }
+  }
+
+  return (
+    <>
+      <Box component="form" className={styles.card} onSubmit={handleFormSubmit}>
+        <TextareaAutosize
+          className={styles.textarea}
+          minRows={1}
+          maxRows={MAX_CHAT_INPUT_ROWS}
+          value={value}
+          onChange={e => onValueChange(e.target.value)}
+          onKeyDown={handleTextareaKeyDown}
+          placeholder={placeholder}
+        />
+        <div className={styles.actions}>
+          <IconButton
+            type="submit"
+            aria-label="Send message"
+            disabled={isSendDisabled}
+            sx={actionButtonSx}
+          >
+            <ArrowUpward />
+          </IconButton>
+        </div>
+      </Box>
+    </>
+  )
+}
+
+export default ChatInputArea


### PR DESCRIPTION
Depends on #3051 

<img width="1180" height="1134" alt="image" src="https://github.com/user-attachments/assets/ab607382-3a6c-4341-a4a9-7e0c6dd7f036" />

<img width="1128" height="183" alt="image" src="https://github.com/user-attachments/assets/2611d1d1-b465-47ba-bc9d-3b8a8167c842" />

<img width="393" height="84" alt="image" src="https://github.com/user-attachments/assets/eace6c56-6ded-4664-9912-40070e619f54" />

<img width="494" height="101" alt="image" src="https://github.com/user-attachments/assets/1a77a8b7-4a08-43b6-98be-fb658c1d651a" />

