### PR TITLE
PORTALS-4426: NF tools database re-architecture

### DIFF
--- a/apps/portals/nf/src/config/resources.ts
+++ b/apps/portals/nf/src/config/resources.ts
@@ -18,7 +18,11 @@ export const observationsSql = 'SELECT * FROM syn51735464'
 export const investigatorSql = `SELECT investigatorName as "firstName", ' ' as "lastName", institution, investigatorSynapseId as "USERID" FROM syn51734029 WHERE (investigatorName IS NOT NULL OR investigatorSynapseId IS NOT NULL)`
 export const developmentPublicationSql = `SELECT * FROM syn51735467`
 export const fundingAgencySql = `SELECT funderName as "Funding Agency" FROM syn51734076`
-export const usageRequirementsSql = `SELECT usageRequirements as "Usage Restrictions" FROM syn26450069 WHERE usageRequirements IS NOT NULL`
+// syn26450069 (the legacy Resource table) was retired in Phase 7 of the LinkML
+// migration (nf-osi/nf-research-tools-schema docs/MIGRATION.md) and is no longer
+// written to -- usageRequirements now lives on syn51730943 (the live, unified
+// Tool view) directly, same as every other tool.
+export const usageRequirementsSql = `SELECT usageRequirements as "Usage Restrictions" FROM syn51730943 WHERE usageRequirements IS NOT NULL`
 export const vendorSql = `SELECT vendorName as "Vendor", vendorUrl as "Vendor Url" FROM syn51735470 WHERE vendorName IS NOT NULL`
 export const catalogNumberSql = `SELECT catalogNumber as "Catalog Number", catalogNumberURL as "Catalog Number URL" FROM syn51735470 WHERE catalogNumber IS NOT NULL`
 export const toolApplicationsSql = `SELECT applications as "Tool Applications" FROM syn26486840 WHERE applications IS NOT NULL`
@@ -48,7 +52,10 @@ export const toolsSearchQueryConfig: SearchQueryConfig = {
     synonyms: 4,
     rrid: 4,
     targetAntigen: 2,
-    diseaseType: 1,
+    // Was diseaseType (Biobank's pre-migration field name, dropped when it was unified
+    // into the shared geneticDisorder column across resource types) -- this boost was a
+    // silent no-op against a nonexistent field until fixed.
+    geneticDisorder: 1,
     description: 1,
   },
 }

--- a/apps/portals/nf/src/config/synapseConfigs/tools.tsx
+++ b/apps/portals/nf/src/config/synapseConfigs/tools.tsx
@@ -18,28 +18,64 @@ export const toolsSchema: TableToGenericCardMapping = {
   subTitle: 'resourceType',
   description: 'description',
   secondaryLabels: [
+    // Universal
     'investigatorName',
     'institution',
     'rrid',
     'synonyms',
+    'latestPublicationDate',
+    'species',
+    // Shared across resource types since the LinkML migration (nf-osi/nf-research-tools-schema
+    // docs/MIGRATION.md) unified these into single columns -- replaces the old per-type
+    // cellLineDisease/animalModelDisease/diseaseType and modelofManifestation/
+    // animalModelOfManifestation names, none of which exist anymore.
+    'geneticDisorder',
+    'manifestation',
+    'organ',
+    'tumorType',
+    // Cell Line
     'cellLineCategory',
-    'cellLineDisease',
-    'modelofManifestation',
+    'tissue',
+    'resistance',
+    // Animal Model
     'backgroundStrain',
     'backgroundSubstrain',
-    'animalModelDisease',
-    'animalModelOfManifestation',
+    'animalState',
+    // Antibody
     'targetAntigen',
     'reactiveSpecies',
     'hostOrganism',
+    'conjugate',
+    // Genetic Reagent
+    'insertName',
+    'insertSpecies',
+    'vectorType',
+    'selectableMarker',
+    // Biobank
     'specimenTissueType',
     'specimenPreparationMethod',
-    'diseaseType',
-    'tumorType',
     'specimenFormat',
     'specimenType',
-    'latestPublicationDate',
-    'species',
+    // Patient-Derived Model
+    'pdmModelSystemType',
+    'pdmHostStrain',
+    'engraftmentSite',
+    // Organoid Protocol
+    'organoidType',
+    'organoidModelType',
+    'organoidDerivationSource',
+    'organoidCellTypes',
+    'cultureSystem',
+    // Computational Tool
+    'computationalToolType',
+    'computationalToolLanguage',
+    'computationalToolPlatformSupport',
+    'licenseType',
+    // Clinical Assessment Tool
+    'clinicalAssessmentType',
+    'clinicalAssessmentTargetPopulation',
+    'clinicalAssessmentDiseaseSpecific',
+    'availabilityStatus',
   ],
   includeShareButton: true,
 }


### PR DESCRIPTION
cc @anngvu for awareness
Addresses nf-osi/nf-research-tools-schema#217 ("Review synapse-web-monorepo to see how we can get more info on cards for new NF tool types"), found while adding new facet columns to the NF tools data source (`syn51730943`).

**`tools.tsx` `secondaryLabels`:**
- Removed `cellLineDisease`/`animalModelDisease`/`diseaseType` and `modelofManifestation`/`animalModelOfManifestation` — none of these columns exist anymore. The LinkML migration on the NF research-tools-schema side (nf-osi/nf-research-tools-schema docs/MIGRATION.md) unified them into shared `geneticDisorder`/`manifestation` columns across resource types.
- Added `geneticDisorder`, `manifestation`, `organ`, `tumorType` (now shared across multiple resource types post-migration).
- Added facets for the 4 tool types that had **none at all**: Computational Tool, Organoid Protocol, Patient-Derived Model, Clinical Assessment Tool.
- Added Genetic Reagent's `insertName`/`insertSpecies`/`vectorType` (previously missing entirely) plus `selectableMarker`.
- Added a few newly-available facets for existing types: `tissue`/`resistance` (Cell Line), `animalState` (Animal Model), `conjugate` (Antibody).

Verified all of these columns exist on the live `syn51730943` view with real populated data across every resource type before opening this PR (ranging from partial to full population depending on the field, consistent with real-world data completeness).

**`resources.ts`:**
- `usageRequirementsSql` was still querying the retired `Resource` table (`syn26450069`, stopped being written to when Phase 7 of the migration retired it) — switched to `syn51730943`, which carries `usageRequirements` directly like every other tool field now.
- `toolsSearchQueryConfig`'s `fieldBoosts` had a `diseaseType` boost — that column doesn't exist post-migration (folded into `geneticDisorder`), so the boost was a silent no-op. Fixed to `geneticDisorder`.

**Not build-tested locally** — pre-commit lint tooling (oxlint) wasn't available in this checkout (dependencies not installed). `secondaryLabels` is typed `string[]` (no strict key union), so this is a low-risk content-only change, but please have CI/a reviewer confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cwbpfDLVQqbNrio62qn1q