### PR TITLE
PORTALS-4382

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.test.tsx
@@ -4,11 +4,14 @@ import {
   mockSelfSignAccessRequirement,
   mockToUAccessRequirement,
 } from '@/mocks/accessRequirement/mockAccessRequirements'
+import { MOCK_DATA_ACCESS_REQUEST } from '@/mocks/dataaccess/MockDataAccessRequest'
 import mockFileEntityData from '@/mocks/entity/mockFileEntity'
 import { server } from '@/mocks/msw/server'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
+import { ACCESS_REQUIREMENT_DATA_ACCESS_REQUEST_FOR_UPDATE } from '@/utils/APIConstants'
 import { AccessRequirement } from '@sage-bionetworks/synapse-types'
 import { act, render, screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
 import AccessRequirementList, {
   AccessRequirementListProps,
   RequestDataStep,
@@ -94,6 +97,70 @@ describe('AccessRequirementList tests', () => {
     // With direct entry there is no earlier wizard step, so Back is hidden.
     expect(
       screen.queryByRole('button', { name: 'Back' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('resumes at SIGNATURE_STATUS when the DAR already has a routed envelope', async () => {
+    const eDucAr = {
+      ...mockManagedACTAccessRequirement,
+      eDucTemplateId: 'template-abc-123',
+    }
+    server.use(
+      http.get(
+        `*${ACCESS_REQUIREMENT_DATA_ACCESS_REQUEST_FOR_UPDATE(eDucAr.id)}`,
+        () =>
+          HttpResponse.json(
+            {
+              ...MOCK_DATA_ACCESS_REQUEST,
+              eDucSignatureEnvelopeId: 'docusign-envelope-abc',
+            },
+            { status: 200 },
+          ),
+      ),
+    )
+
+    await init({
+      ...props,
+      initialWizardEntry: {
+        step: RequestDataStep.UPDATE_RESEARCH_PROJECT,
+        managedACTAccessRequirement: eDucAr,
+      },
+    })
+
+    // Auto-resumes to SIGNATURE_STATUS because the DAR has an envelope routed.
+    await screen.findByText(/Sign a Data Use Certificate/i)
+  })
+
+  it('lands on the research project step when there is no routed envelope', async () => {
+    const eDucAr = {
+      ...mockManagedACTAccessRequirement,
+      eDucTemplateId: 'template-abc-123',
+    }
+    server.use(
+      http.get(
+        `*${ACCESS_REQUIREMENT_DATA_ACCESS_REQUEST_FOR_UPDATE(eDucAr.id)}`,
+        () =>
+          HttpResponse.json(
+            { ...MOCK_DATA_ACCESS_REQUEST, eDucSignatureEnvelopeId: undefined },
+            { status: 200 },
+          ),
+      ),
+    )
+
+    await init({
+      ...props,
+      initialWizardEntry: {
+        step: RequestDataStep.UPDATE_RESEARCH_PROJECT,
+        managedACTAccessRequirement: eDucAr,
+      },
+    })
+
+    // Research project form appears — signature-status step is not shown.
+    await screen.findByLabelText(
+      /First and last names of your Project Lead or PI/i,
+    )
+    expect(
+      screen.queryByText(/Sign a Data Use Certificate/i),
     ).not.toBeInTheDocument()
   })
 })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
@@ -37,7 +37,10 @@ import { EntityLink } from '../EntityLink'
 import IconSvg from '../IconSvg/IconSvg'
 import UserOrTeamBadge from '../UserOrTeamBadge'
 import { AccessRequirementListItem } from './AccessRequirementListItem'
-import { useCanShowManagedACTWikiInWizard } from './AccessRequirementListUtils'
+import {
+  useAutoResumeSignatureStatusStep,
+  useCanShowManagedACTWikiInWizard,
+} from './AccessRequirementListUtils'
 import CancelRequestDataAccess from './ManagedACTAccessRequirementRequestFlow/CancelRequestDataAccess'
 import DataAccessRequestAccessorsFilesForm from './ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm'
 import RequestDataAccessSuccess from './ManagedACTAccessRequirementRequestFlow/RequestDataAccessSuccess'
@@ -234,6 +237,14 @@ export default function AccessRequirementList(
   >()
 
   const canShowManagedACTWikiInWizard = useCanShowManagedACTWikiInWizard()
+
+  useAutoResumeSignatureStatusStep({
+    managedACTAccessRequirement,
+    requestDataStep,
+    researchProjectStep: RequestDataStep.UPDATE_RESEARCH_PROJECT,
+    signatureStatusStep: RequestDataStep.SIGNATURE_STATUS,
+    setRequestDataStep,
+  })
 
   const { data: fetchedRequirementsForTeam } = useGetAccessRequirementsForTeam(
     subjectId!,

--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementListUtils.ts
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementListUtils.ts
@@ -1,6 +1,9 @@
 import { getAccessRequirementStatus } from '@/synapse-client/SynapseClient'
+import { useGetDataAccessRequestForUpdate } from '@/synapse-queries'
 import { useMediaQuery, useTheme } from '@mui/material'
+import { ManagedACTAccessRequirement } from '@sage-bionetworks/synapse-types'
 import { sortBy } from 'lodash-es'
+import { useRef } from 'react'
 
 /**
  * Given an array of access requirement IDs, return the IDs sorted by the user's status, where
@@ -39,4 +42,47 @@ export function useCanShowManagedACTWikiInWizard(): boolean {
   const theme = useTheme()
   const matchesBreakpoint = useMediaQuery(theme.breakpoints.up('md'))
   return matchesBreakpoint
+}
+
+/**
+ * PORTALS-4382: when the ManagedACT wizard is opened for an eDUC-enabled AR that already has a
+ * DocuSign envelope routed, resume at the signature-status step instead of restarting at the
+ * research project step.
+ *
+ * The redirect fires exactly once per wizard session so a user who navigates back to the research
+ * project step later is not kicked forward again. Uses the render-time state-adjustment pattern
+ * (https://react.dev/reference/react/useState#storing-information-from-previous-renders) so React
+ * bails out of the current render and re-renders synchronously without a flash of the wrong step.
+ */
+export function useAutoResumeSignatureStatusStep<TStep extends number>(params: {
+  managedACTAccessRequirement: ManagedACTAccessRequirement | undefined
+  requestDataStep: TStep
+  researchProjectStep: TStep
+  signatureStatusStep: TStep
+  setRequestDataStep: (step: TStep) => void
+}) {
+  const {
+    managedACTAccessRequirement,
+    requestDataStep,
+    researchProjectStep,
+    signatureStatusStep,
+    setRequestDataStep,
+  } = params
+  const hasAutoResumedRef = useRef(false)
+
+  const arId = managedACTAccessRequirement?.id
+  const isEDucEnabled = Boolean(managedACTAccessRequirement?.eDucTemplateId)
+  const { data: existingDar } = useGetDataAccessRequestForUpdate(
+    String(arId ?? ''),
+    { enabled: isEDucEnabled && Boolean(arId), staleTime: Infinity },
+  )
+
+  if (
+    !hasAutoResumedRef.current &&
+    requestDataStep === researchProjectStep &&
+    existingDar?.eDucSignatureEnvelopeId
+  ) {
+    hasAutoResumedRef.current = true
+    setRequestDataStep(signatureStatusStep)
+  }
 }


### PR DESCRIPTION
## PORTALS-4382: Resume in-progress DARs at the right wizard step

### Summary

When a requester reopens the ManagedACT wizard for a DAR that already has a DocuSign envelope routed, land on the signature-status step instead of restarting at the research project step. Fires exactly once per wizard session so a user who navigates back to the research project step later is not kicked forward again.

### Approach

- Extracted the auto-resume logic into a custom hook, [`useAutoResumeSignatureStatusStep`](packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementListUtils.ts), colocated with the other AR-list utilities.
- Uses the [adjust-state-while-rendering](https://react.dev/reference/react/useState#storing-information-from-previous-renders) pattern (with a `useRef` latch) instead of `useState` + `useEffect` — no state mirror, no post-commit flash of the wrong step.
- Hook is generic over the step values so it does not depend on the private `RequestDataStep` enum being exported.

### Files

- [packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementListUtils.ts](packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementListUtils.ts)
  - Added `useAutoResumeSignatureStatusStep`.
- [packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx](packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx)
  - Calls `useAutoResumeSignatureStatusStep` with the current `RequestDataStep` values.
  - Removes `useGetDataAccessRequestForUpdate` and `useEffect` imports that are no longer needed here.
- [packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.test.tsx](packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.test.tsx)
  - Two new tests, both entering via `initialWizardEntry` at `UPDATE_RESEARCH_PROJECT`:
    - `resumes at SIGNATURE_STATUS when the DAR already has a routed envelope`
    - `lands on the research project step when there is no routed envelope`

### Behavior

| Entry path | `eDucSignatureEnvelopeId` set? | Wizard lands on |
| --- | --- | --- |
| Click "Request access" on eDUC AR | Yes | `SIGNATURE_STATUS` |
| Click "Request access" on eDUC AR | No | `UPDATE_RESEARCH_PROJECT` |
| Click "Request access" on non-eDUC AR | n/a | `UPDATE_RESEARCH_PROJECT` (no DAR fetch) |
| `initialWizardEntry: { step: UPDATE_RESEARCH_PROJECT }` on eDUC AR | Yes | `SIGNATURE_STATUS` |
| `initialWizardEntry: { step: SIGNATURE_STATUS }` | n/a | `SIGNATURE_STATUS` (no re-check) |
| User navigates back to `UPDATE_RESEARCH_PROJECT` after auto-resume | Yes | stays on `UPDATE_RESEARCH_PROJECT` (one-shot latch) |

### Not blocked

Unlike PORTALS-4384 / PORTALS-4385, this ticket does not require PLFM-9903 — the wizard already holds the `ManagedACTAccessRequirement` object at click time and can fetch the DAR by AR ID via the existing `useGetDataAccessRequestForUpdate`.

### Testing

- 4/4 `AccessRequirementList.test.tsx` tests pass.
- 52/52 tests pass across the affected wizard files (`AccessRequirementList`, `SignatureStatusStep`, `ManualUploadDucStep`, `EDucPreviewStep`, `ResearchProjectForm`).