### PR TITLE
SWC-7960

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
@@ -17,7 +17,10 @@ import {
   Stack,
   Typography,
 } from '@mui/material'
-import { ManagedACTAccessRequirement } from '@sage-bionetworks/synapse-types'
+import {
+  FileHandleAssociateType,
+  ManagedACTAccessRequirement,
+} from '@sage-bionetworks/synapse-types'
 import { ReactNode } from 'react'
 import { useFetchBlobUrl } from '@/utils/hooks/useFetchBlobUrl'
 import IconSvg from '../../../IconSvg/IconSvg'
@@ -70,9 +73,13 @@ export default function EDucPreviewStep(props: EDucPreviewStepProps) {
 
   const previewFileHandleId = previewFileHandle?.fileHandleId
   const { blobUrl, error: blobError } = useFetchBlobUrl(
-    previewSrcOverride || !previewFileHandleId
+    previewSrcOverride || !previewFileHandleId || !dataAccessRequest?.id
       ? undefined
-      : SynapseClient.getPortalFileHandleServletUrl(previewFileHandleId),
+      : SynapseClient.getPortalFileHandleServletUrl(
+          previewFileHandleId,
+          dataAccessRequest.id,
+          FileHandleAssociateType.DataAccessRequestAttachment,
+        ),
   )
 
   const {

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
@@ -82,8 +82,12 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
   const previewFileHandleId = previewFileHandle?.fileHandleId
   const downloadHref =
     downloadHrefOverride ??
-    (previewFileHandleId
-      ? SynapseClient.getPortalFileHandleServletUrl(previewFileHandleId)
+    (previewFileHandleId && dataAccessRequest?.id
+      ? SynapseClient.getPortalFileHandleServletUrl(
+          previewFileHandleId,
+          dataAccessRequest.id,
+          FileHandleAssociateType.DataAccessRequestAttachment,
+        )
       : undefined)
 
   const [updateDarError, setUpdateDarError] = useState<string | undefined>()

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/SignatureStatusStep/SignatureStatusStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/SignatureStatusStep/SignatureStatusStep.tsx
@@ -29,6 +29,7 @@ import {
 } from '@mui/material'
 import { EDucSignerStatus } from '@sage-bionetworks/synapse-client'
 import {
+  FileHandleAssociateType,
   ManagedACTAccessRequirement,
   RestrictableObjectType,
 } from '@sage-bionetworks/synapse-types'
@@ -102,9 +103,11 @@ export default function SignatureStatusStep(props: SignatureStatusStepProps) {
   )
   const viewDucHref =
     viewDucHrefOverride ??
-    (previewFileHandle?.fileHandleId
+    (previewFileHandle?.fileHandleId && requestId
       ? SynapseClient.getPortalFileHandleServletUrl(
           previewFileHandle.fileHandleId,
+          requestId,
+          FileHandleAssociateType.DataAccessRequestAttachment,
         )
       : undefined)
 


### PR DESCRIPTION
Set the associatedObjectId and FileHandleAssociateType to fall into the appropriate preview path in the FileHandleAssociation servlet.  See https://github.com/Sage-Bionetworks/SynapseWebClient/pull/6041 
