### PR TITLE
SWC-7904 Color due date pill based on task status in CurationTaskCard

### DIFF
--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.module.scss
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.module.scss
@@ -44,13 +44,14 @@
 
 .entityInfo {
   display: flex;
-  gap: 16px;
+  gap: 8px;
 }
 
 .statusContainer {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  justify-content: center;
   gap: 8px;
 }
 

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCard.test.tsx
@@ -142,6 +142,47 @@ describe('CurationTaskCard', () => {
     })
   })
 
+  describe('due date chip', () => {
+    it('shows a neutral color when the task is COMPLETED even if the due date has passed', () => {
+      renderComponent(
+        createMockTaskBundle(
+          { projectId: 'syn123' },
+          { state: 'COMPLETED', dueDate: '2000-01-01' },
+        ),
+      )
+      const chip = screen
+        .getByText(/due/i)
+        .closest('.MuiChip-root') as HTMLElement
+      expect(chip).toHaveStyle({ backgroundColor: '#E0E0E0' })
+    })
+
+    it('shows a neutral color when the task is CANCELED even if the due date has passed', () => {
+      renderComponent(
+        createMockTaskBundle(
+          { projectId: 'syn123' },
+          { state: 'CANCELED', dueDate: '2000-01-01' },
+        ),
+      )
+      const chip = screen
+        .getByText(/due/i)
+        .closest('.MuiChip-root') as HTMLElement
+      expect(chip).toHaveStyle({ backgroundColor: '#E0E0E0' })
+    })
+
+    it('shows an overdue color when the due date has passed and the task is not complete', () => {
+      renderComponent(
+        createMockTaskBundle(
+          { projectId: 'syn123' },
+          { state: 'IN_PROGRESS', dueDate: '2000-01-01' },
+        ),
+      )
+      const chip = screen
+        .getByText(/due/i)
+        .closest('.MuiChip-root') as HTMLElement
+      expect(chip).toHaveStyle({ backgroundColor: '#FFCDD2' })
+    })
+  })
+
   describe('status chip', () => {
     it('shows "Not Started" when status state is NOT_STARTED', () => {
       renderComponent(

--- a/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCardLayout.tsx
+++ b/packages/synapse-react-client/src/features/curator/dashboard/components/CurationTaskCardLayout.tsx
@@ -53,19 +53,27 @@ function TaskStatusChip(props: { state: TaskStatusStateEnum | undefined }) {
   )
 }
 
-function DueDateChip(props: { dueDate: string | undefined }) {
-  const { dueDate } = props
+function DueDateChip(props: {
+  dueDate: string | undefined
+  taskState: TaskStatusStateEnum | undefined
+}) {
+  const { dueDate, taskState } = props
   const dueDateObj = parseDueDate(dueDate)
   if (!dueDateObj) return null
 
-  const daysUntilDue = dueDateObj.diff(dayjs.utc().startOf('day'), 'day')
   const formattedDate = dueDateObj.format('MM/DD/YY')
+  const isTerminal =
+    taskState === TaskStatusStateEnum.COMPLETED ||
+    taskState === TaskStatusStateEnum.CANCELED
 
   let backgroundColor = '#E0E0E0'
-  if (daysUntilDue < 0) {
-    backgroundColor = '#FFCDD2'
-  } else if (daysUntilDue < 30) {
-    backgroundColor = '#FFF9C4'
+  if (!isTerminal) {
+    const daysUntilDue = dueDateObj.diff(dayjs.utc().startOf('day'), 'day')
+    if (daysUntilDue < 0) {
+      backgroundColor = '#FFCDD2'
+    } else if (daysUntilDue < 30) {
+      backgroundColor = '#FFF9C4'
+    }
   }
 
   return (
@@ -163,7 +171,10 @@ export default function CurationTaskCardLayout(
         </div>
         <div className={styles.statusContainer}>
           <TaskStatusChip state={taskBundle.status?.state} />
-          <DueDateChip dueDate={taskBundle.status?.dueDate} />
+          <DueDateChip
+            dueDate={taskBundle.status?.dueDate}
+            taskState={taskBundle.status?.state}
+          />
         </div>
         {!isExpanded && (
           <>


### PR DESCRIPTION
When a task is complete or cancelled, leave the due date pill a neutral color.