### PR TITLE
SWC-7924

### DIFF
--- a/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.module.scss
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.module.scss
@@ -1,11 +1,13 @@
 .chip {
   position: relative;
+  margin-top: var(--remove-button-offset-y, 5px);
+  margin-left: var(--remove-button-offset-x, 8px);
 }
 
 .removeBadge:global(.MuiButtonBase-root) {
   position: absolute;
-  top: -6px;
-  left: -6px;
+  top: calc(-1 * var(--remove-button-offset-y, 5px));
+  left: calc(-1 * var(--remove-button-offset-x, 8px));
   opacity: 0;
   transition: opacity 100ms;
 }

--- a/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.module.scss
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.module.scss
@@ -5,6 +5,14 @@
 }
 
 .removeBadge:global(.MuiButtonBase-root) {
+  border: 1px solid var(--synapse-gray-300);
+  background-color: white;
+  width: 16px;
+  height: 16px;
+  &:hover {
+    background-color: var(--synapse-gray-100);
+  }
+
   position: absolute;
   top: calc(-1 * var(--remove-button-offset-y, 5px));
   left: calc(-1 * var(--remove-button-offset-x, 8px));

--- a/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.tsx
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/AttachmentChip/AttachmentChip.tsx
@@ -100,13 +100,6 @@ export function AttachmentChip({
           onClick={onRemove}
           size="small"
           className={styles.removeBadge}
-          sx={{
-            border: '1px solid',
-            borderColor: 'grey.300',
-            backgroundColor: 'white',
-            width: '16px',
-            height: '16px',
-          }}
         >
           <CloseIcon sx={{ fontSize: '10px' }} />
         </IconButton>

--- a/packages/synapse-react-client/src/components/SynapseChat/components/ChatAttachmentStrip/ChatAttachmentStrip.module.scss
+++ b/packages/synapse-react-client/src/components/SynapseChat/components/ChatAttachmentStrip/ChatAttachmentStrip.module.scss
@@ -3,8 +3,12 @@
 $chip-min-width: 140px;
 
 .strip {
+  --remove-button-offset-x: 8px;
+  --remove-button-offset-y: 5px;
+
   display: flex;
-  gap: 10px;
+  column-gap: calc(10px - var(--remove-button-offset-x));
+  row-gap: calc(10px - var(--remove-button-offset-y));
   overflow-x: auto;
 }
 


### PR DESCRIPTION
- fix style issue where remove button could be clipped. give the chip a margin that matches the button offset to ensure it is visible

|Before|After|
|---|---|
| <img width="750" height="135" alt="image" src="https://github.com/user-attachments/assets/7598d941-9c81-43a6-adb7-27e56e1a1d9f" /> | <img width="720" height="140" alt="image" src="https://github.com/user-attachments/assets/edaa54db-321a-45a9-a0d6-240d33f02d68" />|