### PR TITLE
SWC-7901 - Add JSON Schema client methods and query hooks

### DIFF
--- a/packages/synapse-react-client/src/mocks/jsonschema/mockJsonSchemaListing.ts
+++ b/packages/synapse-react-client/src/mocks/jsonschema/mockJsonSchemaListing.ts
@@ -1,0 +1,170 @@
+import {
+  ListJsonSchemaInfoResponse,
+  ListJsonSchemaVersionInfoResponse,
+  ListOrganizationsResponse,
+} from '@sage-bionetworks/synapse-client'
+
+export const MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME = 'org.sagebionetworks'
+export const MOCK_ORGANIZATION_EXAMPLE_NAME = 'org.example'
+
+export const MOCK_MULTI_VERSION_SCHEMA_NAME = 'MultiVersionSchema'
+export const MOCK_NULL_VERSION_SCHEMA_NAME = 'NullVersionSchema'
+
+/**
+ * Two pages of Organizations, so that consumers that eagerly fetch every page
+ * (e.g. the org Autocomplete) can be exercised end-to-end.
+ */
+export const mockOrganizationsPageOne: ListOrganizationsResponse = {
+  page: [
+    {
+      id: '1',
+      name: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+      createdOn: '2021-01-01T00:00:00.000Z',
+      createdBy: '1',
+    },
+  ],
+  nextPageToken: 'organizations-page-2',
+}
+
+export const mockOrganizationsPageTwo: ListOrganizationsResponse = {
+  page: [
+    {
+      id: '2',
+      name: MOCK_ORGANIZATION_EXAMPLE_NAME,
+      createdOn: '2021-02-01T00:00:00.000Z',
+      createdBy: '1',
+    },
+  ],
+  // No nextPageToken --> this is the last page
+}
+
+/**
+ * Two pages of JsonSchemaInfo for org.sagebionetworks, to exercise infinite scroll of the
+ * schema table. org.example intentionally has no schemas, to exercise the empty state.
+ */
+export const mockJsonSchemasPageOneForSagebionetworks: ListJsonSchemaInfoResponse =
+  {
+    page: [
+      {
+        organizationId: '1',
+        organizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+        schemaId: '101',
+        schemaName: 'repo.model.FileEntity',
+        createdOn: '2021-01-02T00:00:00.000Z',
+        createdBy: '1',
+      },
+      {
+        organizationId: '1',
+        organizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+        schemaId: '102',
+        schemaName: 'repo.model.Project',
+        createdOn: '2021-01-03T00:00:00.000Z',
+        createdBy: '1',
+      },
+      {
+        organizationId: '1',
+        organizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+        schemaId: '103',
+        schemaName: MOCK_MULTI_VERSION_SCHEMA_NAME,
+        createdOn: '2021-01-04T00:00:00.000Z',
+        createdBy: '1',
+      },
+    ],
+    nextPageToken: 'schemas-page-2',
+  }
+
+export const mockJsonSchemasPageTwoForSagebionetworks: ListJsonSchemaInfoResponse =
+  {
+    page: [
+      {
+        organizationId: '1',
+        organizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+        schemaId: '104',
+        schemaName: MOCK_NULL_VERSION_SCHEMA_NAME,
+        createdOn: '2021-01-05T00:00:00.000Z',
+        createdBy: '1',
+      },
+    ],
+    // No nextPageToken --> this is the last page
+  }
+
+export const mockJsonSchemasEmptyResponse: ListJsonSchemaInfoResponse = {
+  page: [],
+}
+
+/**
+ * Two pages of versions for MultiVersionSchema, to exercise both the version <Select> and
+ * infinite scroll of the version list. Ordered lowest-to-highest semantic version across pages,
+ * matching the real API's pagination order.
+ */
+export const mockJsonSchemaVersionsPageOneForMultiVersionSchema: ListJsonSchemaVersionInfoResponse =
+  {
+    page: [
+      {
+        organizationId: '1',
+        organizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+        schemaId: '103',
+        schemaName: MOCK_MULTI_VERSION_SCHEMA_NAME,
+        versionId: '1',
+        $id: `${MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME}-${MOCK_MULTI_VERSION_SCHEMA_NAME}-1.0.0`,
+        semanticVersion: '1.0.0',
+        jsonSHA256Hex: 'sha-1-0-0',
+        createdOn: '2021-03-01T00:00:00.000Z',
+        createdBy: '1',
+      },
+      {
+        organizationId: '1',
+        organizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+        schemaId: '103',
+        schemaName: MOCK_MULTI_VERSION_SCHEMA_NAME,
+        versionId: '2',
+        $id: `${MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME}-${MOCK_MULTI_VERSION_SCHEMA_NAME}-1.1.0`,
+        semanticVersion: '1.1.0',
+        jsonSHA256Hex: 'sha-1-1-0',
+        createdOn: '2021-03-02T00:00:00.000Z',
+        createdBy: '1',
+      },
+    ],
+    nextPageToken: 'multi-version-schema-versions-page-2',
+  }
+
+export const mockJsonSchemaVersionsPageTwoForMultiVersionSchema: ListJsonSchemaVersionInfoResponse =
+  {
+    page: [
+      {
+        organizationId: '1',
+        organizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+        schemaId: '103',
+        schemaName: MOCK_MULTI_VERSION_SCHEMA_NAME,
+        versionId: '3',
+        $id: `${MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME}-${MOCK_MULTI_VERSION_SCHEMA_NAME}-2.0.0`,
+        semanticVersion: '2.0.0',
+        jsonSHA256Hex: 'sha-2-0-0',
+        createdOn: '2021-03-03T00:00:00.000Z',
+        createdBy: '1',
+      },
+    ],
+    // No nextPageToken --> this is the last page
+  }
+
+/**
+ * A single version that was created without a semantic version label, to exercise the
+ * `semanticVersion: null` case.
+ */
+export const mockJsonSchemaVersionsForNullVersionSchema: ListJsonSchemaVersionInfoResponse =
+  {
+    page: [
+      {
+        organizationId: '1',
+        organizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+        schemaId: '104',
+        schemaName: MOCK_NULL_VERSION_SCHEMA_NAME,
+        versionId: '4',
+        $id: `${MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME}-${MOCK_NULL_VERSION_SCHEMA_NAME}`,
+        semanticVersion: undefined,
+        jsonSHA256Hex: 'sha-null-version',
+        createdOn: '2021-04-01T00:00:00.000Z',
+        createdBy: '1',
+      },
+    ],
+  }

--- a/packages/synapse-react-client/src/mocks/msw/handlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers.ts
@@ -17,6 +17,7 @@ import { getEvaluationHandlers } from './handlers/evaluationHandlers'
 import { getFeatureFlagsOverride } from './handlers/featureFlagHandlers'
 import { getFileHandlers } from './handlers/fileHandlers'
 import { getGridHandlers } from './handlers/gridHandlers'
+import { getJsonSchemaListingHandlers } from './handlers/jsonSchemaListingHandlers'
 import { getMessageHandlers } from './handlers/messageHandlers'
 import { getPersonalAccessTokenHandlers } from './handlers/personalAccessTokenHandlers'
 import { getResearchProjectHandlers } from './handlers/researchProjectHandlers'
@@ -70,6 +71,9 @@ export function getHandlersForStorybook(
     researchProject: getResearchProjectHandlers(backendOrigin),
     file: getFileHandlers(backendOrigin),
     grid: getGridHandlers(backendOrigin),
+    jsonSchemaListing: Object.values(
+      getJsonSchemaListingHandlers(backendOrigin),
+    ).flat(),
     discussion: getDiscussionHandlers(backendOrigin),
     subscription: getSubscriptionHandlers(backendOrigin),
     evaluation: getEvaluationHandlers(backendOrigin),

--- a/packages/synapse-react-client/src/mocks/msw/handlers/jsonSchemaListingHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/jsonSchemaListingHandlers.ts
@@ -1,0 +1,84 @@
+// MSW handlers for listing JSON Schema Organizations, Schemas, and Schema Versions
+import {
+  mockJsonSchemasEmptyResponse,
+  mockJsonSchemasPageOneForSagebionetworks,
+  mockJsonSchemasPageTwoForSagebionetworks,
+  mockJsonSchemaVersionsForNullVersionSchema,
+  mockJsonSchemaVersionsPageOneForMultiVersionSchema,
+  mockJsonSchemaVersionsPageTwoForMultiVersionSchema,
+  MOCK_MULTI_VERSION_SCHEMA_NAME,
+  MOCK_NULL_VERSION_SCHEMA_NAME,
+  MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+  mockOrganizationsPageOne,
+  mockOrganizationsPageTwo,
+} from '@/mocks/jsonschema/mockJsonSchemaListing'
+import {
+  ListJsonSchemaInfoRequest,
+  ListJsonSchemaVersionInfoRequest,
+  ListOrganizationsRequest,
+} from '@sage-bionetworks/synapse-client'
+import { http, HttpHandler, HttpResponse } from 'msw'
+
+/**
+ * Returns groups of handlers for listing JSON Schema Organizations, Schemas, and Schema
+ * Versions, so a Storybook story can override a single group (e.g. `organizations`) rather than
+ * replacing every handler.
+ */
+export function getJsonSchemaListingHandlers(
+  backendOrigin: string,
+): Record<string, HttpHandler[]> {
+  return {
+    organizations: [
+      http.post<never, ListOrganizationsRequest>(
+        `${backendOrigin}/repo/v1/schema/organization/list`,
+        async ({ request }) => {
+          const { nextPageToken } = await request.json()
+          const response = nextPageToken
+            ? mockOrganizationsPageTwo
+            : mockOrganizationsPageOne
+          return HttpResponse.json(response, { status: 200 })
+        },
+      ),
+    ],
+    schemas: [
+      http.post<never, ListJsonSchemaInfoRequest>(
+        `${backendOrigin}/repo/v1/schema/list`,
+        async ({ request }) => {
+          const { organizationName, nextPageToken } = await request.json()
+          if (organizationName !== MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME) {
+            return HttpResponse.json(mockJsonSchemasEmptyResponse, {
+              status: 200,
+            })
+          }
+          const response = nextPageToken
+            ? mockJsonSchemasPageTwoForSagebionetworks
+            : mockJsonSchemasPageOneForSagebionetworks
+          return HttpResponse.json(response, { status: 200 })
+        },
+      ),
+    ],
+    versions: [
+      http.post<never, ListJsonSchemaVersionInfoRequest>(
+        `${backendOrigin}/repo/v1/schema/version/list`,
+        async ({ request }) => {
+          const { schemaName, nextPageToken } = await request.json()
+          if (schemaName === MOCK_NULL_VERSION_SCHEMA_NAME) {
+            return HttpResponse.json(
+              mockJsonSchemaVersionsForNullVersionSchema,
+              {
+                status: 200,
+              },
+            )
+          }
+          if (schemaName === MOCK_MULTI_VERSION_SCHEMA_NAME) {
+            const response = nextPageToken
+              ? mockJsonSchemaVersionsPageTwoForMultiVersionSchema
+              : mockJsonSchemaVersionsPageOneForMultiVersionSchema
+            return HttpResponse.json(response, { status: 200 })
+          }
+          return HttpResponse.json({ page: [] }, { status: 200 })
+        },
+      ),
+    ],
+  }
+}

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.test.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.test.ts
@@ -116,6 +116,20 @@ describe('SynapseClient tests', () => {
       expect(mockFn).toHaveBeenNthCalledWith(1, 50, 0)
       expect(mockFn).toHaveBeenNthCalledWith(2, 50, 50)
     })
+
+    it('propagates the original error unchanged, rather than wrapping it', async () => {
+      // Preserving the original error's identity matters: callers may rely on its type (e.g.
+      // SynapseClientError's `.reason`) for error UI, or need to distinguish a genuine failure
+      // from a cancelled fetch (e.g. an AbortError).
+      const originalError = new Error('Something went wrong')
+      const mockFn: FunctionReturningPaginatedResults<string> = vi
+        .fn()
+        .mockRejectedValueOnce(originalError)
+
+      await expect(SynapseClient.getAllOfPaginatedService(mockFn)).rejects.toBe(
+        originalError,
+      )
+    })
   })
 
   describe('getAllOfNextPageTokenPaginatedService', () => {
@@ -154,6 +168,18 @@ describe('SynapseClient tests', () => {
       expect(mockFn).toHaveBeenCalledTimes(2)
       expect(mockFn).toHaveBeenNthCalledWith(1, undefined)
       expect(mockFn).toHaveBeenNthCalledWith(2, 'nextPageToken')
+    })
+
+    it('propagates the original error unchanged, rather than wrapping it', async () => {
+      // Preserving the original error's identity matters: callers may rely on its type (e.g.
+      // SynapseClientError's `.reason`) for error UI, or need to distinguish a genuine failure
+      // from a cancelled fetch (e.g. an AbortError).
+      const originalError = new Error('Something went wrong')
+      const mockFn = vi.fn().mockRejectedValueOnce(originalError)
+
+      await expect(
+        SynapseClient.getAllOfNextPageTokenPaginatedService(mockFn),
+      ).rejects.toBe(originalError)
     })
   })
 })

--- a/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
+++ b/packages/synapse-react-client/src/synapse-client/SynapseClient.ts
@@ -3716,15 +3716,11 @@ export const getAllOfPaginatedService = async <T>(
   const results: T[] = []
 
   while (existsMoreData) {
-    try {
-      const data = await fn(limit, offset)
-      results.push(...data.results)
-      offset += data.results.length
-      if (data.results.length < limit) {
-        existsMoreData = false
-      }
-    } catch (e) {
-      throw Error(`Error on getting paginated results ${e}`)
+    const data = await fn(limit, offset)
+    results.push(...data.results)
+    offset += data.results.length
+    if (data.results.length < limit) {
+      existsMoreData = false
     }
   }
 
@@ -3745,21 +3741,17 @@ export async function getAllOfNextPageTokenPaginatedService<T>(
   const results: T[] = []
 
   while (existsMoreData) {
-    try {
-      const data = await fn(nextPageToken)
-      // Some object models use `results`, others use `page`
-      if ('results' in data) {
-        results.push(...data.results)
-      } else if ('page' in data) {
-        results.push(...data.page)
-      }
-      nextPageToken = data.nextPageToken
+    const data = await fn(nextPageToken)
+    // Some object models use `results`, others use `page`
+    if ('results' in data) {
+      results.push(...data.results)
+    } else if ('page' in data) {
+      results.push(...data.page)
+    }
+    nextPageToken = data.nextPageToken
 
-      if (!nextPageToken) {
-        existsMoreData = false
-      }
-    } catch (e) {
-      throw Error(`Error on getting paginated results ${e}`)
+    if (!nextPageToken) {
+      existsMoreData = false
     }
   }
 

--- a/packages/synapse-react-client/src/synapse-queries/KeyFactory.test.ts
+++ b/packages/synapse-react-client/src/synapse-queries/KeyFactory.test.ts
@@ -593,4 +593,44 @@ describe('KeyFactory tests', () => {
       )
     })
   })
+
+  describe('JSON Schema QueryKeys', () => {
+    test('getListOrganizationsQueryKey is stable and takes no arguments', () => {
+      expectQueryKeyToMatch(
+        keyFactory.getListOrganizationsQueryKey(),
+        keyFactory.getListOrganizationsQueryKey(),
+      )
+    })
+
+    test('getListJsonSchemasQueryKey differs by organization name', () => {
+      const orgAKey = keyFactory.getListJsonSchemasQueryKey('org.a')
+      const orgBKey = keyFactory.getListJsonSchemasQueryKey('org.b')
+
+      expectQueryKeyToMatch(
+        orgAKey,
+        keyFactory.getListJsonSchemasQueryKey('org.a'),
+      )
+      expectQueryKeyNotToMatch(orgAKey, orgBKey)
+    })
+
+    test('getListJsonSchemaVersionsQueryKey differs by organization and schema name', () => {
+      const key = keyFactory.getListJsonSchemaVersionsQueryKey(
+        'org.a',
+        'SchemaOne',
+      )
+
+      expectQueryKeyToMatch(
+        key,
+        keyFactory.getListJsonSchemaVersionsQueryKey('org.a', 'SchemaOne'),
+      )
+      expectQueryKeyNotToMatch(
+        key,
+        keyFactory.getListJsonSchemaVersionsQueryKey('org.a', 'SchemaTwo'),
+      )
+      expectQueryKeyNotToMatch(
+        key,
+        keyFactory.getListJsonSchemaVersionsQueryKey('org.b', 'SchemaOne'),
+      )
+    })
+  })
 })

--- a/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
+++ b/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
@@ -1172,4 +1172,25 @@ export class KeyFactory {
   public getAsyncJobStatusQueryKey(jobId: string) {
     return this.getKey('asyncJobStatus', jobId)
   }
+
+  public getListOrganizationsQueryKey() {
+    return this.getKey('jsonSchema', 'organization', 'list')
+  }
+
+  public getListJsonSchemasQueryKey(organizationName: string) {
+    return this.getKey('jsonSchema', 'list', organizationName)
+  }
+
+  public getListJsonSchemaVersionsQueryKey(
+    organizationName: string,
+    schemaName: string,
+  ) {
+    return this.getKey(
+      'jsonSchema',
+      'version',
+      'list',
+      organizationName,
+      schemaName,
+    )
+  }
 }

--- a/packages/synapse-react-client/src/synapse-queries/jsonschema/index.ts
+++ b/packages/synapse-react-client/src/synapse-queries/jsonschema/index.ts
@@ -1,2 +1,5 @@
 export * from './useEntityBoundSchema'
+export * from './useListJsonSchemasInfinite'
+export * from './useListJsonSchemaVersions'
+export * from './useListOrganizations'
 export * from './useSchema'

--- a/packages/synapse-react-client/src/synapse-queries/jsonschema/useListJsonSchemaVersions.test.ts
+++ b/packages/synapse-react-client/src/synapse-queries/jsonschema/useListJsonSchemaVersions.test.ts
@@ -1,0 +1,105 @@
+import { MOCK_CONTEXT_VALUE } from '@/mocks/MockSynapseContext'
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { ListJsonSchemaVersionInfoResponse } from '@sage-bionetworks/synapse-client'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useListJsonSchemaVersions } from './useListJsonSchemaVersions'
+
+const postRepoV1SchemaVersionListSpy = vi.spyOn(
+  MOCK_CONTEXT_VALUE.synapseClient.jsonSchemaServicesClient,
+  'postRepoV1SchemaVersionList',
+)
+
+const page1: ListJsonSchemaVersionInfoResponse = {
+  page: [
+    {
+      organizationName: 'org.sagebionetworks',
+      schemaName: 'MySchema',
+      versionId: '1',
+      $id: 'org.sagebionetworks-MySchema-2.0.0',
+      semanticVersion: '2.0.0',
+      createdOn: 'today',
+    },
+  ],
+  nextPageToken: 'token-for-page-2',
+}
+
+const page2: ListJsonSchemaVersionInfoResponse = {
+  page: [
+    {
+      organizationName: 'org.sagebionetworks',
+      schemaName: 'MySchema',
+      versionId: '2',
+      $id: 'org.sagebionetworks-MySchema-1.0.0',
+      semanticVersion: '1.0.0',
+      createdOn: 'yesterday',
+    },
+  ],
+}
+
+describe('useListJsonSchemaVersions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches every page of versions scoped to the given organization and schema, and returns them flattened', async () => {
+    postRepoV1SchemaVersionListSpy
+      .mockResolvedValueOnce(page1)
+      .mockResolvedValueOnce(page2)
+
+    const { result } = renderHook(
+      () => useListJsonSchemaVersions('org.sagebionetworks', 'MySchema'),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual([...page1.page!, ...page2.page!])
+    expect(postRepoV1SchemaVersionListSpy).toHaveBeenCalledTimes(2)
+    expect(postRepoV1SchemaVersionListSpy).toHaveBeenNthCalledWith(
+      1,
+      {
+        listJsonSchemaVersionInfoRequest: {
+          organizationName: 'org.sagebionetworks',
+          schemaName: 'MySchema',
+          nextPageToken: undefined,
+        },
+      },
+      expect.objectContaining({ signal: expect.anything() }),
+    )
+    expect(postRepoV1SchemaVersionListSpy).toHaveBeenNthCalledWith(
+      2,
+      {
+        listJsonSchemaVersionInfoRequest: {
+          organizationName: 'org.sagebionetworks',
+          schemaName: 'MySchema',
+          nextPageToken: page1.nextPageToken,
+        },
+      },
+      expect.objectContaining({ signal: expect.anything() }),
+    )
+  })
+
+  it('does not fetch when schemaName is empty', () => {
+    const { result } = renderHook(
+      () => useListJsonSchemaVersions('org.sagebionetworks', ''),
+      { wrapper: createWrapper() },
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(postRepoV1SchemaVersionListSpy).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the original error (not a wrapped one) when a page fails to load', async () => {
+    postRepoV1SchemaVersionListSpy.mockRejectedValueOnce(
+      new Error('Something went wrong'),
+    )
+
+    const { result } = renderHook(
+      () => useListJsonSchemaVersions('org.sagebionetworks', 'MySchema'),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe('Something went wrong')
+  })
+})

--- a/packages/synapse-react-client/src/synapse-queries/jsonschema/useListJsonSchemaVersions.ts
+++ b/packages/synapse-react-client/src/synapse-queries/jsonschema/useListJsonSchemaVersions.ts
@@ -1,0 +1,71 @@
+import { getAllOfNextPageTokenPaginatedService } from '@/synapse-client/SynapseClient'
+import { useSynapseContext } from '@/utils/context/SynapseContext'
+import {
+  JsonSchemaVersionInfo,
+  SynapseClient,
+  SynapseClientError,
+} from '@sage-bionetworks/synapse-client'
+import { queryOptions, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { KeyFactory } from '../KeyFactory'
+
+/**
+ * Shared query definition for {@link useListJsonSchemaVersions}, so it can also be fetched
+ * imperatively (e.g. via `queryClient.fetchQuery`) using the exact same query key/queryFn --
+ * see `useJsonSchemaSelection`'s auto-selection of the latest version.
+ */
+export function getJsonSchemaVersionsQuery(
+  organizationName: string,
+  schemaName: string,
+  context: { synapseClient: SynapseClient; keyFactory: KeyFactory },
+) {
+  const { synapseClient, keyFactory } = context
+  return queryOptions<JsonSchemaVersionInfo[], SynapseClientError>({
+    queryKey: keyFactory.getListJsonSchemaVersionsQueryKey(
+      organizationName,
+      schemaName,
+    ),
+    queryFn: ({ signal }) =>
+      getAllOfNextPageTokenPaginatedService<JsonSchemaVersionInfo>(
+        async nextPageToken => {
+          const response =
+            await synapseClient.jsonSchemaServicesClient.postRepoV1SchemaVersionList(
+              {
+                listJsonSchemaVersionInfoRequest: {
+                  organizationName,
+                  schemaName,
+                  nextPageToken: nextPageToken ?? undefined,
+                },
+              },
+              { signal },
+            )
+          return {
+            page: response.page ?? [],
+            nextPageToken: response.nextPageToken,
+          }
+        },
+      ),
+  })
+}
+
+/**
+ * Lists every version of a single JSON Schema (scoped to an Organization + schema name),
+ * fetching every page in one query. Disabled until both organizationName and schemaName are
+ * provided. Intended to be used lazily, e.g. only for a schema the user has selected.
+ */
+export function useListJsonSchemaVersions(
+  organizationName: string,
+  schemaName: string,
+  options?: Partial<
+    UseQueryOptions<JsonSchemaVersionInfo[], SynapseClientError>
+  >,
+) {
+  const { synapseClient, keyFactory } = useSynapseContext()
+  return useQuery<JsonSchemaVersionInfo[], SynapseClientError>({
+    ...getJsonSchemaVersionsQuery(organizationName, schemaName, {
+      synapseClient,
+      keyFactory,
+    }),
+    ...options,
+    enabled: !!organizationName && !!schemaName && (options?.enabled ?? true),
+  })
+}

--- a/packages/synapse-react-client/src/synapse-queries/jsonschema/useListJsonSchemasInfinite.test.ts
+++ b/packages/synapse-react-client/src/synapse-queries/jsonschema/useListJsonSchemasInfinite.test.ts
@@ -1,0 +1,97 @@
+import { MOCK_CONTEXT_VALUE } from '@/mocks/MockSynapseContext'
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { ListJsonSchemaInfoResponse } from '@sage-bionetworks/synapse-client'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useListJsonSchemasInfinite } from './useListJsonSchemasInfinite'
+
+const postRepoV1SchemaListSpy = vi.spyOn(
+  MOCK_CONTEXT_VALUE.synapseClient.jsonSchemaServicesClient,
+  'postRepoV1SchemaList',
+)
+
+const page1: ListJsonSchemaInfoResponse = {
+  page: [
+    {
+      organizationName: 'org.sagebionetworks',
+      schemaName: 'MySchema',
+      schemaId: '1',
+      createdOn: 'today',
+    },
+  ],
+  nextPageToken: 'token-for-page-2',
+}
+
+const page2: ListJsonSchemaInfoResponse = {
+  page: [
+    {
+      organizationName: 'org.sagebionetworks',
+      schemaName: 'AnotherSchema',
+      schemaId: '2',
+      createdOn: 'today',
+    },
+  ],
+}
+
+describe('useListJsonSchemasInfinite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches schemas scoped to the given organization', async () => {
+    postRepoV1SchemaListSpy.mockResolvedValueOnce(page1)
+
+    const { result } = renderHook(
+      () => useListJsonSchemasInfinite('org.sagebionetworks'),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(postRepoV1SchemaListSpy).toHaveBeenCalledWith({
+      listJsonSchemaInfoRequest: {
+        organizationName: 'org.sagebionetworks',
+        nextPageToken: undefined,
+      },
+    })
+    expect(result.current.data?.pages[0]).toEqual(page1)
+    expect(result.current.hasNextPage).toBe(true)
+  })
+
+  it('fetches subsequent pages using the previous page nextPageToken', async () => {
+    postRepoV1SchemaListSpy
+      .mockResolvedValueOnce(page1)
+      .mockResolvedValueOnce(page2)
+
+    const { result } = renderHook(
+      () => useListJsonSchemasInfinite('org.sagebionetworks'),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true))
+
+    act(() => {
+      result.current.fetchNextPage()
+    })
+
+    await waitFor(() => {
+      expect(result.current.data?.pages[1]).toEqual(page2)
+      expect(result.current.hasNextPage).toBe(false)
+    })
+
+    expect(postRepoV1SchemaListSpy).toHaveBeenLastCalledWith({
+      listJsonSchemaInfoRequest: {
+        organizationName: 'org.sagebionetworks',
+        nextPageToken: page1.nextPageToken,
+      },
+    })
+  })
+
+  it('does not fetch when organizationName is empty', () => {
+    const { result } = renderHook(() => useListJsonSchemasInfinite(''), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(postRepoV1SchemaListSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/synapse-react-client/src/synapse-queries/jsonschema/useListJsonSchemasInfinite.ts
+++ b/packages/synapse-react-client/src/synapse-queries/jsonschema/useListJsonSchemasInfinite.ts
@@ -1,0 +1,52 @@
+import { useSynapseContext } from '@/utils/context/SynapseContext'
+import {
+  ListJsonSchemaInfoResponse,
+  SynapseClientError,
+} from '@sage-bionetworks/synapse-client'
+import {
+  InfiniteData,
+  QueryKey,
+  useInfiniteQuery,
+  UseInfiniteQueryOptions,
+} from '@tanstack/react-query'
+
+/**
+ * Lists the JSON Schemas that belong to a single Organization, one page at a time.
+ * Disabled until an organizationName is provided.
+ */
+export function useListJsonSchemasInfinite<
+  TData = InfiniteData<ListJsonSchemaInfoResponse>,
+>(
+  organizationName: string,
+  options?: Partial<
+    UseInfiniteQueryOptions<
+      ListJsonSchemaInfoResponse,
+      SynapseClientError,
+      TData,
+      QueryKey,
+      ListJsonSchemaInfoResponse['nextPageToken']
+    >
+  >,
+) {
+  const { synapseClient, keyFactory } = useSynapseContext()
+  return useInfiniteQuery<
+    ListJsonSchemaInfoResponse,
+    SynapseClientError,
+    TData,
+    QueryKey,
+    ListJsonSchemaInfoResponse['nextPageToken']
+  >({
+    ...options,
+    enabled: !!organizationName && (options?.enabled ?? true),
+    initialPageParam: undefined,
+    queryKey: keyFactory.getListJsonSchemasQueryKey(organizationName),
+    queryFn: async context =>
+      synapseClient.jsonSchemaServicesClient.postRepoV1SchemaList({
+        listJsonSchemaInfoRequest: {
+          organizationName,
+          nextPageToken: context.pageParam,
+        },
+      }),
+    getNextPageParam: page => page.nextPageToken,
+  })
+}

--- a/packages/synapse-react-client/src/synapse-queries/jsonschema/useListOrganizations.test.ts
+++ b/packages/synapse-react-client/src/synapse-queries/jsonschema/useListOrganizations.test.ts
@@ -1,0 +1,63 @@
+import { MOCK_CONTEXT_VALUE } from '@/mocks/MockSynapseContext'
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { ListOrganizationsResponse } from '@sage-bionetworks/synapse-client'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useListOrganizations } from './useListOrganizations'
+
+const postRepoV1SchemaOrganizationListSpy = vi.spyOn(
+  MOCK_CONTEXT_VALUE.synapseClient.jsonSchemaServicesClient,
+  'postRepoV1SchemaOrganizationList',
+)
+
+const page1: ListOrganizationsResponse = {
+  page: [{ id: '1', name: 'org.sagebionetworks', createdOn: 'today' }],
+  nextPageToken: 'token-for-page-2',
+}
+
+const page2: ListOrganizationsResponse = {
+  page: [{ id: '2', name: 'org.example', createdOn: 'today' }],
+}
+
+describe('useListOrganizations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches every page of organizations, and returns them flattened', async () => {
+    postRepoV1SchemaOrganizationListSpy
+      .mockResolvedValueOnce(page1)
+      .mockResolvedValueOnce(page2)
+
+    const { result } = renderHook(() => useListOrganizations(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual([...page1.page!, ...page2.page!])
+    expect(postRepoV1SchemaOrganizationListSpy).toHaveBeenCalledTimes(2)
+    expect(postRepoV1SchemaOrganizationListSpy).toHaveBeenNthCalledWith(
+      1,
+      { listOrganizationsRequest: { nextPageToken: undefined } },
+      expect.objectContaining({ signal: expect.anything() }),
+    )
+    expect(postRepoV1SchemaOrganizationListSpy).toHaveBeenNthCalledWith(
+      2,
+      { listOrganizationsRequest: { nextPageToken: page1.nextPageToken } },
+      expect.objectContaining({ signal: expect.anything() }),
+    )
+  })
+
+  it('surfaces the original error (not a wrapped one) when a page fails to load', async () => {
+    postRepoV1SchemaOrganizationListSpy.mockRejectedValueOnce(
+      new Error('Something went wrong'),
+    )
+
+    const { result } = renderHook(() => useListOrganizations(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe('Something went wrong')
+  })
+})

--- a/packages/synapse-react-client/src/synapse-queries/jsonschema/useListOrganizations.ts
+++ b/packages/synapse-react-client/src/synapse-queries/jsonschema/useListOrganizations.ts
@@ -1,0 +1,39 @@
+import { getAllOfNextPageTokenPaginatedService } from '@/synapse-client/SynapseClient'
+import { useSynapseContext } from '@/utils/context/SynapseContext'
+import {
+  Organization,
+  SynapseClientError,
+} from '@sage-bionetworks/synapse-client'
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+
+/**
+ * Lists every JSON Schema Organization, fetching every page in one query. Intended to power an
+ * Autocomplete's option list rather than a paginated "load more" UI.
+ */
+export function useListOrganizations(
+  options?: Partial<UseQueryOptions<Organization[], SynapseClientError>>,
+) {
+  const { synapseClient, keyFactory } = useSynapseContext()
+  return useQuery<Organization[], SynapseClientError>({
+    ...options,
+    queryKey: keyFactory.getListOrganizationsQueryKey(),
+    queryFn: ({ signal }) =>
+      getAllOfNextPageTokenPaginatedService<Organization>(
+        async nextPageToken => {
+          const response =
+            await synapseClient.jsonSchemaServicesClient.postRepoV1SchemaOrganizationList(
+              {
+                listOrganizationsRequest: {
+                  nextPageToken: nextPageToken ?? undefined,
+                },
+              },
+              { signal },
+            )
+          return {
+            page: response.page ?? [],
+            nextPageToken: response.nextPageToken,
+          }
+        },
+      ),
+  })
+}


### PR DESCRIPTION
- Add SynapseClient methods and KeyFactory keys for listing JSON
  Schema organizations, schemas, and schema versions
- Add useListOrganizations, useListJsonSchemasInfinite, and
  useListJsonSchemaVersions query hooks with tests
- Add MSW mocks and handlers for the new listing endpoints

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>