### PR TITLE
PORTALS-4383: create in-flight eDUC table and add to the user access …

### DIFF
--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.stories.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.stories.tsx
@@ -6,7 +6,7 @@ import { Meta, StoryObj } from '@storybook/react-vite'
 import { http, HttpResponse } from 'msw'
 import { InFlightEDucSignaturesTable } from './InFlightEDucSignaturesTable'
 
-const populatedList: AccessRequestList = {
+const page1: AccessRequestList = {
   results: [
     {
       requestId: '100',
@@ -27,6 +27,19 @@ const populatedList: AccessRequestList = {
       modifiedOn: '2026-08-19T10:00:00Z',
     },
     {
+      requestId: '199',
+      accessRequirementName: 'Legacy TOU (non-eDUC)',
+      isEDuc: false,
+      status: 'submitted',
+      modifiedOn: '2026-06-05T10:00:00Z',
+    },
+  ],
+  nextPageToken: 'page-2',
+}
+
+const page2: AccessRequestList = {
+  results: [
+    {
       requestId: '102',
       accessRequirementName: 'AMP-PD Data',
       isEDuc: true,
@@ -40,9 +53,19 @@ const populatedList: AccessRequestList = {
 
 const emptyList: AccessRequestList = { results: [] }
 
-function listHandler(response: AccessRequestList) {
-  return http.post(`${MOCK_REPO_ORIGIN}${DATA_ACCESS_REQUEST_LIST}`, () =>
-    HttpResponse.json(response, { status: 200 }),
+function paginatedListHandler(pages: AccessRequestList[]) {
+  return http.post<never, { nextPageToken?: string }>(
+    `${MOCK_REPO_ORIGIN}${DATA_ACCESS_REQUEST_LIST}`,
+    async ({ request }) => {
+      const body = await request.json()
+      const nextPageToken = body?.nextPageToken
+      if (!nextPageToken) {
+        return HttpResponse.json(pages[0], { status: 200 })
+      }
+      const index = Number(nextPageToken.replace(/^page-/, '')) - 1
+      const page = pages[index] ?? { results: [] }
+      return HttpResponse.json(page, { status: 200 })
+    },
   )
 }
 
@@ -64,11 +87,11 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const WithInFlightRequests: Story = {
-  name: 'With in-flight requests',
+  name: 'With in-flight requests (paginated)',
   parameters: {
     msw: {
       handlers: [
-        listHandler(populatedList),
+        paginatedListHandler([page1, page2]),
         ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
       ],
     },
@@ -80,7 +103,7 @@ export const Empty: Story = {
   parameters: {
     msw: {
       handlers: [
-        listHandler(emptyList),
+        paginatedListHandler([emptyList]),
         ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
       ],
     },

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.stories.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.stories.tsx
@@ -1,0 +1,88 @@
+import { getUserProfileHandlers } from '@/mocks/msw/handlers/userProfileHandlers'
+import { DATA_ACCESS_REQUEST_LIST } from '@/utils/APIConstants'
+import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
+import { AccessRequestList } from '@sage-bionetworks/synapse-client'
+import { Meta, StoryObj } from '@storybook/react-vite'
+import { http, HttpResponse } from 'msw'
+import { InFlightEDucSignaturesTable } from './InFlightEDucSignaturesTable'
+
+const populatedList: AccessRequestList = {
+  results: [
+    {
+      requestId: '100',
+      accessRequirementName: 'ROSMAP eDUC',
+      isEDuc: true,
+      status: 'sent',
+      signaturesAcquired: 2,
+      signaturesRequested: 5,
+      modifiedOn: '2026-08-20T10:00:00Z',
+    },
+    {
+      requestId: '101',
+      accessRequirementName: 'MSSM Study Data',
+      isEDuc: true,
+      status: 'delivered',
+      signaturesAcquired: 4,
+      signaturesRequested: 5,
+      modifiedOn: '2026-08-19T10:00:00Z',
+    },
+    {
+      requestId: '102',
+      accessRequirementName: 'AMP-PD Data',
+      isEDuc: true,
+      status: 'completed',
+      signaturesAcquired: 3,
+      signaturesRequested: 3,
+      modifiedOn: '2026-08-21T10:00:00Z',
+    },
+  ],
+}
+
+const emptyList: AccessRequestList = { results: [] }
+
+function listHandler(response: AccessRequestList) {
+  return http.post(`${MOCK_REPO_ORIGIN}${DATA_ACCESS_REQUEST_LIST}`, () =>
+    HttpResponse.json(response, { status: 200 }),
+  )
+}
+
+const meta: Meta<typeof InFlightEDucSignaturesTable> = {
+  title:
+    'Governance/User Access Request History/InFlight eDUC Signatures Table',
+  component: InFlightEDucSignaturesTable,
+  parameters: {
+    stack: 'mock',
+    chromatic: { viewports: [600, 1200] },
+    msw: {
+      handlers: [...getUserProfileHandlers(MOCK_REPO_ORIGIN)],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const WithInFlightRequests: Story = {
+  name: 'With in-flight requests',
+  parameters: {
+    msw: {
+      handlers: [
+        listHandler(populatedList),
+        ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
+}
+
+export const Empty: Story = {
+  name: 'No in-flight requests (renders nothing)',
+  parameters: {
+    msw: {
+      handlers: [
+        listHandler(emptyList),
+        ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
+}

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.test.tsx
@@ -1,86 +1,88 @@
-import { useListUserDataAccessRequests } from '@/synapse-queries'
-import { getUseQueryMock } from '@/testutils/ReactQueryMockUtils'
+import { useListUserDataAccessRequestsInfinite } from '@/synapse-queries'
+import { getUseInfiniteQueryMock } from '@/testutils/ReactQueryMockUtils'
 import {
   AccessRequestList,
   SynapseClientError,
 } from '@sage-bionetworks/synapse-client'
-import { act, render, screen, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import { InFlightEDucSignaturesTable } from './InFlightEDucSignaturesTable'
 
 vi.mock('@/synapse-queries', () => ({
-  useListUserDataAccessRequests: vi.fn(),
+  useListUserDataAccessRequestsInfinite: vi.fn(),
 }))
 
-const mockUseListUserDataAccessRequests = vi.mocked(
-  useListUserDataAccessRequests,
+const mockUseListUserDataAccessRequestsInfinite = vi.mocked(
+  useListUserDataAccessRequestsInfinite,
 )
 
 describe('InFlightEDucSignaturesTable', () => {
-  const { mock, setSuccess, setError } = getUseQueryMock<
-    AccessRequestList,
-    SynapseClientError
-  >()
+  const { mock, setSuccess, setError, mockFetchNextPage } =
+    getUseInfiniteQueryMock<AccessRequestList, SynapseClientError>()
 
   beforeEach(() => {
-    mockUseListUserDataAccessRequests.mockImplementation(mock)
+    mockFetchNextPage.mockClear()
+    mockUseListUserDataAccessRequestsInfinite.mockImplementation(mock)
   })
 
-  it('renders nothing when there are no in-flight eDUC requests', () => {
+  it('renders nothing when the fully-loaded, filtered list is empty', () => {
     const { container } = render(<InFlightEDucSignaturesTable />)
     act(() => {
-      setSuccess({
-        results: [
-          // Non-eDUC request is ignored.
-          { requestId: '1', isEDuc: false, status: 'sent' },
-          // eDUC request past submission is ignored.
-          { requestId: '2', isEDuc: true, status: 'submitted' },
-          // Draft eDUC has not been routed for signature yet — also ignored.
-          { requestId: '3', isEDuc: true, status: 'draft' },
-        ],
-      })
+      setSuccess([
+        {
+          results: [
+            // Non-eDUC is ignored.
+            { requestId: '1', isEDuc: false, status: 'sent' },
+            // eDUC past submission is ignored.
+            { requestId: '2', isEDuc: true, status: 'submitted' },
+            // Draft eDUC has not been routed for signature yet.
+            { requestId: '3', isEDuc: true, status: 'draft' },
+          ],
+        },
+      ])
     })
     expect(container).toBeEmptyDOMElement()
-    expect(screen.queryByRole('table')).not.toBeInTheDocument()
   })
 
   it('renders a row for each in-flight eDUC request with the expected columns', () => {
     render(<InFlightEDucSignaturesTable />)
     act(() => {
-      setSuccess({
-        results: [
-          {
-            requestId: '10',
-            accessRequirementName: 'Requirement A',
-            isEDuc: true,
-            status: 'sent',
-            signaturesAcquired: 2,
-            signaturesRequested: 5,
-          },
-          {
-            requestId: '11',
-            accessRequirementName: 'Requirement B',
-            isEDuc: true,
-            status: 'delivered',
-            signaturesAcquired: 4,
-            signaturesRequested: 5,
-          },
-          {
-            requestId: '12',
-            accessRequirementName: 'Requirement C',
-            isEDuc: true,
-            status: 'completed',
-            signaturesAcquired: 5,
-            signaturesRequested: 5,
-          },
-          // Excluded (non-eDUC).
-          {
-            requestId: '13',
-            accessRequirementName: 'Requirement D',
-            isEDuc: false,
-            status: 'sent',
-          },
-        ],
-      })
+      setSuccess([
+        {
+          results: [
+            {
+              requestId: '10',
+              accessRequirementName: 'Requirement A',
+              isEDuc: true,
+              status: 'sent',
+              signaturesAcquired: 2,
+              signaturesRequested: 5,
+            },
+            {
+              requestId: '11',
+              accessRequirementName: 'Requirement B',
+              isEDuc: true,
+              status: 'delivered',
+              signaturesAcquired: 4,
+              signaturesRequested: 5,
+            },
+            {
+              requestId: '12',
+              accessRequirementName: 'Requirement C',
+              isEDuc: true,
+              status: 'completed',
+              signaturesAcquired: 5,
+              signaturesRequested: 5,
+            },
+            // Non-eDUC row is filtered out.
+            {
+              requestId: '13',
+              accessRequirementName: 'Requirement D',
+              isEDuc: false,
+              status: 'sent',
+            },
+          ],
+        },
+      ])
     })
 
     screen.getByRole('heading', { name: /In-flight eDUC signatures/i })
@@ -92,7 +94,7 @@ describe('InFlightEDucSignaturesTable', () => {
     expect(columnHeaders[2]).toHaveTextContent('Current status')
 
     const rows = within(table).getAllByRole('row')
-    // header + 3 in-flight rows (the non-eDUC row is filtered out).
+    // header + 3 in-flight rows.
     expect(rows).toHaveLength(4)
 
     const row1Cells = within(rows[1]).getAllByRole('cell')
@@ -100,13 +102,63 @@ describe('InFlightEDucSignaturesTable', () => {
     expect(row1Cells[1]).toHaveTextContent('2 of 5')
     expect(row1Cells[2]).toHaveTextContent('Signatures pending')
 
-    const row2Cells = within(rows[2]).getAllByRole('cell')
-    expect(row2Cells[2]).toHaveTextContent('Signatures pending')
-
     const row3Cells = within(rows[3]).getAllByRole('cell')
     expect(row3Cells[0]).toHaveTextContent('Requirement C')
     expect(row3Cells[1]).toHaveTextContent('5 of 5')
     expect(row3Cells[2]).toHaveTextContent('Ready to submit')
+  })
+
+  it('auto-fetches subsequent pages while hasNextPage is true', async () => {
+    render(<InFlightEDucSignaturesTable />)
+    act(() => {
+      setSuccess([{ results: [], nextPageToken: 'page-2' }], true)
+    })
+    await waitFor(() => expect(mockFetchNextPage).toHaveBeenCalled())
+  })
+
+  it('aggregates in-flight rows across all fetched pages', () => {
+    render(<InFlightEDucSignaturesTable />)
+    act(() => {
+      setSuccess([
+        {
+          results: [
+            // No in-flight rows on this page.
+            { requestId: '1', isEDuc: false, status: 'sent' },
+          ],
+        },
+        {
+          results: [
+            {
+              requestId: '20',
+              accessRequirementName: 'Requirement Late',
+              isEDuc: true,
+              status: 'sent',
+              signaturesAcquired: 1,
+              signaturesRequested: 3,
+            },
+          ],
+        },
+      ])
+    })
+
+    // The row from page 2 is visible even though page 1 had no in-flight rows.
+    const rows = within(screen.getByRole('table')).getAllByRole('row')
+    expect(rows).toHaveLength(2) // header + 1 data row
+    expect(within(rows[1]).getAllByRole('cell')[0]).toHaveTextContent(
+      'Requirement Late',
+    )
+  })
+
+  it('shows a skeleton loader while more pages are still being fetched', () => {
+    render(<InFlightEDucSignaturesTable />)
+    act(() => {
+      setSuccess([{ results: [], nextPageToken: 'page-2' }], true)
+    })
+    // No matching rows yet AND another page is coming: show skeleton, not the empty state.
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: /In-flight eDUC signatures/i }),
+    ).not.toBeInTheDocument()
   })
 
   it('shows an error alert when the request list fails to load', () => {

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.test.tsx
@@ -1,0 +1,120 @@
+import { useListUserDataAccessRequests } from '@/synapse-queries'
+import { getUseQueryMock } from '@/testutils/ReactQueryMockUtils'
+import {
+  AccessRequestList,
+  SynapseClientError,
+} from '@sage-bionetworks/synapse-client'
+import { act, render, screen, within } from '@testing-library/react'
+import { InFlightEDucSignaturesTable } from './InFlightEDucSignaturesTable'
+
+vi.mock('@/synapse-queries', () => ({
+  useListUserDataAccessRequests: vi.fn(),
+}))
+
+const mockUseListUserDataAccessRequests = vi.mocked(
+  useListUserDataAccessRequests,
+)
+
+describe('InFlightEDucSignaturesTable', () => {
+  const { mock, setSuccess, setError } = getUseQueryMock<
+    AccessRequestList,
+    SynapseClientError
+  >()
+
+  beforeEach(() => {
+    mockUseListUserDataAccessRequests.mockImplementation(mock)
+  })
+
+  it('renders nothing when there are no in-flight eDUC requests', () => {
+    const { container } = render(<InFlightEDucSignaturesTable />)
+    act(() => {
+      setSuccess({
+        results: [
+          // Non-eDUC request is ignored.
+          { requestId: '1', isEDuc: false, status: 'sent' },
+          // eDUC request past submission is ignored.
+          { requestId: '2', isEDuc: true, status: 'submitted' },
+          // Draft eDUC has not been routed for signature yet — also ignored.
+          { requestId: '3', isEDuc: true, status: 'draft' },
+        ],
+      })
+    })
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('renders a row for each in-flight eDUC request with the expected columns', () => {
+    render(<InFlightEDucSignaturesTable />)
+    act(() => {
+      setSuccess({
+        results: [
+          {
+            requestId: '10',
+            accessRequirementName: 'Requirement A',
+            isEDuc: true,
+            status: 'sent',
+            signaturesAcquired: 2,
+            signaturesRequested: 5,
+          },
+          {
+            requestId: '11',
+            accessRequirementName: 'Requirement B',
+            isEDuc: true,
+            status: 'delivered',
+            signaturesAcquired: 4,
+            signaturesRequested: 5,
+          },
+          {
+            requestId: '12',
+            accessRequirementName: 'Requirement C',
+            isEDuc: true,
+            status: 'completed',
+            signaturesAcquired: 5,
+            signaturesRequested: 5,
+          },
+          // Excluded (non-eDUC).
+          {
+            requestId: '13',
+            accessRequirementName: 'Requirement D',
+            isEDuc: false,
+            status: 'sent',
+          },
+        ],
+      })
+    })
+
+    screen.getByRole('heading', { name: /In-flight eDUC signatures/i })
+    const table = screen.getByRole('table')
+    const columnHeaders = within(table).getAllByRole('columnheader')
+    expect(columnHeaders).toHaveLength(3)
+    expect(columnHeaders[0]).toHaveTextContent('Request type')
+    expect(columnHeaders[1]).toHaveTextContent('Signature progress')
+    expect(columnHeaders[2]).toHaveTextContent('Current status')
+
+    const rows = within(table).getAllByRole('row')
+    // header + 3 in-flight rows (the non-eDUC row is filtered out).
+    expect(rows).toHaveLength(4)
+
+    const row1Cells = within(rows[1]).getAllByRole('cell')
+    expect(row1Cells[0]).toHaveTextContent('Requirement A')
+    expect(row1Cells[1]).toHaveTextContent('2 of 5')
+    expect(row1Cells[2]).toHaveTextContent('Signatures pending')
+
+    const row2Cells = within(rows[2]).getAllByRole('cell')
+    expect(row2Cells[2]).toHaveTextContent('Signatures pending')
+
+    const row3Cells = within(rows[3]).getAllByRole('cell')
+    expect(row3Cells[0]).toHaveTextContent('Requirement C')
+    expect(row3Cells[1]).toHaveTextContent('5 of 5')
+    expect(row3Cells[2]).toHaveTextContent('Ready to submit')
+  })
+
+  it('shows an error alert when the request list fails to load', () => {
+    render(<InFlightEDucSignaturesTable />)
+    act(() => {
+      setError({ reason: 'boom' } as SynapseClientError)
+    })
+    screen.getByText(/couldn't load your in-flight eDUC signatures/i)
+    expect(screen.getByText('boom')).toBeInTheDocument()
+  })
+})

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.test.tsx
@@ -1,43 +1,40 @@
-import { useListUserDataAccessRequestsInfinite } from '@/synapse-queries'
-import { getUseInfiniteQueryMock } from '@/testutils/ReactQueryMockUtils'
+import { useListAllUserDataAccessRequests } from '@/synapse-queries'
+import { getUseQueryMock } from '@/testutils/ReactQueryMockUtils'
 import {
-  AccessRequestList,
+  AccessRequestSummary,
   SynapseClientError,
 } from '@sage-bionetworks/synapse-client'
-import { act, render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, within } from '@testing-library/react'
 import { InFlightEDucSignaturesTable } from './InFlightEDucSignaturesTable'
 
 vi.mock('@/synapse-queries', () => ({
-  useListUserDataAccessRequestsInfinite: vi.fn(),
+  useListAllUserDataAccessRequests: vi.fn(),
 }))
 
-const mockUseListUserDataAccessRequestsInfinite = vi.mocked(
-  useListUserDataAccessRequestsInfinite,
+const mockUseListAllUserDataAccessRequests = vi.mocked(
+  useListAllUserDataAccessRequests,
 )
 
 describe('InFlightEDucSignaturesTable', () => {
-  const { mock, setSuccess, setError, mockFetchNextPage } =
-    getUseInfiniteQueryMock<AccessRequestList, SynapseClientError>()
+  const { mock, setSuccess, setError, setLoading } = getUseQueryMock<
+    AccessRequestSummary[],
+    SynapseClientError
+  >()
 
   beforeEach(() => {
-    mockFetchNextPage.mockClear()
-    mockUseListUserDataAccessRequestsInfinite.mockImplementation(mock)
+    mockUseListAllUserDataAccessRequests.mockImplementation(mock)
   })
 
   it('renders nothing when the fully-loaded, filtered list is empty', () => {
     const { container } = render(<InFlightEDucSignaturesTable />)
     act(() => {
       setSuccess([
-        {
-          results: [
-            // Non-eDUC is ignored.
-            { requestId: '1', isEDuc: false, status: 'sent' },
-            // eDUC past submission is ignored.
-            { requestId: '2', isEDuc: true, status: 'submitted' },
-            // Draft eDUC has not been routed for signature yet.
-            { requestId: '3', isEDuc: true, status: 'draft' },
-          ],
-        },
+        // Non-eDUC is ignored.
+        { requestId: '1', isEDuc: false, status: 'sent' },
+        // eDUC past submission is ignored.
+        { requestId: '2', isEDuc: true, status: 'submitted' },
+        // Draft eDUC has not been routed for signature yet.
+        { requestId: '3', isEDuc: true, status: 'draft' },
       ])
     })
     expect(container).toBeEmptyDOMElement()
@@ -48,39 +45,35 @@ describe('InFlightEDucSignaturesTable', () => {
     act(() => {
       setSuccess([
         {
-          results: [
-            {
-              requestId: '10',
-              accessRequirementName: 'Requirement A',
-              isEDuc: true,
-              status: 'sent',
-              signaturesAcquired: 2,
-              signaturesRequested: 5,
-            },
-            {
-              requestId: '11',
-              accessRequirementName: 'Requirement B',
-              isEDuc: true,
-              status: 'delivered',
-              signaturesAcquired: 4,
-              signaturesRequested: 5,
-            },
-            {
-              requestId: '12',
-              accessRequirementName: 'Requirement C',
-              isEDuc: true,
-              status: 'completed',
-              signaturesAcquired: 5,
-              signaturesRequested: 5,
-            },
-            // Non-eDUC row is filtered out.
-            {
-              requestId: '13',
-              accessRequirementName: 'Requirement D',
-              isEDuc: false,
-              status: 'sent',
-            },
-          ],
+          requestId: '10',
+          accessRequirementName: 'Requirement A',
+          isEDuc: true,
+          status: 'sent',
+          signaturesAcquired: 2,
+          signaturesRequested: 5,
+        },
+        {
+          requestId: '11',
+          accessRequirementName: 'Requirement B',
+          isEDuc: true,
+          status: 'delivered',
+          signaturesAcquired: 4,
+          signaturesRequested: 5,
+        },
+        {
+          requestId: '12',
+          accessRequirementName: 'Requirement C',
+          isEDuc: true,
+          status: 'completed',
+          signaturesAcquired: 5,
+          signaturesRequested: 5,
+        },
+        // Non-eDUC row is filtered out.
+        {
+          requestId: '13',
+          accessRequirementName: 'Requirement D',
+          isEDuc: false,
+          status: 'sent',
         },
       ])
     })
@@ -108,53 +101,11 @@ describe('InFlightEDucSignaturesTable', () => {
     expect(row3Cells[2]).toHaveTextContent('Ready to submit')
   })
 
-  it('auto-fetches subsequent pages while hasNextPage is true', async () => {
+  it('shows a skeleton loader while the request list is loading', () => {
     render(<InFlightEDucSignaturesTable />)
     act(() => {
-      setSuccess([{ results: [], nextPageToken: 'page-2' }], true)
+      setLoading()
     })
-    await waitFor(() => expect(mockFetchNextPage).toHaveBeenCalled())
-  })
-
-  it('aggregates in-flight rows across all fetched pages', () => {
-    render(<InFlightEDucSignaturesTable />)
-    act(() => {
-      setSuccess([
-        {
-          results: [
-            // No in-flight rows on this page.
-            { requestId: '1', isEDuc: false, status: 'sent' },
-          ],
-        },
-        {
-          results: [
-            {
-              requestId: '20',
-              accessRequirementName: 'Requirement Late',
-              isEDuc: true,
-              status: 'sent',
-              signaturesAcquired: 1,
-              signaturesRequested: 3,
-            },
-          ],
-        },
-      ])
-    })
-
-    // The row from page 2 is visible even though page 1 had no in-flight rows.
-    const rows = within(screen.getByRole('table')).getAllByRole('row')
-    expect(rows).toHaveLength(2) // header + 1 data row
-    expect(within(rows[1]).getAllByRole('cell')[0]).toHaveTextContent(
-      'Requirement Late',
-    )
-  })
-
-  it('shows a skeleton loader while more pages are still being fetched', () => {
-    render(<InFlightEDucSignaturesTable />)
-    act(() => {
-      setSuccess([{ results: [], nextPageToken: 'page-2' }], true)
-    })
-    // No matching rows yet AND another page is coming: show skeleton, not the empty state.
     expect(screen.queryByRole('table')).not.toBeInTheDocument()
     expect(
       screen.queryByRole('heading', { name: /In-flight eDUC signatures/i }),

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.tsx
@@ -1,0 +1,117 @@
+import { useListUserDataAccessRequests } from '@/synapse-queries'
+import ColumnHeader from '@/components/TanStackTable/ColumnHeader'
+import StyledTanStackTable from '@/components/TanStackTable/StyledTanStackTable'
+import { SkeletonTable } from '@/components/Skeleton'
+import { Alert, Box, Typography } from '@mui/material'
+import {
+  AccessRequestSummary,
+  AccessRequestSummaryStatusEnum,
+} from '@sage-bionetworks/synapse-client'
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { useMemo } from 'react'
+
+const IN_FLIGHT_STATUSES: readonly AccessRequestSummaryStatusEnum[] = [
+  'sent',
+  'delivered',
+  'completed',
+] as const
+
+const STATUS_DISPLAY: Record<string, string> = {
+  sent: 'Signatures pending',
+  delivered: 'Signatures pending',
+  completed: 'Ready to submit',
+}
+
+const columnHelper = createColumnHelper<AccessRequestSummary>()
+const columns = [
+  columnHelper.accessor('accessRequirementName', {
+    header: props => <ColumnHeader {...props} title={'Request type'} />,
+    enableSorting: false,
+    enableColumnFilter: false,
+  }),
+  columnHelper.display({
+    id: 'signatureProgress',
+    header: props => <ColumnHeader {...props} title={'Signature progress'} />,
+    enableSorting: false,
+    cell: ctx => {
+      const acquired = ctx.row.original.signaturesAcquired ?? 0
+      const requested = ctx.row.original.signaturesRequested ?? 0
+      return `${acquired} of ${requested}`
+    },
+    enableColumnFilter: false,
+    size: 150,
+  }),
+  columnHelper.accessor('status', {
+    header: props => <ColumnHeader {...props} title={'Current status'} />,
+    enableSorting: false,
+    cell: ctx => {
+      const status = ctx.getValue()
+      return status ? (STATUS_DISPLAY[status] ?? status) : ''
+    },
+    enableColumnFilter: false,
+    size: 150,
+  }),
+]
+
+/**
+ * Lists the requester's active eDUC signatures (routed / signed but not yet submitted).
+ * Renders nothing when the filtered list is empty.
+ */
+export function InFlightEDucSignaturesTable() {
+  const {
+    data: accessRequestList,
+    isLoading,
+    error,
+  } = useListUserDataAccessRequests()
+
+  const rows = useMemo(
+    () =>
+      (accessRequestList?.results ?? []).filter(
+        summary =>
+          summary.isEDuc === true &&
+          summary.status !== undefined &&
+          (IN_FLIGHT_STATUSES as readonly string[]).includes(summary.status),
+      ),
+    [accessRequestList],
+  )
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    columnResizeMode: 'onChange',
+  })
+
+  if (error) {
+    return (
+      <Alert severity={'error'}>
+        <strong>
+          Sorry, we couldn&apos;t load your in-flight eDUC signatures.
+        </strong>
+        <br />
+        {error.reason}
+      </Alert>
+    )
+  }
+
+  if (isLoading) {
+    return <SkeletonTable numCols={columns.length} fullWidthCells />
+  }
+
+  if (rows.length === 0) {
+    return null
+  }
+
+  return (
+    <Box>
+      <Typography variant={'headline2'} component={'h2'} gutterBottom>
+        In-flight eDUC signatures
+      </Typography>
+      <StyledTanStackTable table={table} fullWidth={true} />
+    </Box>
+  )
+}

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.tsx
@@ -1,7 +1,7 @@
-import { useListUserDataAccessRequests } from '@/synapse-queries'
+import { SkeletonTable } from '@/components/Skeleton'
 import ColumnHeader from '@/components/TanStackTable/ColumnHeader'
 import StyledTanStackTable from '@/components/TanStackTable/StyledTanStackTable'
-import { SkeletonTable } from '@/components/Skeleton'
+import { useListUserDataAccessRequestsInfinite } from '@/synapse-queries'
 import { Alert, Box, Typography } from '@mui/material'
 import {
   AccessRequestSummary,
@@ -12,7 +12,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 
 const IN_FLIGHT_STATUSES: readonly AccessRequestSummaryStatusEnum[] = [
   'sent',
@@ -59,24 +59,41 @@ const columns = [
 
 /**
  * Lists the requester's active eDUC signatures (routed / signed but not yet submitted).
- * Renders nothing when the filtered list is empty.
+ *
+ * Every page of `POST /dataAccessRequest/list` is fetched before rendering because filtering is
+ * done client-side pending PLFM-9907 (which will add an `isEDuc` server-side filter). Once
+ * server-side filtering ships, this can move to a standard InfiniteTableLayout with "Show More".
+ *
+ * Renders nothing when the fully-loaded, filtered list is empty.
  */
 export function InFlightEDucSignaturesTable() {
   const {
-    data: accessRequestList,
+    data: infiniteData,
     isLoading,
     error,
-  } = useListUserDataAccessRequests()
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useListUserDataAccessRequestsInfinite()
+
+  // Auto-fetch remaining pages so client-side filtering sees the complete list.
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage()
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
   const rows = useMemo(
     () =>
-      (accessRequestList?.results ?? []).filter(
-        summary =>
-          summary.isEDuc === true &&
-          summary.status !== undefined &&
-          (IN_FLIGHT_STATUSES as readonly string[]).includes(summary.status),
-      ),
-    [accessRequestList],
+      (infiniteData?.pages ?? [])
+        .flatMap(page => page.results ?? [])
+        .filter(
+          summary =>
+            summary.isEDuc === true &&
+            summary.status !== undefined &&
+            (IN_FLIGHT_STATUSES as readonly string[]).includes(summary.status),
+        ),
+    [infiniteData],
   )
 
   const table = useReactTable({
@@ -98,11 +115,12 @@ export function InFlightEDucSignaturesTable() {
     )
   }
 
-  if (isLoading) {
+  const isStillLoading = isLoading || hasNextPage || isFetchingNextPage
+  if (isStillLoading && rows.length === 0) {
     return <SkeletonTable numCols={columns.length} fullWidthCells />
   }
 
-  if (rows.length === 0) {
+  if (!isStillLoading && rows.length === 0) {
     return null
   }
 

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.tsx
@@ -1,7 +1,7 @@
 import { SkeletonTable } from '@/components/Skeleton'
 import ColumnHeader from '@/components/TanStackTable/ColumnHeader'
 import StyledTanStackTable from '@/components/TanStackTable/StyledTanStackTable'
-import { useListUserDataAccessRequestsInfinite } from '@/synapse-queries'
+import { useListAllUserDataAccessRequests } from '@/synapse-queries'
 import { Alert, Box, Typography } from '@mui/material'
 import {
   AccessRequestSummary,
@@ -12,7 +12,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 
 const IN_FLIGHT_STATUSES: readonly AccessRequestSummaryStatusEnum[] = [
   'sent',
@@ -60,40 +60,29 @@ const columns = [
 /**
  * Lists the requester's active eDUC signatures (routed / signed but not yet submitted).
  *
- * Every page of `POST /dataAccessRequest/list` is fetched before rendering because filtering is
- * done client-side pending PLFM-9907 (which will add an `isEDuc` server-side filter). Once
- * server-side filtering ships, this can move to a standard InfiniteTableLayout with "Show More".
+ * The underlying query walks every page of `POST /dataAccessRequest/list` inside its `queryFn`
+ * because filtering is done client-side pending PLFM-9907 (which will add an `isEDuc` server-side
+ * filter). Once server-side filtering ships, callers can switch back to a per-page infinite query
+ * with a "Show More" button.
  *
  * Renders nothing when the fully-loaded, filtered list is empty.
  */
 export function InFlightEDucSignaturesTable() {
   const {
-    data: infiniteData,
+    data: summaries,
     isLoading,
     error,
-    hasNextPage,
-    isFetchingNextPage,
-    fetchNextPage,
-  } = useListUserDataAccessRequestsInfinite()
-
-  // Auto-fetch remaining pages so client-side filtering sees the complete list.
-  useEffect(() => {
-    if (hasNextPage && !isFetchingNextPage) {
-      void fetchNextPage()
-    }
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+  } = useListAllUserDataAccessRequests()
 
   const rows = useMemo(
     () =>
-      (infiniteData?.pages ?? [])
-        .flatMap(page => page.results ?? [])
-        .filter(
-          summary =>
-            summary.isEDuc === true &&
-            summary.status !== undefined &&
-            (IN_FLIGHT_STATUSES as readonly string[]).includes(summary.status),
-        ),
-    [infiniteData],
+      (summaries ?? []).filter(
+        summary =>
+          summary.isEDuc === true &&
+          summary.status !== undefined &&
+          (IN_FLIGHT_STATUSES as readonly string[]).includes(summary.status),
+      ),
+    [summaries],
   )
 
   const table = useReactTable({
@@ -115,12 +104,11 @@ export function InFlightEDucSignaturesTable() {
     )
   }
 
-  const isStillLoading = isLoading || hasNextPage || isFetchingNextPage
-  if (isStillLoading && rows.length === 0) {
+  if (isLoading) {
     return <SkeletonTable numCols={columns.length} fullWidthCells />
   }
 
-  if (!isStillLoading && rows.length === 0) {
+  if (rows.length === 0) {
     return null
   }
 

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryPage.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryPage.test.tsx
@@ -22,6 +22,12 @@ import { createMemoryRouter, RouterProvider } from 'react-router'
 vi.mock('@/utils/functions/DateFormatter')
 vi.mock('@/synapse-queries/dataaccess/useDataAccessSubmission')
 vi.mock('@/components/UserOrTeamBadge/UserOrTeamBadge')
+vi.mock(
+  '@/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable',
+  () => ({
+    InFlightEDucSignaturesTable: () => null,
+  }),
+)
 
 vi.mocked(formatDate).mockReturnValue('mock formatted date')
 vi.mocked(UserOrTeamBadge).mockImplementation(() => (

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryPage.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryPage.tsx
@@ -6,6 +6,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material'
+import { InFlightEDucSignaturesTable } from './InFlightEDucSignaturesTable'
 import { UserAccessRequestHistoryTable } from './UserAccessRequestHistoryTable'
 
 type FaqItem = {
@@ -62,6 +63,7 @@ export function UserAccessRequestHistoryPage() {
           </div>
         </>
       )}
+      <InFlightEDucSignaturesTable />
       <UserAccessRequestHistoryTable />
     </Stack>
   )

--- a/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
+++ b/packages/synapse-react-client/src/synapse-queries/KeyFactory.ts
@@ -609,6 +609,12 @@ export class KeyFactory {
     return this.getKey(DATA_ACCESS_REQUEST_QUERY_KEY, 'list', params)
   }
 
+  public listAllDataAccessRequestsQueryKey(
+    params?: Omit<AccessRequestListRequest, 'nextPageToken'>,
+  ) {
+    return this.getKey(DATA_ACCESS_REQUEST_QUERY_KEY, 'list', 'all', params)
+  }
+
   public getDataAccessRequestPreviewQueryKey(requestId: string) {
     return this.getKey(
       DATA_ACCESS_REQUEST_QUERY_KEY,

--- a/packages/synapse-react-client/src/synapse-queries/dataaccess/useEDuc.ts
+++ b/packages/synapse-react-client/src/synapse-queries/dataaccess/useEDuc.ts
@@ -104,6 +104,49 @@ export function useListUserDataAccessRequests(
 }
 
 /**
+ * Infinite-query variant of {@link useListUserDataAccessRequests} that paginates through every
+ * page via `nextPageToken`. Prefer this hook when the caller needs a complete list (for example,
+ * to filter results client-side across all pages).
+ * @see POST /repo/v1/dataAccessRequest/list
+ */
+export function useListUserDataAccessRequestsInfinite<
+  TData = InfiniteData<AccessRequestList>,
+>(
+  request: Omit<AccessRequestListRequest, 'nextPageToken'> = {},
+  options?: Partial<
+    UseInfiniteQueryOptions<
+      AccessRequestList,
+      SynapseClientError,
+      TData,
+      QueryKey,
+      AccessRequestList['nextPageToken']
+    >
+  >,
+) {
+  const { keyFactory, synapseClient } = useSynapseContext()
+
+  return useInfiniteQuery<
+    AccessRequestList,
+    SynapseClientError,
+    TData,
+    QueryKey,
+    AccessRequestList['nextPageToken']
+  >({
+    ...options,
+    queryKey: keyFactory.listDataAccessRequestsQueryKey(request),
+    queryFn: context =>
+      synapseClient.dataAccessServicesClient.postRepoV1DataAccessRequestList({
+        accessRequestListRequest: {
+          ...request,
+          nextPageToken: context.pageParam,
+        },
+      }),
+    initialPageParam: undefined,
+    getNextPageParam: page => page.nextPageToken,
+  })
+}
+
+/**
  * Retrieve the pre-signing preview of the eDUC for a data access request.
  * @see GET /repo/v1/dataAccessRequest/{requestId}/preview
  */

--- a/packages/synapse-react-client/src/synapse-queries/dataaccess/useEDuc.ts
+++ b/packages/synapse-react-client/src/synapse-queries/dataaccess/useEDuc.ts
@@ -1,7 +1,9 @@
+import { getAllOfNextPageTokenPaginatedService } from '@/synapse-client/SynapseClient'
 import { useSynapseContext } from '@/utils/context/SynapseContext'
 import {
   AccessRequestList,
   AccessRequestListRequest,
+  AccessRequestSummary,
   EDucFileHandleId,
   EDucSignatureQuota,
   EDucSignatureStatus,
@@ -104,45 +106,45 @@ export function useListUserDataAccessRequests(
 }
 
 /**
- * Infinite-query variant of {@link useListUserDataAccessRequests} that paginates through every
- * page via `nextPageToken`. Prefer this hook when the caller needs a complete list (for example,
- * to filter results client-side across all pages).
+ * List _all_ data access requests that the calling user created or participates in, walking every
+ * page of `POST /repo/v1/dataAccessRequest/list` via `nextPageToken` inside the queryFn. Returns
+ * the flattened list of {@link AccessRequestSummary}.
+ *
+ * Prefer this hook over {@link useListUserDataAccessRequests} when the caller needs the complete
+ * list (for example, to filter results client-side). This avoids the render-per-page cascade of
+ * `useInfiniteQuery` at the cost of a slightly longer initial load.
+ *
  * @see POST /repo/v1/dataAccessRequest/list
  */
-export function useListUserDataAccessRequestsInfinite<
-  TData = InfiniteData<AccessRequestList>,
->(
+export function useListAllUserDataAccessRequests(
   request: Omit<AccessRequestListRequest, 'nextPageToken'> = {},
   options?: Partial<
-    UseInfiniteQueryOptions<
-      AccessRequestList,
-      SynapseClientError,
-      TData,
-      QueryKey,
-      AccessRequestList['nextPageToken']
-    >
+    UseQueryOptions<AccessRequestSummary[], SynapseClientError>
   >,
 ) {
   const { keyFactory, synapseClient } = useSynapseContext()
 
-  return useInfiniteQuery<
-    AccessRequestList,
-    SynapseClientError,
-    TData,
-    QueryKey,
-    AccessRequestList['nextPageToken']
-  >({
+  return useQuery({
     ...options,
-    queryKey: keyFactory.listDataAccessRequestsQueryKey(request),
-    queryFn: context =>
-      synapseClient.dataAccessServicesClient.postRepoV1DataAccessRequestList({
-        accessRequestListRequest: {
-          ...request,
-          nextPageToken: context.pageParam,
+    queryKey: keyFactory.listAllDataAccessRequestsQueryKey(request),
+    queryFn: () =>
+      getAllOfNextPageTokenPaginatedService<AccessRequestSummary>(
+        async nextPageToken => {
+          const response =
+            await synapseClient.dataAccessServicesClient.postRepoV1DataAccessRequestList(
+              {
+                accessRequestListRequest: {
+                  ...request,
+                  nextPageToken: nextPageToken ?? undefined,
+                },
+              },
+            )
+          return {
+            results: response.results ?? [],
+            nextPageToken: response.nextPageToken,
+          }
         },
-      }),
-    initialPageParam: undefined,
-    getNextPageParam: page => page.nextPageToken,
+      ),
   })
 }
 

--- a/packages/synapse-react-client/src/utils/APIConstants.ts
+++ b/packages/synapse-react-client/src/utils/APIConstants.ts
@@ -212,6 +212,7 @@ export const ACCESS_APPROVAL_BY_ID = (id: string | number) =>
   `${ACCESS_APPROVAL}/${id}`
 
 export const DATA_ACCESS_REQUEST = `${REPO}/dataAccessRequest`
+export const DATA_ACCESS_REQUEST_LIST = `${DATA_ACCESS_REQUEST}/list`
 export const DATA_ACCESS_REQUEST_PREVIEW = (id: string | number) =>
   `${DATA_ACCESS_REQUEST}/${id}/preview`
 export const DATA_ACCESS_REQUEST_SUBMISSION = (id: string | number) =>


### PR DESCRIPTION
…request history page

Note, this asks for all DARs and fliters client-side to eDUC requests (opened https://sagebionetworks.jira.com/browse/PLFM-9907 to move this to the server).  Will show nothing if no eDUC DARs are found

<img width="1447" height="591" alt="Screenshot 2026-08-24 at 9 40 11 AM" src="https://github.com/user-attachments/assets/e67d053a-891a-4a7e-b367-e07708757351" />
