### PR TITLE
SWC-7901 - Add JSON Schema selection state hooks

### DIFF
--- a/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/VersionSelectionType.ts
+++ b/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/VersionSelectionType.ts
@@ -1,0 +1,16 @@
+/**
+ * Documents the possible JsonSchemaPicker version selection configurations.
+ */
+export enum VersionSelectionType {
+  /**
+   * A specific, numbered semantic version must be selected. This is the default. Use this when
+   * the consumer needs a reference to a specific version of the schema, rather than "whichever
+   * version is newest."
+   */
+  REQUIRED = 'REQUIRED',
+  /**
+   * A specific numbered version may be selected, or the user may choose "Latest" to always
+   * reference whichever version of the schema is newest at the time of use.
+   */
+  LATEST_ALLOWED = 'LATEST_ALLOWED',
+}

--- a/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/useJsonSchemaOrganizations.test.ts
+++ b/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/useJsonSchemaOrganizations.test.ts
@@ -1,0 +1,97 @@
+import { MOCK_CONTEXT_VALUE } from '@/mocks/MockSynapseContext'
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { ListOrganizationsResponse } from '@sage-bionetworks/synapse-client'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import {
+  LOADING_ORGANIZATIONS_OPTION,
+  useJsonSchemaOrganizations,
+} from './useJsonSchemaOrganizations'
+
+const postRepoV1SchemaOrganizationListSpy = vi.spyOn(
+  MOCK_CONTEXT_VALUE.synapseClient.jsonSchemaServicesClient,
+  'postRepoV1SchemaOrganizationList',
+)
+
+const SAGEBIONETWORKS_ORG = { id: '1', name: 'org.sagebionetworks' }
+const EXAMPLE_ORG = { id: '2', name: 'org.example' }
+
+function renderOrganizationsHook(defaultOrganizationName?: string) {
+  return renderHook(() => useJsonSchemaOrganizations(defaultOrganizationName), {
+    wrapper: createWrapper(),
+  })
+}
+
+describe('useJsonSchemaOrganizations', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('exposes every organization as an option once loaded', async () => {
+    postRepoV1SchemaOrganizationListSpy.mockResolvedValueOnce({
+      page: [SAGEBIONETWORKS_ORG, EXAMPLE_ORG],
+    })
+
+    const { result } = renderOrganizationsHook()
+
+    await waitFor(() =>
+      expect(result.current.isLoadingAllOrganizations).toBe(false),
+    )
+    expect(result.current.organizationOptions).toEqual([
+      SAGEBIONETWORKS_ORG,
+      EXAMPLE_ORG,
+    ])
+  })
+
+  it('shows a loading placeholder option while fetching, and hides it once loaded', async () => {
+    let resolveFetch:
+      | ((response: ListOrganizationsResponse) => void)
+      | undefined
+    postRepoV1SchemaOrganizationListSpy.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveFetch = resolve
+      }),
+    )
+
+    const { result } = renderOrganizationsHook()
+
+    expect(result.current.isLoadingAllOrganizations).toBe(true)
+    expect(result.current.organizationOptions).toEqual([
+      LOADING_ORGANIZATIONS_OPTION,
+    ])
+
+    resolveFetch?.({ page: [SAGEBIONETWORKS_ORG] })
+
+    await waitFor(() =>
+      expect(result.current.isLoadingAllOrganizations).toBe(false),
+    )
+    expect(result.current.organizationOptions).toEqual([SAGEBIONETWORKS_ORG])
+  })
+
+  it('applies defaultOrganizationName exactly once, and does not reapply it after the selection is cleared', async () => {
+    postRepoV1SchemaOrganizationListSpy.mockResolvedValueOnce({
+      page: [SAGEBIONETWORKS_ORG, EXAMPLE_ORG],
+    })
+
+    const { result } = renderOrganizationsHook(EXAMPLE_ORG.name)
+
+    await waitFor(() =>
+      expect(result.current.selectedOrganization?.name).toBe(EXAMPLE_ORG.name),
+    )
+
+    // If the user (or another effect) clears the selection, a later re-render must not silently
+    // re-apply the default again.
+    act(() => {
+      result.current.setSelectedOrganization(null)
+    })
+    expect(result.current.selectedOrganization).toBeNull()
+  })
+
+  it('surfaces isError when organizations fail to load', async () => {
+    postRepoV1SchemaOrganizationListSpy.mockRejectedValueOnce(
+      new Error('Something went wrong'),
+    )
+
+    const { result } = renderOrganizationsHook()
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.isLoadingAllOrganizations).toBe(false)
+  })
+})

--- a/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/useJsonSchemaOrganizations.ts
+++ b/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/useJsonSchemaOrganizations.ts
@@ -1,0 +1,54 @@
+import { useListOrganizations } from '@/synapse-queries'
+import { Organization } from '@sage-bionetworks/synapse-client'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+/**
+ * Option displayed as a disabled placeholder row while Organizations are still being fetched,
+ * so the loading state is reflected within the option list itself. This avoids relying on the
+ * Autocomplete's `loading` prop, which blocks the list from use while loading.
+ */
+export const LOADING_ORGANIZATIONS_OPTION: Organization = {}
+
+/**
+ * Lists every JSON Schema Organization, and optionally preselects one matching
+ * `defaultOrganizationName` once it becomes available.
+ */
+export function useJsonSchemaOrganizations(defaultOrganizationName?: string) {
+  const [selectedOrganization, setSelectedOrganization] =
+    useState<Organization | null>(null)
+
+  const { data, isLoading, isError, error } = useListOrganizations()
+
+  const organizations = useMemo(() => data ?? [], [data])
+
+  const organizationOptions = useMemo(
+    () =>
+      isLoading
+        ? [LOADING_ORGANIZATIONS_OPTION, ...organizations]
+        : organizations,
+    [organizations, isLoading],
+  )
+
+  // If a default organization name is provided, apply the selection once all organizations have been loaded.
+  const hasAppliedDefaultOrganizationRef = useRef(false)
+  useEffect(() => {
+    if (!hasAppliedDefaultOrganizationRef.current && defaultOrganizationName) {
+      const match = organizations.find(
+        org => org.name === defaultOrganizationName,
+      )
+      if (match) {
+        setSelectedOrganization(match)
+        hasAppliedDefaultOrganizationRef.current = true
+      }
+    }
+  }, [organizations, defaultOrganizationName])
+
+  return {
+    selectedOrganization,
+    setSelectedOrganization,
+    organizationOptions,
+    isLoadingAllOrganizations: isLoading,
+    isError,
+    error,
+  }
+}

--- a/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/useJsonSchemaSelection.test.ts
+++ b/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/useJsonSchemaSelection.test.ts
@@ -1,0 +1,316 @@
+import { MOCK_CONTEXT_VALUE } from '@/mocks/MockSynapseContext'
+import { createWrapperAndQueryClient } from '@/testutils/TestingLibraryUtils'
+import {
+  JsonSchemaInfo,
+  JsonSchemaVersionInfo,
+  ListJsonSchemaVersionInfoResponse,
+} from '@sage-bionetworks/synapse-client'
+import { RowSelectionState } from '@tanstack/react-table'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { VersionSelectionType } from './VersionSelectionType'
+import {
+  JsonSchemaSelection,
+  useJsonSchemaSelection,
+} from './useJsonSchemaSelection'
+
+const postRepoV1SchemaVersionListSpy = vi.spyOn(
+  MOCK_CONTEXT_VALUE.synapseClient.jsonSchemaServicesClient,
+  'postRepoV1SchemaVersionList',
+)
+
+const SCHEMA_A: JsonSchemaInfo = {
+  organizationId: '1',
+  organizationName: 'org.sagebionetworks',
+  schemaId: 'schema-a',
+  schemaName: 'SchemaA',
+}
+const SCHEMA_B: JsonSchemaInfo = {
+  organizationId: '1',
+  organizationName: 'org.sagebionetworks',
+  schemaId: 'schema-b',
+  schemaName: 'SchemaB',
+}
+const SCHEMAS = [SCHEMA_A, SCHEMA_B]
+
+const VERSION_1: JsonSchemaVersionInfo = {
+  organizationId: '1',
+  organizationName: 'org.sagebionetworks',
+  schemaId: 'schema-a',
+  schemaName: 'SchemaA',
+  versionId: '1',
+  $id: 'org.sagebionetworks-SchemaA-1.0.0',
+  semanticVersion: '1.0.0',
+}
+const VERSION_2: JsonSchemaVersionInfo = {
+  organizationId: '1',
+  organizationName: 'org.sagebionetworks',
+  schemaId: 'schema-a',
+  schemaName: 'SchemaA',
+  versionId: '2',
+  $id: 'org.sagebionetworks-SchemaA-2.0.0',
+  semanticVersion: '2.0.0',
+}
+
+function renderSelectionHook(
+  props: Partial<{
+    schemas: JsonSchemaInfo[]
+    versionSelectionType: VersionSelectionType
+    initialSelected: JsonSchemaSelection
+  }> = {},
+) {
+  const onSelectionChange = vi.fn()
+  const { wrapperFn, queryClient } = createWrapperAndQueryClient()
+  const fetchQuerySpy = vi.spyOn(queryClient, 'fetchQuery')
+  const result = renderHook(
+    ({ schemas, versionSelectionType, initialSelected }) =>
+      useJsonSchemaSelection({
+        schemas,
+        versionSelectionType,
+        onSelectionChange,
+        initialSelected,
+      }),
+    {
+      initialProps: {
+        schemas: SCHEMAS,
+        versionSelectionType: VersionSelectionType.REQUIRED,
+        ...props,
+      },
+      wrapper: wrapperFn,
+    },
+  )
+  return { ...result, onSelectionChange, fetchQuerySpy }
+}
+
+function selectSchema(
+  result: {
+    current: { handleRowSelectionChange: (v: RowSelectionState) => void }
+  },
+  schema: JsonSchemaInfo,
+) {
+  act(() => {
+    result.current.handleRowSelectionChange({ [schema.schemaId!]: true })
+  })
+}
+
+/**
+ * Queues a controllable response for the next `postRepoV1SchemaVersionList` call (i.e. the
+ * next schema selected under REQUIRED), returning a function to resolve it on demand -- so
+ * tests can precisely control when the "auto-select latest version" fetch settles relative to
+ * other actions (a manual pick, or selecting a different schema).
+ */
+function mockVersionsFetchPending() {
+  let resolve!: (response: ListJsonSchemaVersionInfoResponse) => void
+  postRepoV1SchemaVersionListSpy.mockReturnValueOnce(
+    new Promise(res => {
+      resolve = res
+    }),
+  )
+  return (versions: JsonSchemaVersionInfo[]) => resolve({ page: versions })
+}
+
+/**
+ * Awaits the promise returned by the given `queryClient.fetchQuery` call
+ */
+async function awaitFetchQueryCall(
+  fetchQuerySpy: ReturnType<typeof vi.spyOn>,
+  callIndex = 0,
+) {
+  await fetchQuerySpy.mock.results[callIndex]?.value
+}
+
+describe('useJsonSchemaSelection', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('reports undefined when nothing is selected', () => {
+    const { result, onSelectionChange } = renderSelectionHook()
+    expect(result.current.selectedSchema).toBeUndefined()
+    expect(onSelectionChange).not.toHaveBeenCalled()
+  })
+
+  it('REQUIRED: reports undefined while a schema is selected but no version has resolved', () => {
+    mockVersionsFetchPending()
+    const { result, onSelectionChange } = renderSelectionHook({
+      versionSelectionType: VersionSelectionType.REQUIRED,
+    })
+
+    selectSchema(result, SCHEMA_A)
+
+    expect(result.current.selectedSchema).toEqual(SCHEMA_A)
+    expect(result.current.selectedVersionInfo).toBeUndefined()
+    expect(onSelectionChange).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('REQUIRED: reports the selection once a version is manually chosen', () => {
+    mockVersionsFetchPending()
+    const { result, onSelectionChange } = renderSelectionHook({
+      versionSelectionType: VersionSelectionType.REQUIRED,
+    })
+
+    selectSchema(result, SCHEMA_A)
+    act(() => {
+      result.current.handleVersionChange(VERSION_2)
+    })
+
+    expect(result.current.selectedVersionInfo).toEqual(VERSION_2)
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      $id: VERSION_2.$id,
+      versionInfo: VERSION_2,
+    })
+  })
+
+  it('REQUIRED: auto-selects and reports the latest version once the version fetch resolves', async () => {
+    const resolveFetch = mockVersionsFetchPending()
+    const { result, onSelectionChange } = renderSelectionHook({
+      versionSelectionType: VersionSelectionType.REQUIRED,
+    })
+
+    selectSchema(result, SCHEMA_A)
+    // The API returns versions lowest-to-highest; the latest is the last element.
+    resolveFetch([VERSION_1, VERSION_2])
+
+    await waitFor(() =>
+      expect(result.current.selectedVersionInfo).toEqual(VERSION_2),
+    )
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      $id: VERSION_2.$id,
+      versionInfo: VERSION_2,
+    })
+  })
+
+  it('REQUIRED: a manual pick made before the auto-fetch resolves wins, and the stale fetch result is discarded', async () => {
+    const resolveFetch = mockVersionsFetchPending()
+    const { result, onSelectionChange, fetchQuerySpy } = renderSelectionHook({
+      versionSelectionType: VersionSelectionType.REQUIRED,
+    })
+
+    selectSchema(result, SCHEMA_A)
+    act(() => {
+      result.current.handleVersionChange(VERSION_1)
+    })
+
+    resolveFetch([VERSION_1, VERSION_2])
+    await act(() => awaitFetchQueryCall(fetchQuerySpy))
+
+    expect(result.current.selectedVersionInfo).toEqual(VERSION_1)
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      $id: VERSION_1.$id,
+      versionInfo: VERSION_1,
+    })
+  })
+
+  it('REQUIRED: selecting a different schema before the auto-fetch resolves discards the stale result', async () => {
+    const resolveFetchForA = mockVersionsFetchPending()
+    const { result, onSelectionChange, fetchQuerySpy } = renderSelectionHook({
+      versionSelectionType: VersionSelectionType.REQUIRED,
+    })
+
+    selectSchema(result, SCHEMA_A)
+    const resolveFetchForB = mockVersionsFetchPending()
+    selectSchema(result, SCHEMA_B)
+
+    resolveFetchForA([VERSION_1, VERSION_2])
+    // Await the fetch for A specifically (call 0) -- the fetch for B (call 1) is still pending.
+    await act(() => awaitFetchQueryCall(fetchQuerySpy, 0))
+
+    expect(result.current.selectedSchema).toEqual(SCHEMA_B)
+    expect(result.current.selectedVersionInfo).toBeUndefined()
+
+    resolveFetchForB([VERSION_1])
+    await waitFor(() =>
+      expect(result.current.selectedVersionInfo).toEqual(VERSION_1),
+    )
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      $id: VERSION_1.$id,
+      versionInfo: VERSION_1,
+    })
+  })
+
+  it('LATEST_ALLOWED: reports an unversioned $id when the version is cleared to "Latest", without fetching versions', () => {
+    const { result, onSelectionChange } = renderSelectionHook({
+      versionSelectionType: VersionSelectionType.LATEST_ALLOWED,
+    })
+
+    selectSchema(result, SCHEMA_A)
+    act(() => {
+      result.current.handleVersionChange(undefined)
+    })
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      $id: `${SCHEMA_A.organizationName}-${SCHEMA_A.schemaName}`,
+      versionInfo: undefined,
+    })
+    // Selecting a row under LATEST_ALLOWED doesn't need to know the latest version up front.
+    expect(postRepoV1SchemaVersionListSpy).not.toHaveBeenCalled()
+  })
+
+  it('resets the resolved version when a different schema is selected', () => {
+    mockVersionsFetchPending()
+    const { result, onSelectionChange } = renderSelectionHook({
+      versionSelectionType: VersionSelectionType.REQUIRED,
+    })
+
+    selectSchema(result, SCHEMA_A)
+    act(() => {
+      result.current.handleVersionChange(VERSION_1)
+    })
+    expect(result.current.selectedVersionInfo).toEqual(VERSION_1)
+
+    mockVersionsFetchPending()
+    selectSchema(result, SCHEMA_B)
+
+    expect(result.current.selectedSchema).toEqual(SCHEMA_B)
+    expect(result.current.selectedVersionInfo).toBeUndefined()
+    // Waiting on a version to resolve for the newly-selected schema under REQUIRED.
+    expect(onSelectionChange).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('reports undefined when the schema is deselected', () => {
+    const { result, onSelectionChange } = renderSelectionHook({
+      versionSelectionType: VersionSelectionType.LATEST_ALLOWED,
+    })
+
+    selectSchema(result, SCHEMA_A)
+    act(() => {
+      result.current.handleRowSelectionChange({})
+    })
+
+    expect(result.current.selectedSchema).toBeUndefined()
+    expect(onSelectionChange).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('supports functional updaters, matching TanStack Table onRowSelectionChange', () => {
+    const { result, onSelectionChange } = renderSelectionHook({
+      versionSelectionType: VersionSelectionType.LATEST_ALLOWED,
+    })
+
+    act(() => {
+      result.current.handleRowSelectionChange(old => ({
+        ...old,
+        [SCHEMA_A.schemaId!]: true,
+      }))
+    })
+
+    expect(result.current.selectedSchema).toEqual(SCHEMA_A)
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      $id: `${SCHEMA_A.organizationName}-${SCHEMA_A.schemaName}`,
+      versionInfo: undefined,
+    })
+  })
+
+  it('seeds rowSelection and selectedVersionInfo from initialSelected, without fetching versions', () => {
+    const initialSelected: JsonSchemaSelection = {
+      $id: VERSION_1.$id,
+      versionInfo: VERSION_1,
+    }
+    const { result } = renderSelectionHook({
+      schemas: SCHEMAS,
+      versionSelectionType: VersionSelectionType.REQUIRED,
+      initialSelected,
+    })
+
+    expect(result.current.selectedSchema).toEqual(SCHEMA_A)
+    expect(result.current.selectedVersionInfo).toEqual(VERSION_1)
+    expect(result.current.rowSelection).toEqual({ [SCHEMA_A.schemaId!]: true })
+    expect(postRepoV1SchemaVersionListSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/useJsonSchemaSelection.ts
+++ b/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/useJsonSchemaSelection.ts
@@ -1,0 +1,179 @@
+import { getJsonSchemaVersionsQuery } from '@/synapse-queries'
+import { useSynapseContext } from '@/utils/context/SynapseContext'
+import {
+  JsonSchemaInfo,
+  JsonSchemaVersionInfo,
+} from '@sage-bionetworks/synapse-client'
+import {
+  functionalUpdate,
+  OnChangeFn,
+  RowSelectionState,
+} from '@tanstack/react-table'
+import { useQueryClient } from '@tanstack/react-query'
+import { useMemo, useRef, useState } from 'react'
+import { VersionSelectionType } from './VersionSelectionType'
+
+export type JsonSchemaSelection = {
+  $id?: string
+  versionInfo?: JsonSchemaVersionInfo
+}
+
+export function getSchemaId(schema: JsonSchemaInfo): string {
+  return schema.schemaId ?? schema.schemaName ?? ''
+}
+
+function buildUnversionedSchemaId(schema: JsonSchemaInfo): string {
+  return `${schema.organizationName}-${schema.schemaName}`
+}
+
+/**
+ * Computes the `JsonSchemaSelection` to report to the consumer for a given schema/version/
+ * VersionSelectionType combination.
+ */
+function resolveSelection(
+  schema: JsonSchemaInfo | undefined,
+  versionInfo: JsonSchemaVersionInfo | undefined,
+  versionSelectionType: VersionSelectionType,
+): JsonSchemaSelection | undefined {
+  if (!schema) {
+    return undefined
+  }
+  if (versionSelectionType === VersionSelectionType.REQUIRED && !versionInfo) {
+    // Waiting for a numbered version to be resolved before reporting a selection.
+    return undefined
+  }
+  if (versionInfo) {
+    return { $id: versionInfo.$id, versionInfo }
+  }
+  return { $id: buildUnversionedSchemaId(schema), versionInfo: undefined }
+}
+
+export type UseJsonSchemaSelectionParams = {
+  schemas: JsonSchemaInfo[]
+  versionSelectionType: VersionSelectionType
+  onSelectionChange: (selection: JsonSchemaSelection | undefined) => void
+  /**
+   * The initially-selected schema/version, e.g. when editing an existing selection. Only
+   * consulted on mount (via useState's lazy initializer) -- to react to a changed
+   * `initialSelected`, remount this hook's consumer with a new `key`, rather than updating this
+   * prop in place.
+   */
+  initialSelected?: JsonSchemaSelection
+}
+
+/**
+ * Manages which JsonSchema (and, depending on `versionSelectionType`, which version of that
+ * schema) is currently selected, and reports the resolved selection to `onSelectionChange`.
+ *
+ * Under {@link VersionSelectionType.REQUIRED}, selecting a schema with no version yet chosen
+ * kicks off a fetch of every version, and auto-selects the latest one once it resolves.
+ */
+export function useJsonSchemaSelection(params: UseJsonSchemaSelectionParams) {
+  const { schemas, versionSelectionType, onSelectionChange, initialSelected } =
+    params
+  const { synapseClient, keyFactory } = useSynapseContext()
+  const queryClient = useQueryClient()
+
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>(() => {
+    const initialSchemaId = initialSelected?.versionInfo
+      ? getSchemaId(initialSelected.versionInfo)
+      : undefined
+    return initialSchemaId ? { [initialSchemaId]: true } : {}
+  })
+  const [selectedVersionInfo, setSelectedVersionInfo] = useState<
+    JsonSchemaVersionInfo | undefined
+  >(initialSelected?.versionInfo)
+
+  // Mirror rowSelection so handleRowSelectionChange (below) can apply a functional updater
+  // against the *current* selection, rather than the (possibly stale) value closed over at
+  // render time.
+  const rowSelectionRef = useRef(rowSelection)
+  rowSelectionRef.current = rowSelection
+
+  // Identifies the most recent row-selection or manual-version-pick request, which ensures
+  // that only the latest invocation applies a state change. This is necessary because the
+  // "auto-select latest version" depends on a network request, and the user may have manually
+  // invoked a different selection before the request resolves.
+  const requestIdRef = useRef(0)
+
+  const selectedSchema = useMemo(() => {
+    const id = Object.keys(rowSelection).find(key => rowSelection[key])
+    return schemas.find(schema => getSchemaId(schema) === id)
+  }, [rowSelection, schemas])
+
+  const applyVersionSelection = (
+    schema: JsonSchemaInfo | undefined,
+    versionInfo: JsonSchemaVersionInfo | undefined,
+  ) => {
+    setSelectedVersionInfo(versionInfo)
+    onSelectionChange(
+      resolveSelection(schema, versionInfo, versionSelectionType),
+    )
+  }
+
+  const handleVersionChange = (
+    versionInfo: JsonSchemaVersionInfo | undefined,
+  ) => {
+    // Invalidate any in-flight "auto-select latest version" fetch -- this manual pick wins.
+    requestIdRef.current++
+    applyVersionSelection(selectedSchema, versionInfo)
+  }
+
+  const handleRowSelectionChange: OnChangeFn<
+    RowSelectionState
+  > = updaterOrValue => {
+    const newRowSelection = functionalUpdate(
+      updaterOrValue,
+      rowSelectionRef.current,
+    )
+    const newSelectedId = Object.keys(newRowSelection).find(
+      key => newRowSelection[key],
+    )
+    const newSelectedSchema = schemas.find(
+      schema => getSchemaId(schema) === newSelectedId,
+    )
+
+    setRowSelection(newRowSelection)
+    setSelectedVersionInfo(undefined)
+    onSelectionChange(
+      resolveSelection(newSelectedSchema, undefined, versionSelectionType),
+    )
+
+    const requestId = ++requestIdRef.current
+
+    if (
+      newSelectedSchema &&
+      versionSelectionType === VersionSelectionType.REQUIRED
+    ) {
+      void queryClient
+        .fetchQuery(
+          getJsonSchemaVersionsQuery(
+            newSelectedSchema.organizationName ?? '',
+            newSelectedSchema.schemaName ?? '',
+            { synapseClient, keyFactory },
+          ),
+        )
+        .then(versions => {
+          // The API returns versions lowest-to-highest, so the latest is the last element.
+          const latest = versions.at(-1)
+          if (requestIdRef.current === requestId && latest) {
+            // Apply against the schema this fetch was for -- not `selectedSchema`, whose
+            // closure here is fixed to this render and may be stale by the time this resolves.
+            applyVersionSelection(newSelectedSchema, latest)
+          }
+        })
+        .catch(() => {
+          // Swallow -- JsonSchemaVersionCell's own query for the same key surfaces the error
+          // in the UI; this fetch only exists to opportunistically auto-select "latest."
+        })
+    }
+  }
+
+  return {
+    rowSelection,
+    selectedVersionInfo,
+    selectedSchema,
+    handleRowSelectionChange,
+    handleVersionChange,
+  }
+}


### PR DESCRIPTION
- Add useJsonSchemaSelection to manage schema/version selection state
- Add useJsonSchemaOrganizations to load organizations for selection
- Add VersionSelectionType to distinguish required vs. optional
  version selection

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>