### PR TITLE
PORTALS-4419

### DIFF
--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
@@ -1675,3 +1675,132 @@ describe('toSearchIndexQuery – exact phrase matching', () => {
     })
   })
 })
+
+// ---------------------------------------------------------------------------
+// Synapse ID detection
+// ---------------------------------------------------------------------------
+
+describe('toSearchIndexQuery – Synapse ID detection', () => {
+  function makeQueryBundleWithText(searchExpression: string) {
+    return makeQueryBundleRequest({
+      additionalFilters: [
+        {
+          concreteType: TEXT_MATCHES_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+          searchExpression,
+        },
+      ],
+    })
+  }
+
+  it('a bare Synapse ID always emits simple_query_string regardless of strategy', () => {
+    const strategies = [
+      undefined,
+      'MULTI_MATCH',
+      'MULTI_MATCH_BEST_FIELDS',
+      'MULTI_MATCH_CROSS_FIELDS',
+      'PHRASE_PREFIX',
+      'BOOSTED_FUZZY',
+      'SIMPLE_QUERY_STRING',
+    ] as const
+
+    for (const queryStrategy of strategies) {
+      const result = toSearchIndexQuery(
+        makeQueryBundleWithText('syn12345'),
+        SEARCH_INDEX_ID,
+        undefined,
+        queryStrategy ? { queryStrategy } : undefined,
+      )
+      expect(result.searchQuery?.query).toEqual({
+        simple_query_string: { query: 'syn12345' },
+      })
+    }
+  })
+
+  it('an uppercase Synapse ID is detected (case-insensitive)', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('SYN12345'),
+      SEARCH_INDEX_ID,
+    )
+    expect(result.searchQuery?.query).toEqual({
+      simple_query_string: { query: 'SYN12345' },
+    })
+  })
+
+  it('a versioned Synapse ID (syn123.4) emits simple_query_string', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('syn12345.7'),
+      SEARCH_INDEX_ID,
+    )
+    expect(result.searchQuery?.query).toEqual({
+      simple_query_string: { query: 'syn12345.7' },
+    })
+  })
+
+  it('a Synapse ID mixed with free-text terms emits simple_query_string', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('syn12345 cancer'),
+      SEARCH_INDEX_ID,
+    )
+    expect(result.searchQuery?.query).toEqual({
+      simple_query_string: { query: 'syn12345 cancer' },
+    })
+  })
+
+  it('field boosts are preserved when routing to simple_query_string for a Synapse ID', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('syn12345'),
+      SEARCH_INDEX_ID,
+      undefined,
+      {
+        queryStrategy: 'BOOSTED_FUZZY',
+        fieldBoosts: { resourceName: 5, synonyms: 4 },
+      },
+    )
+    expect(result.searchQuery?.query).toEqual({
+      simple_query_string: {
+        query: 'syn12345',
+        fields: ['resourceName^5', 'synonyms^4'],
+      },
+    })
+  })
+
+  it('a word that starts with "syn" but is not an ID (e.g. "synapse") is NOT routed to simple_query_string', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('synapse'),
+      SEARCH_INDEX_ID,
+    )
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: { query: 'synapse', fuzziness: 'AUTO' },
+    })
+  })
+
+  it('"synonyms" is NOT detected as a Synapse ID', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('synonyms'),
+      SEARCH_INDEX_ID,
+    )
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: { query: 'synonyms', fuzziness: 'AUTO' },
+    })
+  })
+
+  it('"syn" with no digits is NOT detected as a Synapse ID', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('syn'),
+      SEARCH_INDEX_ID,
+    )
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: { query: 'syn', fuzziness: 'AUTO' },
+    })
+  })
+
+  it('a Synapse ID embedded in a larger word (e.g. "asyn12345") is NOT detected', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleWithText('asyn12345'),
+      SEARCH_INDEX_ID,
+    )
+    expect(result.searchQuery?.query).toEqual({
+      multi_match: { query: 'asyn12345', fuzziness: 'AUTO' },
+    })
+  })
+})

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -128,6 +128,19 @@ function containsQuotedPhrase(text: string): boolean {
   return /"[^"]+"/u.test(text)
 }
 
+/**
+ * Returns true if the query text contains a Synapse entity ID token
+ * (e.g. `syn12345` or `syn12345.4`). `multi_match` with fuzziness AUTO can match
+ * neighbouring IDs (e.g. `syn12345` → `syn12344`), which is almost never desired
+ * for identifier lookups. Callers use this to route ID-containing queries to
+ * `simple_query_string`, which does not apply fuzziness.
+ */
+function containsSynapseId(text: string): boolean {
+  // `syn` followed by digits (optionally `.version`), on word boundaries so
+  // ordinary words like `synapse` or `synonyms` don't match.
+  return /\bsyn\d+(?:\.\d+)?\b/iu.test(text)
+}
+
 function buildQueryClause(
   queryText: string,
   config: SearchQueryConfig = {},
@@ -135,11 +148,11 @@ function buildQueryClause(
   const { queryStrategy = 'MULTI_MATCH', fieldBoosts, fuzziness } = config
   const fields = resolveFields(fieldBoosts)
 
-  // When the query text contains a double-quoted phrase (e.g. "cancer genomics"),
-  // multi_match cannot honour the phrase operator — only simple_query_string can.
-  // Route directly to simple_query_string so phrase matching works regardless of
-  // the configured strategy.
-  if (containsQuotedPhrase(queryText)) {
+  // Route to simple_query_string when the query needs exact-token treatment:
+  //  - a double-quoted phrase (multi_match can't honour the phrase operator), or
+  //  - a Synapse entity ID (fuzziness would match neighbouring IDs).
+  // simple_query_string doesn't apply fuzziness by default, so both cases work.
+  if (containsQuotedPhrase(queryText) || containsSynapseId(queryText)) {
     return {
       simple_query_string: {
         query: queryText,

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -37,6 +37,7 @@ import { omit } from 'lodash-es'
 import dayjs from 'dayjs'
 import { useCallback, useMemo } from 'react'
 import { KeyFactory } from '@/synapse-queries/KeyFactory'
+import { SYNAPSE_ENTITY_ID_TOKEN_REGEX } from '@/utils/functions/RegularExpressions'
 
 // ─── Local OpenSearch DSL types ─────────────────────────────────────────────
 // Narrow typings for the OpenSearch structures we build (query DSL, sort) and
@@ -136,9 +137,7 @@ function containsQuotedPhrase(text: string): boolean {
  * `simple_query_string`, which does not apply fuzziness.
  */
 function containsSynapseId(text: string): boolean {
-  // `syn` followed by digits (optionally `.version`), on word boundaries so
-  // ordinary words like `synapse` or `synonyms` don't match.
-  return /\bsyn\d+(?:\.\d+)?\b/iu.test(text)
+  return SYNAPSE_ENTITY_ID_TOKEN_REGEX.test(text)
 }
 
 function buildQueryClause(

--- a/packages/synapse-react-client/src/utils/functions/RegularExpressions.ts
+++ b/packages/synapse-react-client/src/utils/functions/RegularExpressions.ts
@@ -29,6 +29,14 @@ export function convertDoiToLink(doi: string) {
 export const SYNAPSE_ENTITY_ID_REGEX = /^(syn\d+)(?:\.(\d+))?$/i
 
 /**
+ * Detects a Synapse entity ID token (e.g. `syn12345` or `syn12345.4`) embedded
+ * anywhere in a larger string, using word boundaries so ordinary words like
+ * `synapse` or `synonyms` don't match. Use `SYNAPSE_ENTITY_ID_REGEX` when
+ * validating a whole string, and this pattern when scanning free text.
+ */
+export const SYNAPSE_ENTITY_ID_TOKEN_REGEX = /\bsyn\d+(?:\.\d+)?\b/iu
+
+/**
  * Given a Synapse Entity ID of the form `syn123` or `syn123.4`, returns the
  * Reference object containing the entity ID and optional version number.
  * If the ID is not a valid Synapse Entity ID, returns null.


### PR DESCRIPTION
## Route Synapse ID queries through `simple_query_string`

### Motivation

The default `multi_match` clause applies `fuzziness: AUTO`, which allows up to 2 edits on tokens ≥ 5 characters. For a query like `syn12345`, this means the search will also match neighbouring IDs (`syn12344`, `syn12346`, `syn12340`, etc.) — almost never what a user wants when they paste an entity ID.

This mirrors the existing handling for double-quoted phrases: identifiers, like phrases, need to be treated as exact tokens rather than fuzzy free-text.

### Change

In `SearchQueryUseQueryOptions.ts`:

- Added a `containsSynapseId()` helper using `/\bsyn\d+(?:\.\d+)?\b/iu` to detect Synapse entity ID tokens (with optional `.version` suffix, case-insensitive, on word boundaries).
- Extended the existing quoted-phrase fast-path in `buildQueryClause` so queries containing a Synapse ID also route to `simple_query_string` regardless of the configured `queryStrategy`. Field boosts are preserved.

`simple_query_string` doesn't apply fuzziness by default, so IDs match exactly.

### Behavior

| Query                  | Before (multi_match)                 | After                                            |
|------------------------|--------------------------------------|--------------------------------------------------|
| `syn12345`             | fuzzy match — hits `syn12344` etc.   | `simple_query_string` — exact                    |
| `SYN12345`             | fuzzy                                | `simple_query_string` — exact (case-insensitive) |
| `syn12345.7`           | fuzzy                                | `simple_query_string` — exact, versioned         |
| `syn12345 cancer`      | fuzzy on both                        | `simple_query_string` — ID stays exact           |
| `synapse` / `synonyms` | unchanged (`multi_match`)            | unchanged (`multi_match`)                        |
| `syn` (no digits)      | unchanged                            | unchanged                                        |
| `asyn12345`            | unchanged (no word boundary)         | unchanged                                        |

### Tests

Added 9 tests to `SearchQueryUseQueryOptions.test.ts` covering:

- Bare IDs route to `simple_query_string` across every configured strategy.
- Case-insensitive detection (`SYN12345`).
- Versioned IDs (`syn12345.7`).
- Mixed ID + free-text (`syn12345 cancer`).
- Field-boost preservation on the ID path.
- Negative cases: `synapse`, `synonyms`, bare `syn`, and embedded `asyn12345` all keep the default `multi_match` behavior.
