### PR TITLE
PORTALS-4433, PORTALS-4434

### DIFF
--- a/apps/portals/nf/src/config/synapseConfigs/commonProps.ts
+++ b/apps/portals/nf/src/config/synapseConfigs/commonProps.ts
@@ -8,6 +8,7 @@ export const columnAliases = {
   nf1Genotype: 'NF1 Genotype',
   nf2Genotype: 'NF2 Genotype',
   studyId: 'On Synapse',
+  age: 'Donor Age (years)',
 }
 
 export const searchConfiguration = {

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
@@ -19,6 +19,7 @@ import {
   toSearchIndexQuery,
   type SearchQueryConfig,
 } from './SearchQueryUseQueryOptions'
+import { VALUE_NOT_SET } from '@/utils/SynapseConstants'
 
 const SEARCH_INDEX_ID = 'syn60001'
 
@@ -322,6 +323,91 @@ describe('toSearchIndexQuery', () => {
       }
     )?.range?.event_date
     expect(rangeClause).not.toHaveProperty('gte')
+  })
+
+  it('translates a range facet "Not Assigned" selection into a must_not exists post_filter', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleRequest({
+        selectedFacets: [
+          {
+            concreteType: FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+            columnName: 'age',
+            min: VALUE_NOT_SET,
+            max: VALUE_NOT_SET,
+          },
+        ],
+      }),
+      SEARCH_INDEX_ID,
+      [{ id: 'c1', name: 'age', columnType: 'INTEGER', facetType: 'range' }],
+    )
+    // Must be a "field missing" clause, NOT a range clause containing the sentinel string.
+    expect(result.searchQuery?.post_filter).toEqual({
+      bool: { must_not: [{ exists: { field: 'age' } }] },
+    })
+    expect(result.searchQuery?.post_filter).not.toHaveProperty('range')
+  })
+
+  it('translates "Not Assigned" for DATE range facets without applying date conversion', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleRequest({
+        selectedFacets: [
+          {
+            concreteType: FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+            columnName: 'event_date',
+            min: VALUE_NOT_SET,
+            max: VALUE_NOT_SET,
+          },
+        ],
+      }),
+      SEARCH_INDEX_ID,
+      [
+        {
+          id: 'c1',
+          name: 'event_date',
+          columnType: 'DATE',
+          facetType: 'range',
+        },
+      ],
+    )
+    expect(result.searchQuery?.post_filter).toEqual({
+      bool: { must_not: [{ exists: { field: 'event_date' } }] },
+    })
+  })
+
+  it('excludes a "Not Assigned" range clause from its own column\'s aggregation filter', () => {
+    const result = toSearchIndexQuery(
+      makeQueryBundleRequest({
+        selectedFacets: [
+          {
+            concreteType: FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+            columnName: 'age',
+            min: VALUE_NOT_SET,
+            max: VALUE_NOT_SET,
+          },
+          {
+            concreteType: FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE_VALUE,
+            columnName: 'organ',
+            facetValues: ['Brain'],
+          },
+        ],
+      }),
+      SEARCH_INDEX_ID,
+      [
+        {
+          id: 'c1',
+          name: 'organ',
+          columnType: 'STRING',
+          facetType: 'enumeration',
+        },
+        { id: 'c2', name: 'age', columnType: 'INTEGER', facetType: 'range' },
+      ],
+    )
+    // organ aggregation should be filtered by the age "Not Assigned" clause (drops its own)
+    expect(
+      (result.searchQuery?.aggregations as Record<string, unknown>)?.['organ'],
+    ).toMatchObject({
+      filter: { bool: { must_not: [{ exists: { field: 'age' } }] } },
+    })
   })
 
   it('combines multiple selectedFacets into a bool.must post_filter', () => {

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -38,6 +38,7 @@ import dayjs from 'dayjs'
 import { useCallback, useMemo } from 'react'
 import { KeyFactory } from '@/synapse-queries/KeyFactory'
 import { SYNAPSE_ENTITY_ID_TOKEN_REGEX } from '@/utils/functions/RegularExpressions'
+import { VALUE_NOT_SET } from '@/utils/SynapseConstants'
 
 // ─── Local OpenSearch DSL types ─────────────────────────────────────────────
 // Narrow typings for the OpenSearch structures we build (query DSL, sort) and
@@ -76,6 +77,8 @@ export type SearchQueryConfig = {
 type FilterClause =
   | { terms: Record<string, string[]> }
   | { range: Record<string, { gte?: string; lte?: string }> }
+  // "Field is not set" — emitted when a range facet selects "Not Assigned".
+  | { bool: { must_not: [{ exists: { field: string } }] } }
 
 type MultiMatchClause = {
   multi_match: {
@@ -324,6 +327,16 @@ export function toSearchIndexQuery(
         f.concreteType === FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
     )
     .forEach(f => {
+      // "Not Assigned" selection: the RangeFacetFilter UI sets both bounds to
+      // VALUE_NOT_SET. Translate to an OpenSearch "field missing" clause rather
+      // than emitting the sentinel string as a range bound (which would fail
+      // with NumberFormatException on numeric/date fields).
+      if (f.min === VALUE_NOT_SET && f.max === VALUE_NOT_SET) {
+        filterClauses.push({
+          bool: { must_not: [{ exists: { field: f.columnName } }] },
+        })
+        return
+      }
       const columnType = columnModels?.find(
         cm => cm.name === f.columnName,
       )?.columnType
@@ -401,6 +414,9 @@ export function toSearchIndexQuery(
       const otherClauses = filterClauses.filter(clause => {
         if ('terms' in clause) return !(cm.name in clause.terms)
         if ('range' in clause) return !(cm.name in clause.range)
+        // "Not Assigned" range clause: identify by the field inside must_not.exists.
+        if ('bool' in clause)
+          return clause.bool.must_not[0]?.exists?.field !== cm.name
         return true
       })
       const aggFilter: SelectionFilter =

--- a/packages/synapse-react-client/src/components/widgets/Range.tsx
+++ b/packages/synapse-react-client/src/components/widgets/Range.tsx
@@ -167,7 +167,7 @@ export function Range(props: RangeProps): React.ReactNode {
                 })
               }
               slotProps={{
-                htmlInput: { 'aria-label': 'min' },
+                htmlInput: { 'aria-label': 'min', autoComplete: 'off' },
               }}
             />
           </Box>
@@ -183,7 +183,7 @@ export function Range(props: RangeProps): React.ReactNode {
                 })
               }
               slotProps={{
-                htmlInput: { 'aria-label': 'max' },
+                htmlInput: { 'aria-label': 'max', autoComplete: 'off' },
               }}
             />
           </Box>

--- a/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilter.test.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilter.test.tsx
@@ -412,6 +412,30 @@ describe('RangeFacetFilter tests', () => {
         ])
       })
     })
+
+    it('normalizes NaN bounds from the range control to undefined', async () => {
+      init({ facetResult: rangeFacetResult })
+      await waitFor(() => expect(mockedRangeSlider).toHaveBeenCalled())
+      await waitFor(() => expect(capturedOnApplyClicked).toBeDefined())
+
+      act(() => {
+        capturedOnApplyClicked!({ min: NaN, max: 300 })
+      })
+
+      await waitFor(() => {
+        expect(
+          currentQueryContext?.getCurrentQueryRequest().query.selectedFacets,
+        ).toEqual([
+          {
+            concreteType:
+              'org.sagebionetworks.repo.model.table.FacetColumnRangeRequest',
+            columnName: 'Year',
+            min: undefined,
+            max: '300',
+          },
+        ])
+      })
+    })
   })
 })
 
@@ -472,6 +496,29 @@ describe('RangeFacetFilterUI INTEGER without column bounds', () => {
     const minInput = screen.getByLabelText<HTMLInputElement>('min')
     expect(minInput.type).toBe('number')
     expect(minInput.value).toBe('1997')
+  })
+
+  it('does not seed inputs with NaN when switching from "Not Assigned" → "Range"', async () => {
+    // selectedMin/Max = VALUE_NOT_SET simulates the state after clicking "Not Assigned".
+    // Without treating the sentinel as absent, parseInt('org.sagebionetworks…') = NaN
+    // would seed the min input, and applying with only a max value would emit min='NaN'.
+    render(
+      <RangeFacetFilterUI
+        label="Year"
+        facetResult={{ selectedMin: VALUE_NOT_SET, selectedMax: VALUE_NOT_SET }}
+        columnType="INTEGER"
+        onRangeValueSelected={vi.fn()}
+        onNotSetSelected={vi.fn()}
+        onAnySelected={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    )
+    const rangeOption = screen.getByLabelText('Range')
+    await userEvent.click(rangeOption)
+    const minInput = screen.getByLabelText<HTMLInputElement>('min')
+    const maxInput = screen.getByLabelText<HTMLInputElement>('max')
+    expect(minInput.value).toBe('')
+    expect(maxInput.value).toBe('')
   })
 
   it('renders a RangeSlider when real columnMin and columnMax bounds are provided', async () => {

--- a/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilter.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilter.tsx
@@ -53,10 +53,15 @@ export function RangeFacetFilter(props: RangeFacetFilterProps) {
       columnType={columnModel.columnType}
       hideCollapsible={hideCollapsible}
       onRangeValueSelected={(values: RangeValues) => {
+        // Normalize numbers to strings; drop NaN (lodash isNumber(NaN) === true, so it must be filtered explicitly).
+        const toApiValue = (v: string | number | undefined) => {
+          if (isNumber(v)) return Number.isNaN(v) ? undefined : String(v)
+          return v
+        }
         setRangeFacetValue(
           facetResult,
-          isNumber(values.min) ? String(values.min) : values.min,
-          isNumber(values.max) ? String(values.max) : values.max,
+          toApiValue(values.min),
+          toApiValue(values.max),
         )
       }}
       onNotSetSelected={() => {

--- a/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilterUI.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/RangeFacetFilterUI.tsx
@@ -60,8 +60,15 @@ export function RangeFacetFilterUI(props: RangeFacetFilterProps) {
 
   const hasAnyValue = !selectedMin && !selectedMax
 
-  const currentMin = selectedMin || columnMin
-  const currentMax = selectedMax || columnMax
+  // Treat the "Not Assigned" sentinel as absent when computing initial Range values,
+  // so switching from "Not Assigned" → "Range" doesn't seed inputs with NaN.
+  const effectiveSelectedMin =
+    selectedMin === VALUE_NOT_SET ? undefined : selectedMin
+  const effectiveSelectedMax =
+    selectedMax === VALUE_NOT_SET ? undefined : selectedMax
+
+  const currentMin = effectiveSelectedMin || columnMin
+  const currentMax = effectiveSelectedMax || columnMax
 
   const rangeType = columnType === 'DOUBLE' ? 'number' : 'date'
 
@@ -83,7 +90,7 @@ export function RangeFacetFilterUI(props: RangeFacetFilterProps) {
   }
 
   const [radioValue, setRadioValue] = useState(
-    getRadioValue(currentMin ?? '', hasAnyValue),
+    getRadioValue(selectedMin ?? '', hasAnyValue),
   )
 
   return (
@@ -149,16 +156,19 @@ export function RangeFacetFilterUI(props: RangeFacetFilterProps) {
                 <Range
                   key="Range"
                   initialValues={
-                    selectedMin || selectedMax || columnMin || columnMax
+                    effectiveSelectedMin ||
+                    effectiveSelectedMax ||
+                    columnMin ||
+                    columnMax
                       ? {
                           // From the backend, selectedMin is a formatted date (like "2021-06-15"), but columnMin is a unix timestamp in millis (like "1624651794856")
                           min:
-                            selectedMin ??
+                            effectiveSelectedMin ??
                             (columnMin
                               ? dayjs(parseInt(columnMin)).toString()
                               : undefined),
                           max:
-                            selectedMax ??
+                            effectiveSelectedMax ??
                             (columnMax
                               ? dayjs(parseInt(columnMax)).toString()
                               : undefined),


### PR DESCRIPTION
## Fix: "Not Assigned" range facet crashes SearchIndex query

### Problem
Selecting **"Not Assigned"** on a range facet (e.g. NF → Tools → Age) caused OpenSearch to fail with:

> `number_format_exception: For input string: "org.sagebionetworks.UNDEFINED_NULL_NOTSET"`

### Root cause
`RangeFacetFilter` represents the "Not Assigned" selection by setting both `min` and `max` to the sentinel string `VALUE_NOT_SET` (`org.sagebionetworks.UNDEFINED_NULL_NOTSET`). In [SearchQueryUseQueryOptions.ts](packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts), `toSearchIndexQuery` translated any range selection into an OpenSearch `range: { field: { gte, lte } }` clause — which fails to parse the sentinel string as a number/date.

### Fix
In [SearchQueryUseQueryOptions.ts](packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts):

- When `min === max === VALUE_NOT_SET`, emit a "field missing" clause instead of a range clause:
  ```json
  { "bool": { "must_not": [{ "exists": { "field": "<columnName>" } }] } }
  ```
- Extended the internal `FilterClause` union to include the new missing-field variant.
- Updated the per-facet aggregation "drop own column" filter so the new clause is correctly excluded from its own column's aggregation (keeping the column's counts wide).

### Tests
Added 3 tests in [SearchQueryUseQueryOptions.test.ts](packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts):

- Translates a range facet "Not Assigned" selection into a `must_not exists` `post_filter`.
- Translates "Not Assigned" for DATE range facets without applying date conversion.
- Excludes a "Not Assigned" range clause from its own column's aggregation filter.

Also updated a column alias for NF age (Belinda asserts in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/3113 that this should be rendered as `Donor Age (years)` across the NF portal)