### PR TITLE
Releasing the curie launcher for NF

### DIFF
--- a/apps/portals/nf/src/pages/PortalRoot.tsx
+++ b/apps/portals/nf/src/pages/PortalRoot.tsx
@@ -24,6 +24,7 @@ export default function NfPortalRoot() {
       logoHeaderConfig={logoHeaderConfig}
       logoFooterConfig={logoFooterConfig}
       synapseChatProps={synapseChatConfig}
+      isCurieLauncherEnabled
     />
   )
 }

--- a/apps/synapse-portal-framework/src/components/HeaderSearchBox.tsx
+++ b/apps/synapse-portal-framework/src/components/HeaderSearchBox.tsx
@@ -27,8 +27,7 @@ import { useChatDialogContext } from './ChatDialogContext'
 import { useSynapseContext } from 'synapse-react-client'
 import { useGetSuggestionsForSearchIndex } from 'synapse-react-client/components/SearchQueryWrapper/SearchQueryUseQueryOptions'
 import { SearchIndexConfig } from '../types/portal-util-types'
-import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/index'
-import { FeatureFlagEnum } from 'synapse-react-client/utils/featureflag/FeatureFlags'
+import { useIsCurieLauncherAvailable } from './curie-chat-widget/useIsCurieLauncherAvailable'
 
 type HeaderSearchBoxProps = {
   searchPlaceholder?: string
@@ -56,10 +55,6 @@ const HeaderSearchBox = ({
   hideChatOption = false,
   isChatEnabled = false,
 }: HeaderSearchBoxProps): React.ReactNode => {
-  const isCurieLauncherEnabled = useGetFeatureFlag(
-    FeatureFlagEnum.CURIE_CHAT_WIDGET,
-  )
-  const isPortalChatEnabled = useGetFeatureFlag(FeatureFlagEnum.PORTAL_CHAT)
   const styles = {
     ...defaultStyles,
     ...(variant === 'v2' ? v2Styles : {}),
@@ -72,6 +67,7 @@ const HeaderSearchBox = ({
   const location = useLocation()
   const { isAuthenticated } = useSynapseContext()
   const chatDialogContext = useChatDialogContext()
+  const canUseCurieLauncher = useIsCurieLauncherAvailable()
   const isChatAvailable = chatDialogContext?.isChatAvailable
   const showChatOption =
     isAuthenticated &&
@@ -110,9 +106,6 @@ const HeaderSearchBox = ({
   const handleChange = (event: SelectChangeEvent) => {
     setRole(event.target.value)
   }
-
-  const canUseCurieLauncher =
-    isPortalChatEnabled && isCurieLauncherEnabled && !!isChatAvailable
 
   return (
     <Box className={styles.root} sx={sx}>

--- a/apps/synapse-portal-framework/src/components/PortalContext.tsx
+++ b/apps/synapse-portal-framework/src/components/PortalContext.tsx
@@ -30,6 +30,11 @@ export type PortalContextType = {
   aridhiaConfig?: AridhiaConfig
   /** Optional chat config — only set on portals that enable Synapse Chat. */
   synapseChatProps?: SynapseChatProps
+  /**
+   * Opts the portal into the Curie chat launcher regardless of the
+   * PORTAL_CHAT/CURIE_CHAT_WIDGET feature flags.
+   */
+  isCurieLauncherEnabled?: boolean
 }
 
 export const PortalContext = createContext<PortalContextType | undefined>(

--- a/apps/synapse-portal-framework/src/components/curie-chat-widget/CurieChatWidget.tsx
+++ b/apps/synapse-portal-framework/src/components/curie-chat-widget/CurieChatWidget.tsx
@@ -4,24 +4,15 @@ import { useSynapseContext } from 'synapse-react-client'
 import { useChatDialogContext } from '../ChatDialogContext'
 import { useOneSageURL } from 'synapse-react-client/utils/hooks/useOneSageURL'
 import { storeRedirectURLForOneSageLoginAndGotoURL } from 'synapse-react-client/utils/AppUtils/index'
-import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/index'
-import { FeatureFlagEnum } from 'synapse-react-client/utils/featureflag/FeatureFlags'
+import { useIsCurieLauncherAvailable } from './useIsCurieLauncherAvailable'
 
 function CurieChatDialogLauncher() {
   const { isAuthenticated } = useSynapseContext()
   const chatDialogContext = useChatDialogContext()
   const oneSageUrl = useOneSageURL()
-  const isPortalChatEnabled = useGetFeatureFlag(FeatureFlagEnum.PORTAL_CHAT)
-  const isCurieLauncherEnabled = useGetFeatureFlag(
-    FeatureFlagEnum.CURIE_CHAT_WIDGET,
-  )
+  const canShowCurie = useIsCurieLauncherAvailable()
 
-  const canShowCurie =
-    isPortalChatEnabled &&
-    isCurieLauncherEnabled &&
-    !!chatDialogContext?.isChatAvailable
-
-  if (!canShowCurie) {
+  if (!canShowCurie || !chatDialogContext) {
     return null
   }
 

--- a/apps/synapse-portal-framework/src/components/curie-chat-widget/useIsCurieLauncherAvailable.test.tsx
+++ b/apps/synapse-portal-framework/src/components/curie-chat-widget/useIsCurieLauncherAvailable.test.tsx
@@ -1,0 +1,96 @@
+import { renderHook } from '@testing-library/react'
+import { PropsWithChildren } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/index'
+import { FeatureFlagEnum } from 'synapse-react-client/utils/featureflag/FeatureFlags'
+import { ChatDialogContext } from '../ChatDialogContext'
+import { PortalContext, PortalContextType } from '../PortalContext'
+import { useIsCurieLauncherAvailable } from './useIsCurieLauncherAvailable'
+
+vi.mock('synapse-react-client/synapse-queries/index', () => ({
+  useGetFeatureFlag: vi.fn(),
+}))
+
+function setFeatureFlags(portalChat: boolean, curieWidget: boolean) {
+  vi.mocked(useGetFeatureFlag).mockImplementation(flag => {
+    if (flag === FeatureFlagEnum.PORTAL_CHAT) {
+      return portalChat
+    }
+    if (flag === FeatureFlagEnum.CURIE_CHAT_WIDGET) {
+      return curieWidget
+    }
+    return false
+  })
+}
+
+function renderUseIsCurieLauncherAvailable(options: {
+  isChatAvailable?: boolean
+  isCurieLauncherEnabled?: boolean
+}) {
+  const { isChatAvailable = true, isCurieLauncherEnabled } = options
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <PortalContext.Provider
+      value={{ isCurieLauncherEnabled } as PortalContextType}
+    >
+      <ChatDialogContext.Provider
+        value={{ openChat: vi.fn(), isChatAvailable }}
+      >
+        {children}
+      </ChatDialogContext.Provider>
+    </PortalContext.Provider>
+  )
+  return renderHook(() => useIsCurieLauncherAvailable(), { wrapper })
+}
+
+describe('useIsCurieLauncherAvailable', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('is available when the portal opts in, even if the feature flags are disabled', () => {
+    setFeatureFlags(false, false)
+
+    const { result } = renderUseIsCurieLauncherAvailable({
+      isCurieLauncherEnabled: true,
+    })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('follows the feature flags when the portal has not opted in', () => {
+    setFeatureFlags(true, true)
+
+    const { result } = renderUseIsCurieLauncherAvailable({})
+
+    expect(result.current).toBe(true)
+  })
+
+  it('is unavailable when the portal has not opted in and the feature flags are disabled', () => {
+    setFeatureFlags(false, false)
+
+    const { result } = renderUseIsCurieLauncherAvailable({})
+
+    expect(result.current).toBe(false)
+  })
+
+  it('is unavailable when the portal opts out, even if the feature flags are enabled', () => {
+    setFeatureFlags(true, true)
+
+    const { result } = renderUseIsCurieLauncherAvailable({
+      isCurieLauncherEnabled: false,
+    })
+
+    expect(result.current).toBe(false)
+  })
+
+  it('is unavailable when the portal has no chat configured', () => {
+    setFeatureFlags(true, true)
+
+    const { result } = renderUseIsCurieLauncherAvailable({
+      isChatAvailable: false,
+      isCurieLauncherEnabled: true,
+    })
+
+    expect(result.current).toBe(false)
+  })
+})

--- a/apps/synapse-portal-framework/src/components/curie-chat-widget/useIsCurieLauncherAvailable.ts
+++ b/apps/synapse-portal-framework/src/components/curie-chat-widget/useIsCurieLauncherAvailable.ts
@@ -1,0 +1,20 @@
+import { useContext } from 'react'
+import { useGetFeatureFlag } from 'synapse-react-client/synapse-queries/index'
+import { FeatureFlagEnum } from 'synapse-react-client/utils/featureflag/FeatureFlags'
+import { useChatDialogContext } from '../ChatDialogContext'
+import { PortalContext } from '../PortalContext'
+
+export function useIsCurieLauncherAvailable(): boolean {
+  const portalContext = useContext(PortalContext)
+  const chatDialogContext = useChatDialogContext()
+  const isPortalChatEnabled = useGetFeatureFlag(FeatureFlagEnum.PORTAL_CHAT)
+  const isCurieWidgetEnabled = useGetFeatureFlag(
+    FeatureFlagEnum.CURIE_CHAT_WIDGET,
+  )
+
+  return (
+    !!chatDialogContext?.isChatAvailable &&
+    (portalContext?.isCurieLauncherEnabled ??
+      (isPortalChatEnabled && isCurieWidgetEnabled))
+  )
+}


### PR DESCRIPTION
<img width="1512" height="982" alt="Screenshot 2026-08-28 at 12 59 25 PM" src="https://github.com/user-attachments/assets/c4e84798-d81a-49d6-9105-81b8eeabc914" />
<img width="1512" height="982" alt="Screenshot 2026-08-28 at 1 00 00 PM" src="https://github.com/user-attachments/assets/2bc46267-e149-4b8b-86f9-3b29c4bf4aa6" />
<img width="1512" height="982" alt="Screenshot 2026-08-28 at 1 11 38 PM" src="https://github.com/user-attachments/assets/571f8208-087a-495a-9bc9-805666b0b516" />
<img width="1512" height="982" alt="Screenshot 2026-08-28 at 1 02 24 PM" src="https://github.com/user-attachments/assets/666a12e6-fb5d-42a2-98b0-8931ef40dcdf" />
<img width="1512" height="982" alt="Screenshot 2026-08-28 at 1 03 06 PM" src="https://github.com/user-attachments/assets/fcab74eb-64be-48e7-bbe1-6e3885405716" />

