### PR TITLE
ELITE: use model_name instead of model_summary for the card title

### DIFF
--- a/apps/portals/eliteportal/src/config/synapseConfigs/models.ts
+++ b/apps/portals/eliteportal/src/config/synapseConfigs/models.ts
@@ -8,7 +8,7 @@ const rgbIndex = 5
 
 export const modelSchema: TableToGenericCardMapping = {
   type: SynapseConstants.MODEL,
-  title: 'model_summary',
+  title: 'model_name',
   subTitle: 'developers',
   description: 'model_description',
   secondaryLabels: [


### PR DESCRIPTION
<img width="1467" height="769" alt="Screenshot 2026-07-29 at 2 19 20 PM" src="https://github.com/user-attachments/assets/5c3db409-fba3-4acc-ad84-4252d86ad8e2" />
