### PR TITLE
PORTALS-4403

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.test.tsx
@@ -6,6 +6,7 @@ import { MOCK_DATA_ACCESS_REQUEST } from '@/mocks/dataaccess/MockDataAccessReque
 import { server } from '@/mocks/msw/server'
 import SynapseClient from '@/synapse-client'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { DATA_ACCESS_REQUEST_SIGNATURE } from '@/utils/APIConstants'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
@@ -67,7 +68,7 @@ function renderComponent(props: EDucPreviewStepProps = defaultProps) {
 }
 
 const previewEndpoint = `*/repo/v1/dataAccessRequest/${MOCK_DATA_ACCESS_REQUEST.id}/preview`
-const signatureEndpoint = `*/repo/v1/dataAccessRequest/${MOCK_DATA_ACCESS_REQUEST.id}/signature`
+const signatureEndpoint = `*${DATA_ACCESS_REQUEST_SIGNATURE(MOCK_DATA_ACCESS_REQUEST.id)}`
 
 function successfulPreviewHandler() {
   return http.get(previewEndpoint, () =>

--- a/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
+++ b/packages/synapse-react-client/src/components/StorybookComponentWrapper.tsx
@@ -70,9 +70,8 @@ export function StorybookComponentWrapper(props: {
   const currentStack: SynapseStack = (storybookContext.globals.stack ||
     storybookContext.parameters.stack) as SynapseStack
 
-  useEffect(() => {
-    overrideEndpoint(currentStack)
-  }, [currentStack])
+  // Set endpoint synchronously so SynapseContextProvider picks up the correct basePath on first render.
+  overrideEndpoint(currentStack)
 
   // Subscribe to the framework-agnostic SynapseSessionManager for token/auth state
   // These methods are bound in the SynapseSessionManager constructor, so they are safe to pass directly.

--- a/packages/synapse-react-client/src/components/dataaccess/AccessRequirementDashboard.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/AccessRequirementDashboard.tsx
@@ -111,8 +111,8 @@ export function AccessRequirementDashboard(
     [setReviewerId],
   )
 
-  return (
-    <div className="AccessRequirementDashboard">
+  const accessRequirementsPanel = (
+    <>
       <EntityFinderModal
         configuration={{
           initialScope: FinderScope.ALL_PROJECTS,
@@ -222,7 +222,11 @@ export function AccessRequirementDashboard(
         typeFilter={typeFilter}
         onTypeFilterChange={setTypeFilter}
       />
-    </div>
+    </>
+  )
+
+  return (
+    <div className="AccessRequirementDashboard">{accessRequirementsPanel}</div>
   )
 }
 

--- a/packages/synapse-react-client/src/components/dataaccess/EDucTemplateTable.stories.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/EDucTemplateTable.stories.tsx
@@ -1,0 +1,61 @@
+import { getEDucTemplateHandlers } from '@/mocks/msw/handlers/eDucTemplateHandlers'
+import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
+import { EDUC_TEMPLATE, EDUC_TEMPLATE_VALIDATION } from '@/utils/APIConstants'
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { http, HttpResponse } from 'msw'
+import { EDucTemplateTable } from './EDucTemplateTable'
+
+const meta: Meta<typeof EDucTemplateTable> = {
+  title: 'Governance/eDUC Templates Table',
+  component: EDucTemplateTable,
+  parameters: {
+    stack: 'mock',
+    msw: {
+      handlers: getEDucTemplateHandlers(MOCK_REPO_ORIGIN),
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Demo: Story = {
+  name: 'Templates table',
+}
+
+export const InvalidTemplate: Story = {
+  name: 'Templates table — invalid validation result',
+  parameters: {
+    msw: {
+      handlers: [
+        // Override before the default handler so MSW's first-match wins.
+        http.get(
+          `${MOCK_REPO_ORIGIN}${EDUC_TEMPLATE_VALIDATION(':templateId')}`,
+          () =>
+            HttpResponse.json(
+              {
+                isValid: false,
+                reason: 'Template is missing required signer tab.',
+              },
+              { status: 200 },
+            ),
+        ),
+        ...getEDucTemplateHandlers(MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
+}
+
+export const EmptyList: Story = {
+  name: 'Templates table — empty',
+  parameters: {
+    msw: {
+      handlers: [
+        http.post(`${MOCK_REPO_ORIGIN}${EDUC_TEMPLATE}`, () =>
+          HttpResponse.json({ results: [] }, { status: 200 }),
+        ),
+      ],
+    },
+  },
+}

--- a/packages/synapse-react-client/src/components/dataaccess/EDucTemplateTable.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/EDucTemplateTable.test.tsx
@@ -1,0 +1,171 @@
+import { server } from '@/mocks/msw/server'
+import {
+  mockEDucTemplate1,
+  mockEDucTemplate2,
+  MOCK_EDUC_TEMPLATE_ID_1,
+} from '@/mocks/eDuc/mockEDucTemplates'
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { EDUC_TEMPLATE, EDUC_TEMPLATE_VALIDATION } from '@/utils/APIConstants'
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from '@/utils/functions/getEndpoint'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { EDucTemplateTable } from './EDucTemplateTable'
+
+const REPO_ORIGIN = getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)
+
+function renderComponent() {
+  const user = userEvent.setup()
+  const result = render(<EDucTemplateTable />, {
+    wrapper: createWrapper(),
+  })
+  return { user, ...result }
+}
+
+function templatesHandler(templates = [mockEDucTemplate1, mockEDucTemplate2]) {
+  return http.post(`${REPO_ORIGIN}${EDUC_TEMPLATE}`, () =>
+    HttpResponse.json({ results: templates }, { status: 200 }),
+  )
+}
+
+describe('EDucTemplateTable', () => {
+  beforeAll(() => server.listen())
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  it('renders template rows with name, description, and dates', async () => {
+    server.use(templatesHandler())
+    renderComponent()
+
+    await screen.findByText(mockEDucTemplate1.name!)
+    await screen.findByText(mockEDucTemplate1.description!)
+    await screen.findByText(mockEDucTemplate2.name!)
+    await screen.findByText(mockEDucTemplate2.description!)
+  })
+
+  it('shows an empty-state message when no templates are returned', async () => {
+    server.use(templatesHandler([]))
+    renderComponent()
+
+    await screen.findByText(/No eDUC templates are registered/i)
+  })
+
+  it('shows an error alert when the list query fails', async () => {
+    server.use(
+      http.post(`${REPO_ORIGIN}${EDUC_TEMPLATE}`, () =>
+        HttpResponse.json({ reason: 'list failed' }, { status: 500 }),
+      ),
+    )
+    renderComponent()
+
+    await screen.findByText(/couldn't load the eDUC templates/i)
+    expect(screen.getByText('list failed')).toBeInTheDocument()
+  })
+
+  it('shows a valid indicator when a row is validated successfully', async () => {
+    server.use(
+      templatesHandler(),
+      http.get(`${REPO_ORIGIN}${EDUC_TEMPLATE_VALIDATION(':templateId')}`, () =>
+        HttpResponse.json({ isValid: true }, { status: 200 }),
+      ),
+    )
+    const { user } = renderComponent()
+
+    const firstRow = (await screen.findByText(mockEDucTemplate1.name!)).closest(
+      'tr',
+    )!
+    const validateButton = within(firstRow).getByRole('button', {
+      name: 'Validate',
+    })
+    await user.click(validateButton)
+
+    await within(firstRow).findByText('Valid')
+  })
+
+  it('shows the reason when a row is invalid', async () => {
+    server.use(
+      templatesHandler(),
+      http.get(
+        `${REPO_ORIGIN}${EDUC_TEMPLATE_VALIDATION(MOCK_EDUC_TEMPLATE_ID_1)}`,
+        () =>
+          HttpResponse.json(
+            { isValid: false, reason: 'Missing required tab' },
+            { status: 200 },
+          ),
+      ),
+    )
+    const { user } = renderComponent()
+
+    const firstRow = (await screen.findByText(mockEDucTemplate1.name!)).closest(
+      'tr',
+    )!
+    const validateButton = within(firstRow).getByRole('button', {
+      name: 'Validate',
+    })
+    await user.click(validateButton)
+
+    await within(firstRow).findByText('Missing required tab')
+  })
+
+  it('shows the backend error reason when validation fails', async () => {
+    server.use(
+      templatesHandler(),
+      http.get(
+        `${REPO_ORIGIN}${EDUC_TEMPLATE_VALIDATION(MOCK_EDUC_TEMPLATE_ID_1)}`,
+        () =>
+          HttpResponse.json({ reason: 'Template not found' }, { status: 404 }),
+      ),
+    )
+    const { user } = renderComponent()
+
+    const firstRow = (await screen.findByText(mockEDucTemplate1.name!)).closest(
+      'tr',
+    )!
+    const validateButton = within(firstRow).getByRole('button', {
+      name: 'Validate',
+    })
+    await user.click(validateButton)
+
+    await within(firstRow).findByText('Template not found')
+  })
+
+  it('validates rows independently', async () => {
+    let template1Requests = 0
+    let template2Requests = 0
+    server.use(
+      templatesHandler(),
+      http.get(
+        `${REPO_ORIGIN}${EDUC_TEMPLATE_VALIDATION(':templateId')}`,
+        ({ params }) => {
+          if (params.templateId === mockEDucTemplate1.templateId) {
+            template1Requests += 1
+          } else {
+            template2Requests += 1
+          }
+          return HttpResponse.json({ isValid: true }, { status: 200 })
+        },
+      ),
+    )
+    const { user } = renderComponent()
+
+    const firstRow = (await screen.findByText(mockEDucTemplate1.name!)).closest(
+      'tr',
+    )!
+    const secondRow = (
+      await screen.findByText(mockEDucTemplate2.name!)
+    ).closest('tr')!
+
+    await user.click(within(firstRow).getByRole('button', { name: 'Validate' }))
+
+    await within(firstRow).findByText('Valid')
+    expect(
+      within(secondRow).getByRole('button', { name: 'Validate' }),
+    ).toBeInTheDocument()
+
+    await waitFor(() => expect(template1Requests).toBe(1))
+    expect(template2Requests).toBe(0)
+  })
+})

--- a/packages/synapse-react-client/src/components/dataaccess/EDucTemplateTable.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/EDucTemplateTable.tsx
@@ -3,8 +3,16 @@ import {
   useListEDucTemplates,
 } from '@/synapse-queries'
 import { formatDate } from '@/utils/functions/DateFormatter'
-import { CheckCircleTwoTone, ErrorTwoTone } from '@mui/icons-material'
-import { Alert, Box, Button, Skeleton, Typography } from '@mui/material'
+import { CheckCircleTwoTone, ErrorTwoTone, Replay } from '@mui/icons-material'
+import {
+  Alert,
+  Box,
+  Button,
+  IconButton,
+  Skeleton,
+  Tooltip,
+  Typography,
+} from '@mui/material'
 import { EDucTemplate } from '@sage-bionetworks/synapse-client'
 import {
   createColumnHelper,
@@ -61,7 +69,7 @@ function ValidationCell(props: { templateId: string | undefined }) {
   const { templateId } = props
   const [enabled, setEnabled] = useState(false)
 
-  const { data, error, isFetching } = useGetEDucTemplateValidation(
+  const { data, error, isFetching, refetch } = useGetEDucTemplateValidation(
     templateId ?? '',
     { enabled: enabled && Boolean(templateId) },
   )
@@ -95,6 +103,17 @@ function ValidationCell(props: { templateId: string | undefined }) {
         <Typography variant={'smallText1'} sx={{ color: 'error.main' }}>
           {error.reason}
         </Typography>
+        <Tooltip title={'Re-validate'}>
+          <IconButton
+            size={'small'}
+            onClick={() => {
+              refetch()
+            }}
+            aria-label={'Re-validate'}
+          >
+            <Replay fontSize={'small'} />
+          </IconButton>
+        </Tooltip>
       </Box>
     )
   }
@@ -104,6 +123,17 @@ function ValidationCell(props: { templateId: string | undefined }) {
       <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
         <CheckCircleTwoTone color={'success'} fontSize={'small'} />
         <Typography variant={'smallText1'}>Valid</Typography>
+        <Tooltip title={'Re-validate'}>
+          <IconButton
+            size={'small'}
+            onClick={() => {
+              refetch()
+            }}
+            aria-label={'Re-validate'}
+          >
+            <Replay fontSize={'small'} />
+          </IconButton>
+        </Tooltip>
       </Box>
     )
   }
@@ -114,6 +144,17 @@ function ValidationCell(props: { templateId: string | undefined }) {
       <Typography variant={'smallText1'} sx={{ color: 'error.main' }}>
         {data?.reason ?? 'Invalid'}
       </Typography>
+      <Tooltip title={'Re-validate'}>
+        <IconButton
+          size={'small'}
+          onClick={() => {
+            refetch()
+          }}
+          aria-label={'Re-validate'}
+        >
+          <Replay fontSize={'small'} />
+        </IconButton>
+      </Tooltip>
     </Box>
   )
 }

--- a/packages/synapse-react-client/src/components/dataaccess/EDucTemplateTable.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/EDucTemplateTable.tsx
@@ -67,21 +67,21 @@ const columns = [
 
 function ValidationCell(props: { templateId: string | undefined }) {
   const { templateId } = props
-  const [enabled, setEnabled] = useState(false)
+  const [hasRequestedValidation, setHasRequestedValidation] = useState(false)
 
   const { data, error, isFetching, refetch } = useGetEDucTemplateValidation(
     templateId ?? '',
-    { enabled: enabled && Boolean(templateId) },
+    { enabled: hasRequestedValidation && Boolean(templateId) },
   )
 
   if (!templateId) return null
 
-  if (!enabled) {
+  if (!hasRequestedValidation) {
     return (
       <Button
         variant={'outlined'}
         size={'small'}
-        onClick={() => setEnabled(true)}
+        onClick={() => setHasRequestedValidation(true)}
       >
         Validate
       </Button>

--- a/packages/synapse-react-client/src/components/dataaccess/EDucTemplateTable.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/EDucTemplateTable.tsx
@@ -1,0 +1,194 @@
+import {
+  useGetEDucTemplateValidation,
+  useListEDucTemplates,
+} from '@/synapse-queries'
+import { formatDate } from '@/utils/functions/DateFormatter'
+import { CheckCircleTwoTone, ErrorTwoTone } from '@mui/icons-material'
+import { Alert, Box, Button, Skeleton, Typography } from '@mui/material'
+import { EDucTemplate } from '@sage-bionetworks/synapse-client'
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import dayjs from 'dayjs'
+import { useEffect, useMemo, useState } from 'react'
+import { SynapseSpinner } from '../LoadingScreen/LoadingScreen'
+import ColumnHeader from '../TanStackTable/ColumnHeader'
+import StyledTanStackTable from '../TanStackTable/StyledTanStackTable'
+
+const columnHelper = createColumnHelper<EDucTemplate>()
+
+const columns = [
+  columnHelper.accessor('name', {
+    header: props => <ColumnHeader {...props} title={'Name'} />,
+    cell: ({ getValue }) => getValue() ?? '',
+    enableSorting: false,
+    enableColumnFilter: false,
+  }),
+  columnHelper.accessor('description', {
+    header: props => <ColumnHeader {...props} title={'Description'} />,
+    cell: ({ getValue }) => getValue() ?? '',
+    enableSorting: false,
+    enableColumnFilter: false,
+  }),
+  columnHelper.accessor('createdOn', {
+    header: props => <ColumnHeader {...props} title={'Created on'} />,
+    cell: ({ getValue }) => {
+      const value = getValue()
+      return value ? formatDate(dayjs(value)) : ''
+    },
+    enableSorting: false,
+    enableColumnFilter: false,
+  }),
+  columnHelper.accessor('modifiedOn', {
+    header: props => <ColumnHeader {...props} title={'Modified on'} />,
+    cell: ({ getValue }) => {
+      const value = getValue()
+      return value ? formatDate(dayjs(value)) : ''
+    },
+    enableSorting: false,
+    enableColumnFilter: false,
+  }),
+  columnHelper.display({
+    id: 'validation',
+    header: props => <ColumnHeader {...props} title={'Validation status'} />,
+    cell: ({ row }) => <ValidationCell templateId={row.original.templateId} />,
+  }),
+]
+
+function ValidationCell(props: { templateId: string | undefined }) {
+  const { templateId } = props
+  const [enabled, setEnabled] = useState(false)
+
+  const { data, error, isFetching } = useGetEDucTemplateValidation(
+    templateId ?? '',
+    { enabled: enabled && Boolean(templateId) },
+  )
+
+  if (!templateId) return null
+
+  if (!enabled) {
+    return (
+      <Button
+        variant={'outlined'}
+        size={'small'}
+        onClick={() => setEnabled(true)}
+      >
+        Validate
+      </Button>
+    )
+  }
+
+  if (isFetching) {
+    return (
+      <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
+        <SynapseSpinner size={16} />
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+        <ErrorTwoTone color={'error'} fontSize={'small'} />
+        <Typography variant={'smallText1'} sx={{ color: 'error.main' }}>
+          {error.reason}
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (data?.isValid) {
+    return (
+      <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+        <CheckCircleTwoTone color={'success'} fontSize={'small'} />
+        <Typography variant={'smallText1'}>Valid</Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+      <ErrorTwoTone color={'error'} fontSize={'small'} />
+      <Typography variant={'smallText1'} sx={{ color: 'error.main' }}>
+        {data?.reason ?? 'Invalid'}
+      </Typography>
+    </Box>
+  )
+}
+
+export function EDucTemplateTable() {
+  const {
+    data,
+    isLoading,
+    error,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useListEDucTemplates()
+
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage()
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  const templates = useMemo(
+    () => data?.pages.flatMap(page => page.results ?? []) ?? [],
+    [data],
+  )
+
+  const table = useReactTable<EDucTemplate>({
+    data: templates,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: row => row.templateId ?? '',
+  })
+
+  if (isLoading || (hasNextPage && templates.length === 0)) {
+    return (
+      <Box>
+        <Skeleton
+          variant={'rectangular'}
+          height={200}
+          data-testid={'EDucTemplateTable-loading'}
+        />
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Alert severity={'error'}>
+        <strong>Sorry, we couldn&apos;t load the eDUC templates.</strong>
+        <br />
+        {error.reason}
+      </Alert>
+    )
+  }
+
+  if (templates.length === 0) {
+    return (
+      <Alert severity={'info'}>
+        No eDUC templates are registered in DocuSign.
+      </Alert>
+    )
+  }
+
+  return (
+    <Box>
+      <Typography variant={'body1'} sx={{ mb: 2, color: 'grey.700' }}>
+        Templates are managed in DocuSign. Use the <strong>Validate</strong>{' '}
+        action to check whether a template meets Synapse&apos;s eDUC
+        requirements.
+      </Typography>
+      <StyledTanStackTable
+        table={table}
+        styledTableContainerProps={{ sx: { my: 2 } }}
+      />
+    </Box>
+  )
+}
+
+export default EDucTemplateTable

--- a/packages/synapse-react-client/src/components/dataaccess/ReviewerDashboard.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/ReviewerDashboard.test.tsx
@@ -122,9 +122,10 @@ describe('ReviewerDashboard tests', () => {
 
     await screen.findByRole('tablist')
     const tabs = screen.getAllByRole('tab')
-    expect(tabs).toHaveLength(3)
+    expect(tabs).toHaveLength(4)
 
     screen.getByRole('tab', { name: 'Access Requirements' })
+    screen.getByRole('tab', { name: 'eDUC Templates' })
     screen.getByRole('tab', { name: 'Submissions' })
     screen.getByRole('tab', { name: 'User Access History' })
   })

--- a/packages/synapse-react-client/src/components/dataaccess/ReviewerDashboard.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/ReviewerDashboard.tsx
@@ -19,6 +19,7 @@ import OrientationBanner from '../OrientationBanner'
 import { UserHistoryDashboard } from './AccessHistoryDashboard'
 import { AccessRequirementDashboard } from './AccessRequirementDashboard'
 import { DataAccessSubmissionDashboard } from './AccessSubmissionDashboard'
+import { EDucTemplateTable } from './EDucTemplateTable'
 import SubmissionPage from './SubmissionPage/SubmissionPage'
 
 function LinkTab(props: { href: string; children: ReactNode; icon: IconName }) {
@@ -67,6 +68,11 @@ export function ReviewerDashboard(props: ReviewerDashboardProps) {
                   Access Requirements
                 </LinkTab>
               )}
+              {hasActPermissions && (
+                <LinkTab href="/EDucTemplates" icon="fileOutlined">
+                  eDUC Templates
+                </LinkTab>
+              )}
               {hasReviewerPermissions && (
                 <LinkTab href="/Submissions" icon="discussion">
                   Submissions
@@ -89,6 +95,10 @@ export function ReviewerDashboard(props: ReviewerDashboardProps) {
           {
             path: 'AccessRequirements',
             element: hasActPermissions ? <AccessRequirementDashboard /> : null,
+          },
+          {
+            path: 'EDucTemplates',
+            element: hasActPermissions ? <EDucTemplateTable /> : null,
           },
           {
             path: 'Submissions',

--- a/packages/synapse-react-client/src/mocks/msw/handlers/eDucTemplateHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/eDucTemplateHandlers.ts
@@ -1,5 +1,8 @@
-import { EDUC_TEMPLATE } from '@/utils/APIConstants'
-import { EDucTemplatePage } from '@sage-bionetworks/synapse-client'
+import { EDUC_TEMPLATE, EDUC_TEMPLATE_VALIDATION } from '@/utils/APIConstants'
+import {
+  EDucTemplatePage,
+  EDucTemplateValidationResult,
+} from '@sage-bionetworks/synapse-client'
 import { http, HttpResponse } from 'msw'
 import { mockEDucTemplates } from '../../eDuc/mockEDucTemplates'
 
@@ -11,5 +14,12 @@ export function getEDucTemplateHandlers(backendOrigin: string) {
       }
       return HttpResponse.json(response)
     }),
+    http.get(
+      `${backendOrigin}${EDUC_TEMPLATE_VALIDATION(':templateId')}`,
+      () => {
+        const response: EDucTemplateValidationResult = { isValid: true }
+        return HttpResponse.json(response)
+      },
+    ),
   ]
 }

--- a/packages/synapse-react-client/src/utils/APIConstants.ts
+++ b/packages/synapse-react-client/src/utils/APIConstants.ts
@@ -222,6 +222,8 @@ export const ACCESS_REQUIREMENT_DATA_ACCESS_REQUEST_FOR_UPDATE = (
   `${ACCESS_REQUIREMENT_BY_ID(accessRequirementId)}/dataAccessRequestForUpdate`
 
 export const EDUC_TEMPLATE = `${REPO}/eDuc/template`
+export const EDUC_TEMPLATE_VALIDATION = (templateId: string) =>
+  `${EDUC_TEMPLATE}/${templateId}/validation`
 
 export const RESEARCH_PROJECT = `${REPO}/researchProject`
 export const ACCESS_REQUIREMENT_RESEARCH_PROJECT_FOR_UPDATE = (


### PR DESCRIPTION
Builds off of https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/3094

Adds templates table, and eDUC templates tab to AR dashboard (visible to ACT only)

<img width="1510" height="610" alt="Screenshot 2026-08-18 at 3 39 52 PM" src="https://github.com/user-attachments/assets/829967a7-bd58-4149-8a16-b9b155f70012" />
After clicking on the "Validate" button on each row.
<img width="1511" height="633" alt="Screenshot 2026-08-18 at 3 40 03 PM" src="https://github.com/user-attachments/assets/8763fde6-cbcf-4e6b-a81a-61718d9d075f" />

Also, a dedicated set of stories for the templates table itself (all valid, all invalid, and empty).
<img width="1502" height="588" alt="Screenshot 2026-08-18 at 3 33 55 PM" src="https://github.com/user-attachments/assets/5fe41237-f116-4122-99c5-49e98c128909" />
<img width="1512" height="709" alt="Screenshot 2026-08-18 at 3 34 04 PM" src="https://github.com/user-attachments/assets/40bc95e4-f97b-41da-abdf-992ecc946266" />
<img width="1512" height="668" alt="Screenshot 2026-08-18 at 3 34 11 PM" src="https://github.com/user-attachments/assets/0708228d-62b9-4e35-abe8-46a050bef806" />
