### PR TITLE
SRC 4.0.31

### DIFF
--- a/packages/synapse-react-client/package.json
+++ b/packages/synapse-react-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "4.0.30",
+  "version": "4.0.31",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/synapse-types/package.json
+++ b/packages/synapse-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sage-bionetworks/synapse-types",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Also noticed synapse-types playwright errors in SWC ([example](https://github.com/Sage-Bionetworks/SynapseWebClient/actions/runs/30585818241/job/91017657827)), so proposing we also bump synapse-types in an attempt to fix