### PR TITLE
PORTALS-4381

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.test.tsx
@@ -11,6 +11,7 @@ import { AccessRequirement } from '@sage-bionetworks/synapse-types'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import AccessRequirementList, {
   AccessRequirementListProps,
+  RequestDataStep,
 } from './AccessRequirementList'
 import * as AccessRequirementListUtils from './AccessRequirementListUtils'
 
@@ -71,5 +72,28 @@ describe('AccessRequirementList tests', () => {
     await waitFor(() =>
       expect(screen.getAllByTestId('RequirementItem')).toHaveLength(8),
     )
+  })
+
+  it('opens directly at the initialWizardEntry step (bypassing the AR list)', async () => {
+    await init({
+      ...props,
+      initialWizardEntry: {
+        step: RequestDataStep.SIGNATURE_STATUS,
+        managedACTAccessRequirement: {
+          ...mockManagedACTAccessRequirement,
+          eDucTemplateId: 'template-abc-123',
+        },
+      },
+    })
+
+    // Wizard is showing the signature-status step, not the AR list.
+    await screen.findByRole('heading', {
+      name: /Sign a Data Use Certificate/i,
+    })
+    expect(screen.queryAllByTestId('RequirementItem')).toHaveLength(0)
+    // With direct entry there is no earlier wizard step, so Back is hidden.
+    expect(
+      screen.queryByRole('button', { name: 'Back' }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
@@ -69,6 +69,20 @@ export type AccessRequirementListProps = {
   customDialogActions?: ReactNode
   /* Optional callback invoked if a submission is created via this component */
   onSubmissionCreated?: (submissionId: string) => void
+  /**
+   * Optionally open the wizard directly at a specific ManagedACTAccessRequirement step instead of
+   * the default access requirement list. Useful for deep-link routes and for resuming an in-progress
+   * eDUC signature flow (jump straight to `RequestDataStep.SIGNATURE_STATUS`).
+   *
+   * The `managedACTAccessRequirement` is bundled with the step because every ManagedACT wizard step
+   * requires it — passing them together prevents entering a step with no AR selected.
+   *
+   * Does not affect the traditional-DUC (non-eDUC) flow, which is entered from the AR list.
+   */
+  initialWizardEntry?: {
+    step: RequestDataStep
+    managedACTAccessRequirement: ManagedACTAccessRequirement
+  }
 } & (
   | {
       /**
@@ -133,7 +147,7 @@ const isARUnsupported = (accessRequirement: AccessRequirement) => {
 /**
  * Represents a distinct screen in the wizard used to apply to a ManagedACTAccessRequirement
  */
-enum RequestDataStep {
+export enum RequestDataStep {
   SHOW_ALL_ARS = 0,
   UPDATE_RESEARCH_PROJECT = 1,
   UPDATE_ACCESSORS_AND_FILES = 2,
@@ -159,6 +173,15 @@ export type RequestDataStepCallbackArgs = {
  *
  * The component shows the user the approval status of each AR and provides a workflow for accepting the terms of or
  * creating a submission for any of the Access Requirements.
+ *
+ * ### Wizard entry
+ *
+ * By default the component opens on the AR list ({@link RequestDataStep.SHOW_ALL_ARS}) and the user
+ * navigates into the ManagedACT wizard by clicking Request Access on a specific AR.
+ *
+ * To open the wizard directly at a specific step (for example, to resume an in-progress eDUC signature
+ * flow or to serve a deep-link route), pass {@link AccessRequirementListProps.initialWizardEntry} with
+ * the target step and the {@link ManagedACTAccessRequirement} the wizard should operate on.
  */
 export default function AccessRequirementList(
   props: AccessRequirementListProps,
@@ -170,6 +193,7 @@ export default function AccessRequirementList(
     requestObjectName,
     customDialogActions,
     onSubmissionCreated = noop,
+    initialWizardEntry,
   } = props
 
   const isShowingRequirementsForEntity = 'entityId' in props
@@ -197,11 +221,13 @@ export default function AccessRequirementList(
   let { dialogTitle = 'Data Access Request' } = props
   const { isAuthenticated } = useSynapseContext()
   const [requestDataStep, setRequestDataStep] = useState<RequestDataStep>(
-    RequestDataStep.SHOW_ALL_ARS,
+    initialWizardEntry?.step ?? RequestDataStep.SHOW_ALL_ARS,
   )
   const oneSageURL = useOneSageURL()
   const [managedACTAccessRequirement, setManagedACTAccessRequirement] =
-    useState<ManagedACTAccessRequirement>()
+    useState<ManagedACTAccessRequirement | undefined>(
+      initialWizardEntry?.managedACTAccessRequirement,
+    )
   const [researchProjectId, setResearchProjectId] = useState<string>('')
   const [dataAccessRequest, setDataAccessRequest] = useState<
     Request | Renewal | undefined
@@ -462,9 +488,17 @@ export default function AccessRequirementList(
           subjectId={subjectId ?? ''}
           subjectType={subjectType ?? RestrictableObjectType.ENTITY}
           onHide={onHide}
-          onBackClicked={() => {
-            requestDataStepCallback({ step: RequestDataStep.EDUC_PREVIEW })
-          }}
+          onBackClicked={
+            // When entered directly via initialWizardEntry there is no earlier wizard step to
+            // return to, so omit the callback and let the step hide its Back button.
+            initialWizardEntry
+              ? undefined
+              : () => {
+                  requestDataStepCallback({
+                    step: RequestDataStep.EDUC_PREVIEW,
+                  })
+                }
+          }
           onSubmissionCreated={submissionId => {
             requestDataStepCallback({ step: RequestDataStep.COMPLETE })
             onSubmissionCreated(submissionId)

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/SignatureStatusStep/SignatureStatusStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/SignatureStatusStep/SignatureStatusStep.test.tsx
@@ -203,6 +203,19 @@ describe('SignatureStatusStep', () => {
     expect(mockOnBackClicked).toHaveBeenCalledTimes(1)
   })
 
+  it('hides the Back button when onBackClicked is not provided', async () => {
+    server.use(
+      http.get(statusEndpoint, () =>
+        HttpResponse.json(partiallySignedStatus, { status: 200 }),
+      ),
+    )
+    renderComponent({ onBackClicked: undefined })
+    await screen.findByRole('button', { name: 'Submit' })
+    expect(
+      screen.queryByRole('button', { name: 'Back' }),
+    ).not.toBeInTheDocument()
+  })
+
   it('invokes onHide when the close icon is clicked', async () => {
     server.use(
       http.get(statusEndpoint, () =>

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/SignatureStatusStep/SignatureStatusStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/SignatureStatusStep/SignatureStatusStep.tsx
@@ -41,7 +41,12 @@ export type SignatureStatusStepProps = {
   subjectId: string
   subjectType: RestrictableObjectType
   onHide: () => void
-  onBackClicked: () => void
+  /**
+   * Called when the user clicks the Back button. When omitted, the Back button is hidden —
+   * used when the step is reached via direct entry (e.g. a deep-link route) rather than
+   * through the wizard flow, so there is no meaningful previous step to return to.
+   */
+  onBackClicked?: () => void
   onSubmissionCreated: (submissionId: string) => void
   /**
    * Optional href override for the "View DUC" link. When set, the preview file handle fetch
@@ -276,9 +281,11 @@ export default function SignatureStatusStep(props: SignatureStatusStepProps) {
         )}
       </DialogContent>
       <DialogActions>
-        <Button variant={'outlined'} onClick={onBackClicked}>
-          Back
-        </Button>
+        {onBackClicked && (
+          <Button variant={'outlined'} onClick={onBackClicked}>
+            Back
+          </Button>
+        )}
         <Box sx={{ flexGrow: 1 }} />
         <Button
           variant={'contained'}


### PR DESCRIPTION
This sets us up for the ability to jump directly to the signature status/submission page.  Here's the design:
<img width="558" height="544" alt="Screenshot 2026-08-21 at 1 48 27 PM" src="https://github.com/user-attachments/assets/a3199d04-5a29-4784-9745-58c48fae8fe6" />

We need the AR for this functionality, which the [POST /dataAccessRequest/list](https://rest-docs.synapse.org/rest/POST/dataAccessRequest/list.html) does not currently provide.  See
https://sagebionetworks.jira.com/browse/PLFM-9903
Once I have this, we'll be able to implement this mockup from [the design](https://www.figma.com/design/NTl6yBQLbZ5IRvxbMaydr5/eDuc?node-id=293-9936&m=dev):
<img width="748" height="335" alt="Screenshot 2026-08-21 at 1 51 33 PM" src="https://github.com/user-attachments/assets/2a0e5501-cbe9-4bcc-9ff7-40941e89a853" />
