### PR TITLE
SWC-7928 reorder grid columns

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -472,16 +472,7 @@ function SynapseGridInner({
                     spacing={1}
                     sx={{ justifyContent: 'flex-end' }}
                   >
-                    <GridMenuButton
-                      variant="outlined"
-                      startIcon={<HelpOutline />}
-                      href="https://docs.synapse.org/synapse-docs/managing-metadata-with-curator"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      sx={{ mr: 'auto' }}
-                    >
-                      Help and Instructions
-                    </GridMenuButton>
+                    {/* Keep this sync indicator first in the stack, otherwise it will cause other buttons to shift */}
                     {(!hasCompletedInitialSync || isSyncing) && (
                       <Box
                         sx={{
@@ -496,12 +487,23 @@ function SynapseGridInner({
                         </Typography>
                       </Box>
                     )}
+                    <GridMenuButton
+                      variant="outlined"
+                      startIcon={<HelpOutline />}
+                      href="https://docs.synapse.org/synapse-docs/managing-metadata-with-curator"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{ mr: 'auto' }}
+                    >
+                      Help and Instructions
+                    </GridMenuButton>
                     {undoUI}
                     {redoUI}
                     <ReorderColumnsButton
                       columnNames={modelSnapshot?.columnNames ?? []}
                       columnOrder={modelSnapshot?.columnOrder ?? []}
                       jsonSchema={jsonSchema}
+                      upsertKey={upsertKey}
                       onReorder={handleReorderColumns}
                     />
                     <GridMenuButton

--- a/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/SynapseGrid.tsx
@@ -1,6 +1,7 @@
 import CertificationRequirement from '@/components/AccessRequirementList/RequirementItem/CertificationRequirement'
 import ExportCsvFromGridButton from '@/components/DataGrid/components/ExportCsvFromGridButton'
 import GridMenuButton from '@/components/DataGrid/components/GridMenuButton/GridMenuButton'
+import ReorderColumnsButton from '@/components/DataGrid/components/ReorderColumnsButton'
 import UploadCsvToGridButton from '@/components/DataGrid/components/UploadCsvToGridButton'
 import useGetSchemaForGrid from '@/components/DataGrid/hooks/useGetSchemaForGrid'
 import SyncGridWithSourceButton from '@/components/DataGrid/SyncGridWithSourceButton'
@@ -339,6 +340,16 @@ function SynapseGridInner({
     [],
   )
 
+  const handleReorderColumns = useCallback(
+    (newColumnOrder: number[]) => {
+      if (!model) return
+      applyAndCommitChanges(model, [
+        { type: 'REORDER_COLUMNS', newColumnOrder },
+      ])
+    },
+    [model, applyAndCommitChanges],
+  )
+
   if (!isLoading && !userBundle?.isCertified) {
     return <CertificationRequirement />
   }
@@ -487,6 +498,12 @@ function SynapseGridInner({
                     )}
                     {undoUI}
                     {redoUI}
+                    <ReorderColumnsButton
+                      columnNames={modelSnapshot?.columnNames ?? []}
+                      columnOrder={modelSnapshot?.columnOrder ?? []}
+                      jsonSchema={jsonSchema}
+                      onReorder={handleReorderColumns}
+                    />
                     <GridMenuButton
                       variant={'outlined'}
                       onClick={() => setChatOpen(true)}

--- a/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsButton.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsButton.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { JSONSchema7 } from 'json-schema'
+import ReorderColumnsButton from './ReorderColumnsButton'
+
+describe('ReorderColumnsButton', () => {
+  const columnNames = ['a', 'b']
+  const columnOrder = [0, 1]
+  const jsonSchema: JSONSchema7 = {
+    properties: {
+      a: { type: 'string' },
+      b: { type: 'string' },
+    },
+  }
+
+  it('does not show the dialog initially', () => {
+    render(
+      <ReorderColumnsButton
+        columnNames={columnNames}
+        columnOrder={columnOrder}
+        jsonSchema={jsonSchema}
+        onReorder={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('opens the dialog when the button is clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReorderColumnsButton
+        columnNames={columnNames}
+        columnOrder={columnOrder}
+        jsonSchema={jsonSchema}
+        onReorder={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /reorder columns/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('calls onReorder and closes the dialog when Save is clicked', async () => {
+    const user = userEvent.setup()
+    const onReorder = vi.fn()
+    render(
+      <ReorderColumnsButton
+        columnNames={columnNames}
+        columnOrder={columnOrder}
+        jsonSchema={jsonSchema}
+        onReorder={onReorder}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /reorder columns/i }))
+    await user.click(screen.getByRole('button', { name: 'Move a down' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onReorder).toHaveBeenCalledWith([1, 0])
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('closes the dialog without calling onReorder when Cancel is clicked', async () => {
+    const user = userEvent.setup()
+    const onReorder = vi.fn()
+    render(
+      <ReorderColumnsButton
+        columnNames={columnNames}
+        columnOrder={columnOrder}
+        jsonSchema={jsonSchema}
+        onReorder={onReorder}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /reorder columns/i }))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onReorder).not.toHaveBeenCalled()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('disables the button when there are fewer than 2 columns', () => {
+    render(
+      <ReorderColumnsButton
+        columnNames={['a']}
+        columnOrder={[0]}
+        jsonSchema={jsonSchema}
+        onReorder={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: /reorder columns/i }),
+    ).toBeDisabled()
+  })
+})

--- a/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsButton.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsButton.tsx
@@ -1,0 +1,45 @@
+import GridMenuButton from '@/components/DataGrid/components/GridMenuButton/GridMenuButton'
+import ReorderColumnsDialog from '@/components/DataGrid/components/ReorderColumnsDialog'
+import { SwapVert } from '@mui/icons-material'
+import { JSONSchema7 } from 'json-schema'
+import { useState } from 'react'
+
+export type ReorderColumnsButtonProps = {
+  columnNames: string[]
+  columnOrder: number[]
+  jsonSchema: JSONSchema7 | undefined
+  onReorder: (newColumnOrder: number[]) => void
+}
+
+export default function ReorderColumnsButton(props: ReorderColumnsButtonProps) {
+  const { columnNames, columnOrder, jsonSchema, onReorder } = props
+
+  const [showDialog, setShowDialog] = useState(false)
+
+  return (
+    <>
+      {showDialog && (
+        // Explicitly unmount the dialog when it is closed so its working order resets
+        <ReorderColumnsDialog
+          open={showDialog}
+          columnNames={columnNames}
+          columnOrder={columnOrder}
+          jsonSchema={jsonSchema}
+          onSave={newColumnOrder => {
+            onReorder(newColumnOrder)
+            setShowDialog(false)
+          }}
+          onCancel={() => setShowDialog(false)}
+        />
+      )}
+      <GridMenuButton
+        variant="outlined"
+        startIcon={<SwapVert />}
+        onClick={() => setShowDialog(true)}
+        disabled={columnOrder.length < 2}
+      >
+        Reorder Columns
+      </GridMenuButton>
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsButton.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsButton.tsx
@@ -1,6 +1,6 @@
 import GridMenuButton from '@/components/DataGrid/components/GridMenuButton/GridMenuButton'
 import ReorderColumnsDialog from '@/components/DataGrid/components/ReorderColumnsDialog'
-import { SwapVert } from '@mui/icons-material'
+import { SwapHoriz } from '@mui/icons-material'
 import { JSONSchema7 } from 'json-schema'
 import { useState } from 'react'
 
@@ -8,11 +8,12 @@ export type ReorderColumnsButtonProps = {
   columnNames: string[]
   columnOrder: number[]
   jsonSchema: JSONSchema7 | undefined
+  upsertKey?: string[]
   onReorder: (newColumnOrder: number[]) => void
 }
 
 export default function ReorderColumnsButton(props: ReorderColumnsButtonProps) {
-  const { columnNames, columnOrder, jsonSchema, onReorder } = props
+  const { columnNames, columnOrder, jsonSchema, upsertKey, onReorder } = props
 
   const [showDialog, setShowDialog] = useState(false)
 
@@ -25,6 +26,7 @@ export default function ReorderColumnsButton(props: ReorderColumnsButtonProps) {
           columnNames={columnNames}
           columnOrder={columnOrder}
           jsonSchema={jsonSchema}
+          upsertKey={upsertKey}
           onSave={newColumnOrder => {
             onReorder(newColumnOrder)
             setShowDialog(false)
@@ -34,7 +36,7 @@ export default function ReorderColumnsButton(props: ReorderColumnsButtonProps) {
       )}
       <GridMenuButton
         variant="outlined"
-        startIcon={<SwapVert />}
+        startIcon={<SwapHoriz />}
         onClick={() => setShowDialog(true)}
         disabled={columnOrder.length < 2}
       >

--- a/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.stories.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.stories.tsx
@@ -31,3 +31,9 @@ export const AlreadyInDefaultOrder: Story = {
     columnOrder: [1, 2, 0, 3],
   },
 }
+
+export const WithUpsertKey: Story = {
+  args: {
+    upsertKey: ['name'],
+  },
+}

--- a/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.stories.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from '@storybook/react-vite'
+import ReorderColumnsDialog from './ReorderColumnsDialog'
+
+const meta = {
+  title: 'Components/DataGrid/ReorderColumnsDialog',
+  component: ReorderColumnsDialog,
+  args: {
+    open: true,
+    columnNames: ['species', 'name', 'age', 'notes'],
+    columnOrder: [0, 1, 2, 3],
+    jsonSchema: {
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'integer' },
+        species: { type: 'string' },
+        notes: { type: 'string' },
+      },
+    },
+    onSave: (newColumnOrder: number[]) => console.log('onSave', newColumnOrder),
+    onCancel: () => console.log('onCancel'),
+  },
+} satisfies Meta<typeof ReorderColumnsDialog>
+export default meta
+
+type Story = StoryObj<typeof ReorderColumnsDialog>
+
+export const Default: Story = {}
+
+export const AlreadyInDefaultOrder: Story = {
+  args: {
+    columnOrder: [1, 2, 0, 3],
+  },
+}

--- a/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.test.tsx
@@ -120,4 +120,25 @@ describe('ReorderColumnsDialog', () => {
     expect(getListItemNames()).toEqual(['a', 'b', 'c'])
     expect(resetButton).toBeDisabled()
   })
+
+  it('moves upsert key columns to the front when reset to the default order', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReorderColumnsDialog
+        open
+        columnNames={columnNames}
+        columnOrder={columnOrder}
+        jsonSchema={jsonSchema}
+        upsertKey={['c']}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Reset to Default Order' }),
+    )
+
+    expect(getListItemNames()).toEqual(['c', 'a', 'b'])
+  })
 })

--- a/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { JSONSchema7 } from 'json-schema'
+import ReorderColumnsDialog from './ReorderColumnsDialog'
+
+describe('ReorderColumnsDialog', () => {
+  const columnNames = ['b', 'a', 'c']
+  // Displays as b, a, c (identity indices 0, 1, 2)
+  const columnOrder = [0, 1, 2]
+  const jsonSchema: JSONSchema7 = {
+    properties: {
+      a: { type: 'string' },
+      b: { type: 'string' },
+      c: { type: 'string' },
+    },
+  }
+
+  function getListItemNames() {
+    return screen
+      .getAllByRole('listitem')
+      .map(item => within(item).getByText(/^[abc]$/).textContent)
+  }
+
+  it('renders columns in the given display order', () => {
+    render(
+      <ReorderColumnsDialog
+        open
+        columnNames={columnNames}
+        columnOrder={columnOrder}
+        jsonSchema={jsonSchema}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(getListItemNames()).toEqual(['b', 'a', 'c'])
+  })
+
+  it('disables the first row up button and the last row down button', () => {
+    render(
+      <ReorderColumnsDialog
+        open
+        columnNames={columnNames}
+        columnOrder={columnOrder}
+        jsonSchema={jsonSchema}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Move b up' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Move c down' })).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'Move b down' }),
+    ).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Move c up' })).not.toBeDisabled()
+  })
+
+  it('moves a column down and saves the new order', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    render(
+      <ReorderColumnsDialog
+        open
+        columnNames={columnNames}
+        columnOrder={columnOrder}
+        jsonSchema={jsonSchema}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Move b down' }))
+    expect(getListItemNames()).toEqual(['a', 'b', 'c'])
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onSave).toHaveBeenCalledWith([1, 0, 2])
+  })
+
+  it('calls onCancel when Cancel is clicked, without calling onSave', async () => {
+    const user = userEvent.setup()
+    const onCancel = vi.fn()
+    const onSave = vi.fn()
+    render(
+      <ReorderColumnsDialog
+        open
+        columnNames={columnNames}
+        columnOrder={columnOrder}
+        jsonSchema={jsonSchema}
+        onSave={onSave}
+        onCancel={onCancel}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('resets to the schema-defined default order and disables itself once matched', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReorderColumnsDialog
+        open
+        columnNames={columnNames}
+        columnOrder={columnOrder}
+        jsonSchema={jsonSchema}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    const resetButton = screen.getByRole('button', {
+      name: 'Reset to Default Order',
+    })
+    expect(resetButton).not.toBeDisabled()
+
+    await user.click(resetButton)
+
+    expect(getListItemNames()).toEqual(['a', 'b', 'c'])
+    expect(resetButton).toBeDisabled()
+  })
+})

--- a/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.tsx
@@ -19,6 +19,7 @@ export type ReorderColumnsDialogProps = {
   columnNames: string[]
   columnOrder: number[]
   jsonSchema: JSONSchema7 | undefined
+  upsertKey?: string[]
   onSave: (newColumnOrder: number[]) => void
   onCancel: () => void
 }
@@ -31,13 +32,21 @@ function moveItem(order: number[], from: number, to: number): number[] {
 }
 
 export default function ReorderColumnsDialog(props: ReorderColumnsDialogProps) {
-  const { open, columnNames, columnOrder, jsonSchema, onSave, onCancel } = props
+  const {
+    open,
+    columnNames,
+    columnOrder,
+    jsonSchema,
+    upsertKey,
+    onSave,
+    onCancel,
+  } = props
 
   const [workingOrder, setWorkingOrder] = useState<number[]>(columnOrder)
 
   const defaultOrder = useMemo(
-    () => computeDefaultColumnOrder(columnNames, jsonSchema),
-    [columnNames, jsonSchema],
+    () => computeDefaultColumnOrder(columnNames, jsonSchema, upsertKey),
+    [columnNames, jsonSchema, upsertKey],
   )
 
   return (

--- a/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/components/ReorderColumnsDialog.tsx
@@ -1,0 +1,107 @@
+import { ConfirmationDialog } from '@/components/ConfirmationDialog'
+import { computeDefaultColumnOrder } from '@/components/DataGrid/utils/computeDefaultColumnOrder'
+import { North, RestartAlt, South } from '@mui/icons-material'
+import {
+  Box,
+  Button,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+} from '@mui/material'
+import { JSONSchema7 } from 'json-schema'
+import isEqual from 'lodash-es/isEqual'
+import { useMemo, useState } from 'react'
+
+export type ReorderColumnsDialogProps = {
+  open: boolean
+  columnNames: string[]
+  columnOrder: number[]
+  jsonSchema: JSONSchema7 | undefined
+  onSave: (newColumnOrder: number[]) => void
+  onCancel: () => void
+}
+
+function moveItem(order: number[], from: number, to: number): number[] {
+  const next = [...order]
+  const [moved] = next.splice(from, 1)
+  next.splice(to, 0, moved)
+  return next
+}
+
+export default function ReorderColumnsDialog(props: ReorderColumnsDialogProps) {
+  const { open, columnNames, columnOrder, jsonSchema, onSave, onCancel } = props
+
+  const [workingOrder, setWorkingOrder] = useState<number[]>(columnOrder)
+
+  const defaultOrder = useMemo(
+    () => computeDefaultColumnOrder(columnNames, jsonSchema),
+    [columnNames, jsonSchema],
+  )
+
+  return (
+    <ConfirmationDialog
+      open={open}
+      title="Reorder Columns"
+      content={
+        <Box>
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+            <Button
+              variant="text"
+              startIcon={<RestartAlt />}
+              onClick={() => setWorkingOrder(defaultOrder)}
+              disabled={isEqual(workingOrder, defaultOrder)}
+            >
+              Reset to Default Order
+            </Button>
+          </Box>
+          <List disablePadding>
+            {workingOrder.map((colIndex, displayIndex) => {
+              const columnName = columnNames[colIndex]
+              return (
+                <ListItem
+                  key={colIndex}
+                  divider
+                  secondaryAction={
+                    <Stack direction="row" spacing={0.5}>
+                      <IconButton
+                        aria-label={`Move ${columnName} up`}
+                        size="small"
+                        disabled={displayIndex === 0}
+                        onClick={() =>
+                          setWorkingOrder(order =>
+                            moveItem(order, displayIndex, displayIndex - 1),
+                          )
+                        }
+                      >
+                        <North fontSize="small" />
+                      </IconButton>
+                      <IconButton
+                        aria-label={`Move ${columnName} down`}
+                        size="small"
+                        disabled={displayIndex === workingOrder.length - 1}
+                        onClick={() =>
+                          setWorkingOrder(order =>
+                            moveItem(order, displayIndex, displayIndex + 1),
+                          )
+                        }
+                      >
+                        <South fontSize="small" />
+                      </IconButton>
+                    </Stack>
+                  }
+                >
+                  <ListItemText primary={columnName} />
+                </ListItem>
+              )
+            })}
+          </List>
+        </Box>
+      }
+      confirmButtonProps={{ children: 'Save' }}
+      onConfirm={() => onSave(workingOrder)}
+      onCancel={onCancel}
+    />
+  )
+}

--- a/packages/synapse-react-client/src/components/DataGrid/utils/applyModelChange.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/applyModelChange.test.ts
@@ -564,6 +564,53 @@ describe('applyModelChange', () => {
     expect(snapshot.selection['A']).toEqual(selA)
     expect(snapshot.selection['B']).toEqual(selB)
   })
+
+  it('REORDER_COLUMNS replaces columnOrder with the new order', () => {
+    const model = createModel()
+    model.api.arr(['columnOrder'])?.ins(0, [s.con(0), s.con(1)])
+
+    applyModelChange(
+      model,
+      { type: 'REORDER_COLUMNS', newColumnOrder: [1, 0] },
+      schemaPropertyInfo,
+    )
+
+    const snapshot = model.api.getSnapshot()
+    expect(snapshot.columnOrder).toEqual([1, 0])
+    expect(snapshot.columnNames).toEqual(['col1', 'col2'])
+  })
+
+  it('REORDER_COLUMNS does not affect row data, only display order', () => {
+    const model = createModel()
+    model.api.arr(['columnOrder'])?.ins(0, [s.con(0), s.con(1)])
+
+    applyModelChange(
+      model,
+      { type: 'CREATE', rowIndex: 0, rowData: { col1: 'a', col2: 'b' } },
+      schemaPropertyInfo,
+    )
+    applyModelChange(
+      model,
+      { type: 'REORDER_COLUMNS', newColumnOrder: [1, 0] },
+      schemaPropertyInfo,
+    )
+
+    const snapshot = model.api.getSnapshot()
+    expect(snapshot.rows[0].data).toEqual(['a', 'b'])
+    expect(snapshot.columnOrder).toEqual([1, 0])
+  })
+
+  it('REORDER_COLUMNS handles an initially empty columnOrder', () => {
+    const model = createModel()
+
+    applyModelChange(
+      model,
+      { type: 'REORDER_COLUMNS', newColumnOrder: [0, 1] },
+      schemaPropertyInfo,
+    )
+
+    expect(model.api.getSnapshot().columnOrder).toEqual([0, 1])
+  })
 })
 
 describe('getDefaultValueForProperty', () => {

--- a/packages/synapse-react-client/src/components/DataGrid/utils/applyModelChange.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/applyModelChange.ts
@@ -21,6 +21,7 @@ export type ModelChange =
       replicaId: string
       selection: ReplicaSelectionModel
     }
+  | { type: 'REORDER_COLUMNS'; newColumnOrder: number[] }
 
 export function getDefaultValueForProperty(
   row: DataGridRow,
@@ -106,6 +107,18 @@ export function applyModelChange(
         .obj(['selection'])
         .set({ [change.replicaId]: s.con(change.selection) })
 
+      break
+    }
+    case 'REORDER_COLUMNS': {
+      const columnOrderArr = model.api.arr(['columnOrder'])
+      const currentLength = columnOrderArr?.length() ?? 0
+      if (currentLength > 0) {
+        columnOrderArr?.del(0, currentLength)
+      }
+      columnOrderArr?.ins(
+        0,
+        change.newColumnOrder.map(index => s.con(index)),
+      )
       break
     }
   }

--- a/packages/synapse-react-client/src/components/DataGrid/utils/computeDefaultColumnOrder.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/computeDefaultColumnOrder.test.ts
@@ -55,4 +55,56 @@ describe('computeDefaultColumnOrder', () => {
 
     expect(computeDefaultColumnOrder(columnNames, jsonSchema)).toEqual([1, 0])
   })
+
+  it('moves upsert key columns to the beginning, ahead of schema order', () => {
+    const columnNames = ['col1', 'col2', 'col3']
+    const jsonSchema: JSONSchema7 = {
+      properties: {
+        col1: { type: 'string' },
+        col2: { type: 'string' },
+        col3: { type: 'string' },
+      },
+    }
+
+    expect(
+      computeDefaultColumnOrder(columnNames, jsonSchema, ['col3']),
+    ).toEqual([2, 0, 1])
+  })
+
+  it('preserves the given order of multiple upsert key columns', () => {
+    const columnNames = ['col1', 'col2', 'col3']
+    const jsonSchema: JSONSchema7 = {
+      properties: {
+        col1: { type: 'string' },
+        col2: { type: 'string' },
+        col3: { type: 'string' },
+      },
+    }
+
+    expect(
+      computeDefaultColumnOrder(columnNames, jsonSchema, ['col2', 'col1']),
+    ).toEqual([1, 0, 2])
+  })
+
+  it('places upsert key columns first even when jsonSchema is undefined', () => {
+    const columnNames = ['col1', 'col2', 'col3']
+
+    expect(computeDefaultColumnOrder(columnNames, undefined, ['col2'])).toEqual(
+      [1, 0, 2],
+    )
+  })
+
+  it('ignores upsert key names that do not correspond to a grid column', () => {
+    const columnNames = ['col1', 'col2']
+    const jsonSchema: JSONSchema7 = {
+      properties: {
+        col1: { type: 'string' },
+        col2: { type: 'string' },
+      },
+    }
+
+    expect(
+      computeDefaultColumnOrder(columnNames, jsonSchema, ['unknownColumn']),
+    ).toEqual([0, 1])
+  })
 })

--- a/packages/synapse-react-client/src/components/DataGrid/utils/computeDefaultColumnOrder.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/computeDefaultColumnOrder.test.ts
@@ -1,0 +1,58 @@
+import { JSONSchema7 } from 'json-schema'
+import { computeDefaultColumnOrder } from './computeDefaultColumnOrder'
+
+describe('computeDefaultColumnOrder', () => {
+  it('orders columns by their position in the JSON schema properties', () => {
+    const columnNames = ['col1', 'col2', 'col3']
+    const jsonSchema: JSONSchema7 = {
+      properties: {
+        col3: { type: 'string' },
+        col1: { type: 'string' },
+        col2: { type: 'string' },
+      },
+    }
+
+    expect(computeDefaultColumnOrder(columnNames, jsonSchema)).toEqual([
+      2, 0, 1,
+    ])
+  })
+
+  it('appends columns absent from the schema, in identity-index order', () => {
+    const columnNames = ['col1', 'col2', 'col3']
+    const jsonSchema: JSONSchema7 = {
+      properties: {
+        col2: { type: 'string' },
+      },
+    }
+
+    expect(computeDefaultColumnOrder(columnNames, jsonSchema)).toEqual([
+      1, 0, 2,
+    ])
+  })
+
+  it('falls back to identity order when jsonSchema is undefined', () => {
+    const columnNames = ['col1', 'col2', 'col3']
+
+    expect(computeDefaultColumnOrder(columnNames, undefined)).toEqual([0, 1, 2])
+  })
+
+  it('falls back to identity order when jsonSchema has no properties', () => {
+    const columnNames = ['col1', 'col2']
+    const jsonSchema: JSONSchema7 = {}
+
+    expect(computeDefaultColumnOrder(columnNames, jsonSchema)).toEqual([0, 1])
+  })
+
+  it('ignores schema properties that do not correspond to a grid column', () => {
+    const columnNames = ['col1', 'col2']
+    const jsonSchema: JSONSchema7 = {
+      properties: {
+        unknownColumn: { type: 'string' },
+        col2: { type: 'string' },
+        col1: { type: 'string' },
+      },
+    }
+
+    expect(computeDefaultColumnOrder(columnNames, jsonSchema)).toEqual([1, 0])
+  })
+})

--- a/packages/synapse-react-client/src/components/DataGrid/utils/computeDefaultColumnOrder.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/computeDefaultColumnOrder.ts
@@ -1,0 +1,32 @@
+import { JSONSchema7 } from 'json-schema'
+
+/**
+ * Computes the "default" column display order: the order properties are defined in the JSON schema,
+ * with any columns not present in the schema appended afterward in their identity-index order.
+ */
+export function computeDefaultColumnOrder(
+  columnNames: string[],
+  jsonSchema: JSONSchema7 | undefined,
+): number[] {
+  const schemaPropertyNames = jsonSchema?.properties
+    ? Object.keys(jsonSchema.properties)
+    : []
+  const orderedIndices: number[] = []
+  const seen = new Set<number>()
+
+  schemaPropertyNames.forEach(name => {
+    const index = columnNames.indexOf(name)
+    if (index !== -1 && !seen.has(index)) {
+      orderedIndices.push(index)
+      seen.add(index)
+    }
+  })
+
+  columnNames.forEach((_, index) => {
+    if (!seen.has(index)) {
+      orderedIndices.push(index)
+    }
+  })
+
+  return orderedIndices
+}

--- a/packages/synapse-react-client/src/components/DataGrid/utils/computeDefaultColumnOrder.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/computeDefaultColumnOrder.ts
@@ -1,12 +1,14 @@
 import { JSONSchema7 } from 'json-schema'
 
 /**
- * Computes the "default" column display order: the order properties are defined in the JSON schema,
- * with any columns not present in the schema appended afterward in their identity-index order.
+ * Computes the "default" column display order: upsert key columns first (in the order given),
+ * then the order properties are defined in the JSON schema, with any remaining columns appended
+ * afterward in their identity-index order.
  */
 export function computeDefaultColumnOrder(
   columnNames: string[],
   jsonSchema: JSONSchema7 | undefined,
+  upsertKeyColumnNames?: string[],
 ): number[] {
   const schemaPropertyNames = jsonSchema?.properties
     ? Object.keys(jsonSchema.properties)
@@ -14,13 +16,16 @@ export function computeDefaultColumnOrder(
   const orderedIndices: number[] = []
   const seen = new Set<number>()
 
-  schemaPropertyNames.forEach(name => {
+  const addColumnByName = (name: string) => {
     const index = columnNames.indexOf(name)
     if (index !== -1 && !seen.has(index)) {
       orderedIndices.push(index)
       seen.add(index)
     }
-  })
+  }
+
+  upsertKeyColumnNames?.forEach(addColumnByName)
+  schemaPropertyNames.forEach(addColumnByName)
 
   columnNames.forEach((_, index) => {
     if (!seen.has(index)) {


### PR DESCRIPTION
Add a button to the grid that opens a dialog to reorder columns
<img width="1118" height="239" alt="button" src="https://github.com/user-attachments/assets/85f9129a-c124-41de-bd6a-c02e14b43cf7" />
<img width="745" height="980" alt="dialog" src="https://github.com/user-attachments/assets/bcf7d8e4-08f3-4980-9f58-6cdefac04f9d" />

