### PR TITLE
PORTALS-4375

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsEditor.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsEditor.tsx
@@ -17,6 +17,7 @@ import { ReactNode } from 'react'
 import IconSvg from '../../IconSvg/IconSvg'
 import { UserBadge } from '../../UserCard/UserBadge'
 import UserSearchBox from '../../UserSearchBox/UserSearchBox'
+import { longFieldLabelSx } from './styles'
 
 export type DataAccessRequestAccessorsEditorProps = {
   /* The current set of accessor changes for a data access request */
@@ -83,7 +84,7 @@ export default function DataAccessRequestAccessorsEditor(
       <Typography variant={'headline3'} sx={{ mt: 4, mb: 2 }}>
         Collaborators
       </Typography>
-      <Typography variant={'body1'} sx={{ mb: 1 }}>
+      <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 1 }}>
         List the Synapse usernames of all collaborators at your institution
         included in this data access request. Each collaborator must have a
         Synapse account and be able to receive messages at their registered
@@ -92,7 +93,7 @@ export default function DataAccessRequestAccessorsEditor(
       <Typography
         component={'div'}
         variant={'body1'}
-        sx={{ mb: 1 }}
+        sx={{ ...longFieldLabelSx, mb: 1 }}
         className={'requester-label'}
       >
         {helpText}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsEditor.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsEditor.tsx
@@ -81,7 +81,13 @@ export default function DataAccessRequestAccessorsEditor(
   return (
     <>
       <Typography variant={'headline3'} sx={{ mt: 4, mb: 2 }}>
-        Data Requesters
+        Collaborators
+      </Typography>
+      <Typography variant={'body1'} sx={{ mb: 1 }}>
+        List the Synapse usernames of all collaborators at your institution
+        included in this data access request. Each collaborator must have a
+        Synapse account and be able to receive messages at their registered
+        email address.
       </Typography>
       <Typography
         component={'div'}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.stories.tsx
@@ -65,3 +65,14 @@ export const Renewal: Story = {
     researchProjectId: MOCK_RESEARCH_PROJECT_ID,
   },
 }
+export const Step2EDucEnabled: Story = {
+  args: {
+    subjectId: MOCK_FOLDER_ID,
+    subjectType: RestrictableObjectType.ENTITY,
+    managedACTAccessRequirement: {
+      ...mockManagedACTAccessRequirement,
+      eDucTemplateId: 'educ-template-123',
+    },
+    researchProjectId: MOCK_RESEARCH_PROJECT_ID,
+  },
+}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.test.tsx
@@ -586,4 +586,101 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
       expect(mockOnBackClicked).toHaveBeenCalled()
     })
   })
+
+  describe('when the AR has an eDucTemplateId', () => {
+    const eDucProps: DataAccessRequestAccessorsFilesFormProps = {
+      ...defaultProps,
+      managedACTAccessRequirement: {
+        ...mockManagedACTAccessRequirement,
+        eDucTemplateId: 'educ-template-123',
+      },
+    }
+
+    it('renders Signing Official name and email fields', async () => {
+      mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
+      renderComponent(eDucProps)
+
+      await screen.findByLabelText(
+        /First and last names of your Signing Official/i,
+      )
+      await screen.findByLabelText(
+        /Institutional Email of your Signing Official/i,
+      )
+    })
+
+    it('keeps Submit disabled until SO name and email are provided', async () => {
+      mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
+      const { user } = renderComponent(eDucProps)
+
+      const submitButton = await screen.findByRole('button', { name: 'Submit' })
+      expect(submitButton).toBeDisabled()
+
+      const nameField = screen.getByLabelText(
+        /First and last names of your Signing Official/i,
+      )
+      const emailField = screen.getByLabelText(
+        /Institutional Email of your Signing Official/i,
+      )
+
+      await user.type(nameField, 'Jane Smith')
+      expect(submitButton).toBeDisabled()
+
+      await user.type(emailField, 'jane@example.edu')
+      await waitFor(() => expect(submitButton).toBeEnabled())
+    })
+
+    it('includes signingOfficial in the saved DAR on Submit', async () => {
+      mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
+      const { user } = renderComponent(eDucProps)
+
+      const nameField = await screen.findByLabelText(
+        /First and last names of your Signing Official/i,
+      )
+      const emailField = screen.getByLabelText(
+        /Institutional Email of your Signing Official/i,
+      )
+
+      await user.type(nameField, 'Jane Smith')
+      await user.type(emailField, 'jane@example.edu')
+
+      const submitButton = await screen.findByRole('button', { name: 'Submit' })
+      await waitFor(() => expect(submitButton).toBeEnabled())
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        const lastCall = mockUpdateDataAccessRequest.mock.calls.filter(
+          call => call[0].signingOfficial,
+        )
+        expect(lastCall.length).toBeGreaterThan(0)
+        const savedRequest = lastCall[lastCall.length - 1][0]
+        expect(savedRequest.signingOfficial).toMatchObject({
+          name: 'Jane Smith',
+          institutionalEmail: 'jane@example.edu',
+        })
+      })
+    })
+
+    it('prefills SO fields from existing DAR', async () => {
+      mockGetDataRequestForUpdate.mockResolvedValue({
+        ...MOCK_DATA_ACCESS_REQUEST,
+        signingOfficial: {
+          name: 'Pre-filled Official',
+          institutionalEmail: 'prefilled@example.edu',
+        },
+      })
+      renderComponent(eDucProps)
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText(
+            /First and last names of your Signing Official/i,
+          ).value,
+        ).toBe('Pre-filled Official')
+        expect(
+          screen.getByLabelText(/Institutional Email of your Signing Official/i)
+            .value,
+        ).toBe('prefilled@example.edu')
+      })
+    })
+  })
 })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.test.tsx
@@ -674,12 +674,13 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
         expect(
           screen.getByLabelText(
             /First and last names of your Signing Official/i,
-          ).value,
-        ).toBe('Pre-filled Official')
+          ),
+        ).toHaveValue('Pre-filled Official')
         expect(
-          screen.getByLabelText(/Institutional Email of your Signing Official/i)
-            .value,
-        ).toBe('prefilled@example.edu')
+          screen.getByLabelText(
+            /Institutional Email of your Signing Official/i,
+          ),
+        ).toHaveValue('prefilled@example.edu')
       })
     })
   })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
@@ -193,6 +193,9 @@ export default function DataAccessRequestAccessorsFilesForm(
     updateDataAccessRequestIsPending ||
     submitDataAccessRequestIsPending
 
+  const disableSubmitButton =
+    submitDataAccessRequestIsPending || (isEDucEnabled && (!soName || !soEmail))
+
   /**
    * This effect comprises a collection of updates we should immediately apply to a data access request.
    */
@@ -697,10 +700,7 @@ export default function DataAccessRequestAccessorsFilesForm(
         </Button>
         <Button
           variant="contained"
-          disabled={
-            submitDataAccessRequestIsPending ||
-            (isEDucEnabled && (!soName || !soEmail))
-          }
+          disabled={disableSubmitButton}
           onClick={() => {
             handleSubmit()
           }}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
@@ -43,6 +43,7 @@ import IconSvg from '../../../IconSvg/IconSvg'
 import DataAccessRequestAccessorsEditor, {
   DataAccessRequestAccessorsEditorProps,
 } from '../DataAccessRequestAccessorsEditor'
+import { longFieldLabelSx } from '../styles'
 import DocumentTemplate from '../DocumentTemplate'
 import ManagedACTAccessRequirementFormWikiWrapper from '../ManagedACTAccessRequirementFormWikiWrapper'
 import { UploadDocumentField } from '../UploadDocumentField'
@@ -445,7 +446,7 @@ export default function DataAccessRequestAccessorsFilesForm(
             }}
             onSubmit={e => e.preventDefault()}
           >
-            <Typography variant={'body1'} sx={{ mb: 2 }}>
+            <Typography variant={'body1'} sx={{ mb: 2, fontSize: '16px' }}>
               Please provide the information below to submit the request for
               access.
             </Typography>
@@ -455,7 +456,10 @@ export default function DataAccessRequestAccessorsFilesForm(
                 <Typography variant={'headline3'} sx={{ mb: 2 }}>
                   Signing Official
                 </Typography>
-                <Typography variant={'body1'} sx={{ mb: 2 }}>
+                <Typography
+                  variant={'body1'}
+                  sx={{ ...longFieldLabelSx, mb: 2 }}
+                >
                   The signing official is a member of your institution with
                   oversight authority who is NOT part of the study team (i.e.,
                   not the Project Lead, not a Data Requester or Collaborator,
@@ -532,12 +536,19 @@ export default function DataAccessRequestAccessorsFilesForm(
                 <Typography variant={'headline3'} sx={{ mt: 4, mb: 2 }}>
                   Fill out and upload a Data Use Certificate
                 </Typography>
-                <Typography variant={'body1'} sx={{ my: 2 }}>
+                <Typography
+                  variant={'body1'}
+                  sx={{ ...longFieldLabelSx, my: 2 }}
+                >
                   You must download and fill out a Data Use Certificate (DUC).
                   Be sure to upload the completed DUC below once you&apos;ve
                   completed it.
                 </Typography>
-                <Typography variant={'body1'} component={'ol'}>
+                <Typography
+                  variant={'body1'}
+                  component={'ol'}
+                  sx={longFieldLabelSx}
+                >
                   <li>Download the DUC template file.</li>
                   <li>
                     Fill out the DUC template, following the instructions in the
@@ -571,7 +582,10 @@ export default function DataAccessRequestAccessorsFilesForm(
                 <Typography variant={'headline3'} sx={{ my: 2 }}>
                   IRB Approval
                 </Typography>
-                <Typography variant={'body1'} sx={{ my: 2 }}>
+                <Typography
+                  variant={'body1'}
+                  sx={{ ...longFieldLabelSx, my: 2 }}
+                >
                   Upload a signed IRB letter on institutional letterhead. The
                   letter must include the names of all the datasets requested,
                   as well as the names of the data requesters above. Use the
@@ -601,7 +615,10 @@ export default function DataAccessRequestAccessorsFilesForm(
                   <Typography variant={'headline3'} sx={{ my: 2 }}>
                     Upload other required documents
                   </Typography>
-                  <Typography variant={'body1'} sx={{ my: 2 }}>
+                  <Typography
+                    variant={'body1'}
+                    sx={{ ...longFieldLabelSx, my: 2 }}
+                  >
                     You must upload other required documents. Please review the
                     instructions to gain data access to determine which
                     documents must also be uploaded.

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
@@ -11,10 +11,12 @@ import {
   IconButton,
   Link,
   Stack,
+  TextField,
   Typography,
 } from '@mui/material'
 import { deepEquals } from '@rjsf/utils'
 import { SynapseClientError } from '@sage-bionetworks/synapse-client/util/SynapseClientError'
+import isEmpty from 'lodash-es/isEmpty'
 import {
   AccessorChange,
   AccessType,
@@ -25,6 +27,7 @@ import {
   Renewal,
   Request,
   RestrictableObjectType,
+  SigningOfficial,
   UploadCallbackResp,
 } from '@sage-bionetworks/synapse-types'
 import { ReactNode, useEffect, useState } from 'react'
@@ -46,8 +49,9 @@ import { UploadDocumentField } from '../UploadDocumentField'
 
 function AccessorRequirementHelpText(props: {
   managedACTAccessRequirement: ManagedACTAccessRequirement
+  isEDucEnabled: boolean
 }) {
-  const { managedACTAccessRequirement } = props
+  const { managedACTAccessRequirement, isEDucEnabled } = props
   let link: string = ''
   let msg: string = ''
 
@@ -69,7 +73,7 @@ function AccessorRequirementHelpText(props: {
   }
   return (
     <>
-      {managedACTAccessRequirement.isDUCRequired ? (
+      {managedACTAccessRequirement.isDUCRequired && !isEDucEnabled ? (
         <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', py: 1 }}>
           <NewReleasesOutlined sx={{ color: 'error.main' }} />
           <div>
@@ -138,11 +142,14 @@ export default function DataAccessRequestAccessorsFilesForm(
   const { isAuthenticated } = useSynapseContext()
   const { data: user } = useGetCurrentUserProfile({ enabled: isAuthenticated })
   const [alert, setAlert] = useState<AlertProps | undefined>()
+  const isEDucEnabled = Boolean(managedACTAccessRequirement.eDucTemplateId)
   const [accessorChanges, setAccessorChanges] = useState<
     AccessorChange[] | undefined
   >()
   const [summaryOfUse, setSummaryOfUse] = useState<string | undefined>()
   const [publication, setPublication] = useState<string | undefined>()
+  const [soName, setSoName] = useState<string>('')
+  const [soEmail, setSoEmail] = useState<string>('')
 
   const { data: dataAccessRequest, isLoading: isLoadingGetDataAccessRequest } =
     useGetDataAccessRequestForUpdate(String(managedACTAccessRequirement.id), {
@@ -268,19 +275,36 @@ export default function DataAccessRequestAccessorsFilesForm(
       ) {
         setSummaryOfUse(dataAccessRequest.summaryOfUse)
       }
+      if (isEDucEnabled) {
+        const so = dataAccessRequest.signingOfficial
+        if (isEmpty(soName) && so?.name) {
+          setSoName(so.name)
+        }
+        if (isEmpty(soEmail) && so?.institutionalEmail) {
+          setSoEmail(so.institutionalEmail)
+        }
+      }
     }
     // Intentionally only re-synchronize state when server state changes
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [dataAccessRequest])
 
   function getDataAccessRequestWithLocalState(): Request | Renewal {
-    return {
+    const base = {
       ...dataAccessRequest,
-      // append local state to the request
       accessorChanges: accessorChanges,
       publication,
       summaryOfUse,
     } as Request | Renewal
+    if (isEDucEnabled) {
+      const nextSo: SigningOfficial = {
+        ...dataAccessRequest?.signingOfficial,
+        name: soName || undefined,
+        institutionalEmail: soEmail || undefined,
+      }
+      return { ...base, signingOfficial: nextSo }
+    }
+    return base
   }
 
   async function handleSubmit() {
@@ -426,6 +450,47 @@ export default function DataAccessRequestAccessorsFilesForm(
               access.
             </Typography>
 
+            {isEDucEnabled && (
+              <>
+                <Typography variant={'headline3'} sx={{ mb: 2 }}>
+                  Signing Official
+                </Typography>
+                <Typography variant={'body1'} sx={{ mb: 2 }}>
+                  The signing official is a member of your institution with
+                  oversight authority who is NOT part of the study team (i.e.,
+                  not the Project Lead, not a Data Requester or Collaborator,
+                  and not the Principal Investigator). They do not need a
+                  Synapse account but must be able to receive messages at the
+                  email address provided below.
+                </Typography>
+                <TextField
+                  id="so-name"
+                  label="First and last names of your Signing Official"
+                  placeholder="First and last name of signing official, ex: John Smith"
+                  fullWidth
+                  type="text"
+                  disabled={isLoading}
+                  value={soName}
+                  required
+                  onChange={e => setSoName(e.target.value)}
+                  sx={{ mb: 2 }}
+                />
+                <TextField
+                  id="so-email"
+                  label="Institutional Email of your Signing Official"
+                  type="email"
+                  placeholder="Individual with signing authority, e.g. jane.smith@institution.edu"
+                  fullWidth
+                  disabled={isLoading}
+                  value={soEmail}
+                  required
+                  onChange={e => setSoEmail(e.target.value)}
+                  sx={{ mb: 2 }}
+                />
+                <Divider sx={{ my: 4 }} />
+              </>
+            )}
+
             {dataAccessRequest && user && (
               <DataAccessRequestAccessorsEditor
                 accessorChanges={accessorChanges || []}
@@ -434,18 +499,19 @@ export default function DataAccessRequestAccessorsFilesForm(
                 helpText={
                   <AccessorRequirementHelpText
                     managedACTAccessRequirement={managedACTAccessRequirement}
+                    isEDucEnabled={isEDucEnabled}
                   />
                 }
               />
             )}
 
-            {(managedACTAccessRequirement?.isDUCRequired ||
+            {((managedACTAccessRequirement?.isDUCRequired && !isEDucEnabled) ||
               managedACTAccessRequirement?.isIRBApprovalRequired ||
               managedACTAccessRequirement?.areOtherAttachmentsRequired) && (
               <Divider sx={{ my: 4 }} />
             )}
-            {/* DUC */}
-            {managedACTAccessRequirement?.isDUCRequired && (
+            {/* DUC — hidden for eDUC ARs, which handle DUC via the eDUC flow */}
+            {managedACTAccessRequirement?.isDUCRequired && !isEDucEnabled && (
               <>
                 {managedACTAccessRequirement?.ducTemplateFileHandleId && (
                   <DocumentTemplate
@@ -614,7 +680,10 @@ export default function DataAccessRequestAccessorsFilesForm(
         </Button>
         <Button
           variant="contained"
-          disabled={submitDataAccessRequestIsPending}
+          disabled={
+            submitDataAccessRequestIsPending ||
+            (isEDucEnabled && (!soName || !soEmail))
+          }
           onClick={() => {
             handleSubmit()
           }}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
@@ -700,6 +700,7 @@ export default function DataAccessRequestAccessorsFilesForm(
         </Button>
         <Button
           variant="contained"
+          loading={submitDataAccessRequestIsPending}
           disabled={disableSubmitButton}
           onClick={() => {
             handleSubmit()

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DocumentTemplate.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DocumentTemplate.tsx
@@ -4,6 +4,7 @@ import { FileHandleAssociation } from '@sage-bionetworks/synapse-types'
 import { ReactNode } from 'react'
 import DirectDownloadButton from '../../DirectDownloadButton'
 import IconSvg from '../../IconSvg/IconSvg'
+import { longFieldLabelSx } from './styles'
 
 export type DownloadDocumentTemplateProps = {
   title: ReactNode
@@ -36,7 +37,7 @@ export default function DocumentTemplate(props: DownloadDocumentTemplateProps) {
       <Typography variant={'headline3'} sx={{ mt: 4, mb: 2 }}>
         {title}
       </Typography>
-      <Typography variant={'body1'} sx={{ my: 2 }}>
+      <Typography variant={'body1'} sx={{ ...longFieldLabelSx, my: 2 }}>
         {description}
       </Typography>
       <Typography variant={'body1'}>Download this file:</Typography>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.stories.tsx
@@ -2,6 +2,7 @@ import { mockManagedACTAccessRequirement } from '@/mocks/accessRequirement/mockA
 import { getAccessRequirementHandlers } from '@/mocks/msw/handlers/accessRequirementHandlers'
 import { getDataAccessRequestHandlers } from '@/mocks/msw/handlers/dataAccessRequestHandlers'
 import { getResearchProjectHandlers } from '@/mocks/msw/handlers/researchProjectHandlers'
+import { getUserProfileHandlers } from '@/mocks/msw/handlers/userProfileHandlers'
 import { getWikiHandlers } from '@/mocks/msw/handlers/wikiHandlers'
 import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
 import { Meta, StoryObj } from '@storybook/react-vite'
@@ -38,6 +39,17 @@ export const Step1: Story = {
 
 export const Step1EDucEnabled: Story = {
   name: 'Step 1 - eDUC enabled (with PI selector + email)',
+  parameters: {
+    msw: {
+      handlers: [
+        ...getResearchProjectHandlers(MOCK_REPO_ORIGIN),
+        ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
+        ...getDataAccessRequestHandlers(MOCK_REPO_ORIGIN),
+        ...getWikiHandlers(MOCK_REPO_ORIGIN),
+        ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
   args: {
     managedACTAccessRequirement: {
       ...mockManagedACTAccessRequirement,

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.stories.tsx
@@ -1,5 +1,6 @@
 import { mockManagedACTAccessRequirement } from '@/mocks/accessRequirement/mockAccessRequirements'
 import { getAccessRequirementHandlers } from '@/mocks/msw/handlers/accessRequirementHandlers'
+import { getDataAccessRequestHandlers } from '@/mocks/msw/handlers/dataAccessRequestHandlers'
 import { getResearchProjectHandlers } from '@/mocks/msw/handlers/researchProjectHandlers'
 import { getWikiHandlers } from '@/mocks/msw/handlers/wikiHandlers'
 import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
@@ -17,6 +18,7 @@ const meta: Meta = {
       handlers: [
         ...getResearchProjectHandlers(MOCK_REPO_ORIGIN),
         ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
+        ...getDataAccessRequestHandlers(MOCK_REPO_ORIGIN),
         ...getWikiHandlers(MOCK_REPO_ORIGIN),
       ],
     },
@@ -31,5 +33,15 @@ export const Step1: Story = {
   name: 'Step 1 - Research Project Information',
   args: {
     managedACTAccessRequirement: mockManagedACTAccessRequirement,
+  },
+}
+
+export const Step1EDucEnabled: Story = {
+  name: 'Step 1 - eDUC enabled (with PI selector + email)',
+  args: {
+    managedACTAccessRequirement: {
+      ...mockManagedACTAccessRequirement,
+      eDucTemplateId: 'template-abc-123',
+    },
   },
 }

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.test.tsx
@@ -2,6 +2,7 @@ import {
   mockManagedACTAccessRequirement,
   mockManagedACTAccessRequirementWikiPageKey,
 } from '@/mocks/accessRequirement/mockAccessRequirements'
+import { MOCK_DATA_ACCESS_REQUEST } from '@/mocks/dataaccess/MockDataAccessRequest'
 import {
   MOCK_EMPTY_RESEARCH_PROJECT,
   MOCK_RESEARCH_PROJECT,
@@ -20,6 +21,7 @@ import {
 import userEvent, { UserEvent } from '@testing-library/user-event'
 import * as SynapseClient from '@/synapse-client/SynapseClient'
 import MarkdownSynapse from '../../../Markdown/MarkdownSynapse'
+import * as UserSearchBoxModule from '../../../UserSearchBox/UserSearchBox'
 import * as AccessRequirementListUtils from '../../AccessRequirementListUtils'
 import ResearchProjectForm, {
   ResearchProjectFormProps,
@@ -52,6 +54,17 @@ const mockSaveResearchProject = vi
       ...submitted,
     }),
   )
+
+const mockGetDataAccessRequestForUpdate = vi
+  .spyOn(SynapseClient, 'getDataAccessRequestForUpdate')
+  .mockImplementation(() => Promise.resolve(MOCK_DATA_ACCESS_REQUEST))
+const mockUpdateDataAccessRequest = vi
+  .spyOn(SynapseClient, 'updateDataAccessRequest')
+  .mockImplementation(submitted => Promise.resolve(submitted))
+
+const mockedUserSearchBox = vi
+  .spyOn(UserSearchBoxModule, 'default')
+  .mockImplementation(() => <div data-testid={'UserSearchBox-MOCK'}></div>)
 
 vi.spyOn(SynapseClient, 'getWikiPageKeyForAccessRequirement').mockResolvedValue(
   mockManagedACTAccessRequirementWikiPageKey,
@@ -428,5 +441,111 @@ describe('ResearchProjectForm', { timeout: 30_000 }, () => {
         objectType: mockManagedACTAccessRequirementWikiPageKey.ownerObjectType,
       }),
     )
+  })
+
+  describe('when the AR has an eDucTemplateId', () => {
+    const eDucTemplateId = 'template-abc-123'
+    const eDucAr = {
+      ...mockManagedACTAccessRequirement,
+      isIDURequired: false,
+      eDucTemplateId,
+    }
+
+    beforeEach(() => {
+      // Restore the default mock impl in case a previous test replaced it.
+      mockSaveResearchProject.mockImplementation(submitted =>
+        Promise.resolve({
+          id: CREATED_RESEARCH_PROJECT_ID,
+          ...submitted,
+        }),
+      )
+    })
+
+    it('renders the Synapse PI user selector and PI email input', async () => {
+      await setUp({
+        ...defaultProps,
+        managedACTAccessRequirement: eDucAr,
+      })
+      expect(screen.getByTestId('UserSearchBox-MOCK')).toBeInTheDocument()
+      expect(
+        screen.getByLabelText(
+          'Institutional Email of your Project Lead or PI',
+          { exact: false },
+        ),
+      ).toBeInTheDocument()
+    })
+
+    it('blocks Save & Continue until PI user + email are provided', async () => {
+      const { user, projectLeadInput, institutionInput, saveChangesButton } =
+        await setUp({
+          ...defaultProps,
+          managedACTAccessRequirement: eDucAr,
+        })
+
+      await user.type(projectLeadInput, 'Jane Doe')
+      await user.type(institutionInput, 'My Institution')
+      expect(saveChangesButton).toBeDisabled()
+
+      const piEmailInput = screen.getByLabelText(
+        'Institutional Email of your Project Lead or PI',
+        { exact: false },
+      )
+      await user.type(piEmailInput, 'pi@example.edu')
+      // still disabled: no PI user selected
+      expect(saveChangesButton).toBeDisabled()
+
+      // Simulate selecting a PI Synapse user
+      act(() => {
+        mockedUserSearchBox.mock.lastCall![0].onChange!('9999', {} as never)
+      })
+
+      await waitFor(() => expect(saveChangesButton).not.toBeDisabled())
+    })
+
+    it('saves institution + PI on the DAR when the user clicks Save & Continue', async () => {
+      const { user, projectLeadInput, institutionInput } = await setUp({
+        ...defaultProps,
+        managedACTAccessRequirement: eDucAr,
+      })
+
+      await waitFor(() =>
+        expect(mockGetDataAccessRequestForUpdate).toHaveBeenCalled(),
+      )
+
+      await user.type(projectLeadInput, 'Jane Doe')
+      await user.type(institutionInput, 'My Institution')
+      await user.type(
+        screen.getByLabelText(
+          'Institutional Email of your Project Lead or PI',
+          { exact: false },
+        ),
+        'pi@example.edu',
+      )
+      act(() => {
+        mockedUserSearchBox.mock.lastCall![0].onChange!('9999', {} as never)
+      })
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Save and Continue' }),
+        ).not.toBeDisabled(),
+      )
+      await clickSaveAndContinue(user)
+
+      await waitFor(() => {
+        expect(mockUpdateDataAccessRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: MOCK_DATA_ACCESS_REQUEST.id,
+            institution: 'My Institution',
+            principalInvestigator: {
+              userId: '9999',
+              name: 'Jane Doe',
+              institutionalEmail: 'pi@example.edu',
+            },
+          }),
+          MOCK_ACCESS_TOKEN,
+        )
+      })
+    })
   })
 })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.tsx
@@ -1,5 +1,7 @@
 import {
+  useGetDataAccessRequestForUpdate,
   useGetResearchProject,
+  useUpdateDataAccessRequest,
   useUpdateResearchProject,
 } from '@/synapse-queries'
 import { InfoTwoTone } from '@mui/icons-material'
@@ -17,15 +19,20 @@ import {
 } from '@mui/material'
 import {
   ManagedACTAccessRequirement,
+  PrincipalInvestigator,
+  Renewal,
+  Request,
   ResearchProject,
+  TYPE_FILTER,
 } from '@sage-bionetworks/synapse-types'
 import isEmpty from 'lodash-es/isEmpty'
-import { FormEvent, useEffect, useState } from 'react'
+import { FormEvent, useEffect, useRef, useState } from 'react'
 import HelpPopover from '../../../HelpPopover'
 import IconSvg from '../../../IconSvg/IconSvg'
 import TextFieldWithWordLimit, {
   getWordCount,
 } from '../../../TextField/TextFieldWithWordLimit'
+import UserSearchBox from '../../../UserSearchBox/UserSearchBox'
 import { AlertProps } from '../DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm'
 import ManagedACTAccessRequirementFormWikiWrapper from '../ManagedACTAccessRequirementFormWikiWrapper'
 
@@ -44,10 +51,13 @@ export type ResearchProjectFormProps = {
  */
 export default function ResearchProjectForm(props: ResearchProjectFormProps) {
   const { onSave, managedACTAccessRequirement, onHide } = props
+  const isEDucEnabled = Boolean(managedACTAccessRequirement.eDucTemplateId)
   const [projectLead, setProjectLead] = useState<string>('')
   const [institution, setInstitution] = useState<string>('')
   const [intendedDataUseStatement, setIntendedDataUseStatement] =
     useState<string>('')
+  const [piUserId, setPiUserId] = useState<string | null>(null)
+  const [piEmail, setPiEmail] = useState<string>('')
   const [alert, setAlert] = useState<AlertProps | undefined>()
 
   const [showConfirmationScreen, setShowConfirmationScreen] = useState(false)
@@ -57,6 +67,18 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
       // Infinite staleTime ensures this won't be refetched unless explicitly invalidated by the mutation
       staleTime: Infinity,
     })
+
+  const {
+    data: existingDataAccessRequest,
+    isLoading: isLoadingDataAccessRequest,
+  } = useGetDataAccessRequestForUpdate(String(managedACTAccessRequirement.id), {
+    enabled: isEDucEnabled,
+    staleTime: Infinity,
+  })
+  const existingDarRef = useRef(existingDataAccessRequest)
+  useEffect(() => {
+    existingDarRef.current = existingDataAccessRequest
+  }, [existingDataAccessRequest])
 
   // Populate the form with existing data if it exists
   useEffect(() => {
@@ -82,15 +104,46 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
     // projectLead, or intendedDataUseStatement if they have been modified
   ])
 
-  const { mutate, isPending: updateIsPending } = useUpdateResearchProject({
-    onSuccess: data => {
-      if (onSave) {
-        onSave(data)
-      }
-    },
+  // Prefill eDUC-only PI fields from any previously-saved DAR values.
+  useEffect(() => {
+    if (!isEDucEnabled || !existingDataAccessRequest) return
+    const pi = existingDataAccessRequest.principalInvestigator
+    if (piUserId === null && pi?.userId) {
+      setPiUserId(pi.userId)
+    }
+    if (isEmpty(piEmail) && pi?.institutionalEmail) {
+      setPiEmail(pi.institutionalEmail)
+    }
+    // PORTALS-4375: initialize from existingDataAccessRequest, but do not reset
+    // fields once the user has interacted with them.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isEDucEnabled,
+    existingDataAccessRequest?.principalInvestigator?.userId,
+    existingDataAccessRequest?.principalInvestigator?.institutionalEmail,
+  ])
+
+  const { mutateAsync: updateResearchProject, isPending: updateIsPending } =
+    useUpdateResearchProject({
+      onError: e => {
+        console.log(
+          'RequestDataAccessStep1: Error updating research project data: ',
+          e,
+        )
+        setAlert({
+          key: 'error',
+          message: getErrorMessage(e.reason),
+        })
+      },
+    })
+
+  const {
+    mutateAsync: updateDataAccessRequest,
+    isPending: updateDarIsPending,
+  } = useUpdateDataAccessRequest({
     onError: e => {
       console.log(
-        'RequestDataAccessStep1: Error updating research project data: ',
+        'RequestDataAccessStep1: Error updating data access request: ',
         e,
       )
       setAlert({
@@ -100,7 +153,11 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
     },
   })
 
-  const isLoading = isLoadingInitialData || updateIsPending
+  const isLoading =
+    isLoadingInitialData ||
+    (isEDucEnabled && isLoadingDataAccessRequest) ||
+    updateIsPending ||
+    updateDarIsPending
 
   const getErrorMessage = (reason: string = '') => {
     return (
@@ -112,25 +169,53 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
     )
   }
 
-  const handleSubmit = (e: FormEvent<HTMLElement>) => {
+  const handleSubmit = async (e: FormEvent<HTMLElement>) => {
     e.preventDefault()
     if (!showConfirmationScreen) {
       setShowConfirmationScreen(true)
-    } else {
-      mutate({
+      return
+    }
+    setShowConfirmationScreen(false)
+    let updatedResearchProject: ResearchProject
+    try {
+      updatedResearchProject = await updateResearchProject({
         ...existingResearchProject,
         accessRequirementId: String(managedACTAccessRequirement.id),
         institution: institution,
         projectLead: projectLead,
         intendedDataUseStatement: intendedDataUseStatement || undefined,
       })
-      setShowConfirmationScreen(false)
+    } catch {
+      // Error is surfaced via useUpdateResearchProject's onError handler.
+      return
+    }
+    if (isEDucEnabled && existingDarRef.current) {
+      const existingDar = existingDarRef.current
+      const nextPi: PrincipalInvestigator = {
+        ...existingDar.principalInvestigator,
+        userId: piUserId ?? undefined,
+        name: projectLead || undefined,
+        institutionalEmail: piEmail || undefined,
+      }
+      try {
+        await updateDataAccessRequest({
+          ...existingDar,
+          institution: institution,
+          principalInvestigator: nextPi,
+        } as Request | Renewal)
+      } catch {
+        return
+      }
+    }
+    if (onSave) {
+      onSave(updatedResearchProject)
     }
   }
 
   const formIsValid =
     projectLead &&
     institution &&
+    (!isEDucEnabled || (piUserId && piEmail)) &&
     (!managedACTAccessRequirement.isIDURequired ||
       (intendedDataUseStatement &&
         getWordCount(intendedDataUseStatement) >=
@@ -169,7 +254,9 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
           >
             <Box
               component={'form'}
-              onSubmit={handleSubmit}
+              onSubmit={e => {
+                void handleSubmit(e)
+              }}
               sx={{
                 '& .MuiTextField-root': {
                   marginBottom: '20px',
@@ -180,7 +267,7 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
                 id={'project-lead'}
                 label={
                   <Box sx={{ display: 'inline' }}>
-                    <span>First and last names of your project lead or PI</span>
+                    <span>First and last names of your Project Lead or PI</span>
                     <HelpPopover
                       Icon={InfoTwoTone}
                       containerSx={{ float: 'right' }}
@@ -217,6 +304,42 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
                 required
                 onChange={e => setInstitution(e.target.value)}
               />
+
+              {isEDucEnabled && (
+                <Box sx={{ mb: '20px' }}>
+                  <Typography
+                    component="label"
+                    htmlFor="pi-user"
+                    variant="body1"
+                    sx={{ display: 'block', mb: 1 }}
+                  >
+                    Synapse username of your Project Lead or PI
+                    <Box component="span" sx={{ color: 'error.main' }}>
+                      {' '}
+                      *
+                    </Box>
+                  </Typography>
+                  <UserSearchBox
+                    inputId="pi-user"
+                    typeFilter={TYPE_FILTER.USERS_ONLY}
+                    value={piUserId}
+                    onChange={principalId => setPiUserId(principalId)}
+                    placeholder="Search Synapse for your Project Lead or PI"
+                  />
+                  <TextField
+                    id="pi-email"
+                    label="Institutional Email of your Project Lead or PI"
+                    type="email"
+                    placeholder="pi@example.edu"
+                    fullWidth
+                    disabled={isLoading}
+                    value={piEmail}
+                    required
+                    onChange={e => setPiEmail(e.target.value)}
+                    sx={{ mt: 2 }}
+                  />
+                </Box>
+              )}
 
               {managedACTAccessRequirement.isIDURequired && (
                 <TextFieldWithWordLimit
@@ -276,7 +399,9 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
           variant="contained"
           type="submit"
           disabled={isLoading || !formIsValid}
-          onClick={handleSubmit}
+          onClick={e => {
+            void handleSubmit(e)
+          }}
         >
           {updateIsPending ? 'Saving...' : 'Save and Continue'}
         </Button>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.tsx
@@ -175,7 +175,6 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
       setShowConfirmationScreen(true)
       return
     }
-    setShowConfirmationScreen(false)
     let updatedResearchProject: ResearchProject
     try {
       updatedResearchProject = await updateResearchProject({
@@ -186,7 +185,7 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
         intendedDataUseStatement: intendedDataUseStatement || undefined,
       })
     } catch {
-      // Error is surfaced via useUpdateResearchProject's onError handler.
+      setShowConfirmationScreen(false)
       return
     }
     if (isEDucEnabled && existingDarRef.current) {
@@ -204,6 +203,7 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
           principalInvestigator: nextPi,
         } as Request | Renewal)
       } catch {
+        setShowConfirmationScreen(false)
         return
       }
     }

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/styles.ts
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/styles.ts
@@ -1,0 +1,6 @@
+import { SxProps } from '@mui/material'
+
+export const longFieldLabelSx: SxProps = {
+  fontSize: '14px',
+  fontWeight: 400,
+}

--- a/packages/synapse-types/src/AccessRequirement/RequestInterface.ts
+++ b/packages/synapse-types/src/AccessRequirement/RequestInterface.ts
@@ -4,6 +4,19 @@
  */
 import { AccessorChange } from './AccessorChange'
 
+export interface PrincipalInvestigator {
+  userId?: string
+  name?: string
+  title?: string
+  institutionalEmail?: string
+}
+
+export interface SigningOfficial {
+  name?: string
+  title?: string
+  institutionalEmail?: string
+}
+
 export interface RequestInterface {
   id: string
   accessRequirementId: string
@@ -18,6 +31,12 @@ export interface RequestInterface {
   accessorChanges: AccessorChange[]
   etag: string
   concreteType: string
+  /* The institution of the collaborators. Used by the eDUC signing flow. */
+  institution?: string
+  /* Principal Investigator information. Used by the eDUC signing flow. */
+  principalInvestigator?: PrincipalInvestigator
+  /* Signing Official information. Used by the eDUC signing flow. */
+  signingOfficial?: SigningOfficial
 }
 
 export interface Request extends RequestInterface {


### PR DESCRIPTION
## PORTALS-4375: Add eDUC-specific fields to the DAR wizard

### Page 1 — `ResearchProjectForm`

- When `managedACTAccessRequirement.eDucTemplateId` is set:
  - A **Synapse user selector** (`UserSearchBox`) is added for
    "Synapse username of your Project Lead or PI"
  - An **email field** is added for
    "Institutional Email of your Project Lead or PI"
  - The form is gated: Submit is blocked until both the user selector
    and email field are filled
  - On save, `principalInvestigator` (`{ userId, name, institutionalEmail }`)
    is merged into the DAR via a second `updateDataAccessRequest` call
  - Existing DAR values prefill the fields on load (init-once pattern)
- Added `PrincipalInvestigator` and `SigningOfficial` interfaces to
  `synapse-types` `RequestInterface`
- Added `Step1EDucEnabled` Storybook story

### Page 2 — `DataAccessRequestAccessorsFilesForm`

- When `managedACTAccessRequirement.eDucTemplateId` is set:
  - A **Signing Official** section is rendered above Collaborators, with:
    - Name field: "First and last names of your Signing Official"
    - Email field: "Institutional Email of your Signing Official"
    - Description: "The signing official is a member of your institution
      with oversight authority who is NOT part of the study team…"
  - `signingOfficial` (`{ name, institutionalEmail }`) is merged into
    the DAR via the existing `updateRequestAsync` call on Submit
  - Submit is blocked until both SO fields are filled
  - Existing DAR values prefill the fields on load
  - The "Download DUC Template" and "Fill out and upload a Data Use
    Certificate" sections are hidden (eDUC handles DUC separately)
  - The DUC collaborator notice ("You must list the Synapse user names
    of all collaborators listed in your DUC") is suppressed
- "Data Requesters" renamed to **"Collaborators"** throughout
- Added Collaborators description text
- Added `Step2EDucEnabled` Storybook story

### Tests

- `ResearchProjectForm.test.tsx`: 3 new eDUC tests (11 total)
- `DataAccessRequestAccessorsFilesForm.test.tsx`: 4 new eDUC tests (19 total)

<img width="1490" height="631" alt="Screenshot 2026-08-12 at 5 41 00 PM" src="https://github.com/user-attachments/assets/d0872cd4-da66-477a-a88f-1d71401fe3e7" />
<img width="1490" height="384" alt="Screenshot 2026-08-12 at 5 41 14 PM" src="https://github.com/user-attachments/assets/7baebe7d-3906-48b3-a663-eb30d7019e59" />


