### PR TITLE
PORTALS-4377

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
@@ -43,6 +43,7 @@ import DataAccessRequestAccessorsFilesForm from './ManagedACTAccessRequirementRe
 import RequestDataAccessSuccess from './ManagedACTAccessRequirementRequestFlow/RequestDataAccessSuccess'
 import ResearchProjectForm from './ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm'
 import ReviewDucStep from './ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep'
+import EDucPreviewStep from './ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep'
 import AuthenticatedRequirement from './RequirementItem/AuthenticatedRequirement'
 import CertificationRequirement from './RequirementItem/CertificationRequirement'
 import TwoFactorAuthEnabledRequirement from './RequirementItem/TwoFactorAuthEnabledRequirement'
@@ -138,6 +139,7 @@ enum RequestDataStep {
   PROMPT_LOGIN = 4,
   COMPLETE = 5,
   REVIEW_DUC = 6,
+  EDUC_PREVIEW = 7,
 }
 
 export type RequestDataStepCallbackArgs = {
@@ -340,6 +342,7 @@ export default function AccessRequirementList(
       RequestDataStep.UPDATE_ACCESSORS_AND_FILES,
       RequestDataStep.UPDATE_RESEARCH_PROJECT,
       RequestDataStep.REVIEW_DUC,
+      RequestDataStep.EDUC_PREVIEW,
     ].includes(requestDataStep) && canShowManagedACTWikiInWizard
       ? 'xl'
       : 'md'
@@ -400,17 +403,33 @@ export default function AccessRequirementList(
       renderContent = (
         <ReviewDucStep
           managedACTAccessRequirement={managedACTAccessRequirement!}
-          subjectId={subjectId ?? ''}
-          subjectType={subjectType ?? RestrictableObjectType.ENTITY}
           onHide={onHide}
           onBackClicked={() => {
             requestDataStepCallback({
               step: RequestDataStep.UPDATE_ACCESSORS_AND_FILES,
             })
           }}
-          onSubmissionCreated={submissionId => {
+          onCreateDuc={() => {
+            requestDataStepCallback({ step: RequestDataStep.EDUC_PREVIEW })
+          }}
+        />
+      )
+      break
+    case RequestDataStep.EDUC_PREVIEW:
+      renderContent = (
+        <EDucPreviewStep
+          managedACTAccessRequirement={managedACTAccessRequirement!}
+          onHide={onHide}
+          onBackClicked={() => {
+            requestDataStepCallback({ step: RequestDataStep.REVIEW_DUC })
+          }}
+          // TODO PORTALS-4378: replace with the electronic-signature step.
+          onSendForSignature={() => {
             requestDataStepCallback({ step: RequestDataStep.COMPLETE })
-            onSubmissionCreated(submissionId)
+          }}
+          // TODO PORTALS-4379: replace with the manual print-and-upload step.
+          onManualUpload={() => {
+            requestDataStepCallback({ step: RequestDataStep.COMPLETE })
           }}
         />
       )

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.test.tsx
@@ -30,6 +30,8 @@ import { SynapseClientError } from '@sage-bionetworks/synapse-client/util/Synaps
 import {
   AccessorChange,
   AccessType,
+  Renewal,
+  Request,
   RestrictableObjectType,
   SubmissionState,
 } from '@sage-bionetworks/synapse-types'
@@ -98,13 +100,15 @@ const mockGetDataRequestForUpdate = vi.spyOn(
   'getDataAccessRequestForUpdate',
 )
 
+function respondToUpdateWithUpdatedObject(req: Request | Renewal) {
+  // Update the 'GET' mock to return the updated object
+  mockGetDataRequestForUpdate.mockResolvedValue(req)
+  return Promise.resolve(req)
+}
+
 const mockUpdateDataAccessRequest = vi
   .spyOn(SynapseClient, 'updateDataAccessRequest')
-  .mockImplementation(req => {
-    // Update the 'GET' mock to return the updated object
-    mockGetDataRequestForUpdate.mockResolvedValue(req)
-    return Promise.resolve(req)
-  })
+  .mockImplementation(respondToUpdateWithUpdatedObject)
 
 vi.spyOn(SynapseClient, 'getFiles').mockResolvedValue({ requestedFiles: [] })
 
@@ -597,6 +601,13 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
       },
     }
 
+    beforeEach(() => {
+      // Restore the default mock impl in case a previous test replaced it.
+      mockUpdateDataAccessRequest.mockImplementation(
+        respondToUpdateWithUpdatedObject,
+      )
+    })
+
     it('renders Signing Official name and email fields', async () => {
       mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
       renderComponent(eDucProps)
@@ -770,6 +781,69 @@ describe('DataAccessRequestAccessorsFilesForm tests', () => {
 
       await waitFor(() => expect(mockOnEDucContinue).toHaveBeenCalledTimes(1))
       expect(mockCreateSubmission).not.toHaveBeenCalled()
+    })
+
+    it('keeps the Signing Official fields enabled while the request is updated in the background', async () => {
+      mockGetDataRequestForUpdate.mockResolvedValue({
+        ...MOCK_DATA_ACCESS_REQUEST,
+        accessorChanges: [],
+      })
+      // The update never resolves, so the mutation remains pending
+      mockUpdateDataAccessRequest.mockImplementation(
+        () => new Promise(() => {}),
+      )
+
+      const { user } = renderComponent(eDucProps)
+
+      const nameField = await screen.findByLabelText(
+        /First and last names of your Signing Official/i,
+      )
+      const emailField = screen.getByLabelText(
+        /Institutional Email of your Signing Official/i,
+      )
+
+      // The pending background update adds the current user as an accessor
+      await waitFor(() =>
+        expect(mockUpdateDataAccessRequest).toHaveBeenCalled(),
+      )
+
+      expect(nameField).toBeEnabled()
+      expect(emailField).toBeEnabled()
+      await user.type(nameField, 'Jane Smith')
+      expect(nameField).toHaveValue('Jane Smith')
+    })
+
+    it('does not repeatedly update the request when the server response omits the applied changes', async () => {
+      // Simulate a server that does not persist the accessorChanges we send. Each response is a distinct object, as
+      // it would be over the wire, so the applied changes are not visible to the next render.
+      let etag = 0
+      mockGetDataRequestForUpdate.mockImplementation(() =>
+        Promise.resolve({
+          ...MOCK_DATA_ACCESS_REQUEST,
+          accessorChanges: [],
+          etag: String(etag),
+        }),
+      )
+      mockUpdateDataAccessRequest.mockImplementation(req =>
+        Promise.resolve({ ...req, accessorChanges: [], etag: String(++etag) }),
+      )
+
+      renderComponent(eDucProps)
+
+      await screen.findByLabelText(
+        /First and last names of your Signing Official/i,
+      )
+      await waitFor(() =>
+        expect(mockUpdateDataAccessRequest).toHaveBeenCalled(),
+      )
+      // Give the effect a chance to re-fire in response to the refetched request
+      await waitFor(() =>
+        expect(mockGetDataRequestForUpdate.mock.calls.length).toBeGreaterThan(
+          1,
+        ),
+      )
+
+      expect(mockUpdateDataAccessRequest).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
@@ -30,7 +30,7 @@ import {
   SigningOfficial,
   UploadCallbackResp,
 } from '@sage-bionetworks/synapse-types'
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 import {
   useGetCurrentUserProfile,
   useGetDataAccessRequestForUpdate,
@@ -160,6 +160,7 @@ export default function DataAccessRequestAccessorsFilesForm(
   const [publication, setPublication] = useState<string | undefined>()
   const [soName, setSoName] = useState<string>('')
   const [soEmail, setSoEmail] = useState<string>('')
+  const hasAppliedImmediateUpdates = useRef(false)
 
   const { data: dataAccessRequest, isLoading: isLoadingGetDataAccessRequest } =
     useGetDataAccessRequestForUpdate(String(managedACTAccessRequirement.id), {
@@ -202,6 +203,13 @@ export default function DataAccessRequestAccessorsFilesForm(
     updateDataAccessRequestIsPending ||
     submitDataAccessRequestIsPending
 
+  /**
+   * Fields backed by local state are not synced with the server until the request is submitted, so an in-flight
+   * background update to the request must not block the user from editing them.
+   */
+  const disableLocalStateFields =
+    isLoadingGetDataAccessRequest || submitDataAccessRequestIsPending
+
   const disableSubmitButton =
     submitDataAccessRequestIsPending || (isEDucEnabled && (!soName || !soEmail))
 
@@ -209,7 +217,7 @@ export default function DataAccessRequestAccessorsFilesForm(
    * This effect comprises a collection of updates we should immediately apply to a data access request.
    */
   useEffect(() => {
-    if (dataAccessRequest && user) {
+    if (dataAccessRequest && user && !hasAppliedImmediateUpdates.current) {
       let shouldUpdate = false
 
       // Attach the researchProjectId to the request
@@ -254,6 +262,9 @@ export default function DataAccessRequestAccessorsFilesForm(
       }
 
       if (shouldUpdate) {
+        // Only attempt these updates once. If the server does not echo back a value we applied here, retrying would
+        // loop indefinitely, leaving the form perpetually in a pending state.
+        hasAppliedImmediateUpdates.current = true
         updateRequestAsync(dataAccessRequest)
       }
     }
@@ -489,7 +500,7 @@ export default function DataAccessRequestAccessorsFilesForm(
                   placeholder="First and last name of signing official, ex: John Smith"
                   fullWidth
                   type="text"
-                  disabled={isLoading}
+                  disabled={disableLocalStateFields}
                   value={soName}
                   required
                   onChange={e => setSoName(e.target.value)}
@@ -501,7 +512,7 @@ export default function DataAccessRequestAccessorsFilesForm(
                   type="email"
                   placeholder="Individual with signing authority, e.g. jane.smith@institution.edu"
                   fullWidth
-                  disabled={isLoading}
+                  disabled={disableLocalStateFields}
                   value={soEmail}
                   required
                   onChange={e => setSoEmail(e.target.value)}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.stories.tsx
@@ -51,6 +51,10 @@ export const Preview: Story = {
   name: 'eDUC preview step',
   args: {
     managedACTAccessRequirement: eDucManagedACTAccessRequirement,
+    // The real pdf.js viewer is not served in Storybook, so point the iframe at a public
+    // sample PDF that the browser can render directly.
+    previewSrcOverride:
+      'https://www.rd.usda.gov/sites/default/files/pdf-sample_0.pdf',
   },
 }
 

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.stories.tsx
@@ -14,7 +14,7 @@ const eDucManagedACTAccessRequirement = {
   eDucTemplateId: 'template-abc-123',
 }
 
-// pdf.js will attempt to load a file from Synapse; the story renders the chrome around it.
+// The story renders the chrome around the iframe; the iframe src is overridden via previewSrcOverride.
 const previewHandler = http.get(
   `${MOCK_REPO_ORIGIN}/repo/v1/dataAccessRequest/${MOCK_DATA_ACCESS_REQUEST.id}/preview`,
   () =>
@@ -51,7 +51,7 @@ export const Preview: Story = {
   name: 'eDUC preview step',
   args: {
     managedACTAccessRequirement: eDucManagedACTAccessRequirement,
-    // The real pdf.js viewer is not served in Storybook, so point the iframe at a public
+    // The real portal servlet is not served in Storybook, so point the iframe at a public
     // sample PDF that the browser can render directly.
     previewSrcOverride:
       'https://www.rd.usda.gov/sites/default/files/pdf-sample_0.pdf',

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.stories.tsx
@@ -1,0 +1,80 @@
+import { mockManagedACTAccessRequirement } from '@/mocks/accessRequirement/mockAccessRequirements'
+import { MOCK_DATA_ACCESS_REQUEST } from '@/mocks/dataaccess/MockDataAccessRequest'
+import { getAccessRequirementHandlers } from '@/mocks/msw/handlers/accessRequirementHandlers'
+import { getDataAccessRequestHandlers } from '@/mocks/msw/handlers/dataAccessRequestHandlers'
+import { getUserProfileHandlers } from '@/mocks/msw/handlers/userProfileHandlers'
+import { getWikiHandlers } from '@/mocks/msw/handlers/wikiHandlers'
+import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { http, HttpResponse } from 'msw'
+import EDucPreviewStep from './EDucPreviewStep'
+
+const eDucManagedACTAccessRequirement = {
+  ...mockManagedACTAccessRequirement,
+  eDucTemplateId: 'template-abc-123',
+}
+
+// pdf.js will attempt to load a file from Synapse; the story renders the chrome around it.
+const previewHandler = http.get(
+  `${MOCK_REPO_ORIGIN}/repo/v1/dataAccessRequest/${MOCK_DATA_ACCESS_REQUEST.id}/preview`,
+  () =>
+    HttpResponse.json(
+      { fileHandleId: 'mock-preview-file-handle-123' },
+      { status: 200 },
+    ),
+)
+
+const meta: Meta<typeof EDucPreviewStep> = {
+  title:
+    'Governance/Data Access Request Flow/Managed Access Requirement/Step 2c - eDUC Preview',
+  component: EDucPreviewStep,
+  parameters: {
+    stack: 'mock',
+    chromatic: { viewports: [600, 1200] },
+    msw: {
+      handlers: [
+        previewHandler,
+        ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
+        ...getWikiHandlers(MOCK_REPO_ORIGIN),
+        ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
+        ...getDataAccessRequestHandlers(MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Preview: Story = {
+  name: 'eDUC preview step',
+  args: {
+    managedACTAccessRequirement: eDucManagedACTAccessRequirement,
+  },
+}
+
+export const PreviewError: Story = {
+  name: 'eDUC preview — error state',
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(
+          `${MOCK_REPO_ORIGIN}/repo/v1/dataAccessRequest/${MOCK_DATA_ACCESS_REQUEST.id}/preview`,
+          () =>
+            HttpResponse.json(
+              { reason: 'Preview could not be generated at this time.' },
+              { status: 500 },
+            ),
+        ),
+        ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
+        ...getWikiHandlers(MOCK_REPO_ORIGIN),
+        ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
+        ...getDataAccessRequestHandlers(MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
+  args: {
+    managedACTAccessRequirement: eDucManagedACTAccessRequirement,
+  },
+}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.test.tsx
@@ -1,0 +1,172 @@
+import {
+  mockManagedACTAccessRequirement,
+  mockManagedACTAccessRequirementWikiPageKey,
+} from '@/mocks/accessRequirement/mockAccessRequirements'
+import { MOCK_DATA_ACCESS_REQUEST } from '@/mocks/dataaccess/MockDataAccessRequest'
+import { server } from '@/mocks/msw/server'
+import SynapseClient from '@/synapse-client'
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import MarkdownSynapse from '../../../Markdown/MarkdownSynapse'
+import * as AccessRequirementListUtils from '../../AccessRequirementListUtils'
+import EDucPreviewStep, { EDucPreviewStepProps } from './EDucPreviewStep'
+
+vi.mock('../../../Markdown/MarkdownSynapse', () => ({
+  __esModule: true,
+  default: vi.fn(),
+}))
+const mockMarkdownSynapse = vi.mocked(MarkdownSynapse)
+mockMarkdownSynapse.mockImplementation(() => (
+  <div data-testid={'MarkdownSynapseContent'}></div>
+))
+
+const mockGetDataRequestForUpdate = vi.spyOn(
+  SynapseClient,
+  'getDataAccessRequestForUpdate',
+)
+
+vi.spyOn(SynapseClient, 'getWikiPageKeyForAccessRequirement').mockResolvedValue(
+  mockManagedACTAccessRequirementWikiPageKey,
+)
+vi.spyOn(
+  AccessRequirementListUtils,
+  'useCanShowManagedACTWikiInWizard',
+).mockReturnValue(true)
+
+const mockOnHide = vi.fn()
+const mockOnBackClicked = vi.fn()
+const mockOnSendForSignature = vi.fn()
+const mockOnManualUpload = vi.fn()
+
+const defaultProps: EDucPreviewStepProps = {
+  managedACTAccessRequirement: {
+    ...mockManagedACTAccessRequirement,
+    eDucTemplateId: 'educ-template-123',
+  },
+  onHide: mockOnHide,
+  onBackClicked: mockOnBackClicked,
+  onSendForSignature: mockOnSendForSignature,
+  onManualUpload: mockOnManualUpload,
+}
+
+function renderComponent(props: EDucPreviewStepProps = defaultProps) {
+  const user = userEvent.setup()
+  const component = render(<EDucPreviewStep {...props} />, {
+    wrapper: createWrapper({ withErrorBoundary: true }),
+  })
+  return { user, component }
+}
+
+const previewEndpoint = `*/repo/v1/dataAccessRequest/${MOCK_DATA_ACCESS_REQUEST.id}/preview`
+
+describe('EDucPreviewStep', () => {
+  beforeAll(() => server.listen())
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  beforeEach(() => {
+    mockOnHide.mockReset()
+    mockOnBackClicked.mockReset()
+    mockOnSendForSignature.mockReset()
+    mockOnManualUpload.mockReset()
+    mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
+  })
+
+  it('shows a loading skeleton while the preview is loading', async () => {
+    server.use(
+      http.get(previewEndpoint, () => new Promise<HttpResponse>(() => {})),
+    )
+    renderComponent()
+
+    await screen.findByTestId('EDucPreviewStep-loading')
+  })
+
+  it('renders the pdf.js iframe when the preview loads successfully', async () => {
+    server.use(
+      http.get(previewEndpoint, () =>
+        HttpResponse.json(
+          { fileHandleId: 'preview-file-handle-456' },
+          { status: 200 },
+        ),
+      ),
+    )
+    renderComponent()
+
+    const iframe = await screen.findByTitle('eDUC preview')
+    expect(iframe.getAttribute('src')).toMatch(/pdf\.js\/web\/viewer\.html/)
+    expect(iframe.getAttribute('src')).toMatch(
+      /fileHandleId%3Dpreview-file-handle-456/,
+    )
+  })
+
+  it('shows an error alert when the preview query fails', async () => {
+    server.use(
+      http.get(previewEndpoint, () =>
+        HttpResponse.json({ reason: 'preview failed' }, { status: 500 }),
+      ),
+    )
+    renderComponent()
+
+    await screen.findByText(/couldn't load your DUC preview/i)
+    expect(screen.getByText('preview failed')).toBeInTheDocument()
+  })
+
+  it('invokes onBackClicked when Back is clicked', async () => {
+    server.use(
+      http.get(previewEndpoint, () =>
+        HttpResponse.json(
+          { fileHandleId: 'preview-file-handle-456' },
+          { status: 200 },
+        ),
+      ),
+    )
+    const { user } = renderComponent()
+
+    const backButton = await screen.findByRole('button', { name: 'Back' })
+    await user.click(backButton)
+
+    expect(mockOnBackClicked).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes onSendForSignature when the Send button is clicked', async () => {
+    server.use(
+      http.get(previewEndpoint, () =>
+        HttpResponse.json(
+          { fileHandleId: 'preview-file-handle-456' },
+          { status: 200 },
+        ),
+      ),
+    )
+    const { user } = renderComponent()
+
+    const sendButton = await screen.findByRole('button', {
+      name: 'Send for electronic signature',
+    })
+    await waitFor(() => expect(sendButton).toBeEnabled())
+    await user.click(sendButton)
+
+    expect(mockOnSendForSignature).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes onManualUpload when the Manually print button is clicked', async () => {
+    server.use(
+      http.get(previewEndpoint, () =>
+        HttpResponse.json(
+          { fileHandleId: 'preview-file-handle-456' },
+          { status: 200 },
+        ),
+      ),
+    )
+    const { user } = renderComponent()
+
+    const uploadButton = await screen.findByRole('button', {
+      name: 'Manually print and upload PDF',
+    })
+    await waitFor(() => expect(uploadButton).toBeEnabled())
+    await user.click(uploadButton)
+
+    expect(mockOnManualUpload).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.test.tsx
@@ -13,6 +13,13 @@ import MarkdownSynapse from '../../../Markdown/MarkdownSynapse'
 import * as AccessRequirementListUtils from '../../AccessRequirementListUtils'
 import EDucPreviewStep, { EDucPreviewStepProps } from './EDucPreviewStep'
 
+vi.mock('@/utils/hooks/useFetchBlobUrl', () => ({
+  useFetchBlobUrl: vi.fn().mockReturnValue({
+    blobUrl: 'blob:mockBlobUrl',
+    error: undefined,
+  }),
+}))
+
 vi.mock('../../../Markdown/MarkdownSynapse', () => ({
   __esModule: true,
   default: vi.fn(),
@@ -83,7 +90,7 @@ describe('EDucPreviewStep', () => {
     await screen.findByTestId('EDucPreviewStep-loading')
   })
 
-  it('renders the pdf.js iframe when the preview loads successfully', async () => {
+  it('renders the iframe when the preview loads successfully', async () => {
     server.use(
       http.get(previewEndpoint, () =>
         HttpResponse.json(
@@ -95,10 +102,7 @@ describe('EDucPreviewStep', () => {
     renderComponent()
 
     const iframe = await screen.findByTitle('eDUC preview')
-    expect(iframe.getAttribute('src')).toMatch(/pdf\.js\/web\/viewer\.html/)
-    expect(iframe.getAttribute('src')).toMatch(
-      /fileHandleId%3Dpreview-file-handle-456/,
-    )
+    expect(iframe).toHaveAttribute('src', 'blob:mockBlobUrl')
   })
 
   it('shows an error alert when the preview query fails', async () => {

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.test.tsx
@@ -82,9 +82,7 @@ describe('EDucPreviewStep', () => {
   })
 
   it('shows a loading skeleton while the preview is loading', async () => {
-    server.use(
-      http.get(previewEndpoint, () => new Promise<HttpResponse>(() => {})),
-    )
+    server.use(http.get(previewEndpoint, () => new Promise<never>(() => {})))
     renderComponent()
 
     await screen.findByTestId('EDucPreviewStep-loading')

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
@@ -31,16 +31,15 @@ export type EDucPreviewStepProps = {
   onSendForSignature: () => void
   onManualUpload: () => void
   /**
-   * Optional iframe `src` override for demos and stories. When set, replaces the pdf.js viewer
-   * URL that is normally built from the eDUC preview file handle. Production callers should not
-   * set this.
+   * Optional iframe `src` override for demos and stories. When set, the blob fetch is skipped
+   * and this URL is used directly as the iframe src. Production callers should not set this.
    */
   previewSrcOverride?: string
 }
 
 /**
  * Wizard step shown after the "Review / Create a DUC" step (PORTALS-4414).
- * Displays the generated eDUC document in a pdf.js viewer iframe so the user can review it
+ * Displays the generated eDUC document in an iframe so the user can review it
  * before sending it for electronic signature (PORTALS-4378) or manually printing and
  * uploading a signed PDF (PORTALS-4379).
  */

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
@@ -3,7 +3,6 @@ import {
   useGetDataAccessRequestPreview,
 } from '@/synapse-queries'
 import SynapseClient from '@/synapse-client'
-import { BackendDestinationEnum, getEndpoint } from '@/utils/functions'
 import {
   Alert,
   Box,
@@ -19,6 +18,7 @@ import {
 } from '@mui/material'
 import { ManagedACTAccessRequirement } from '@sage-bionetworks/synapse-types'
 import { ReactNode } from 'react'
+import { useFetchBlobUrl } from '@/utils/hooks/useFetchBlobUrl'
 import IconSvg from '../../../IconSvg/IconSvg'
 import { longFieldLabelSx } from '../styles'
 
@@ -30,6 +30,12 @@ export type EDucPreviewStepProps = {
   onBackClicked: () => void
   onSendForSignature: () => void
   onManualUpload: () => void
+  /**
+   * Optional iframe `src` override for demos and stories. When set, replaces the pdf.js viewer
+   * URL that is normally built from the eDUC preview file handle. Production callers should not
+   * set this.
+   */
+  previewSrcOverride?: string
 }
 
 /**
@@ -45,6 +51,7 @@ export default function EDucPreviewStep(props: EDucPreviewStepProps) {
     onBackClicked,
     onSendForSignature,
     onManualUpload,
+    previewSrcOverride,
   } = props
 
   const { data: dataAccessRequest, isLoading: isLoadingDar } =
@@ -61,10 +68,18 @@ export default function EDucPreviewStep(props: EDucPreviewStepProps) {
     enabled: Boolean(dataAccessRequest?.id),
   })
 
-  const isLoading =
-    isLoadingDar || (Boolean(dataAccessRequest?.id) && isLoadingPreview)
   const previewFileHandleId = previewFileHandle?.fileHandleId
-  const actionsDisabled = isLoading || !previewFileHandleId
+  const { blobUrl, error: blobError } = useFetchBlobUrl(
+    previewSrcOverride || !previewFileHandleId
+      ? undefined
+      : SynapseClient.getPortalFileHandleServletUrl(previewFileHandleId),
+  )
+
+  const isLoading =
+    isLoadingDar ||
+    (Boolean(dataAccessRequest?.id) && isLoadingPreview) ||
+    (!previewSrcOverride && !!previewFileHandleId && !blobUrl && !blobError)
+  const actionsDisabled = isLoading || (!previewSrcOverride && !blobUrl)
 
   return (
     <>
@@ -95,24 +110,23 @@ export default function EDucPreviewStep(props: EDucPreviewStepProps) {
             data-testid={'EDucPreviewStep-loading'}
           />
         )}
-        {!isLoading && previewError && (
+        {!isLoading && (previewError || blobError) && (
           <Alert severity={'error'}>
             <strong>Sorry, we couldn&apos;t load your DUC preview.</strong>
             <br />
-            {previewError.reason}
+            {previewError?.reason ?? blobError?.message}
           </Alert>
         )}
-        {!isLoading && !previewError && previewFileHandleId && (
-          <iframe
-            title={'eDUC preview'}
-            src={`${getEndpoint(
-              BackendDestinationEnum.PORTAL_ENDPOINT,
-            )}pdf.js/web/viewer.html?file=${encodeURIComponent(
-              SynapseClient.getPortalFileHandleServletUrl(previewFileHandleId),
-            )}`}
-            style={{ border: 0, width: '100%', height: PDF_PREVIEW_HEIGHT }}
-          />
-        )}
+        {!isLoading &&
+          !previewError &&
+          !blobError &&
+          (previewSrcOverride || blobUrl) && (
+            <iframe
+              title={'eDUC preview'}
+              src={previewSrcOverride ?? blobUrl}
+              style={{ border: 0, width: '100%', height: PDF_PREVIEW_HEIGHT }}
+            />
+          )}
 
         <Box
           sx={{

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
@@ -1,0 +1,189 @@
+import {
+  useGetDataAccessRequestForUpdate,
+  useGetDataAccessRequestPreview,
+} from '@/synapse-queries'
+import SynapseClient from '@/synapse-client'
+import { BackendDestinationEnum, getEndpoint } from '@/utils/functions'
+import {
+  Alert,
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { ManagedACTAccessRequirement } from '@sage-bionetworks/synapse-types'
+import { ReactNode } from 'react'
+import IconSvg from '../../../IconSvg/IconSvg'
+import { longFieldLabelSx } from '../styles'
+
+const PDF_PREVIEW_HEIGHT = '500px'
+
+export type EDucPreviewStepProps = {
+  managedACTAccessRequirement: ManagedACTAccessRequirement
+  onHide: () => void
+  onBackClicked: () => void
+  onSendForSignature: () => void
+  onManualUpload: () => void
+}
+
+/**
+ * Wizard step shown after the "Review / Create a DUC" step (PORTALS-4414).
+ * Displays the generated eDUC document in a pdf.js viewer iframe so the user can review it
+ * before sending it for electronic signature (PORTALS-4378) or manually printing and
+ * uploading a signed PDF (PORTALS-4379).
+ */
+export default function EDucPreviewStep(props: EDucPreviewStepProps) {
+  const {
+    managedACTAccessRequirement,
+    onHide,
+    onBackClicked,
+    onSendForSignature,
+    onManualUpload,
+  } = props
+
+  const { data: dataAccessRequest, isLoading: isLoadingDar } =
+    useGetDataAccessRequestForUpdate(String(managedACTAccessRequirement.id), {
+      staleTime: Infinity,
+      throwOnError: true,
+    })
+
+  const {
+    data: previewFileHandle,
+    isLoading: isLoadingPreview,
+    error: previewError,
+  } = useGetDataAccessRequestPreview(dataAccessRequest?.id ?? '', {
+    enabled: Boolean(dataAccessRequest?.id),
+  })
+
+  const isLoading =
+    isLoadingDar || (Boolean(dataAccessRequest?.id) && isLoadingPreview)
+  const previewFileHandleId = previewFileHandle?.fileHandleId
+  const actionsDisabled = isLoading || !previewFileHandleId
+
+  return (
+    <>
+      <DialogTitle>
+        <Stack direction="row" sx={{ alignItems: 'center', gap: '5px' }}>
+          Request Access
+          <Box sx={{ flexGrow: 1 }} />
+          <IconButton onClick={onHide}>
+            <IconSvg icon={'close'} wrap={false} sx={{ color: 'grey.700' }} />
+          </IconButton>
+        </Stack>
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant={'body1'} sx={{ fontWeight: 700, mb: 1 }}>
+          Take a minute to preview your DUC
+        </Typography>
+        <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 2 }}>
+          Please ensure that all information is correct, as incorrect
+          information will result in the rejection of your access request. Use
+          the Back button to return to previous steps and modify any details.
+        </Typography>
+
+        {isLoading && (
+          <Skeleton
+            variant={'rectangular'}
+            width={'100%'}
+            height={PDF_PREVIEW_HEIGHT}
+            data-testid={'EDucPreviewStep-loading'}
+          />
+        )}
+        {!isLoading && previewError && (
+          <Alert severity={'error'}>
+            <strong>Sorry, we couldn&apos;t load your DUC preview.</strong>
+            <br />
+            {previewError.reason}
+          </Alert>
+        )}
+        {!isLoading && !previewError && previewFileHandleId && (
+          <iframe
+            title={'eDUC preview'}
+            src={`${getEndpoint(
+              BackendDestinationEnum.PORTAL_ENDPOINT,
+            )}pdf.js/web/viewer.html?file=${encodeURIComponent(
+              SynapseClient.getPortalFileHandleServletUrl(previewFileHandleId),
+            )}`}
+            style={{ border: 0, width: '100%', height: PDF_PREVIEW_HEIGHT }}
+          />
+        )}
+
+        <Box
+          sx={{
+            mt: 3,
+            border: '1px solid',
+            borderColor: 'grey.300',
+            borderRadius: 1,
+          }}
+        >
+          <ActionRow
+            title={'Email DUC to Collaborators'}
+            description={
+              'Complete and sign the DUC online by emailing a secure DocuSign link to your listed collaborators. Notifications will be sent directly to the email address associated with their Synapse accounts. This is fastest way to get access.'
+            }
+            action={
+              <Button
+                variant={'contained'}
+                disabled={actionsDisabled}
+                onClick={onSendForSignature}
+              >
+                Send for electronic signature
+              </Button>
+            }
+          />
+          <Divider />
+          <ActionRow
+            title={'Print and upload a PDF instead'}
+            description={
+              'Download the DUC, sign it by hand, and upload the completed document.'
+            }
+            action={
+              <Button
+                variant={'outlined'}
+                disabled={actionsDisabled}
+                onClick={onManualUpload}
+              >
+                Manually print and upload PDF
+              </Button>
+            }
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button variant={'outlined'} onClick={onBackClicked}>
+          Back
+        </Button>
+      </DialogActions>
+    </>
+  )
+}
+
+function ActionRow(props: {
+  title: string
+  description: string
+  action: ReactNode
+}) {
+  const { title, description, action } = props
+  return (
+    <Stack
+      direction={{ xs: 'column', sm: 'row' }}
+      sx={{ alignItems: { sm: 'center' }, gap: 2, p: 2 }}
+    >
+      <Box sx={{ flexGrow: 1 }}>
+        <Typography variant={'body1'} sx={{ fontWeight: 700, mb: 0.5 }}>
+          {title}
+        </Typography>
+        <Typography variant={'body1'} sx={longFieldLabelSx}>
+          {description}
+        </Typography>
+      </Box>
+      <Box sx={{ flexShrink: 0 }}>{action}</Box>
+    </Stack>
+  )
+}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.test.tsx
@@ -547,5 +547,50 @@ describe('ResearchProjectForm', { timeout: 30_000 }, () => {
         )
       })
     })
+
+    it('attaches the newly created researchProjectId to the DAR', async () => {
+      mockGetDataAccessRequestForUpdate.mockResolvedValue({
+        ...MOCK_DATA_ACCESS_REQUEST,
+        researchProjectId: undefined as unknown as string,
+      })
+
+      const { user, projectLeadInput, institutionInput } = await setUp({
+        ...defaultProps,
+        managedACTAccessRequirement: eDucAr,
+      })
+
+      await waitFor(() =>
+        expect(mockGetDataAccessRequestForUpdate).toHaveBeenCalled(),
+      )
+
+      await user.type(projectLeadInput, 'Jane Doe')
+      await user.type(institutionInput, 'My Institution')
+      await user.type(
+        screen.getByLabelText(
+          'Institutional Email of your Project Lead or PI',
+          { exact: false },
+        ),
+        'pi@example.edu',
+      )
+      act(() => {
+        mockedUserSearchBox.mock.lastCall![0].onChange!('9999', {} as never)
+      })
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Save and Continue' }),
+        ).not.toBeDisabled(),
+      )
+      await clickSaveAndContinue(user)
+
+      await waitFor(() => {
+        expect(mockUpdateDataAccessRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            researchProjectId: CREATED_RESEARCH_PROJECT_ID,
+          }),
+          MOCK_ACCESS_TOKEN,
+        )
+      })
+    })
   })
 })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.tsx
@@ -199,6 +199,9 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
       try {
         await updateDataAccessRequest({
           ...existingDar,
+          // The DAR is fetched before the ResearchProject exists, so it may not have an id yet
+          researchProjectId:
+            existingDar.researchProjectId ?? updatedResearchProject.id,
           institution: institution,
           principalInvestigator: nextPi,
         } as Request | Renewal)
@@ -291,20 +294,6 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
                   },
                 }}
               />
-              <TextField
-                id={'institution'}
-                label={'Your Institution'}
-                placeholder={
-                  'Full, unabbreviated name of the institution you are affiliated with'
-                }
-                fullWidth
-                type="text"
-                disabled={isLoading}
-                value={institution}
-                required
-                onChange={e => setInstitution(e.target.value)}
-              />
-
               {isEDucEnabled && (
                 <Box sx={{ mb: '20px' }}>
                   <Typography
@@ -340,6 +329,20 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
                   />
                 </Box>
               )}
+
+              <TextField
+                id={'institution'}
+                label={'Your Institution'}
+                placeholder={
+                  'Full, unabbreviated name of the institution you are affiliated with'
+                }
+                fullWidth
+                type="text"
+                disabled={isLoading}
+                value={institution}
+                required
+                onChange={e => setInstitution(e.target.value)}
+              />
 
               {managedACTAccessRequirement.isIDURequired && (
                 <TextFieldWithWordLimit

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep.stories.tsx
@@ -1,6 +1,5 @@
 import { mockManagedACTAccessRequirement } from '@/mocks/accessRequirement/mockAccessRequirements'
 import { MOCK_DATA_ACCESS_REQUEST } from '@/mocks/dataaccess/MockDataAccessRequest'
-import { MOCK_FOLDER_ID } from '@/mocks/entity/mockEntity'
 import { getAccessRequirementHandlers } from '@/mocks/msw/handlers/accessRequirementHandlers'
 import { getDataAccessRequestHandlers } from '@/mocks/msw/handlers/dataAccessRequestHandlers'
 import { getUserProfileHandlers } from '@/mocks/msw/handlers/userProfileHandlers'
@@ -8,10 +7,7 @@ import { getWikiHandlers } from '@/mocks/msw/handlers/wikiHandlers'
 import { MOCK_USER_ID, MOCK_USER_ID_2 } from '@/mocks/user/mock_user_profile'
 import { ACCESS_REQUIREMENT_DATA_ACCESS_REQUEST_FOR_UPDATE } from '@/utils/APIConstants'
 import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
-import {
-  AccessType,
-  RestrictableObjectType,
-} from '@sage-bionetworks/synapse-types'
+import { AccessType } from '@sage-bionetworks/synapse-types'
 import { Meta, StoryObj } from '@storybook/react-vite'
 import { http, HttpResponse } from 'msw'
 import ReviewDucStep from './ReviewDucStep'
@@ -73,7 +69,5 @@ export const ReviewDuc: Story = {
   name: 'Review / Create a DUC step',
   args: {
     managedACTAccessRequirement: eDucManagedACTAccessRequirement,
-    subjectId: MOCK_FOLDER_ID,
-    subjectType: RestrictableObjectType.ENTITY,
   },
 }

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep.test.tsx
@@ -3,8 +3,6 @@ import {
   mockManagedACTAccessRequirementWikiPageKey,
 } from '@/mocks/accessRequirement/mockAccessRequirements'
 import { MOCK_DATA_ACCESS_REQUEST } from '@/mocks/dataaccess/MockDataAccessRequest'
-import { mockSubmittedSubmission } from '@/mocks/dataaccess/MockSubmission'
-import { MOCK_FILE_ENTITY_ID } from '@/mocks/entity/mockFileEntity'
 import {
   MOCK_USER_ID,
   MOCK_USER_ID_2,
@@ -12,11 +10,7 @@ import {
 } from '@/mocks/user/mock_user_profile'
 import SynapseClient from '@/synapse-client'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
-import {
-  AccessType,
-  RestrictableObjectType,
-  SubmissionState,
-} from '@sage-bionetworks/synapse-types'
+import { AccessType } from '@sage-bionetworks/synapse-types'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MarkdownSynapse from '../../../Markdown/MarkdownSynapse'
@@ -48,15 +42,6 @@ const mockGetDataRequestForUpdate = vi.spyOn(
   'getDataAccessRequestForUpdate',
 )
 
-const mockSubmitDataAccessRequest = vi
-  .spyOn(SynapseClient, 'submitDataAccessRequest')
-  .mockResolvedValue({
-    submissionId: mockSubmittedSubmission.id,
-    submittedBy: mockSubmittedSubmission.submittedBy,
-    state: SubmissionState.SUBMITTED,
-    modifiedOn: mockSubmittedSubmission.modifiedOn,
-  })
-
 vi.spyOn(SynapseClient, 'getWikiPageKeyForAccessRequirement').mockResolvedValue(
   mockManagedACTAccessRequirementWikiPageKey,
 )
@@ -67,18 +52,16 @@ vi.spyOn(
 
 const mockOnHide = vi.fn()
 const mockOnBackClicked = vi.fn()
-const mockOnSubmissionCreated = vi.fn()
+const mockOnCreateDuc = vi.fn()
 
 const defaultProps: ReviewDucStepProps = {
   managedACTAccessRequirement: {
     ...mockManagedACTAccessRequirement,
     eDucTemplateId: 'educ-template-123',
   },
-  subjectId: MOCK_FILE_ENTITY_ID,
-  subjectType: RestrictableObjectType.ENTITY,
   onHide: mockOnHide,
   onBackClicked: mockOnBackClicked,
-  onSubmissionCreated: mockOnSubmissionCreated,
+  onCreateDuc: mockOnCreateDuc,
 }
 
 function renderComponent(props: ReviewDucStepProps = defaultProps) {
@@ -93,8 +76,7 @@ describe('ReviewDucStep', () => {
   beforeEach(() => {
     mockOnHide.mockReset()
     mockOnBackClicked.mockReset()
-    mockOnSubmissionCreated.mockReset()
-    mockSubmitDataAccessRequest.mockClear()
+    mockOnCreateDuc.mockReset()
   })
 
   it('renders the "Sign a Data Use Certificate" heading and instructional text', async () => {
@@ -180,7 +162,7 @@ describe('ReviewDucStep', () => {
     expect(mockOnHide).toHaveBeenCalledTimes(1)
   })
 
-  it('submits the DAR and calls onSubmissionCreated when Create a DUC is clicked', async () => {
+  it('invokes onCreateDuc when Create a DUC is clicked', async () => {
     mockGetDataRequestForUpdate.mockResolvedValue(MOCK_DATA_ACCESS_REQUEST)
     const { user } = renderComponent()
 
@@ -190,21 +172,6 @@ describe('ReviewDucStep', () => {
     await waitFor(() => expect(createButton).toBeEnabled())
     await user.click(createButton)
 
-    await waitFor(() => {
-      expect(mockSubmitDataAccessRequest).toHaveBeenCalledWith(
-        expect.objectContaining({
-          requestId: MOCK_DATA_ACCESS_REQUEST.id,
-          requestEtag: MOCK_DATA_ACCESS_REQUEST.etag,
-          subjectId: MOCK_FILE_ENTITY_ID,
-          subjectType: RestrictableObjectType.ENTITY,
-        }),
-        expect.anything(),
-      )
-    })
-    await waitFor(() =>
-      expect(mockOnSubmissionCreated).toHaveBeenCalledWith(
-        mockSubmittedSubmission.id,
-      ),
-    )
+    expect(mockOnCreateDuc).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep.tsx
@@ -1,14 +1,9 @@
-import {
-  useGetDataAccessRequestForUpdate,
-  useSubmitDataAccessRequest,
-} from '@/synapse-queries'
-import { SynapseClientError } from '@sage-bionetworks/synapse-client/util/SynapseClientError'
+import { useGetDataAccessRequestForUpdate } from '@/synapse-queries'
 import { ExpandMore } from '@mui/icons-material'
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
-  Alert,
   Box,
   Button,
   DialogActions,
@@ -18,11 +13,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material'
-import {
-  ManagedACTAccessRequirement,
-  RestrictableObjectType,
-} from '@sage-bionetworks/synapse-types'
-import { useState } from 'react'
+import { ManagedACTAccessRequirement } from '@sage-bionetworks/synapse-types'
 import IconSvg from '../../../IconSvg/IconSvg'
 import { UserBadge } from '../../../UserCard/UserBadge'
 import ManagedACTAccessRequirementFormWikiWrapper from '../ManagedACTAccessRequirementFormWikiWrapper'
@@ -30,11 +21,13 @@ import { longFieldLabelSx } from '../styles'
 
 export type ReviewDucStepProps = {
   managedACTAccessRequirement: ManagedACTAccessRequirement
-  subjectId: string
-  subjectType: RestrictableObjectType
   onHide: () => void
   onBackClicked: () => void
-  onSubmissionCreated: (submissionId: string) => void
+  /**
+   * Called when the user clicks "Create a DUC". The parent advances to the eDUC preview step
+   * (PORTALS-4377), where the generated document is displayed for review before signing.
+   */
+  onCreateDuc: () => void
 }
 
 /**
@@ -42,16 +35,8 @@ export type ReviewDucStepProps = {
  * Lets the user confirm their collaborators, PI, and Signing Official before generating the DUC.
  */
 export default function ReviewDucStep(props: ReviewDucStepProps) {
-  const {
-    managedACTAccessRequirement,
-    subjectId,
-    subjectType,
-    onHide,
-    onBackClicked,
-    onSubmissionCreated,
-  } = props
-
-  const [error, setError] = useState<string | undefined>()
+  const { managedACTAccessRequirement, onHide, onBackClicked, onCreateDuc } =
+    props
 
   const { data: dataAccessRequest, isLoading } =
     useGetDataAccessRequestForUpdate(String(managedACTAccessRequirement.id), {
@@ -59,32 +44,9 @@ export default function ReviewDucStep(props: ReviewDucStepProps) {
       throwOnError: true,
     })
 
-  const { mutate: submit, isPending: isSubmitting } =
-    useSubmitDataAccessRequest({
-      onSuccess: submission => {
-        onSubmissionCreated(submission.submissionId)
-      },
-      onError: (e: SynapseClientError) => {
-        setError(e.reason)
-      },
-    })
-
   const accessorChanges = dataAccessRequest?.accessorChanges ?? []
   const pi = dataAccessRequest?.principalInvestigator
   const so = dataAccessRequest?.signingOfficial
-
-  const handleCreateDuc = () => {
-    if (!dataAccessRequest) return
-    submit({
-      request: {
-        requestId: dataAccessRequest.id,
-        requestEtag: dataAccessRequest.etag,
-        subjectId,
-        subjectType,
-      },
-      accessRequirementId: String(managedACTAccessRequirement.id),
-    })
-  }
 
   return (
     <>
@@ -230,30 +192,19 @@ export default function ReviewDucStep(props: ReviewDucStepProps) {
             </Accordion>
           </Box>
         </ManagedACTAccessRequirementFormWikiWrapper>
-        {error && (
-          <Alert severity={'error'} sx={{ mt: 2 }}>
-            <strong>Sorry, there is an error creating your DUC.</strong>
-            <br />
-            {error}
-          </Alert>
-        )}
       </DialogContent>
       <DialogActions>
-        <Button
-          variant={'outlined'}
-          disabled={isSubmitting}
-          onClick={onBackClicked}
-        >
+        <Button variant={'outlined'} onClick={onBackClicked}>
           Back
         </Button>
         <Box sx={{ flexGrow: 1 }} />
-        <Button variant={'outlined'} disabled={isSubmitting} onClick={onHide}>
+        <Button variant={'outlined'} onClick={onHide}>
           Cancel
         </Button>
         <Button
           variant={'contained'}
-          disabled={isLoading || isSubmitting}
-          onClick={handleCreateDuc}
+          disabled={isLoading}
+          onClick={onCreateDuc}
         >
           Create a DUC
         </Button>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/UploadDocumentField.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/UploadDocumentField.tsx
@@ -18,6 +18,7 @@ type UploadDocumentFieldProps = {
   isMultiFileUpload?: boolean
   onClearAttachment?: (fileHandleId: string) => void
   isLoading?: boolean
+  disabled?: boolean
   uploadBtnVariant?: ButtonProps['variant']
 }
 
@@ -30,6 +31,7 @@ export function UploadDocumentField(props: UploadDocumentFieldProps) {
     isMultiFileUpload = false,
     onClearAttachment,
     isLoading = false,
+    disabled = false,
     uploadBtnVariant = 'outlined',
   } = props
   const [isUploading, setIsUploading] = useState(false)
@@ -65,7 +67,7 @@ export function UploadDocumentField(props: UploadDocumentFieldProps) {
         }}
         label={`Upload ${documentName}`}
         buttonProps={{
-          disabled: isLoading,
+          disabled: isLoading || disabled,
           variant: uploadBtnVariant,
           endIcon: <IconSvg icon={'upload'} wrap={false} />,
         }}

--- a/packages/synapse-react-client/src/components/FilePreview/PdfPreview.test.tsx
+++ b/packages/synapse-react-client/src/components/FilePreview/PdfPreview.test.tsx
@@ -1,16 +1,18 @@
 import { mockFileHandle } from '@/mocks/mock_file_handle'
-import SynapseClient from '@/synapse-client'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
-import {
-  BackendDestinationEnum,
-  getEndpoint,
-} from '@/utils/functions/getEndpoint'
 import {
   FileHandleAssociateType,
   FileHandleAssociation,
 } from '@sage-bionetworks/synapse-types'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import PdfPreview, { maxPdfSize, PdfPreviewProps } from './PdfPreview'
+
+vi.mock('@/utils/hooks/useFetchBlobUrl', () => ({
+  useFetchBlobUrl: vi.fn().mockReturnValue({
+    blobUrl: 'blob:mockBlobUrl',
+    error: undefined,
+  }),
+}))
 
 function renderComponent(props: PdfPreviewProps) {
   return render(<PdfPreview {...props} />, { wrapper: createWrapper() })
@@ -22,30 +24,16 @@ const mockFHA: FileHandleAssociation = {
   fileHandleId: mockFileHandle.id,
 }
 
-const expectedEncodedFhaUrl = encodeURIComponent(
-  SynapseClient.getPortalFileHandleServletUrl(
-    mockFHA.fileHandleId,
-    mockFHA.associateObjectId,
-    mockFHA.associateObjectType,
-  ),
-)
-const expectedIFrameSource = `${getEndpoint(
-  BackendDestinationEnum.PORTAL_ENDPOINT,
-)}pdf.js/web/viewer.html?file=${expectedEncodedFhaUrl}`
-
 describe('PDF Preview tests', () => {
-  it('PDF is rendered', async () => {
+  it('PDF is rendered', () => {
     const { container } = renderComponent({
       fileHandle: mockFileHandle,
       fileHandleAssociation: mockFHA,
     })
 
-    let frame: HTMLIFrameElement | null = null
-    await waitFor(() => {
-      frame = container.querySelector('iframe')
-      expect(frame).toBeDefined()
-      expect(frame).toHaveAttribute('src', expectedIFrameSource)
-    })
+    const frame = container.querySelector('iframe')
+    expect(frame).toBeInTheDocument()
+    expect(frame).toHaveAttribute('src', 'blob:mockBlobUrl')
   })
   it('PDF is not rendered if too large', async () => {
     renderComponent({

--- a/packages/synapse-react-client/src/components/FilePreview/PdfPreview.tsx
+++ b/packages/synapse-react-client/src/components/FilePreview/PdfPreview.tsx
@@ -1,12 +1,11 @@
 import SynapseClient from '@/synapse-client'
-import { BackendDestinationEnum, getEndpoint } from '@/utils/functions'
 import { calculateFriendlyFileSize } from '@/utils/functions/calculateFriendlyFileSize'
-import { Alert } from '@mui/material'
+import { Alert, Skeleton } from '@mui/material'
 import {
   FileHandle,
   FileHandleAssociation,
 } from '@sage-bionetworks/synapse-types'
-import { useRef } from 'react'
+import { useFetchBlobUrl } from '@/utils/hooks/useFetchBlobUrl'
 
 export type PdfPreviewProps = {
   fileHandle: FileHandle
@@ -23,7 +22,16 @@ const friendlyMaxPdfSize = calculateFriendlyFileSize(maxPdfSize) // 30MB
  */
 export default function PdfPreview(props: PdfPreviewProps) {
   const { fileHandle, fileHandleAssociation: fha } = props
-  const frameEl = useRef(null)
+
+  const { blobUrl, error: blobError } = useFetchBlobUrl(
+    fileHandle.contentSize > maxPdfSize
+      ? undefined
+      : SynapseClient.getPortalFileHandleServletUrl(
+          fha.fileHandleId,
+          fha.associateObjectId,
+          fha.associateObjectType,
+        ),
+  )
 
   const friendlyFileSize = calculateFriendlyFileSize(fileHandle.contentSize)
   if (fileHandle.contentSize > maxPdfSize) {
@@ -34,21 +42,20 @@ export default function PdfPreview(props: PdfPreviewProps) {
       </Alert>
     )
   }
-  const fhaUrl = SynapseClient.getPortalFileHandleServletUrl(
-    fha.fileHandleId,
-    fha.associateObjectId,
-    fha.associateObjectType,
-  )
+
+  if (blobError) {
+    return (
+      <Alert severity="error" sx={{ marginBottom: '20px' }}>
+        The PDF preview could not be loaded: {blobError.message}
+      </Alert>
+    )
+  }
+
+  if (!blobUrl) {
+    return <Skeleton variant="rectangular" width="100%" height="800px" />
+  }
+
   return (
-    <>
-      <iframe
-        ref={frameEl}
-        src={`${getEndpoint(
-          BackendDestinationEnum.PORTAL_ENDPOINT,
-        )}pdf.js/web/viewer.html?file=${encodeURIComponent(fhaUrl)}`}
-        height="800px"
-        style={{ border: 0, width: '100%' }}
-      />
-    </>
+    <iframe src={blobUrl} height="800px" style={{ border: 0, width: '100%' }} />
   )
 }

--- a/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementFields.tsx
+++ b/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementFields.tsx
@@ -278,10 +278,6 @@ export const SetManagedAccessRequirementFields = forwardRef(
                     setUpdatedAr({
                       ...updatedAr,
                       eDucTemplateId: template?.templateId,
-                      // mutually exclusive with file upload
-                      ...(template
-                        ? { ducTemplateFileHandleId: undefined }
-                        : {}),
                     })
                   }
                   getOptionLabel={template => template.name ?? ''}

--- a/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementFields.tsx
+++ b/packages/synapse-react-client/src/components/SetManagedAccessRequirementFields/SetManagedAccessRequirementFields.tsx
@@ -147,6 +147,7 @@ export const SetManagedAccessRequirementFields = forwardRef(
         setUpdatedAr({
           ...updatedAr,
           ducTemplateFileHandleId: uploadResponse.fileHandleId,
+          eDucTemplateId: undefined, // mutually exclusive with file upload
         })
       } else if (!data.success && data.error) {
         setUploadDucTemplateError(
@@ -249,6 +250,7 @@ export const SetManagedAccessRequirementFields = forwardRef(
                 <UploadDocumentField
                   id="duc"
                   isLoading={isUpdatingAccessRequirement}
+                  disabled={!updatedAr.isDUCRequired}
                   uploadCallback={resp => uploadDucTemplateCallback(resp)}
                   documentName="Template DUC"
                   fileHandleAssociations={
@@ -270,11 +272,16 @@ export const SetManagedAccessRequirementFields = forwardRef(
                   id="eDucTemplate"
                   options={eDucTemplates}
                   loading={isLoadingEDucTemplates}
+                  disabled={!updatedAr.isDUCRequired}
                   value={selectedEDucTemplate}
                   onChange={(_event, template) =>
                     setUpdatedAr({
                       ...updatedAr,
                       eDucTemplateId: template?.templateId,
+                      // mutually exclusive with file upload
+                      ...(template
+                        ? { ducTemplateFileHandleId: undefined }
+                        : {}),
                     })
                   }
                   getOptionLabel={template => template.name ?? ''}

--- a/packages/synapse-react-client/src/utils/hooks/useFetchBlobUrl.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useFetchBlobUrl.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Fetches a URL with credentials and returns a blob object URL.
+ * The object URL is revoked when the hook unmounts or the URL changes.
+ */
+export function useFetchBlobUrl(url: string | undefined): {
+  blobUrl: string | undefined
+  error: Error | undefined
+} {
+  const [blobUrl, setBlobUrl] = useState<string | undefined>()
+  const [error, setError] = useState<Error | undefined>()
+
+  useEffect(() => {
+    if (!url) return
+
+    const controller = new AbortController()
+    let objectUrl: string | undefined
+
+    fetch(url, { credentials: 'include', signal: controller.signal })
+      .then(r => r.blob())
+      .then(blob => {
+        objectUrl = URL.createObjectURL(blob)
+        setBlobUrl(objectUrl)
+      })
+      .catch(e => {
+        if (e instanceof Error && e.name === 'AbortError') return
+        setError(e instanceof Error ? e : new Error(String(e)))
+      })
+
+    return () => {
+      controller.abort()
+      if (objectUrl) URL.revokeObjectURL(objectUrl)
+    }
+  }, [url])
+
+  return { blobUrl, error }
+}

--- a/packages/synapse-react-client/src/utils/hooks/useFetchBlobUrl.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useFetchBlobUrl.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useCreateUrlForData } from './usePreFetchResource'
 
 /**
  * Fetches a URL with credentials and returns a blob object URL.
@@ -8,31 +9,26 @@ export function useFetchBlobUrl(url: string | undefined): {
   blobUrl: string | undefined
   error: Error | undefined
 } {
-  const [blobUrl, setBlobUrl] = useState<string | undefined>()
-  const [error, setError] = useState<Error | undefined>()
+  const { data: blob, error } = useQuery({
+    queryKey: ['useFetchBlobUrl', url],
+    queryFn: async () => {
+      const response = await fetch(url!, { credentials: 'include' })
+      return response.blob()
+    },
+    enabled: !!url,
+    // Fetched blobs should not be refetched automatically since the URL may expire.
+    staleTime: Infinity,
+  })
 
-  useEffect(() => {
-    if (!url) return
+  const blobUrl = useCreateUrlForData(blob)
 
-    const controller = new AbortController()
-    let objectUrl: string | undefined
-
-    fetch(url, { credentials: 'include', signal: controller.signal })
-      .then(r => r.blob())
-      .then(blob => {
-        objectUrl = URL.createObjectURL(blob)
-        setBlobUrl(objectUrl)
-      })
-      .catch(e => {
-        if (e instanceof Error && e.name === 'AbortError') return
-        setError(e instanceof Error ? e : new Error(String(e)))
-      })
-
-    return () => {
-      controller.abort()
-      if (objectUrl) URL.revokeObjectURL(objectUrl)
-    }
-  }, [url])
-
-  return { blobUrl, error }
+  return {
+    blobUrl,
+    error:
+      error instanceof Error
+        ? error
+        : error != null
+          ? new Error(String(error))
+          : undefined,
+  }
 }


### PR DESCRIPTION
Small update to the AR editor.  isDUCRequired must be set to true to use the eDUC template.
<img width="749" height="653" alt="Screenshot 2026-08-17 at 2 30 19 PM" src="https://github.com/user-attachments/assets/34c26981-aaa1-496a-9a7e-51cee1f9e7ef" />
<img width="1140" height="710" alt="Screenshot 2026-08-17 at 1 42 13 PM" src="https://github.com/user-attachments/assets/7016c923-78c3-46f8-94f5-b08d75736136" />

<img width="1152" height="713" alt="Screenshot 2026-08-17 at 1 42 49 PM" src="https://github.com/user-attachments/assets/fb0641ba-f59e-40fe-a179-b510c15e9772" />
<img width="1149" height="712" alt="Screenshot 2026-08-17 at 1 42 30 PM" src="https://github.com/user-attachments/assets/158f3bdc-19e1-4f51-b29b-8dcd4473c900" />
Note, fails to fetch due to CORS.  Verified that directly loading the synapse.org FHA portal servlet URL successfully downloads the file.  The preview should work properly in the staging/prod environment.
<img width="1169" height="546" alt="Screenshot 2026-08-17 at 2 34 09 PM" src="https://github.com/user-attachments/assets/8c0fc2e9-89f9-4858-a238-ef12ce1f07e1" />

