### PR TITLE
PORTALS-4379

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
@@ -345,7 +345,6 @@ export default function AccessRequirementList(
       RequestDataStep.UPDATE_RESEARCH_PROJECT,
       RequestDataStep.REVIEW_DUC,
       RequestDataStep.EDUC_PREVIEW,
-      RequestDataStep.MANUAL_UPLOAD_DUC,
     ].includes(requestDataStep) && canShowManagedACTWikiInWizard
       ? 'xl'
       : 'md'

--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
@@ -44,6 +44,7 @@ import RequestDataAccessSuccess from './ManagedACTAccessRequirementRequestFlow/R
 import ResearchProjectForm from './ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm'
 import ReviewDucStep from './ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep'
 import EDucPreviewStep from './ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep'
+import ManualUploadDucStep from './ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep'
 import AuthenticatedRequirement from './RequirementItem/AuthenticatedRequirement'
 import CertificationRequirement from './RequirementItem/CertificationRequirement'
 import TwoFactorAuthEnabledRequirement from './RequirementItem/TwoFactorAuthEnabledRequirement'
@@ -140,6 +141,7 @@ enum RequestDataStep {
   COMPLETE = 5,
   REVIEW_DUC = 6,
   EDUC_PREVIEW = 7,
+  MANUAL_UPLOAD_DUC = 8,
 }
 
 export type RequestDataStepCallbackArgs = {
@@ -343,6 +345,7 @@ export default function AccessRequirementList(
       RequestDataStep.UPDATE_RESEARCH_PROJECT,
       RequestDataStep.REVIEW_DUC,
       RequestDataStep.EDUC_PREVIEW,
+      RequestDataStep.MANUAL_UPLOAD_DUC,
     ].includes(requestDataStep) && canShowManagedACTWikiInWizard
       ? 'xl'
       : 'md'
@@ -427,9 +430,27 @@ export default function AccessRequirementList(
           onSendForSignature={() => {
             requestDataStepCallback({ step: RequestDataStep.COMPLETE })
           }}
-          // TODO PORTALS-4379: replace with the manual print-and-upload step.
           onManualUpload={() => {
+            requestDataStepCallback({
+              step: RequestDataStep.MANUAL_UPLOAD_DUC,
+            })
+          }}
+        />
+      )
+      break
+    case RequestDataStep.MANUAL_UPLOAD_DUC:
+      renderContent = (
+        <ManualUploadDucStep
+          managedACTAccessRequirement={managedACTAccessRequirement!}
+          subjectId={subjectId ?? ''}
+          subjectType={subjectType ?? RestrictableObjectType.ENTITY}
+          onHide={onHide}
+          onBackClicked={() => {
+            requestDataStepCallback({ step: RequestDataStep.EDUC_PREVIEW })
+          }}
+          onSubmissionCreated={submissionId => {
             requestDataStepCallback({ step: RequestDataStep.COMPLETE })
+            onSubmissionCreated(submissionId)
           }}
         />
       )

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/CancelRequestDataAccess.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/CancelRequestDataAccess.tsx
@@ -59,7 +59,7 @@ function CancelRequestDataAccess(props: CancelRequestDataAccessProps) {
         >
           Save Changes
           <Box sx={{ flexGrow: 1 }} />
-          <IconButton onClick={onHide}>
+          <IconButton aria-label={'Close'} onClick={onHide}>
             <IconSvg icon={'close'} wrap={false} sx={{ color: 'grey.700' }} />
           </IconButton>
         </Stack>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.stories.tsx
@@ -4,6 +4,7 @@ import { getAccessRequirementHandlers } from '@/mocks/msw/handlers/accessRequire
 import { getDataAccessRequestHandlers } from '@/mocks/msw/handlers/dataAccessRequestHandlers'
 import { getUserProfileHandlers } from '@/mocks/msw/handlers/userProfileHandlers'
 import { getWikiHandlers } from '@/mocks/msw/handlers/wikiHandlers'
+import { DATA_ACCESS_REQUEST_PREVIEW } from '@/utils/APIConstants'
 import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
 import { Meta, StoryObj } from '@storybook/react-vite'
 import { http, HttpResponse } from 'msw'
@@ -16,7 +17,7 @@ const eDucManagedACTAccessRequirement = {
 
 // The story renders the chrome around the iframe; the iframe src is overridden via previewSrcOverride.
 const previewHandler = http.get(
-  `${MOCK_REPO_ORIGIN}/repo/v1/dataAccessRequest/${MOCK_DATA_ACCESS_REQUEST.id}/preview`,
+  `${MOCK_REPO_ORIGIN}${DATA_ACCESS_REQUEST_PREVIEW(MOCK_DATA_ACCESS_REQUEST.id)}`,
   () =>
     HttpResponse.json(
       { fileHandleId: 'mock-preview-file-handle-123' },
@@ -64,7 +65,7 @@ export const PreviewError: Story = {
     msw: {
       handlers: [
         http.get(
-          `${MOCK_REPO_ORIGIN}/repo/v1/dataAccessRequest/${MOCK_DATA_ACCESS_REQUEST.id}/preview`,
+          `${MOCK_REPO_ORIGIN}${DATA_ACCESS_REQUEST_PREVIEW(MOCK_DATA_ACCESS_REQUEST.id)}`,
           () =>
             HttpResponse.json(
               { reason: 'Preview could not be generated at this time.' },

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.test.tsx
@@ -6,7 +6,10 @@ import { MOCK_DATA_ACCESS_REQUEST } from '@/mocks/dataaccess/MockDataAccessReque
 import { server } from '@/mocks/msw/server'
 import SynapseClient from '@/synapse-client'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
-import { DATA_ACCESS_REQUEST_SIGNATURE } from '@/utils/APIConstants'
+import {
+  DATA_ACCESS_REQUEST_PREVIEW,
+  DATA_ACCESS_REQUEST_SIGNATURE,
+} from '@/utils/APIConstants'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
@@ -67,7 +70,7 @@ function renderComponent(props: EDucPreviewStepProps = defaultProps) {
   return { user, component }
 }
 
-const previewEndpoint = `*/repo/v1/dataAccessRequest/${MOCK_DATA_ACCESS_REQUEST.id}/preview`
+const previewEndpoint = `*${DATA_ACCESS_REQUEST_PREVIEW(MOCK_DATA_ACCESS_REQUEST.id)}`
 const signatureEndpoint = `*${DATA_ACCESS_REQUEST_SIGNATURE(MOCK_DATA_ACCESS_REQUEST.id)}`
 
 function successfulPreviewHandler() {

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
@@ -103,7 +103,7 @@ export default function EDucPreviewStep(props: EDucPreviewStepProps) {
         <Stack direction="row" sx={{ alignItems: 'center', gap: '5px' }}>
           Request Access
           <Box sx={{ flexGrow: 1 }} />
-          <IconButton onClick={onHide}>
+          <IconButton aria-label={'Close'} onClick={onHide}>
             <IconSvg icon={'close'} wrap={false} sx={{ color: 'grey.700' }} />
           </IconButton>
         </Stack>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.stories.tsx
@@ -26,6 +26,15 @@ const mockDarWithCollaborators = {
     { userId: String(MOCK_USER_ID), type: AccessType.GAIN_ACCESS },
     { userId: String(MOCK_USER_ID_2), type: AccessType.GAIN_ACCESS },
   ],
+  principalInvestigator: {
+    userId: String(MOCK_USER_ID),
+    name: 'Dr. Jane Smith',
+    institutionalEmail: 'jane.smith@example.edu',
+  },
+  signingOfficial: {
+    name: 'John Official',
+    institutionalEmail: 'john.official@example.edu',
+  },
   ducFileHandleId: undefined,
 }
 

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.stories.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.stories.tsx
@@ -1,0 +1,71 @@
+import { mockManagedACTAccessRequirement } from '@/mocks/accessRequirement/mockAccessRequirements'
+import { MOCK_DATA_ACCESS_REQUEST } from '@/mocks/dataaccess/MockDataAccessRequest'
+import { getAccessRequirementHandlers } from '@/mocks/msw/handlers/accessRequirementHandlers'
+import { getDataAccessRequestHandlers } from '@/mocks/msw/handlers/dataAccessRequestHandlers'
+import { getUserProfileHandlers } from '@/mocks/msw/handlers/userProfileHandlers'
+import { getWikiHandlers } from '@/mocks/msw/handlers/wikiHandlers'
+import { MOCK_USER_ID, MOCK_USER_ID_2 } from '@/mocks/user/mock_user_profile'
+import { ACCESS_REQUIREMENT_DATA_ACCESS_REQUEST_FOR_UPDATE } from '@/utils/APIConstants'
+import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
+import {
+  AccessType,
+  RestrictableObjectType,
+} from '@sage-bionetworks/synapse-types'
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { http, HttpResponse } from 'msw'
+import ManualUploadDucStep from './ManualUploadDucStep'
+
+const eDucManagedACTAccessRequirement = {
+  ...mockManagedACTAccessRequirement,
+  eDucTemplateId: 'template-abc-123',
+}
+
+const mockDarWithCollaborators = {
+  ...MOCK_DATA_ACCESS_REQUEST,
+  accessorChanges: [
+    { userId: String(MOCK_USER_ID), type: AccessType.GAIN_ACCESS },
+    { userId: String(MOCK_USER_ID_2), type: AccessType.GAIN_ACCESS },
+  ],
+  ducFileHandleId: undefined,
+}
+
+const overrideDarHandler = http.get(
+  `${MOCK_REPO_ORIGIN}${ACCESS_REQUIREMENT_DATA_ACCESS_REQUEST_FOR_UPDATE(
+    eDucManagedACTAccessRequirement.id,
+  )}`,
+  () => HttpResponse.json(mockDarWithCollaborators, { status: 200 }),
+)
+
+const meta: Meta<typeof ManualUploadDucStep> = {
+  title:
+    'Governance/Data Access Request Flow/Managed Access Requirement/Step 2d - Manual Upload DUC',
+  component: ManualUploadDucStep,
+  parameters: {
+    stack: 'mock',
+    chromatic: { viewports: [600, 1200] },
+    msw: {
+      handlers: [
+        overrideDarHandler,
+        ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
+        ...getWikiHandlers(MOCK_REPO_ORIGIN),
+        ...getAccessRequirementHandlers(MOCK_REPO_ORIGIN),
+        ...getDataAccessRequestHandlers(MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const ManualUpload: Story = {
+  name: 'Manual print & upload DUC step',
+  args: {
+    managedACTAccessRequirement: eDucManagedACTAccessRequirement,
+    subjectId: '9876543',
+    subjectType: RestrictableObjectType.ENTITY,
+    downloadHrefOverride:
+      'https://www.rd.usda.gov/sites/default/files/pdf-sample_0.pdf',
+  },
+}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
@@ -33,7 +33,7 @@ import ManualUploadDucStep, {
 // Controls what response the mock upload button fires; reset to success in beforeEach.
 let mockUploadResponse: UploadCallbackResp = {
   success: true,
-  resp: { fileHandleId: 'new-file-123' },
+  resp: { fileHandleId: 'new-file-123', fileName: 'signed-duc.pdf' },
 }
 
 vi.mock('../UploadDocumentField', () => ({
@@ -125,7 +125,7 @@ describe('ManualUploadDucStep', () => {
     mockOnSubmissionCreated.mockReset()
     mockUploadResponse = {
       success: true,
-      resp: { fileHandleId: 'new-file-123' },
+      resp: { fileHandleId: 'new-file-123', fileName: 'signed-duc.pdf' },
     }
     mockGetDataRequestForUpdate.mockResolvedValue({
       ...MOCK_DATA_ACCESS_REQUEST,

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
@@ -13,13 +13,15 @@ import SynapseClient from '@/synapse-client'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
 import {
   DATA_ACCESS_REQUEST,
+  DATA_ACCESS_REQUEST_PREVIEW,
   DATA_ACCESS_REQUEST_SUBMISSION,
 } from '@/utils/APIConstants'
 import {
   AccessType,
   RestrictableObjectType,
+  UploadCallbackResp,
 } from '@sage-bionetworks/synapse-types'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import MarkdownSynapse from '../../../Markdown/MarkdownSynapse'
@@ -27,6 +29,18 @@ import * as AccessRequirementListUtils from '../../AccessRequirementListUtils'
 import ManualUploadDucStep, {
   ManualUploadDucStepProps,
 } from './ManualUploadDucStep'
+
+// Capture the uploadCallback prop so tests can fire it directly.
+let capturedUploadCallback: ((resp: UploadCallbackResp) => void) | undefined
+
+vi.mock('../UploadDocumentField', () => ({
+  UploadDocumentField: vi.fn(
+    (props: { uploadCallback: (resp: UploadCallbackResp) => void }) => {
+      capturedUploadCallback = props.uploadCallback
+      return null
+    },
+  ),
+}))
 
 vi.mock('../../../Markdown/MarkdownSynapse', () => ({
   __esModule: true,
@@ -87,7 +101,7 @@ function renderComponent(props: Partial<ManualUploadDucStepProps> = {}) {
   return { user, component }
 }
 
-const previewEndpoint = `*/repo/v1/dataAccessRequest/${MOCK_DATA_ACCESS_REQUEST.id}/preview`
+const previewEndpoint = `*${DATA_ACCESS_REQUEST_PREVIEW(MOCK_DATA_ACCESS_REQUEST.id)}`
 const updateEndpoint = `*${DATA_ACCESS_REQUEST}`
 const submissionEndpoint = `*${DATA_ACCESS_REQUEST_SUBMISSION(
   MOCK_DATA_ACCESS_REQUEST.id,
@@ -210,10 +224,7 @@ describe('ManualUploadDucStep', () => {
 
   it('invokes onHide when the close icon is clicked', async () => {
     const { user } = renderComponent()
-    const closeButton = await screen.findAllByRole('button')
-    // First button in the DialogTitle is the close IconButton.
-    const iconClose = closeButton.find(b => b.querySelector('svg'))
-    await user.click(iconClose!)
+    await user.click(await screen.findByRole('button', { name: 'Close' }))
     expect(mockOnHide).toHaveBeenCalledTimes(1)
   })
 
@@ -274,6 +285,38 @@ describe('ManualUploadDucStep', () => {
 
     await screen.findByText(/couldn't submit your request/i)
     expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(mockOnSubmissionCreated).not.toHaveBeenCalled()
+  })
+
+  it('shows the save-error alert when the upload callback signals a failure', async () => {
+    renderComponent()
+    await screen.findByRole('button', { name: 'Submit Request' })
+    act(() => {
+      capturedUploadCallback!({
+        success: false,
+        error: { reason: 'File upload failed' },
+      })
+    })
+    await screen.findByText(/couldn't save your change/i)
+    expect(screen.getByText('File upload failed')).toBeInTheDocument()
+  })
+
+  it('shows the save-error alert when the pre-submit DAR persist fails', async () => {
+    mockGetDataRequestForUpdate.mockResolvedValue({
+      ...MOCK_DATA_ACCESS_REQUEST,
+      ducFileHandleId: 'signed-duc-987',
+    })
+    server.use(
+      http.post(updateEndpoint, () =>
+        HttpResponse.json({ reason: 'Server error' }, { status: 500 }),
+      ),
+    )
+    const { user } = renderComponent()
+    const submit = await screen.findByRole('button', { name: 'Submit Request' })
+    await waitFor(() => expect(submit).toBeEnabled())
+    await user.click(submit)
+    await screen.findByText(/couldn't save your change/i)
+    expect(screen.getByText('Server error')).toBeInTheDocument()
     expect(mockOnSubmissionCreated).not.toHaveBeenCalled()
   })
 })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
@@ -1,0 +1,279 @@
+import {
+  mockManagedACTAccessRequirement,
+  mockManagedACTAccessRequirementWikiPageKey,
+} from '@/mocks/accessRequirement/mockAccessRequirements'
+import { MOCK_DATA_ACCESS_REQUEST } from '@/mocks/dataaccess/MockDataAccessRequest'
+import { server } from '@/mocks/msw/server'
+import {
+  MOCK_USER_ID,
+  MOCK_USER_ID_2,
+  mockUserData,
+} from '@/mocks/user/mock_user_profile'
+import SynapseClient from '@/synapse-client'
+import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import {
+  DATA_ACCESS_REQUEST,
+  DATA_ACCESS_REQUEST_SUBMISSION,
+} from '@/utils/APIConstants'
+import {
+  AccessType,
+  RestrictableObjectType,
+} from '@sage-bionetworks/synapse-types'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import MarkdownSynapse from '../../../Markdown/MarkdownSynapse'
+import * as AccessRequirementListUtils from '../../AccessRequirementListUtils'
+import ManualUploadDucStep, {
+  ManualUploadDucStepProps,
+} from './ManualUploadDucStep'
+
+vi.mock('../../../Markdown/MarkdownSynapse', () => ({
+  __esModule: true,
+  default: vi.fn(),
+}))
+const mockMarkdownSynapse = vi.mocked(MarkdownSynapse)
+mockMarkdownSynapse.mockImplementation(() => (
+  <div data-testid={'MarkdownSynapseContent'}></div>
+))
+
+vi.spyOn(SynapseClient, 'getUserProfileById').mockImplementation(id => {
+  return Promise.resolve(
+    mockUserData.find(user => String(user.id) === String(id))!.userProfile!,
+  )
+})
+vi.spyOn(SynapseClient, 'getUserBundle').mockImplementation(id => {
+  return Promise.resolve(
+    mockUserData.find(user => String(user.id) === String(id))!.userBundle!,
+  )
+})
+
+const mockGetDataRequestForUpdate = vi.spyOn(
+  SynapseClient,
+  'getDataAccessRequestForUpdate',
+)
+
+vi.spyOn(SynapseClient, 'getWikiPageKeyForAccessRequirement').mockResolvedValue(
+  mockManagedACTAccessRequirementWikiPageKey,
+)
+vi.spyOn(
+  AccessRequirementListUtils,
+  'useCanShowManagedACTWikiInWizard',
+).mockReturnValue(true)
+
+const mockOnHide = vi.fn()
+const mockOnBackClicked = vi.fn()
+const mockOnSubmissionCreated = vi.fn()
+
+const defaultProps: ManualUploadDucStepProps = {
+  managedACTAccessRequirement: {
+    ...mockManagedACTAccessRequirement,
+    eDucTemplateId: 'educ-template-123',
+  },
+  subjectId: '9876543',
+  subjectType: RestrictableObjectType.ENTITY,
+  onHide: mockOnHide,
+  onBackClicked: mockOnBackClicked,
+  onSubmissionCreated: mockOnSubmissionCreated,
+  downloadHrefOverride: 'https://example.com/mock-duc.pdf',
+}
+
+function renderComponent(props: Partial<ManualUploadDucStepProps> = {}) {
+  const user = userEvent.setup()
+  const component = render(
+    <ManualUploadDucStep {...defaultProps} {...props} />,
+    { wrapper: createWrapper({ withErrorBoundary: true }) },
+  )
+  return { user, component }
+}
+
+const previewEndpoint = `*/repo/v1/dataAccessRequest/${MOCK_DATA_ACCESS_REQUEST.id}/preview`
+const updateEndpoint = `*${DATA_ACCESS_REQUEST}`
+const submissionEndpoint = `*${DATA_ACCESS_REQUEST_SUBMISSION(
+  MOCK_DATA_ACCESS_REQUEST.id,
+)}`
+
+describe('ManualUploadDucStep', () => {
+  beforeAll(() => server.listen())
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  beforeEach(() => {
+    mockOnHide.mockReset()
+    mockOnBackClicked.mockReset()
+    mockOnSubmissionCreated.mockReset()
+    mockGetDataRequestForUpdate.mockResolvedValue({
+      ...MOCK_DATA_ACCESS_REQUEST,
+      ducFileHandleId: undefined,
+      accessorChanges: [
+        { userId: String(MOCK_USER_ID), type: AccessType.GAIN_ACCESS },
+        { userId: String(MOCK_USER_ID_2), type: AccessType.GAIN_ACCESS },
+      ],
+    })
+  })
+
+  it('renders the "Submit a signed PDF" heading and instructional text', async () => {
+    renderComponent()
+
+    await screen.findByRole('heading', {
+      name: /Submit a signed PDF instead of e-signatures/i,
+    })
+    expect(
+      screen.getByText(
+        /Instead of signing the Data Use Certificate \(DUC\) using DocuSign/i,
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/we recommend using e-signatures/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders a collapsed "Review your list of collaborators" panel by default', async () => {
+    renderComponent()
+    const summary = await screen.findByRole('button', {
+      name: /Review your list of collaborators/i,
+    })
+    expect(summary).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('expands the collaborators panel and lists accessors', async () => {
+    const { user } = renderComponent()
+    const summary = await screen.findByRole('button', {
+      name: /Review your list of collaborators/i,
+    })
+    await user.click(summary)
+    await waitFor(() =>
+      expect(summary).toHaveAttribute('aria-expanded', 'true'),
+    )
+    // Each accessor renders a UserBadge — verify the profile lookup was invoked for both.
+    await waitFor(() => {
+      expect(SynapseClient.getUserBundle).toHaveBeenCalledWith(
+        String(MOCK_USER_ID),
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+  })
+
+  it('renders the Download DUC anchor with the override href', async () => {
+    renderComponent()
+    const downloadLink = await screen.findByRole('link', {
+      name: /Download DUC for Signatures/i,
+    })
+    expect(downloadLink).toHaveAttribute(
+      'href',
+      'https://example.com/mock-duc.pdf',
+    )
+  })
+
+  it('shows an error alert when the preview query fails and no override is provided', async () => {
+    server.use(
+      http.get(previewEndpoint, () =>
+        HttpResponse.json({ reason: 'preview failed' }, { status: 500 }),
+      ),
+    )
+    renderComponent({ downloadHrefOverride: undefined })
+
+    await screen.findByText(/couldn't prepare your DUC for download/i)
+    expect(screen.getByText('preview failed')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: /Download DUC for Signatures/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('disables the Submit Request button when no signed DUC has been uploaded', async () => {
+    renderComponent()
+    const submit = await screen.findByRole('button', {
+      name: 'Submit Request',
+    })
+    expect(submit).toBeDisabled()
+  })
+
+  it('enables Submit Request when the DAR already has a ducFileHandleId', async () => {
+    mockGetDataRequestForUpdate.mockResolvedValue({
+      ...MOCK_DATA_ACCESS_REQUEST,
+      ducFileHandleId: 'signed-duc-987',
+    })
+    renderComponent()
+    const submit = await screen.findByRole('button', {
+      name: 'Submit Request',
+    })
+    await waitFor(() => expect(submit).toBeEnabled())
+  })
+
+  it('invokes onBackClicked when Back is clicked', async () => {
+    const { user } = renderComponent()
+    const backButton = await screen.findByRole('button', { name: 'Back' })
+    await user.click(backButton)
+    expect(mockOnBackClicked).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes onHide when the close icon is clicked', async () => {
+    const { user } = renderComponent()
+    const closeButton = await screen.findAllByRole('button')
+    // First button in the DialogTitle is the close IconButton.
+    const iconClose = closeButton.find(b => b.querySelector('svg'))
+    await user.click(iconClose!)
+    expect(mockOnHide).toHaveBeenCalledTimes(1)
+  })
+
+  it('submits the DAR and invokes onSubmissionCreated on success', async () => {
+    mockGetDataRequestForUpdate.mockResolvedValue({
+      ...MOCK_DATA_ACCESS_REQUEST,
+      ducFileHandleId: 'signed-duc-987',
+    })
+    let updateCallCount = 0
+    let submitCallCount = 0
+    server.use(
+      http.post(updateEndpoint, async ({ request }) => {
+        updateCallCount += 1
+        const body = (await request.json()) as { id: string; etag: string }
+        return HttpResponse.json({ ...body, etag: 'new-etag' }, { status: 201 })
+      }),
+      http.post(submissionEndpoint, () => {
+        submitCallCount += 1
+        return HttpResponse.json({ submissionId: 'sub-42' }, { status: 201 })
+      }),
+    )
+
+    const { user } = renderComponent()
+    const submit = await screen.findByRole('button', {
+      name: 'Submit Request',
+    })
+    await waitFor(() => expect(submit).toBeEnabled())
+    await user.click(submit)
+
+    await waitFor(() =>
+      expect(mockOnSubmissionCreated).toHaveBeenCalledWith('sub-42'),
+    )
+    expect(updateCallCount).toBe(1)
+    expect(submitCallCount).toBe(1)
+  })
+
+  it('shows an error alert when the submission call fails', async () => {
+    mockGetDataRequestForUpdate.mockResolvedValue({
+      ...MOCK_DATA_ACCESS_REQUEST,
+      ducFileHandleId: 'signed-duc-987',
+    })
+    server.use(
+      http.post(updateEndpoint, async ({ request }) => {
+        const body = (await request.json()) as { id: string; etag: string }
+        return HttpResponse.json({ ...body, etag: 'new-etag' }, { status: 201 })
+      }),
+      http.post(submissionEndpoint, () =>
+        HttpResponse.json({ reason: 'Something went wrong' }, { status: 500 }),
+      ),
+    )
+
+    const { user } = renderComponent()
+    const submit = await screen.findByRole('button', {
+      name: 'Submit Request',
+    })
+    await waitFor(() => expect(submit).toBeEnabled())
+    await user.click(submit)
+
+    await screen.findByText(/couldn't submit your request/i)
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(mockOnSubmissionCreated).not.toHaveBeenCalled()
+  })
+})

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
@@ -21,7 +21,7 @@ import {
   RestrictableObjectType,
   UploadCallbackResp,
 } from '@sage-bionetworks/synapse-types'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import MarkdownSynapse from '../../../Markdown/MarkdownSynapse'
@@ -30,15 +30,22 @@ import ManualUploadDucStep, {
   ManualUploadDucStepProps,
 } from './ManualUploadDucStep'
 
-// Capture the uploadCallback prop so tests can fire it directly.
-let capturedUploadCallback: ((resp: UploadCallbackResp) => void) | undefined
+// Controls what response the mock upload button fires; reset to success in beforeEach.
+let mockUploadResponse: UploadCallbackResp = {
+  success: true,
+  resp: { fileHandleId: 'new-file-123' },
+}
 
 vi.mock('../UploadDocumentField', () => ({
   UploadDocumentField: vi.fn(
-    (props: { uploadCallback: (resp: UploadCallbackResp) => void }) => {
-      capturedUploadCallback = props.uploadCallback
-      return null
-    },
+    (props: {
+      uploadCallback: (resp: UploadCallbackResp) => void
+      documentName: string
+    }) => (
+      <button onClick={() => props.uploadCallback(mockUploadResponse)}>
+        Upload {props.documentName}
+      </button>
+    ),
   ),
 }))
 
@@ -116,6 +123,10 @@ describe('ManualUploadDucStep', () => {
     mockOnHide.mockReset()
     mockOnBackClicked.mockReset()
     mockOnSubmissionCreated.mockReset()
+    mockUploadResponse = {
+      success: true,
+      resp: { fileHandleId: 'new-file-123' },
+    }
     mockGetDataRequestForUpdate.mockResolvedValue({
       ...MOCK_DATA_ACCESS_REQUEST,
       ducFileHandleId: undefined,
@@ -289,14 +300,14 @@ describe('ManualUploadDucStep', () => {
   })
 
   it('shows the save-error alert when the upload callback signals a failure', async () => {
-    renderComponent()
-    await screen.findByRole('button', { name: 'Submit Request' })
-    act(() => {
-      capturedUploadCallback!({
-        success: false,
-        error: { reason: 'File upload failed' },
-      })
-    })
+    mockUploadResponse = {
+      success: false,
+      error: { reason: 'File upload failed' },
+    }
+    const { user } = renderComponent()
+    await user.click(
+      await screen.findByRole('button', { name: /Upload Signed DUC/i }),
+    )
     await screen.findByText(/couldn't save your change/i)
     expect(screen.getByText('File upload failed')).toBeInTheDocument()
   })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
@@ -128,10 +128,10 @@ describe('ManualUploadDucStep', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders a collapsed "Review your list of collaborators" panel by default', async () => {
+  it('renders a collapsed collaborators & signing official panel by default', async () => {
     renderComponent()
     const summary = await screen.findByRole('button', {
-      name: /Review your list of collaborators/i,
+      name: /Review your collaborators & signing official/i,
     })
     expect(summary).toHaveAttribute('aria-expanded', 'false')
   })
@@ -139,7 +139,7 @@ describe('ManualUploadDucStep', () => {
   it('expands the collaborators panel and lists accessors', async () => {
     const { user } = renderComponent()
     const summary = await screen.findByRole('button', {
-      name: /Review your list of collaborators/i,
+      name: /Review your collaborators & signing official/i,
     })
     await user.click(summary)
     await waitFor(() =>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
@@ -3,6 +3,7 @@ import {
   useGetDataAccessRequestPreview,
   useSubmitDataAccessRequest,
   useUpdateDataAccessRequest,
+  useVoidDataAccessRequestSignature,
 } from '@/synapse-queries'
 import SynapseClient from '@/synapse-client'
 import { ExpandMore } from '@mui/icons-material'
@@ -65,11 +66,14 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
     downloadHrefOverride,
   } = props
 
-  const { data: dataAccessRequest, isLoading: isLoadingDar } =
-    useGetDataAccessRequestForUpdate(String(managedACTAccessRequirement.id), {
-      staleTime: Infinity,
-      throwOnError: true,
-    })
+  const {
+    data: dataAccessRequest,
+    isLoading: isLoadingDar,
+    refetch: refetchDar,
+  } = useGetDataAccessRequestForUpdate(String(managedACTAccessRequirement.id), {
+    staleTime: Infinity,
+    throwOnError: true,
+  })
 
   const {
     data: previewFileHandle,
@@ -97,6 +101,11 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
     onError: e => setUpdateError(e.reason),
   })
 
+  const { mutateAsync: voidSignatureAsync, isPending: isVoidingSignature } =
+    useVoidDataAccessRequestSignature({
+      onError: e => setUpdateError(e.reason),
+    })
+
   const { mutate: submit, isPending: isSubmitting } =
     useSubmitDataAccessRequest({
       onSuccess: submission => onSubmissionCreated(submission.submissionId),
@@ -123,9 +132,10 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
     !dataAccessRequest ||
     !signedDucFileHandleId ||
     isUpdating ||
+    isVoidingSignature ||
     isSubmitting
 
-  const handleUpload = (resp: UploadCallbackResp) => {
+  const handleUpload = async (resp: UploadCallbackResp) => {
     if (!resp.success || !resp.resp || !dataAccessRequest) {
       const errorObj = resp.error as { reason?: unknown } | undefined
       const reason =
@@ -138,8 +148,23 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
       return
     }
     setUpdateError(undefined)
+    // Only void a prior eDUC signature routing if one was actually sent. If the user ejected
+    // from EDucPreviewStep before sending for signature, there's nothing to void.
+    const hasSignatureEnvelope = Boolean(
+      dataAccessRequest.eDucSignatureEnvelopeId,
+    )
+    let latestDar = dataAccessRequest
+    if (hasSignatureEnvelope) {
+      try {
+        await voidSignatureAsync(dataAccessRequest.id)
+      } catch {
+        return
+      }
+      const refreshed = await refetchDar()
+      latestDar = refreshed.data ?? dataAccessRequest
+    }
     updateRequest({
-      ...dataAccessRequest,
+      ...latestDar,
       ducFileHandleId: resp.resp.fileHandleId,
     })
   }
@@ -300,8 +325,10 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
                 <UploadDocumentField
                   id={'signed-duc'}
                   documentName={'Signed DUC'}
-                  isLoading={isUpdating}
-                  uploadCallback={handleUpload}
+                  isLoading={isUpdating || isVoidingSignature}
+                  uploadCallback={resp => {
+                    handleUpload(resp)
+                  }}
                   fileHandleAssociations={signedDucFileHandleAssociations}
                 />
               )}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
@@ -31,7 +31,6 @@ import {
 import { useState } from 'react'
 import IconSvg from '../../../IconSvg/IconSvg'
 import { UserBadge } from '../../../UserCard/UserBadge'
-import ManagedACTAccessRequirementFormWikiWrapper from '../ManagedACTAccessRequirementFormWikiWrapper'
 import { UploadDocumentField } from '../UploadDocumentField'
 import { longFieldLabelSx } from '../styles'
 
@@ -128,8 +127,13 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
 
   const handleUpload = (resp: UploadCallbackResp) => {
     if (!resp.success || !resp.resp || !dataAccessRequest) {
-      if (resp.error) {
-        setUpdateError(resp.error.reason)
+      const errorObj = resp.error as { reason?: unknown } | undefined
+      const reason =
+        errorObj && typeof errorObj.reason === 'string'
+          ? errorObj.reason
+          : undefined
+      if (reason) {
+        setUpdateError(reason)
       }
       return
     }
@@ -169,169 +173,156 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
         </Stack>
       </DialogTitle>
       <DialogContent>
-        <ManagedACTAccessRequirementFormWikiWrapper
-          managedACTAccessRequirementId={String(managedACTAccessRequirement.id)}
-        >
-          <Box>
-            <Typography variant={'headline3'} sx={{ mb: 2 }}>
-              Submit a signed PDF instead of e-signatures
-            </Typography>
-            <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 2 }}>
-              Instead of signing the Data Use Certificate (DUC) using DocuSign,
-              you can download the DUC as a PDF and then upload it after it has
-              been signed by your collaborators, your project lead, and your
-              Signing Official.
-            </Typography>
-            <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 3 }}>
-              However, we recommend using e-signatures, as it is usually faster,
-              and prevents common errors which can result in your request being
-              rejected.
-            </Typography>
+        <Box>
+          <Typography variant={'headline3'} sx={{ mb: 2 }}>
+            Submit a signed PDF instead of e-signatures
+          </Typography>
+          <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 2 }}>
+            Instead of signing the Data Use Certificate (DUC) using DocuSign,
+            you can download the DUC as a PDF and then upload it after it has
+            been signed by your collaborators, your project lead, and your
+            Signing Official.
+          </Typography>
+          <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 3 }}>
+            However, we recommend using e-signatures, as it is usually faster,
+            and prevents common errors which can result in your request being
+            rejected.
+          </Typography>
 
-            <Accordion
-              defaultExpanded={false}
-              disableGutters
-              sx={{
-                boxShadow: 'none',
-                borderTop: '1px solid',
-                borderBottom: '1px solid',
-                borderColor: 'grey.300',
-                '&:before': { display: 'none' },
-                mb: 3,
-              }}
+          <Accordion
+            defaultExpanded={false}
+            disableGutters
+            sx={{
+              boxShadow: 'none',
+              borderTop: '1px solid',
+              borderBottom: '1px solid',
+              borderColor: 'grey.300',
+              '&:before': { display: 'none' },
+              mb: 3,
+            }}
+          >
+            <AccordionSummary
+              expandIcon={<ExpandMore />}
+              aria-controls="review-collaborators-content"
+              id="review-collaborators-header"
             >
-              <AccordionSummary
-                expandIcon={<ExpandMore />}
-                aria-controls="review-collaborators-content"
-                id="review-collaborators-header"
-              >
-                <Typography variant={'headline3'}>
-                  Review your list of collaborators
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Stack sx={{ gap: 1 }}>
-                  {accessorChanges.length === 0 && !isLoadingDar && (
-                    <Typography variant={'body1'} sx={longFieldLabelSx}>
-                      No collaborators added.
-                    </Typography>
-                  )}
-                  {accessorChanges.map(ac => (
-                    <UserBadge
-                      key={ac.userId}
-                      userId={ac.userId}
-                      showAccountLevelIcon={true}
-                      disableLink={true}
-                      showFullName={true}
-                    />
-                  ))}
-                </Stack>
-              </AccordionDetails>
-            </Accordion>
-
-            <Typography variant={'headline3'} sx={{ mb: 2 }}>
-              Instructions
-            </Typography>
-            <Stack
-              direction={{ xs: 'column', md: 'row' }}
-              sx={{ gap: 4, alignItems: 'flex-start' }}
-            >
-              <Box sx={{ flex: 1 }}>
-                <Typography variant={'body1'} sx={{ fontWeight: 700, mb: 1 }}>
-                  Step 1. Download your Data Use Certificate
-                </Typography>
-                <Typography
-                  variant={'body1'}
-                  sx={{ ...longFieldLabelSx, mb: 2 }}
-                >
-                  As a first step, you will need to download a PDF of the Data
-                  Use Certificate with the names of your Collaborators and
-                  Signing Official. Make sure the names are correct and complete
-                  before downloading.
-                </Typography>
-                <Typography
-                  variant={'body1'}
-                  sx={{ ...longFieldLabelSx, mb: 2 }}
-                >
-                  If needed, you can modify the printed list of collaborators by
-                  adding or removing names on the paper copy before uploading.
-                </Typography>
-                {previewError ? (
-                  <Alert severity={'error'}>
-                    <strong>
-                      Sorry, we couldn&apos;t prepare your DUC for download.
-                    </strong>
-                    <br />
-                    {previewError.reason}
-                  </Alert>
-                ) : (
-                  <Button
-                    component="a"
-                    href={downloadHref ?? undefined}
-                    target="_blank"
-                    rel="noopener"
-                    variant={'outlined'}
-                    disabled={isDownloadDisabled}
-                    endIcon={<IconSvg icon={'download'} wrap={false} />}
-                  >
-                    Download DUC for Signatures
-                  </Button>
+              <Typography variant={'headline3'}>
+                Review your list of collaborators
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Stack sx={{ gap: 1 }}>
+                {accessorChanges.length === 0 && !isLoadingDar && (
+                  <Typography variant={'body1'} sx={longFieldLabelSx}>
+                    No collaborators added.
+                  </Typography>
                 )}
-              </Box>
-              <Box sx={{ flex: 1 }}>
-                <Typography variant={'body1'} sx={{ fontWeight: 700, mb: 1 }}>
-                  Step 2. Fill out and upload a Data Use Certificate
-                </Typography>
-                <Typography
-                  variant={'body1'}
-                  sx={{ ...longFieldLabelSx, mb: 2 }}
-                >
-                  You must download and fill out a Data Use Certificate (DUC).
-                  Be sure to upload the completed DUC below.
-                </Typography>
-                <Typography
-                  variant={'body1'}
-                  component={'ol'}
-                  sx={{ ...longFieldLabelSx, mb: 2, pl: 3 }}
-                >
-                  <li>Download the DUC document.</li>
-                  <li>
-                    Fill out the DUC, following the instructions in the PDF.
-                  </li>
-                  <li>
-                    Upload the completed certificate using the button below:
-                  </li>
-                </Typography>
-                {isLoadingDar ? (
-                  <Skeleton variant={'rectangular'} width={200} height={36} />
-                ) : (
-                  <UploadDocumentField
-                    id={'signed-duc'}
-                    documentName={'Signed DUC'}
-                    isLoading={isUpdating}
-                    uploadCallback={handleUpload}
-                    fileHandleAssociations={signedDucFileHandleAssociations}
+                {accessorChanges.map(ac => (
+                  <UserBadge
+                    key={ac.userId}
+                    userId={ac.userId}
+                    showAccountLevelIcon={true}
+                    disableLink={true}
+                    showFullName={true}
                   />
-                )}
-              </Box>
-            </Stack>
+                ))}
+              </Stack>
+            </AccordionDetails>
+          </Accordion>
 
-            {updateError && (
-              <Alert severity={'error'} sx={{ mt: 2 }}>
-                <strong>Sorry, we couldn&apos;t save your uploaded DUC.</strong>
-                <br />
-                {updateError}
-              </Alert>
-            )}
-            {submitError && (
-              <Alert severity={'error'} sx={{ mt: 2 }}>
-                <strong>Sorry, we couldn&apos;t submit your request.</strong>
-                <br />
-                {submitError}
-              </Alert>
-            )}
-          </Box>
-        </ManagedACTAccessRequirementFormWikiWrapper>
+          <Typography variant={'headline3'} sx={{ mb: 2 }}>
+            Instructions
+          </Typography>
+          <Stack
+            direction={{ xs: 'column', md: 'row' }}
+            sx={{ gap: 4, alignItems: 'flex-start' }}
+          >
+            <Box sx={{ flex: 1 }}>
+              <Typography variant={'body1'} sx={{ fontWeight: 700, mb: 1 }}>
+                Step 1. Download your Data Use Certificate
+              </Typography>
+              <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 2 }}>
+                As a first step, you will need to download a PDF of the Data Use
+                Certificate with the names of your Collaborators and Signing
+                Official. Make sure the names are correct and complete before
+                downloading.
+              </Typography>
+              <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 2 }}>
+                If needed, you can modify the printed list of collaborators by
+                adding or removing names on the paper copy before uploading.
+              </Typography>
+              {previewError ? (
+                <Alert severity={'error'}>
+                  <strong>
+                    Sorry, we couldn&apos;t prepare your DUC for download.
+                  </strong>
+                  <br />
+                  {previewError.reason}
+                </Alert>
+              ) : (
+                <Button
+                  component="a"
+                  href={downloadHref ?? undefined}
+                  target="_blank"
+                  rel="noopener"
+                  variant={'outlined'}
+                  disabled={isDownloadDisabled}
+                  endIcon={<IconSvg icon={'download'} wrap={false} />}
+                >
+                  Download DUC for Signatures
+                </Button>
+              )}
+            </Box>
+            <Box sx={{ flex: 1 }}>
+              <Typography variant={'body1'} sx={{ fontWeight: 700, mb: 1 }}>
+                Step 2. Fill out and upload a Data Use Certificate
+              </Typography>
+              <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 2 }}>
+                You must download and fill out a Data Use Certificate (DUC). Be
+                sure to upload the completed DUC below.
+              </Typography>
+              <Typography
+                variant={'body1'}
+                component={'ol'}
+                sx={{ ...longFieldLabelSx, mb: 2, pl: 3 }}
+              >
+                <li>Download the DUC document.</li>
+                <li>
+                  Fill out the DUC, following the instructions in the PDF.
+                </li>
+                <li>
+                  Upload the completed certificate using the button below:
+                </li>
+              </Typography>
+              {isLoadingDar ? (
+                <Skeleton variant={'rectangular'} width={200} height={36} />
+              ) : (
+                <UploadDocumentField
+                  id={'signed-duc'}
+                  documentName={'Signed DUC'}
+                  isLoading={isUpdating}
+                  uploadCallback={handleUpload}
+                  fileHandleAssociations={signedDucFileHandleAssociations}
+                />
+              )}
+            </Box>
+          </Stack>
+
+          {updateError && (
+            <Alert severity={'error'} sx={{ mt: 2 }}>
+              <strong>Sorry, we couldn&apos;t save your uploaded DUC.</strong>
+              <br />
+              {updateError}
+            </Alert>
+          )}
+          {submitError && (
+            <Alert severity={'error'} sx={{ mt: 2 }}>
+              <strong>Sorry, we couldn&apos;t submit your request.</strong>
+              <br />
+              {submitError}
+            </Alert>
+          )}
+        </Box>
       </DialogContent>
       <DialogActions>
         <Button variant={'outlined'} onClick={onBackClicked}>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
@@ -86,26 +86,26 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
       ? SynapseClient.getPortalFileHandleServletUrl(previewFileHandleId)
       : undefined)
 
-  const [updateError, setUpdateError] = useState<string | undefined>()
-  const [submitError, setSubmitError] = useState<string | undefined>()
+  const [updateDarError, setUpdateDarError] = useState<string | undefined>()
+  const [submitDarError, setSubmitDarError] = useState<string | undefined>()
 
   const {
-    mutate: updateRequest,
-    mutateAsync: updateRequestAsync,
+    mutate: updateDar,
+    mutateAsync: updateDarAsync,
     isPending: isUpdating,
   } = useUpdateDataAccessRequest({
-    onError: e => setUpdateError(e.reason),
+    onError: e => setUpdateDarError(e.reason),
   })
 
   const { mutateAsync: voidSignatureAsync, isPending: isVoidingSignature } =
     useVoidDataAccessRequestSignature({
-      onError: e => setUpdateError(e.reason),
+      onError: e => setUpdateDarError(e.reason),
     })
 
   const { mutate: submit, isPending: isSubmitting } =
     useSubmitDataAccessRequest({
       onSuccess: submission => onSubmissionCreated(submission.submissionId),
-      onError: e => setSubmitError(e.reason),
+      onError: e => setSubmitDarError(e.reason),
     })
 
   const accessorChanges = dataAccessRequest?.accessorChanges ?? []
@@ -141,11 +141,11 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
           ? errorObj.reason
           : undefined
       if (reason) {
-        setUpdateError(reason)
+        setUpdateDarError(reason)
       }
       return
     }
-    setUpdateError(undefined)
+    setUpdateDarError(undefined)
     // Only void a prior eDUC signature routing if one was actually sent. If the user ejected
     // from EDucPreviewStep before sending for signature, there's nothing to void.
     const hasSignatureEnvelope = Boolean(
@@ -161,7 +161,7 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
       const refreshed = await refetchDar()
       latestDar = refreshed.data ?? dataAccessRequest
     }
-    updateRequest({
+    updateDar({
       ...latestDar,
       ducFileHandleId: resp.resp.fileHandleId,
     })
@@ -169,9 +169,9 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
 
   const handleSubmit = async () => {
     if (!dataAccessRequest) return
-    setSubmitError(undefined)
+    setSubmitDarError(undefined)
     // Persist the DAR once more so the submission uses the latest etag.
-    const latest = await updateRequestAsync(dataAccessRequest).catch(() => null)
+    const latest = await updateDarAsync(dataAccessRequest).catch(() => null)
     if (!latest) return
     submit({
       request: {
@@ -190,7 +190,7 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
         <Stack direction="row" sx={{ alignItems: 'center', gap: '5px' }}>
           Request Access
           <Box sx={{ flexGrow: 1 }} />
-          <IconButton onClick={onHide}>
+          <IconButton aria-label={'Close'} onClick={onHide}>
             <IconSvg icon={'close'} wrap={false} sx={{ color: 'grey.700' }} />
           </IconButton>
         </Stack>
@@ -301,18 +301,18 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
             </Box>
           </Stack>
 
-          {updateError && (
+          {updateDarError && (
             <Alert severity={'error'} sx={{ mt: 2 }}>
-              <strong>Sorry, we couldn&apos;t save your uploaded DUC.</strong>
+              <strong>Sorry, we couldn&apos;t save your change.</strong>
               <br />
-              {updateError}
+              {updateDarError}
             </Alert>
           )}
-          {submitError && (
+          {submitDarError && (
             <Alert severity={'error'} sx={{ mt: 2 }}>
               <strong>Sorry, we couldn&apos;t submit your request.</strong>
               <br />
-              {submitError}
+              {submitDarError}
             </Alert>
           )}
         </Box>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
@@ -6,11 +6,7 @@ import {
   useVoidDataAccessRequestSignature,
 } from '@/synapse-queries'
 import SynapseClient from '@/synapse-client'
-import { ExpandMore } from '@mui/icons-material'
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
   Alert,
   Box,
   Button,
@@ -31,7 +27,7 @@ import {
 } from '@sage-bionetworks/synapse-types'
 import { useState } from 'react'
 import IconSvg from '../../../IconSvg/IconSvg'
-import { UserBadge } from '../../../UserCard/UserBadge'
+import { ReviewCollaboratorsAndSigningOfficialAccordion } from '../ReviewCollaboratorsAndSigningOfficialAccordion'
 import { UploadDocumentField } from '../UploadDocumentField'
 import { longFieldLabelSx } from '../styles'
 
@@ -113,6 +109,8 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
     })
 
   const accessorChanges = dataAccessRequest?.accessorChanges ?? []
+  const pi = dataAccessRequest?.principalInvestigator
+  const so = dataAccessRequest?.signingOfficial
   const signedDucFileHandleId = dataAccessRequest?.ducFileHandleId
   const signedDucFileHandleAssociations: FileHandleAssociation[] =
     signedDucFileHandleId && dataAccessRequest?.id
@@ -214,46 +212,14 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
             rejected.
           </Typography>
 
-          <Accordion
-            defaultExpanded={false}
-            disableGutters
-            sx={{
-              boxShadow: 'none',
-              borderTop: '1px solid',
-              borderBottom: '1px solid',
-              borderColor: 'grey.300',
-              '&:before': { display: 'none' },
-              mb: 3,
-            }}
-          >
-            <AccordionSummary
-              expandIcon={<ExpandMore />}
-              aria-controls="review-collaborators-content"
-              id="review-collaborators-header"
-            >
-              <Typography variant={'headline3'}>
-                Review your list of collaborators
-              </Typography>
-            </AccordionSummary>
-            <AccordionDetails>
-              <Stack sx={{ gap: 1 }}>
-                {accessorChanges.length === 0 && !isLoadingDar && (
-                  <Typography variant={'body1'} sx={longFieldLabelSx}>
-                    No collaborators added.
-                  </Typography>
-                )}
-                {accessorChanges.map(ac => (
-                  <UserBadge
-                    key={ac.userId}
-                    userId={ac.userId}
-                    showAccountLevelIcon={true}
-                    disableLink={true}
-                    showFullName={true}
-                  />
-                ))}
-              </Stack>
-            </AccordionDetails>
-          </Accordion>
+          <Box sx={{ mb: 3 }}>
+            <ReviewCollaboratorsAndSigningOfficialAccordion
+              accessorChanges={accessorChanges}
+              principalInvestigator={pi}
+              signingOfficial={so}
+              isLoading={isLoadingDar}
+            />
+          </Box>
 
           <Typography variant={'headline3'} sx={{ mb: 2 }}>
             Instructions

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
@@ -1,0 +1,354 @@
+import {
+  useGetDataAccessRequestForUpdate,
+  useGetDataAccessRequestPreview,
+  useSubmitDataAccessRequest,
+  useUpdateDataAccessRequest,
+} from '@/synapse-queries'
+import SynapseClient from '@/synapse-client'
+import { ExpandMore } from '@mui/icons-material'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material'
+import {
+  FileHandleAssociateType,
+  FileHandleAssociation,
+  ManagedACTAccessRequirement,
+  RestrictableObjectType,
+  UploadCallbackResp,
+} from '@sage-bionetworks/synapse-types'
+import { useState } from 'react'
+import IconSvg from '../../../IconSvg/IconSvg'
+import { UserBadge } from '../../../UserCard/UserBadge'
+import ManagedACTAccessRequirementFormWikiWrapper from '../ManagedACTAccessRequirementFormWikiWrapper'
+import { UploadDocumentField } from '../UploadDocumentField'
+import { longFieldLabelSx } from '../styles'
+
+export type ManualUploadDucStepProps = {
+  managedACTAccessRequirement: ManagedACTAccessRequirement
+  subjectId: string
+  subjectType: RestrictableObjectType
+  onHide: () => void
+  onBackClicked: () => void
+  onSubmissionCreated: (submissionId: string) => void
+  /**
+   * Optional href override for the "Download DUC for Signatures" anchor. When set, the preview
+   * file handle fetch is skipped and this URL is used directly. Used by stories and tests where
+   * the portal servlet is not available.
+   */
+  downloadHrefOverride?: string
+}
+
+/**
+ * Wizard step shown after the eDUC preview (PORTALS-4377) when the user chooses to manually
+ * print, sign, and upload a PDF instead of using electronic signatures. Lets the user download
+ * the partially-populated DUC, upload a signed copy, and submit the request.
+ */
+export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
+  const {
+    managedACTAccessRequirement,
+    subjectId,
+    subjectType,
+    onHide,
+    onBackClicked,
+    onSubmissionCreated,
+    downloadHrefOverride,
+  } = props
+
+  const { data: dataAccessRequest, isLoading: isLoadingDar } =
+    useGetDataAccessRequestForUpdate(String(managedACTAccessRequirement.id), {
+      staleTime: Infinity,
+      throwOnError: true,
+    })
+
+  const {
+    data: previewFileHandle,
+    isLoading: isLoadingPreview,
+    error: previewError,
+  } = useGetDataAccessRequestPreview(dataAccessRequest?.id ?? '', {
+    enabled: Boolean(dataAccessRequest?.id) && !downloadHrefOverride,
+  })
+
+  const previewFileHandleId = previewFileHandle?.fileHandleId
+  const downloadHref =
+    downloadHrefOverride ??
+    (previewFileHandleId
+      ? SynapseClient.getPortalFileHandleServletUrl(previewFileHandleId)
+      : undefined)
+
+  const [updateError, setUpdateError] = useState<string | undefined>()
+  const [submitError, setSubmitError] = useState<string | undefined>()
+
+  const {
+    mutate: updateRequest,
+    mutateAsync: updateRequestAsync,
+    isPending: isUpdating,
+  } = useUpdateDataAccessRequest({
+    onError: e => setUpdateError(e.reason),
+  })
+
+  const { mutate: submit, isPending: isSubmitting } =
+    useSubmitDataAccessRequest({
+      onSuccess: submission => onSubmissionCreated(submission.submissionId),
+      onError: e => setSubmitError(e.reason),
+    })
+
+  const accessorChanges = dataAccessRequest?.accessorChanges ?? []
+  const signedDucFileHandleId = dataAccessRequest?.ducFileHandleId
+  const signedDucFileHandleAssociations: FileHandleAssociation[] =
+    signedDucFileHandleId && dataAccessRequest?.id
+      ? [
+          {
+            fileHandleId: signedDucFileHandleId,
+            associateObjectType:
+              FileHandleAssociateType.DataAccessRequestAttachment,
+            associateObjectId: dataAccessRequest.id,
+          },
+        ]
+      : []
+
+  const isDownloadDisabled = isLoadingDar || isLoadingPreview || !downloadHref
+  const isSubmitDisabled =
+    isLoadingDar ||
+    !dataAccessRequest ||
+    !signedDucFileHandleId ||
+    isUpdating ||
+    isSubmitting
+
+  const handleUpload = (resp: UploadCallbackResp) => {
+    if (!resp.success || !resp.resp || !dataAccessRequest) {
+      if (resp.error) {
+        setUpdateError(resp.error.reason)
+      }
+      return
+    }
+    setUpdateError(undefined)
+    updateRequest({
+      ...dataAccessRequest,
+      ducFileHandleId: resp.resp.fileHandleId,
+    })
+  }
+
+  const handleSubmit = async () => {
+    if (!dataAccessRequest) return
+    setSubmitError(undefined)
+    // Persist the DAR once more so the submission uses the latest etag.
+    const latest = await updateRequestAsync(dataAccessRequest).catch(() => null)
+    if (!latest) return
+    submit({
+      request: {
+        requestId: latest.id,
+        requestEtag: latest.etag,
+        subjectId,
+        subjectType,
+      },
+      accessRequirementId: String(managedACTAccessRequirement.id),
+    })
+  }
+
+  return (
+    <>
+      <DialogTitle>
+        <Stack direction="row" sx={{ alignItems: 'center', gap: '5px' }}>
+          Request Access
+          <Box sx={{ flexGrow: 1 }} />
+          <IconButton onClick={onHide}>
+            <IconSvg icon={'close'} wrap={false} sx={{ color: 'grey.700' }} />
+          </IconButton>
+        </Stack>
+      </DialogTitle>
+      <DialogContent>
+        <ManagedACTAccessRequirementFormWikiWrapper
+          managedACTAccessRequirementId={String(managedACTAccessRequirement.id)}
+        >
+          <Box>
+            <Typography variant={'headline3'} sx={{ mb: 2 }}>
+              Submit a signed PDF instead of e-signatures
+            </Typography>
+            <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 2 }}>
+              Instead of signing the Data Use Certificate (DUC) using DocuSign,
+              you can download the DUC as a PDF and then upload it after it has
+              been signed by your collaborators, your project lead, and your
+              Signing Official.
+            </Typography>
+            <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 3 }}>
+              However, we recommend using e-signatures, as it is usually faster,
+              and prevents common errors which can result in your request being
+              rejected.
+            </Typography>
+
+            <Accordion
+              defaultExpanded={false}
+              disableGutters
+              sx={{
+                boxShadow: 'none',
+                borderTop: '1px solid',
+                borderBottom: '1px solid',
+                borderColor: 'grey.300',
+                '&:before': { display: 'none' },
+                mb: 3,
+              }}
+            >
+              <AccordionSummary
+                expandIcon={<ExpandMore />}
+                aria-controls="review-collaborators-content"
+                id="review-collaborators-header"
+              >
+                <Typography variant={'headline3'}>
+                  Review your list of collaborators
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Stack sx={{ gap: 1 }}>
+                  {accessorChanges.length === 0 && !isLoadingDar && (
+                    <Typography variant={'body1'} sx={longFieldLabelSx}>
+                      No collaborators added.
+                    </Typography>
+                  )}
+                  {accessorChanges.map(ac => (
+                    <UserBadge
+                      key={ac.userId}
+                      userId={ac.userId}
+                      showAccountLevelIcon={true}
+                      disableLink={true}
+                      showFullName={true}
+                    />
+                  ))}
+                </Stack>
+              </AccordionDetails>
+            </Accordion>
+
+            <Typography variant={'headline3'} sx={{ mb: 2 }}>
+              Instructions
+            </Typography>
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              sx={{ gap: 4, alignItems: 'flex-start' }}
+            >
+              <Box sx={{ flex: 1 }}>
+                <Typography variant={'body1'} sx={{ fontWeight: 700, mb: 1 }}>
+                  Step 1. Download your Data Use Certificate
+                </Typography>
+                <Typography
+                  variant={'body1'}
+                  sx={{ ...longFieldLabelSx, mb: 2 }}
+                >
+                  As a first step, you will need to download a PDF of the Data
+                  Use Certificate with the names of your Collaborators and
+                  Signing Official. Make sure the names are correct and complete
+                  before downloading.
+                </Typography>
+                <Typography
+                  variant={'body1'}
+                  sx={{ ...longFieldLabelSx, mb: 2 }}
+                >
+                  If needed, you can modify the printed list of collaborators by
+                  adding or removing names on the paper copy before uploading.
+                </Typography>
+                {previewError ? (
+                  <Alert severity={'error'}>
+                    <strong>
+                      Sorry, we couldn&apos;t prepare your DUC for download.
+                    </strong>
+                    <br />
+                    {previewError.reason}
+                  </Alert>
+                ) : (
+                  <Button
+                    component="a"
+                    href={downloadHref ?? undefined}
+                    target="_blank"
+                    rel="noopener"
+                    variant={'outlined'}
+                    disabled={isDownloadDisabled}
+                    endIcon={<IconSvg icon={'download'} wrap={false} />}
+                  >
+                    Download DUC for Signatures
+                  </Button>
+                )}
+              </Box>
+              <Box sx={{ flex: 1 }}>
+                <Typography variant={'body1'} sx={{ fontWeight: 700, mb: 1 }}>
+                  Step 2. Fill out and upload a Data Use Certificate
+                </Typography>
+                <Typography
+                  variant={'body1'}
+                  sx={{ ...longFieldLabelSx, mb: 2 }}
+                >
+                  You must download and fill out a Data Use Certificate (DUC).
+                  Be sure to upload the completed DUC below.
+                </Typography>
+                <Typography
+                  variant={'body1'}
+                  component={'ol'}
+                  sx={{ ...longFieldLabelSx, mb: 2, pl: 3 }}
+                >
+                  <li>Download the DUC document.</li>
+                  <li>
+                    Fill out the DUC, following the instructions in the PDF.
+                  </li>
+                  <li>
+                    Upload the completed certificate using the button below:
+                  </li>
+                </Typography>
+                {isLoadingDar ? (
+                  <Skeleton variant={'rectangular'} width={200} height={36} />
+                ) : (
+                  <UploadDocumentField
+                    id={'signed-duc'}
+                    documentName={'Signed DUC'}
+                    isLoading={isUpdating}
+                    uploadCallback={handleUpload}
+                    fileHandleAssociations={signedDucFileHandleAssociations}
+                  />
+                )}
+              </Box>
+            </Stack>
+
+            {updateError && (
+              <Alert severity={'error'} sx={{ mt: 2 }}>
+                <strong>Sorry, we couldn&apos;t save your uploaded DUC.</strong>
+                <br />
+                {updateError}
+              </Alert>
+            )}
+            {submitError && (
+              <Alert severity={'error'} sx={{ mt: 2 }}>
+                <strong>Sorry, we couldn&apos;t submit your request.</strong>
+                <br />
+                {submitError}
+              </Alert>
+            )}
+          </Box>
+        </ManagedACTAccessRequirementFormWikiWrapper>
+      </DialogContent>
+      <DialogActions>
+        <Button variant={'outlined'} onClick={onBackClicked}>
+          Back
+        </Button>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button
+          variant={'contained'}
+          disabled={isSubmitDisabled}
+          loading={isSubmitting}
+          onClick={() => {
+            handleSubmit()
+          }}
+        >
+          Submit Request
+        </Button>
+      </DialogActions>
+    </>
+  )
+}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/RequestDataAccessSuccess.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/RequestDataAccessSuccess.tsx
@@ -30,7 +30,7 @@ export default function RequestDataAccessSuccess(
         >
           Your Data Access Request Has Been Submitted
           <Box sx={{ flexGrow: 1 }} />
-          <IconButton onClick={onHide}>
+          <IconButton aria-label={'Close'} onClick={onHide}>
             <IconSvg icon={'close'} wrap={false} sx={{ color: 'grey.700' }} />
           </IconButton>
         </Stack>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ResearchProjectForm/ResearchProjectForm.tsx
@@ -238,7 +238,7 @@ export default function ResearchProjectForm(props: ResearchProjectFormProps) {
         >
           Request Access
           <Box sx={{ flexGrow: 1 }} />
-          <IconButton onClick={onHide}>
+          <IconButton aria-label={'Close'} onClick={onHide}>
             <IconSvg icon={'close'} wrap={false} sx={{ color: 'grey.700' }} />
           </IconButton>
         </Stack>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewCollaboratorsAndSigningOfficialAccordion.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewCollaboratorsAndSigningOfficialAccordion.tsx
@@ -1,0 +1,140 @@
+import { ExpandMore } from '@mui/icons-material'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Stack,
+  Typography,
+} from '@mui/material'
+import {
+  AccessorChange,
+  PrincipalInvestigator,
+  SigningOfficial,
+} from '@sage-bionetworks/synapse-types'
+import { UserBadge } from '../../UserCard/UserBadge'
+import { longFieldLabelSx } from './styles'
+
+export type ReviewCollaboratorsAndSigningOfficialAccordionProps = {
+  accessorChanges: AccessorChange[]
+  principalInvestigator?: PrincipalInvestigator
+  signingOfficial?: SigningOfficial
+  isLoading?: boolean
+}
+
+/**
+ * Collapsible summary of the DAR's collaborators, PI, and signing official.
+ * Shared by ReviewDucStep and ManualUploadDucStep.
+ */
+export function ReviewCollaboratorsAndSigningOfficialAccordion(
+  props: ReviewCollaboratorsAndSigningOfficialAccordionProps,
+) {
+  const {
+    accessorChanges,
+    principalInvestigator: pi,
+    signingOfficial: so,
+    isLoading = false,
+  } = props
+
+  return (
+    <Accordion
+      defaultExpanded={false}
+      disableGutters
+      sx={{
+        boxShadow: 'none',
+        border: '1px solid',
+        borderColor: 'grey.300',
+        '&:before': { display: 'none' },
+      }}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMore />}
+        aria-controls="review-collaborators-so-content"
+        id="review-collaborators-so-header"
+      >
+        <Typography variant={'headline3'}>
+          Review your collaborators &amp; signing official
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Typography
+          variant={'body1'}
+          sx={{ ...longFieldLabelSx, fontWeight: 700, mb: 1 }}
+        >
+          Your collaborators:
+        </Typography>
+        <Stack sx={{ mb: 3, gap: 1 }}>
+          {accessorChanges.length === 0 && !isLoading && (
+            <Typography variant={'body1'} sx={longFieldLabelSx}>
+              No collaborators added.
+            </Typography>
+          )}
+          {accessorChanges.map(ac => (
+            <UserBadge
+              key={ac.userId}
+              userId={ac.userId}
+              showAccountLevelIcon={true}
+              disableLink={true}
+              showFullName={true}
+            />
+          ))}
+        </Stack>
+
+        <Typography
+          variant={'body1'}
+          sx={{ ...longFieldLabelSx, fontWeight: 700, mb: 1 }}
+        >
+          Your Project Lead or PI:
+        </Typography>
+        <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 1 }}>
+          Your Project Lead or PI will also receive access to the requested
+          data.
+        </Typography>
+        <Box sx={{ mb: 3 }}>
+          {pi?.userId && (
+            <UserBadge
+              userId={pi.userId}
+              showAccountLevelIcon={true}
+              disableLink={true}
+              showFullName={true}
+            />
+          )}
+          {pi?.name && (
+            <Typography variant={'body1'} sx={longFieldLabelSx}>
+              {pi.name}
+            </Typography>
+          )}
+          {pi?.institutionalEmail && (
+            <Typography variant={'body1'} sx={longFieldLabelSx}>
+              {pi.institutionalEmail}
+            </Typography>
+          )}
+        </Box>
+
+        <Typography
+          variant={'body1'}
+          sx={{ ...longFieldLabelSx, fontWeight: 700, mb: 1 }}
+        >
+          Your signing official:
+        </Typography>
+        <Typography variant={'body1'} sx={{ ...longFieldLabelSx, mb: 1 }}>
+          A member of your institution who is NOT part of the study team (i.e.,
+          not the Project Lead, not a Data Requester or Collaborator, and not
+          the Project Lead or PI).
+        </Typography>
+        <Box>
+          {so?.name && (
+            <Typography variant={'body1'} sx={longFieldLabelSx}>
+              {so.name}
+            </Typography>
+          )}
+          {so?.institutionalEmail && (
+            <Typography variant={'body1'} sx={longFieldLabelSx}>
+              {so.institutionalEmail}
+            </Typography>
+          )}
+        </Box>
+      </AccordionDetails>
+    </Accordion>
+  )
+}

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep.tsx
@@ -1,9 +1,5 @@
 import { useGetDataAccessRequestForUpdate } from '@/synapse-queries'
-import { ExpandMore } from '@mui/icons-material'
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
   Box,
   Button,
   DialogActions,
@@ -15,8 +11,8 @@ import {
 } from '@mui/material'
 import { ManagedACTAccessRequirement } from '@sage-bionetworks/synapse-types'
 import IconSvg from '../../../IconSvg/IconSvg'
-import { UserBadge } from '../../../UserCard/UserBadge'
 import ManagedACTAccessRequirementFormWikiWrapper from '../ManagedACTAccessRequirementFormWikiWrapper'
+import { ReviewCollaboratorsAndSigningOfficialAccordion } from '../ReviewCollaboratorsAndSigningOfficialAccordion'
 import { longFieldLabelSx } from '../styles'
 
 export type ReviewDucStepProps = {
@@ -85,106 +81,12 @@ export default function ReviewDucStep(props: ReviewDucStepProps) {
               Official.
             </Typography>
 
-            <Accordion
-              defaultExpanded={false}
-              disableGutters
-              sx={{
-                boxShadow: 'none',
-                border: '1px solid',
-                borderColor: 'grey.300',
-                '&:before': { display: 'none' },
-              }}
-            >
-              <AccordionSummary
-                expandIcon={<ExpandMore />}
-                aria-controls="review-collaborators-so-content"
-                id="review-collaborators-so-header"
-              >
-                <Typography variant={'headline3'}>
-                  Review your collaborators & signing official
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Typography
-                  variant={'body1'}
-                  sx={{ ...longFieldLabelSx, fontWeight: 700, mb: 1 }}
-                >
-                  Your collaborators:
-                </Typography>
-                <Stack sx={{ mb: 3, gap: 1 }}>
-                  {accessorChanges.map(ac => (
-                    <UserBadge
-                      key={ac.userId}
-                      userId={ac.userId}
-                      showAccountLevelIcon={true}
-                      disableLink={true}
-                      showFullName={true}
-                    />
-                  ))}
-                </Stack>
-
-                <Typography
-                  variant={'body1'}
-                  sx={{ ...longFieldLabelSx, fontWeight: 700, mb: 1 }}
-                >
-                  Your Project Lead or PI:
-                </Typography>
-                <Typography
-                  variant={'body1'}
-                  sx={{ ...longFieldLabelSx, mb: 1 }}
-                >
-                  Your Project Lead or PI will also receive access to the
-                  requested data.
-                </Typography>
-                <Box sx={{ mb: 3 }}>
-                  {pi?.userId && (
-                    <UserBadge
-                      userId={pi.userId}
-                      showAccountLevelIcon={true}
-                      disableLink={true}
-                      showFullName={true}
-                    />
-                  )}
-                  {pi?.name && (
-                    <Typography variant={'body1'} sx={longFieldLabelSx}>
-                      {pi.name}
-                    </Typography>
-                  )}
-                  {pi?.institutionalEmail && (
-                    <Typography variant={'body1'} sx={longFieldLabelSx}>
-                      {pi.institutionalEmail}
-                    </Typography>
-                  )}
-                </Box>
-
-                <Typography
-                  variant={'body1'}
-                  sx={{ ...longFieldLabelSx, fontWeight: 700, mb: 1 }}
-                >
-                  Your signing official:
-                </Typography>
-                <Typography
-                  variant={'body1'}
-                  sx={{ ...longFieldLabelSx, mb: 1 }}
-                >
-                  A member of your institution who is NOT part of the study team
-                  (i.e., not the Project Lead, not a Data Requester or
-                  Collaborator, and not the Project Lead or PI).
-                </Typography>
-                <Box>
-                  {so?.name && (
-                    <Typography variant={'body1'} sx={longFieldLabelSx}>
-                      {so.name}
-                    </Typography>
-                  )}
-                  {so?.institutionalEmail && (
-                    <Typography variant={'body1'} sx={longFieldLabelSx}>
-                      {so.institutionalEmail}
-                    </Typography>
-                  )}
-                </Box>
-              </AccordionDetails>
-            </Accordion>
+            <ReviewCollaboratorsAndSigningOfficialAccordion
+              accessorChanges={accessorChanges}
+              principalInvestigator={pi}
+              signingOfficial={so}
+              isLoading={isLoading}
+            />
           </Box>
         </ManagedACTAccessRequirementFormWikiWrapper>
       </DialogContent>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ReviewDucStep/ReviewDucStep.tsx
@@ -50,7 +50,7 @@ export default function ReviewDucStep(props: ReviewDucStepProps) {
         <Stack direction="row" sx={{ alignItems: 'center', gap: '5px' }}>
           Request Access
           <Box sx={{ flexGrow: 1 }} />
-          <IconButton onClick={onHide}>
+          <IconButton aria-label={'Close'} onClick={onHide}>
             <IconSvg icon={'close'} wrap={false} sx={{ color: 'grey.700' }} />
           </IconButton>
         </Stack>

--- a/packages/synapse-react-client/src/utils/APIConstants.ts
+++ b/packages/synapse-react-client/src/utils/APIConstants.ts
@@ -212,6 +212,8 @@ export const ACCESS_APPROVAL_BY_ID = (id: string | number) =>
   `${ACCESS_APPROVAL}/${id}`
 
 export const DATA_ACCESS_REQUEST = `${REPO}/dataAccessRequest`
+export const DATA_ACCESS_REQUEST_PREVIEW = (id: string | number) =>
+  `${DATA_ACCESS_REQUEST}/${id}/preview`
 export const DATA_ACCESS_REQUEST_SUBMISSION = (id: string | number) =>
   `${DATA_ACCESS_REQUEST}/${id}/submission`
 export const DATA_ACCESS_REQUEST_SIGNATURE = (id: string | number) =>

--- a/packages/synapse-types/src/AccessRequirement/RequestInterface.ts
+++ b/packages/synapse-types/src/AccessRequirement/RequestInterface.ts
@@ -37,6 +37,8 @@ export interface RequestInterface {
   principalInvestigator?: PrincipalInvestigator
   /* Signing Official information. Used by the eDUC signing flow. */
   signingOfficial?: SigningOfficial
+  /* DocuSign envelope ID for the routed eDUC. Set when the request has been sent for e-signature. */
+  eDucSignatureEnvelopeId?: string
 }
 
 export interface Request extends RequestInterface {

--- a/packages/synapse-types/src/AccessRequirement/RequestInterface.ts
+++ b/packages/synapse-types/src/AccessRequirement/RequestInterface.ts
@@ -25,7 +25,7 @@ export interface RequestInterface {
   modifiedOn: string
   createdBy: string
   modifiedBy: string
-  ducFileHandleId: string
+  ducFileHandleId?: string
   irbFileHandleId: string
   attachments?: string[]
   accessorChanges: AccessorChange[]


### PR DESCRIPTION
Adds a new Manual Submission step to the eDUC workflow (ejects out of the eSignature workflow).

The DELETE signature should remove the `eDucSignatureEnvelopeId`, but it doesn't seem to today (so the request updates because the backend does not accept `ducFileHandleId` being set if `eDucSignatureEnvelopeId` is set).

New step:
<img width="801" height="657" alt="Screenshot 2026-08-20 at 9 31 46 AM" src="https://github.com/user-attachments/assets/10d93962-e58d-484d-b115-3567006530fe" />
Expanding the "Review your collaborators & signing official" (now a shared component used by this new step, as well as the previous step)
<img width="813" height="663" alt="Screenshot 2026-08-20 at 9 32 10 AM" src="https://github.com/user-attachments/assets/ea097ac0-e782-4858-a6a9-82c33be8c453" />
Scroll down to see the Download (of the pdf preview based on the DAR info), and Manual Upload:
<img width="804" height="663" alt="Screenshot 2026-08-20 at 9 31 56 AM" src="https://github.com/user-attachments/assets/1870fce3-83d3-47bc-aa94-39a4548cd4f1" />

