### PR TITLE
SWC-7901 - Add JsonSchemaPickerModal

### DIFF
--- a/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/JsonSchemaPickerModal.stories.tsx
+++ b/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/JsonSchemaPickerModal.stories.tsx
@@ -1,0 +1,100 @@
+import { getJsonSchemaListingHandlers } from '@/mocks/msw/handlers/jsonSchemaListingHandlers'
+import {
+  MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+  mockJsonSchemaVersionsPageTwoForMultiVersionSchema,
+} from '@/mocks/jsonschema/mockJsonSchemaListing'
+import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { http, HttpResponse } from 'msw'
+import { JsonSchemaPickerModal } from './JsonSchemaPickerModal'
+import { VersionSelectionType } from './VersionSelectionType'
+import { fn } from 'storybook/test'
+
+const meta = {
+  title: 'Synapse/JsonSchema/JsonSchemaPickerModal',
+  component: JsonSchemaPickerModal,
+  args: {
+    open: true,
+    onConfirm: fn(),
+    onCancel: fn(),
+  },
+  parameters: {
+    stack: 'mock',
+    msw: {
+      handlers: getJsonSchemaListingHandlers(MOCK_REPO_ORIGIN),
+    },
+  },
+} satisfies Meta<typeof JsonSchemaPickerModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        organizations: [
+          http.post(
+            `${MOCK_REPO_ORIGIN}/repo/v1/schema/organization/list`,
+            () => new Promise<never>(() => {}),
+          ),
+        ],
+      },
+    },
+  },
+}
+
+export const ErrorState: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        organizations: [
+          http.post(
+            `${MOCK_REPO_ORIGIN}/repo/v1/schema/organization/list`,
+            () =>
+              HttpResponse.json(
+                { reason: 'Unable to load organizations' },
+                { status: 500 },
+              ),
+          ),
+        ],
+      },
+    },
+  },
+}
+
+export const WithDefaultOrganization: Story = {
+  args: {
+    defaultOrganizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+  },
+}
+
+export const RequiredVersion: Story = {
+  name: 'Version Selection: REQUIRED',
+  args: {
+    defaultOrganizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+    versionSelectionType: VersionSelectionType.REQUIRED,
+  },
+}
+
+export const LatestAllowedVersion: Story = {
+  name: 'Version Selection: LATEST_ALLOWED',
+  args: {
+    defaultOrganizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+    versionSelectionType: VersionSelectionType.LATEST_ALLOWED,
+  },
+}
+
+export const WithInitialSelected: Story = {
+  name: 'With Initial Selection (e.g. Editing an Existing Binding)',
+  args: {
+    defaultOrganizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+    versionSelectionType: VersionSelectionType.REQUIRED,
+    initialSelected: {
+      // Preselects the MultiVersionSchema row, with its 2.0.0 version already chosen.
+      versionInfo: mockJsonSchemaVersionsPageTwoForMultiVersionSchema.page![0],
+    },
+  },
+}

--- a/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/JsonSchemaPickerModal.test.tsx
+++ b/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/JsonSchemaPickerModal.test.tsx
@@ -1,0 +1,167 @@
+import {
+  MOCK_MULTI_VERSION_SCHEMA_NAME,
+  MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+} from '@/mocks/jsonschema/mockJsonSchemaListing'
+import { server } from '@/mocks/msw/server'
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { mockVirtualizedTableLayout } from '@/testutils/VirtualizedTableTestUtils'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { JsonSchemaPickerModal } from './JsonSchemaPickerModal'
+
+function renderModal(
+  props: Partial<
+    Omit<Parameters<typeof JsonSchemaPickerModal>[0], 'onConfirm' | 'onCancel'>
+  > = {},
+) {
+  const onConfirm = vi.fn()
+  const onCancel = vi.fn()
+  const result = render(
+    <JsonSchemaPickerModal
+      open
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      {...props}
+    />,
+    { wrapper: createWrapper() },
+  )
+  return { ...result, onConfirm, onCancel }
+}
+
+async function selectSchema(schemaName: string) {
+  const combobox = screen.getByRole('combobox', { name: 'Organization' })
+  await userEvent.click(combobox)
+  const option = await screen.findByRole('option', {
+    name: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+  })
+  await userEvent.click(option)
+
+  const table = await screen.findByRole('table')
+  await within(table).findByText(schemaName)
+  const row = within(table)
+    .getAllByRole('row')
+    .find(row => within(row).queryByText(schemaName))!
+  await userEvent.click(
+    within(row).getByRole('checkbox', { name: `Select ${schemaName}` }),
+  )
+  return row
+}
+
+describe('JsonSchemaPickerModal', () => {
+  let restoreVirtualizedTableLayout: () => void
+  beforeAll(() => {
+    server.listen()
+    restoreVirtualizedTableLayout = mockVirtualizedTableLayout()
+  })
+  afterEach(() => server.resetHandlers())
+  afterAll(() => {
+    server.close()
+    restoreVirtualizedTableLayout()
+  })
+
+  it('renders the default title and confirm button copy', () => {
+    renderModal()
+    expect(screen.getByText('Select a Schema')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Add Selected Schema' }),
+    ).toBeInTheDocument()
+  })
+
+  it('disables the confirm button until a selection is made, then enables it', async () => {
+    renderModal()
+
+    const confirmButton = screen.getByRole('button', {
+      name: 'Add Selected Schema',
+    })
+    expect(confirmButton).toBeDisabled()
+
+    await selectSchema(MOCK_MULTI_VERSION_SCHEMA_NAME)
+
+    await waitFor(() => expect(confirmButton).toBeEnabled(), { timeout: 3000 })
+  })
+
+  it('calls onConfirm with the selected schema $id and versionInfo', async () => {
+    const { onConfirm } = renderModal()
+
+    await selectSchema(MOCK_MULTI_VERSION_SCHEMA_NAME)
+
+    const confirmButton = screen.getByRole('button', {
+      name: 'Add Selected Schema',
+    })
+    await waitFor(() => expect(confirmButton).toBeEnabled(), { timeout: 3000 })
+    await userEvent.click(confirmButton)
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      $id: expect.stringContaining(MOCK_MULTI_VERSION_SCHEMA_NAME),
+      versionInfo: expect.objectContaining({
+        schemaName: MOCK_MULTI_VERSION_SCHEMA_NAME,
+      }),
+    })
+  })
+
+  it('calls onCancel when Cancel is clicked, without calling onConfirm', async () => {
+    const { onCancel, onConfirm } = renderModal()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('does not carry a selection across a cancel and reopen', async () => {
+    const { rerender, onConfirm, onCancel } = renderModal()
+
+    await selectSchema(MOCK_MULTI_VERSION_SCHEMA_NAME)
+    const confirmButton = screen.getByRole('button', {
+      name: 'Add Selected Schema',
+    })
+    await waitFor(() => expect(confirmButton).toBeEnabled(), { timeout: 3000 })
+
+    rerender(
+      <JsonSchemaPickerModal
+        open={false}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    )
+    rerender(
+      <JsonSchemaPickerModal open onConfirm={onConfirm} onCancel={onCancel} />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Add Selected Schema' }),
+    ).toBeDisabled()
+  })
+
+  it('enables the confirm button immediately when opened with an initialSelected', () => {
+    renderModal({
+      initialSelected: {
+        $id: `${MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME}-${MOCK_MULTI_VERSION_SCHEMA_NAME}-1.1.0`,
+        versionInfo: {
+          organizationName: MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME,
+          schemaId: '103',
+          schemaName: MOCK_MULTI_VERSION_SCHEMA_NAME,
+          versionId: '2',
+          $id: `${MOCK_ORGANIZATION_SAGEBIONETWORKS_NAME}-${MOCK_MULTI_VERSION_SCHEMA_NAME}-1.1.0`,
+          semanticVersion: '1.1.0',
+        },
+      },
+    })
+
+    expect(
+      screen.getByRole('button', { name: 'Add Selected Schema' }),
+    ).toBeEnabled()
+  })
+
+  it('supports custom title and confirm button copy', () => {
+    renderModal({
+      title: 'Choose a Template',
+      confirmButtonCopy: 'Use Template',
+    })
+
+    expect(screen.getByText('Choose a Template')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Use Template' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/JsonSchemaPickerModal.tsx
+++ b/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/JsonSchemaPickerModal.tsx
@@ -1,0 +1,79 @@
+import { ConfirmationDialog } from '@/components/ConfirmationDialog'
+import { useState } from 'react'
+import { JsonSchemaPicker, JsonSchemaSelection } from './JsonSchemaPicker'
+import { VersionSelectionType } from './VersionSelectionType'
+
+export type JsonSchemaPickerModalProps = {
+  open: boolean
+  /** Called with the confirmed schema selection when the user clicks the confirm button. */
+  onConfirm: (result: JsonSchemaSelection) => void
+  onCancel: () => void
+  /** If provided, and a matching Organization is found, it will be preselected. */
+  defaultOrganizationName?: string
+  /** Controls whether a concrete numbered version must be selected, or if "Latest" is an option. */
+  versionSelectionType?: VersionSelectionType
+  /** The initially-selected schema/version, e.g. when editing an existing selection. */
+  initialSelected?: JsonSchemaSelection
+  title?: string
+  confirmButtonCopy?: string
+}
+
+/**
+ * A modal dialog for selecting a single JSON Schema (and, depending on
+ * {@link VersionSelectionType}, a version of that schema).
+ */
+export function JsonSchemaPickerModal(props: JsonSchemaPickerModalProps) {
+  const { open, ...rest } = props
+
+  // Keyed by `open` so that `selected` (declared below) is discarded whenever the dialog
+  // transitions between open and closed, rather than surviving a cancel-then-reopen.
+  return (
+    <JsonSchemaPickerModalDialog
+      key={open ? 'open' : 'closed'}
+      open={open}
+      {...rest}
+    />
+  )
+}
+
+function JsonSchemaPickerModalDialog(props: JsonSchemaPickerModalProps) {
+  const {
+    open,
+    onConfirm,
+    onCancel,
+    defaultOrganizationName,
+    versionSelectionType,
+    initialSelected,
+    title = 'Select a Schema',
+    confirmButtonCopy = 'Add Selected Schema',
+  } = props
+
+  const [selected, setSelected] = useState<JsonSchemaSelection | undefined>(
+    initialSelected,
+  )
+
+  return (
+    <ConfirmationDialog
+      open={open}
+      title={title}
+      maxWidth="xl"
+      confirmButtonProps={{ children: confirmButtonCopy, disabled: !selected }}
+      onConfirm={() => {
+        if (selected) {
+          onConfirm(selected)
+        }
+      }}
+      onCancel={onCancel}
+      content={
+        <JsonSchemaPicker
+          defaultOrganizationName={defaultOrganizationName}
+          versionSelectionType={versionSelectionType}
+          initialSelected={initialSelected}
+          onSelectionChange={setSelected}
+        />
+      }
+    />
+  )
+}
+
+export default JsonSchemaPickerModal

--- a/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/index.ts
+++ b/packages/synapse-react-client/src/components/JsonSchema/JsonSchemaPicker/index.ts
@@ -3,4 +3,6 @@ export type {
   JsonSchemaPickerProps,
   JsonSchemaSelection,
 } from './JsonSchemaPicker'
+export { JsonSchemaPickerModal } from './JsonSchemaPickerModal'
+export type { JsonSchemaPickerModalProps } from './JsonSchemaPickerModal'
 export { VersionSelectionType } from './VersionSelectionType'


### PR DESCRIPTION
- Add JsonSchemaPickerModal, wrapping JsonSchemaPicker in a confirm/
  cancel dialog and resetting selection state on each open via a
  fresh key rather than leaking state across close/reopen
- Add Storybook stories demonstrating required- and
  latest-allowed-version selection

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>