### PR TITLE
PORTALS-4417 Switch NF portal news

### DIFF
--- a/apps/portals/nf/src/config/navbarConfig.ts
+++ b/apps/portals/nf/src/config/navbarConfig.ts
@@ -67,7 +67,7 @@ export const navbarConfig: NavbarConfig = {
       name: 'About',
       path: '/About',
       children: [
-        { name: 'News', path: 'https://news.nfdataportal.org/' },
+        { name: 'News', path: 'https://news.nf.synapse.org/' },
         {
           name: 'Roadmap',
           path: 'https://nfosi-community-tools.vercel.app/roadmap',

--- a/apps/portals/nf/src/pages/HomePage.tsx
+++ b/apps/portals/nf/src/pages/HomePage.tsx
@@ -79,7 +79,7 @@ const STUDIES_INITIAL_LIMIT = 3
 const FEATURED_USER_CARD_SQL = `${peopleSql} where isFeatured=true`
 const FEATURED_USER_CARD_COUNT = 3
 
-const RSS_URL = 'https://news.nfdataportal.org'
+const RSS_URL = 'https://news.nf.synapse.org'
 const RSS_FILTER = { value: 'featured' }
 
 const GOALS_ENTITY_ID = 'syn23516796'
@@ -172,7 +172,9 @@ export default function HomePage() {
             url={RSS_URL}
             itemsToShow={3}
             allowCategories={[
-              'Newsletter',
+              'New Feature',
+              'Researcher Spotlight',
+              'Press Release',
               'Hackathon',
               'Publication',
               'Funding',


### PR DESCRIPTION
NF news site migrated off WordPress; point the homepage RSS feed and navbar News link at the new site, which supports the same /tag/<slug>/?feed=rss2 convention RssFeedCards already expects. Also refresh allowCategories to match the new site's actual category vocab.