### PR TITLE
SWC-7890: Update attachment associateObjectType in chat

### DIFF
--- a/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.test.tsx
@@ -287,7 +287,7 @@ describe('SynapseChat - allowAttachments', () => {
     const [message, attachments] = mockSendChat.mock.calls[0]
     expect(message).toBe('hello')
     expect(attachments).toHaveLength(1)
-    expect(attachments[0].associateObjectType).toBe('MessageAttachment')
+    expect(attachments[0].associateObjectType).toBe('FileEntity')
     // The uploader's own bare file handle is referenced by id; see buildChatAttachmentAssociation.
     expect(attachments[0].associateObjectId).toBe(attachments[0].fileHandleId)
     expect(screen.getByRole('textbox')).toHaveValue('')

--- a/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.tsx
@@ -200,12 +200,12 @@ export function SynapseChat({
         ? attachments.map(attachment => ({
             fileHandleId: attachment.fileHandleId,
             // The backend short-circuits the FileHandleAssociation auth check for a user's own
-            // uploaded file handle, so associateObjectId/associateObjectType are effectively
-            // unused here. FileHandleAssociateType has no dedicated value for "the uploader's
+            // uploaded file handle, so associateObjectId/associateObjectType are not totally
+            // accurate here. FileHandleAssociateType has no dedicated value for "the uploader's
             // own bare file handle", so this stubs associateObjectId to the fileHandleId itself
-            // and picks an arbitrary existing enum value.
+            // and the FileEntity associate type, which supports the short-circuit path.
             associateObjectId: attachment.fileHandleId,
-            associateObjectType: FileHandleAssociateType.MessageAttachment,
+            associateObjectType: FileHandleAssociateType.FileEntity,
           }))
         : undefined,
     )


### PR DESCRIPTION
The MessageAttachment associate type does not support the short-circuit "file handle uploader" path. FileEntity does.