### PR TITLE
SWC-7955

### DIFF
--- a/packages/synapse-react-client/src/components/EntityTreeTable/hooks/useTableColumns.tsx
+++ b/packages/synapse-react-client/src/components/EntityTreeTable/hooks/useTableColumns.tsx
@@ -51,7 +51,7 @@ export const useTableColumns = (
       header: NameColumnHeader,
       cell: NameCell,
       enableSorting: enableSorting,
-      size: 450, // Default width for Name column
+      size: 600,
     })
     if (isMediumAndUp) {
       baseColumns.push({
@@ -59,13 +59,15 @@ export const useTableColumns = (
         header: '',
         cell: EntityBadgeIconsCell,
         enableSorting: false,
-        size: 120, // Default width for Badges column
+        enableResizing: false,
+        size: 120,
       })
       baseColumns.push({
         id: 'id',
         header: IdColumnHeader,
         cell: IdCell,
         enableSorting: false,
+        size: 110,
       })
     }
     if (isXtraLarge) {
@@ -75,6 +77,7 @@ export const useTableColumns = (
         header: CreatedOnColumnHeader,
         cell: CreatedOnCell,
         enableSorting: enableSorting,
+        size: 130,
       })
     }
 
@@ -85,6 +88,7 @@ export const useTableColumns = (
         header: ModifiedOnColumnHeader,
         cell: ModifiedOnCell,
         enableSorting: enableSorting,
+        size: 130,
       })
     }
 
@@ -94,6 +98,7 @@ export const useTableColumns = (
         header: 'Modified By',
         cell: ModifiedByCell,
         enableSorting: false,
+        size: 130,
       })
     }
 
@@ -103,6 +108,7 @@ export const useTableColumns = (
         header: 'Size',
         cell: FileEntitySizeCell,
         enableSorting: false,
+        size: 80,
       })
     }
     if (isXtraLarge) {

--- a/packages/synapse-react-client/src/components/TanStackTable/TanStackTableUtils.ts
+++ b/packages/synapse-react-client/src/components/TanStackTable/TanStackTableUtils.ts
@@ -18,8 +18,9 @@ export function getCommonPinningStyles(column: Column<any>): CSSProperties {
   const isFirstRightPinnedColumn =
     isPinned === 'right' && column.getIsFirstColumn('right')
 
+  if (!isPinned) return {}
   return {
-    background: isPinned ? 'inherit' : undefined,
+    background: 'inherit',
     boxShadow: isLastLeftPinnedColumn
       ? '-4px 0 4px -4px gray inset'
       : isFirstRightPinnedColumn
@@ -27,9 +28,9 @@ export function getCommonPinningStyles(column: Column<any>): CSSProperties {
         : undefined,
     left: isPinned === 'left' ? `${column.getStart('left')}px` : undefined,
     right: isPinned === 'right' ? `${column.getAfter('right')}px` : undefined,
-    opacity: isPinned ? 0.95 : 1,
-    position: isPinned ? 'sticky' : 'relative',
+    opacity: 0.95,
+    position: 'sticky',
     width: column.getSize(),
-    zIndex: isPinned ? 1 : 0,
+    zIndex: 1,
   }
 }


### PR DESCRIPTION
## EntityTreeTable — fix name column not using available width

### Problem
Long entity names in the `name` column were being truncated with an ellipsis even
though there appeared to be empty space to the right of the text. Attempting to
resize the `name` column wider made the situation *worse* — the visible name text
got shorter and the badges area got larger.

### Root cause
The badges column has an empty header (`header: ''`). Because it's directly to the
right of `name`, the resizer on badges' right edge visually sits where a user would
reasonably expect the `name` column's right edge to be. Users (and the person who
reported the bug) grabbed the **badges** column's right resizer instead of the
**name** column's right resizer.

That interaction:
- Grew the `badges` column's declared width (not `name`).
- Increased the sum of declared widths, so the extra space distributed proportionally
  by `table-layout: fixed` shrank — reducing `name`'s proportional gain and making its
  effective width smaller.
- Made it *look* like resizing `name` shrank `name` and grew `badges`.

Separately, two contributing issues surfaced during investigation:
1. Metadata columns (`id`, `createdOn`, `modifiedOn`, `modifiedBy`, `size`, `md5`) had
   no explicit `size` and defaulted to TanStack's 150px — wider than their content
   needed — leaving less proportional extra for `name`.
2. `getCommonPinningStyles` unconditionally returned `width: column.getSize()` (and
   `position: 'relative'`, `opacity`, `zIndex`) for every column, overriding the
   CSS-variable-based `calc(var(--header-…-size) * 1px)` width used on `<th>`/`<td>`.
   This defeated the resize-memoization pattern in `StyledTanStackTable`, which
   drives column sizes from CSS variables so body cells don't need to re-render on
   every mouse move during a drag.

### Changes

**`packages/synapse-react-client/src/components/EntityTreeTable/hooks/useTableColumns.tsx`**
- Set `enableResizing: false` on the `badges` column so it no longer has a resizer.
  The only resizer between `name` and `id` is now `name`'s own right-edge resizer,
  eliminating the wrong-handle bug.
- Give each column an explicit `size` roughly matching its content so the `name`
  column keeps the majority of any leftover width:

  | Column      | Before        | After |
  | ----------- | ------------- | ----- |
  | name        | 450           | 600   |
  | badges      | 120           | 120 (not resizable) |
  | id          | 150 (default) | 110   |
  | createdOn   | 150 (default) | 130   |
  | modifiedOn  | 150 (default) | 130   |
  | modifiedBy  | 150 (default) | 130   |
  | size        | 150 (default) | 80    |
  | md5         | 150 (default) | 150   |
  | download    | 90            | 90    |

**`packages/synapse-react-client/src/components/TanStackTable/TanStackTableUtils.ts`**
Make `getCommonPinningStyles` return `{}` for unpinned columns. Only pinned columns
now receive `position: sticky`, `left`/`right` offsets, `background`, `boxShadow`,
`opacity`, `zIndex`, and an inline `width`. Unpinned `<th>`/`<td>` widths now come
from the CSS-variable `calc(...)` set by `StyledTanStackTable`, restoring the
memoization pattern so body cells don't re-render during a column resize.

### Verified in Storybook (viewport 1600px, `EntityTreeTable` story)
With the sample filename `"CHAIN ki Collaboration Report Out - Tuesday, June 26, 2018 8.10.37 AM.csv"`:

- Before: `name` column 461px, link 401px, text `scrollWidth` 536 → truncated.
- After:  `name` column 623px, link 563px, text `scrollWidth` 563 → full name shown.

Dragging `name`'s right resizer +200px correctly grows `name` 623 → 800 and shrinks
`badges` 125 → 120. Attempting to grab a badges resizer is now impossible.

All 707 tests across `TanStackTable`, `EntityTreeTable`, `SynapseTable`,
`EntityHeaderTable`, and `DataGrid` continue to pass.