### PR TITLE
Improve MSW handlers for agent chat

### DIFF
--- a/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
+++ b/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
@@ -26,6 +26,7 @@ import {
 import { createMemoryRouter } from 'react-router'
 import { RouterProvider } from 'react-router/dom'
 import { SynapseToastContainer } from './ToastMessage'
+import { MOCK_USER_ID } from '@/mocks/user/mock_user_profile'
 
 const storybookQueryClient = new QueryClient(defaultQueryClientConfig)
 
@@ -149,6 +150,15 @@ export function StorybookComponentWrapper(props: {
     storybookContext.args.isAuthenticated,
   ])
 
+  const effectiveUserId: string | undefined = useMemo(() => {
+    if (currentStack === 'mock') {
+      return storybookContext.args.isAuthenticated
+        ? String(MOCK_USER_ID)
+        : undefined
+    }
+    return sessionState.userId
+  }, [sessionState.userId, currentStack, storybookContext.args.isAuthenticated])
+
   const refreshSession = useCallback(async () => {
     await sessionManager.refreshSession()
   }, [])
@@ -161,7 +171,7 @@ export function StorybookComponentWrapper(props: {
     () => ({
       token: effectiveToken,
       realmId: sessionState.realmId,
-      userId: sessionState.userId,
+      userId: effectiveUserId,
       isAuthenticated: effectiveIsAuthenticated,
       hasInitializedSession: sessionState.hasInitializedSession,
       refreshSession,
@@ -175,7 +185,7 @@ export function StorybookComponentWrapper(props: {
       effectiveToken,
       effectiveIsAuthenticated,
       sessionState.realmId,
-      sessionState.userId,
+      effectiveUserId,
       sessionState.hasInitializedSession,
       refreshSession,
       clearSession,

--- a/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.stories.ts
+++ b/packages/synapse-react-client/src/components/SynapseChat/SynapseChat.stories.ts
@@ -1,11 +1,12 @@
 import { getChatbotHandlers } from '@/mocks/msw/handlers/chatHandlers'
-import { getEntityHandlers } from '@/mocks/msw/handlers/entityHandlers'
-import { getFileHandlers } from '@/mocks/msw/handlers/fileHandlers'
-import { getUserProfileHandlers } from '@/mocks/msw/handlers/userProfileHandlers'
 import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
 import { Meta, StoryObj } from '@storybook/react-vite'
 import { HttpHandler } from 'msw'
 import SynapseChat from './SynapseChat'
+
+const handlers: Record<string, HttpHandler[]> = {
+  chatbot: getChatbotHandlers(MOCK_REPO_ORIGIN),
+}
 
 const meta = {
   title: 'Synapse/Chat',
@@ -13,6 +14,10 @@ const meta = {
   parameters: {
     requireLogin: true,
     chromatic: { viewports: [600, 1200] },
+    stack: 'mock',
+    msw: {
+      handlers,
+    },
   },
   argTypes: {
     isAuthenticated: {
@@ -26,20 +31,8 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-const handlers: Record<string, HttpHandler[]> = {
-  userProfile: getUserProfileHandlers(MOCK_REPO_ORIGIN),
-  entity: getEntityHandlers(MOCK_REPO_ORIGIN),
-  chatbot: getChatbotHandlers(MOCK_REPO_ORIGIN),
-}
-
 export const ChatWithSynapse: Story = {
   args: { initialMessage: 'hello' },
-  parameters: {
-    stack: 'mock',
-    msw: {
-      handlers,
-    },
-  },
 }
 
 /**
@@ -49,15 +42,4 @@ export const ChatWithSynapse: Story = {
  */
 export const WithAttachments: Story = {
   args: { allowAttachments: true },
-  parameters: {
-    stack: 'mock',
-    msw: {
-      handlers: [
-        ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
-        ...getEntityHandlers(MOCK_REPO_ORIGIN),
-        ...getChatbotHandlers(MOCK_REPO_ORIGIN),
-        ...getFileHandlers(MOCK_REPO_ORIGIN),
-      ],
-    },
-  },
 }

--- a/packages/synapse-react-client/src/components/UserCard/UserCard.test.tsx
+++ b/packages/synapse-react-client/src/components/UserCard/UserCard.test.tsx
@@ -1,5 +1,8 @@
 import { server } from '@/mocks/msw/server'
-import { mockUserProfileData } from '@/mocks/user/mock_user_profile'
+import {
+  mockUserProfileData,
+  mockUserProfileData2,
+} from '@/mocks/user/mock_user_profile'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
 import { SynapseConstants } from '@/utils'
 import { PROFILE_IMAGE_PREVIEW } from '@/utils/APIConstants'
@@ -98,16 +101,20 @@ describe('UserCard tests', () => {
     }
 
     it('creates a small avatar', async () => {
-      renderAvatar({ ...props, avatarSize: 'SMALL' })
+      renderAvatar({
+        ...props,
+        userProfile: mockUserProfileData2,
+        avatarSize: 'SMALL',
+      })
       const imageElement = await screen.findByRole('img')
-      // No profile pic fetched, so the avatar should have the first initial
-      await screen.findByText(firstName[0])
+      // This user has no profile pic mocked, so the avatar should have the first initial
+      await screen.findByText(mockUserProfileData2.firstName[0])
       expect(getComputedStyle(imageElement).width).toBe('20px')
       expect(imageElement.style.backgroundImage).toBe('')
     })
 
     it('avatar text pulls from username if no first name', async () => {
-      const userWithNoFirstName = cloneDeep(mockUserProfileData)
+      const userWithNoFirstName = cloneDeep(mockUserProfileData2)
       userWithNoFirstName.firstName = ''
       renderAvatar({
         ...props,
@@ -115,17 +122,21 @@ describe('UserCard tests', () => {
         avatarSize: 'SMALL',
       })
       const imageElement = await screen.findByRole('img')
-      // No profile pic fetched, so the avatar should have the first initial
-      await screen.findByText(mockUserProfileData.userName[0])
+      // This user has no profile pic mocked, so the avatar should have the first initial
+      await screen.findByText(mockUserProfileData2.userName![0])
       expect(getComputedStyle(imageElement).width).toBe('20px')
       expect(imageElement.style.backgroundImage).toBe('')
     })
 
     it('creates a large avatar', async () => {
-      renderAvatar({ ...props, avatarSize: 'LARGE' })
+      renderAvatar({
+        ...props,
+        userProfile: mockUserProfileData2,
+        avatarSize: 'LARGE',
+      })
       const imageElement = await screen.findByRole('img')
-      // No profile pic fetched, so the avatar should have the first initial
-      await screen.findByText(firstName[0])
+      // This user has no profile pic mocked, so the avatar should have the first initial
+      await screen.findByText(mockUserProfileData2.firstName[0])
       expect(getComputedStyle(imageElement).width).toBe('80px')
       expect(imageElement.style.backgroundImage).toBe('')
     })

--- a/packages/synapse-react-client/src/mocks/msw/handlers/fileHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/fileHandlers.ts
@@ -7,7 +7,7 @@ import {
 } from '@sage-bionetworks/synapse-types'
 import { uniqueId } from 'lodash-es'
 import { http, HttpResponse } from 'msw'
-import { MOCK_FILE_HANDLE_ID, mockFileHandles } from '../../mock_file_handle'
+import { mockFileHandles } from '../../mock_file_handle'
 import { MOCK_USER_ID } from '../../user/mock_user_profile'
 import { SynapseApiResponse } from '../handlers'
 
@@ -39,10 +39,13 @@ export function getFileHandlers(backendOrigin: string) {
     ),
 
     http.post(`${backendOrigin}${FILE}/file/multipart`, () => {
+      // Each upload must get its own fileHandleId -- reusing MOCK_FILE_HANDLE_ID for every
+      // call made multi-file uploads (e.g. in chat attachments) collide on the same id, so
+      // removing one attachment would remove them all.
       const response: SynapseApiResponse<MultipartUploadStatus> = {
         state: 'COMPLETED',
-        resultFileHandleId: MOCK_FILE_HANDLE_ID,
-        uploadId: 'mockUploadId',
+        resultFileHandleId: uniqueId('mockFileHandleId'),
+        uploadId: uniqueId('mockUploadId'),
         startedBy: String(MOCK_USER_ID),
         startedOn: new Date().toISOString(),
         updatedOn: new Date().toISOString(),
@@ -51,19 +54,22 @@ export function getFileHandlers(backendOrigin: string) {
 
       return HttpResponse.json(response, { status: 201 })
     }),
-    http.put(`${backendOrigin}${FILE}/file/multipart/:id/complete`, () => {
-      const response: SynapseApiResponse<MultipartUploadStatus> = {
-        state: 'COMPLETED',
-        resultFileHandleId: MOCK_FILE_HANDLE_ID,
-        uploadId: 'mockUploadId',
-        startedBy: String(MOCK_USER_ID),
-        startedOn: new Date().toISOString(),
-        updatedOn: new Date().toISOString(),
-        partsState: '1',
-      }
+    http.put(
+      `${backendOrigin}${FILE}/file/multipart/:id/complete`,
+      ({ params }) => {
+        const response: SynapseApiResponse<MultipartUploadStatus> = {
+          state: 'COMPLETED',
+          resultFileHandleId: uniqueId('mockFileHandleId'),
+          uploadId: String(params.id),
+          startedBy: String(MOCK_USER_ID),
+          startedOn: new Date().toISOString(),
+          updatedOn: new Date().toISOString(),
+          partsState: '1',
+        }
 
-      return HttpResponse.json(response, { status: 201 })
-    }),
+        return HttpResponse.json(response, { status: 201 })
+      },
+    ),
 
     http.post<never, ExternalFileHandleInterface>(
       `${backendOrigin}${FILE}/externalFileHandle`,

--- a/packages/synapse-react-client/src/mocks/msw/handlers/userProfileHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/userProfileHandlers.ts
@@ -21,6 +21,8 @@ import {
 import { http, HttpResponse } from 'msw'
 import { mockPaginatedEntityHeaders } from '../../entity/mockEntity'
 import {
+  MOCK_USER_ID,
+  MOCK_USER_PROFILE_IMAGE_URL,
   mockUserBundle,
   mockUserData,
   mockUserProfileData,
@@ -166,14 +168,21 @@ export const getUserProfileHandlers = (backendOrigin: string) => [
   }),
 
   /**
-   * Return a 404 when fetching the profile image
+   * Return a presigned URL for the current mock user's profile image, and a 404 for every
+   * other user (i.e. they have no profile image).
    */
-  http.get(`${backendOrigin}${PROFILE_IMAGE_PREVIEW(':userId')}`, () => {
-    return HttpResponse.json(
-      { reason: 'user has no profile image' },
-      { status: 404 },
-    )
-  }),
+  http.get(
+    `${backendOrigin}${PROFILE_IMAGE_PREVIEW(':userId')}`,
+    ({ params }) => {
+      if (params.userId === String(MOCK_USER_ID)) {
+        return HttpResponse.json(MOCK_USER_PROFILE_IMAGE_URL, { status: 200 })
+      }
+      return HttpResponse.json(
+        { reason: 'Mock user has no profile image' },
+        { status: 404 },
+      )
+    },
+  ),
 
   http.get(`${backendOrigin}${NOTIFICATION_EMAIL}`, () => {
     return HttpResponse.json(

--- a/packages/synapse-react-client/src/mocks/user/mock_user_profile.ts
+++ b/packages/synapse-react-client/src/mocks/user/mock_user_profile.ts
@@ -6,6 +6,8 @@ import {
 
 export const MOCK_USER_ID = 999
 export const MOCK_USER_NAME = 'myUserName'
+export const MOCK_USER_PROFILE_IMAGE_URL =
+  'https://upload.wikimedia.org/wikipedia/commons/9/95/Bufo-alvarius-coloradokr%C3%B6te.jpg'
 
 export const mockUserProfileData = {
   summary: 'My summary bio',


### PR DESCRIPTION
- Give default mock user a profile picture
- Creating a mock file handle generates a unique ID to avoid collisions