### PR TITLE
SWC-7964 Show error message when 2FA reset fails

### DIFF
--- a/packages/synapse-react-client/src/components/ChangePassword/ChangePassword.test.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/ChangePassword.test.tsx
@@ -590,7 +590,7 @@ describe('ChangePassword tests', () => {
     expect(otpInputs).toHaveLength(6)
   })
 
-  it('supports requesting 2FA reset using a password', async () => {
+  it('supports requesting 2FA reset using the current password', async () => {
     const userId = MOCK_USER_ID
     const twoFaToken = 'mock-2fa-token'
     server.use(
@@ -655,7 +655,8 @@ describe('ChangePassword tests', () => {
       expect(reset2faSpy).toHaveBeenCalledWith({
         userId: MOCK_USER_ID,
         twoFaResetEndpoint: expect.any(String),
-        // The current password must be used. A twoFaToken returned by the changePassword service cannot be used to reset 2FA.
+        // The current password must be used. A twoFaToken returned by the changePassword service cannot be used to
+        // reset 2FA: the 2fa/reset endpoint only accepts a twoFaToken minted for an AUTHENTICATION (login) challenge.
         password: currentPassword,
       })
 

--- a/packages/synapse-react-client/src/components/ChangePassword/ChangePassword.test.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/ChangePassword.test.tsx
@@ -4,7 +4,10 @@ import {
   getSuccessfulChangePasswordHandler,
 } from '@/mocks/msw/handlers/changePasswordHandlers'
 import { getFeatureFlagsOverride } from '@/mocks/msw/handlers/featureFlagHandlers'
-import { getResetTwoFactorAuthHandlers } from '@/mocks/msw/handlers/resetTwoFactorAuthHandlers'
+import {
+  getResetTwoFactorAuthBadRequestHandler,
+  getResetTwoFactorAuthHandlers,
+} from '@/mocks/msw/handlers/resetTwoFactorAuthHandlers'
 import { server } from '@/mocks/msw/server'
 import {
   MOCK_USER_ID,
@@ -660,5 +663,59 @@ describe('ChangePassword tests', () => {
       expect(newPasswordField).not.toBeInTheDocument()
       expect(confirmPasswordField).not.toBeInTheDocument()
     })
+  })
+
+  it('shows an error message when requesting 2FA reset fails', async () => {
+    const errorMessage = 'Password is incorrect.'
+
+    server.use(
+      getRequires2FAChangePasswordHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        MOCK_USER_ID,
+        'twoFaToken',
+      ),
+      getResetTwoFactorAuthBadRequestHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        errorMessage,
+      ),
+    )
+
+    const currentPassword = 'currentPassword'
+    const newPassword = 'newPassword'
+
+    const {
+      user,
+      currentPasswordField,
+      newPasswordField,
+      confirmPasswordField,
+      submitButton,
+    } = setUp()
+
+    await user.type(currentPasswordField, currentPassword)
+    await user.type(newPasswordField, newPassword)
+    await user.type(confirmPasswordField, newPassword)
+
+    await user.click(submitButton)
+
+    const show2FAResetOptionsButton = await screen.findByText(
+      BEGIN_RESET_2FA_BUTTON_TEXT,
+    )
+    await user.click(show2FAResetOptionsButton)
+
+    const sendResetEmailButton = await screen.findByRole('button', {
+      name: SEND_RESET_2FA_EMAIL_BUTTON_TEXT,
+    })
+
+    await user.click(sendResetEmailButton)
+
+    // The failure is surfaced to the user instead of being silently swallowed.
+    await screen.findByText(
+      `Failed to reset two-factor authentication: ${errorMessage}`,
+    )
+
+    // The confirmation text (shown on success) must NOT appear.
+    expect(
+      screen.queryByText(TWO_FACTOR_RESET_CONFIRMATION_TEXT),
+    ).not.toBeInTheDocument()
   })
 })

--- a/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.test.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.test.tsx
@@ -14,6 +14,7 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { noop } from 'lodash-es'
 import { MemoryRouter } from 'react-router'
+import { BEGIN_RESET_2FA_BUTTON_TEXT } from '../Authentication/OneTimePasswordForm'
 import * as ToastMessage from '../ToastMessage/ToastMessage'
 import ChangePasswordWithToken from './ChangePasswordWithToken'
 import { TWO_FACTOR_AUTH_CHANGE_PASSWORD_PROMPT } from './useChangePasswordFormState'
@@ -23,6 +24,7 @@ const mockDisplayToast = vi
   .mockImplementation(() => noop)
 
 const changePasswordSpy = vi.spyOn(SynapseClient, 'changePassword')
+const reset2faSpy = vi.spyOn(SynapseClient, 'resetTwoFactorAuth')
 
 const passwordResetSignedToken: PasswordResetSignedToken = {
   concreteType: 'org.sagebionetworks.repo.model.auth.PasswordResetSignedToken',
@@ -400,5 +402,52 @@ describe('ChangePasswordWithToken tests', () => {
     // The TOTP form should still be shown
     const otpInputs = await getTOTPInputs()
     expect(otpInputs).toHaveLength(6)
+  })
+
+  it('shows Service Desk recovery guidance instead of an interactive 2FA reset, since this flow has no credential the reset endpoint accepts', async () => {
+    const userId = MOCK_USER_ID
+    const twoFaToken = 'mock-2fa-token'
+    server.use(
+      // The first call will indicate that 2FA is required
+      getRequires2FAChangePasswordHandler(
+        getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+        userId,
+        twoFaToken,
+      ),
+    )
+
+    const newPassword = 'newPassword'
+
+    const { user, newPasswordField, confirmPasswordField, submitButton } =
+      setUp()
+
+    await user.type(newPasswordField, newPassword)
+    await user.type(confirmPasswordField, newPassword)
+
+    await user.click(submitButton)
+
+    // TOTP form should pop up
+    await getTOTPInputs()
+
+    // This flow authenticated via an emailed reset token: there's no current password to send,
+    // and the 2FA challenge token is scoped to PASSWORD_CHANGE, which the 2fa/reset endpoint
+    // rejects (it only accepts a token from an AUTHENTICATION/login challenge). The interactive
+    // "reset 2FA" option, which can never succeed here, must not be offered.
+    const revealGuidanceLink = await screen.findByText(
+      BEGIN_RESET_2FA_BUTTON_TEXT,
+    )
+
+    // Clicking it must not fire a request to the reset endpoint...
+    await user.click(revealGuidanceLink)
+    expect(reset2faSpy).not.toHaveBeenCalled()
+
+    // ...instead it reveals guidance pointing the user at the Synapse Service Desk.
+    const serviceDeskLink = await screen.findByRole('link', {
+      name: 'Synapse Service Desk',
+    })
+    expect(serviceDeskLink).toHaveAttribute(
+      'href',
+      'https://sagebionetworks.jira.com/servicedesk/customer/portal/9',
+    )
   })
 })

--- a/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/ChangePasswordWithToken.tsx
@@ -1,7 +1,8 @@
 import { validatePassword } from '@/utils/functions/StringUtils'
-import { Alert, Button, TextField } from '@mui/material'
+import { Alert, Button, Link, TextField, Typography } from '@mui/material'
 import { PasswordResetSignedToken } from '@sage-bionetworks/synapse-types'
 import { FormEvent, useState } from 'react'
+import { BEGIN_RESET_2FA_BUTTON_TEXT } from '../Authentication/OneTimePasswordForm'
 import { displayToast } from '../ToastMessage'
 import useChangePasswordFormState from './useChangePasswordFormState'
 
@@ -19,6 +20,10 @@ export default function ChangePasswordWithToken(
   const [newPasswordError, setNewPasswordError] = useState<string | undefined>(
     undefined,
   )
+  const [
+    showTwoFactorAuthRecoveryGuidance,
+    setShowTwoFactorAuthRecoveryGuidance,
+  ] = useState(false)
 
   const {
     promptForTwoFactorAuth,
@@ -27,6 +32,13 @@ export default function ChangePasswordWithToken(
     handleChangePasswordWithResetToken,
     error,
   } = useChangePasswordFormState({
+    // This flow authenticates via an emailed password-reset token: the user has no current
+    // password, and their 2FA challenge token is scoped to PASSWORD_CHANGE, which the 2fa/reset
+    // endpoint rejects (it only accepts a token from an AUTHENTICATION/login challenge, e.g. one
+    // obtained by signing in with a linked SSO provider). There is no credential this flow can
+    // offer to self-service reset 2FA, so we hide the interactive reset option (it would only
+    // fail) and instead show guidance below.
+    hideReset2FA: true,
     onChangePasswordSuccess: () => {
       setNewPassword('')
       setConfirmPassword('')
@@ -47,7 +59,40 @@ export default function ChangePasswordWithToken(
   return (
     <div>
       {promptForTwoFactorAuth ? (
-        <TwoFactorAuthPrompt />
+        <>
+          <TwoFactorAuthPrompt />
+          {!showTwoFactorAuthRecoveryGuidance ? (
+            <Link
+              align={'center'}
+              color={'grey.700'}
+              sx={{ display: 'block', mx: 'auto', my: 2 }}
+              onClick={() => setShowTwoFactorAuthRecoveryGuidance(true)}
+            >
+              {BEGIN_RESET_2FA_BUTTON_TEXT}
+            </Link>
+          ) : (
+            <>
+              <Typography variant={'body1'} sx={{ my: 2 }} align={'center'}>
+                Because you're resetting your password by email, we can't verify
+                your identity strongly enough to reset two-factor authentication
+                here. Please contact the{' '}
+                <Link
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://sagebionetworks.jira.com/servicedesk/customer/portal/9"
+                >
+                  Synapse Service Desk
+                </Link>{' '}
+                for help recovering your account.
+              </Typography>
+              <Typography variant={'body1'} sx={{ my: 2 }} align={'center'}>
+                If you have a Google or ORCID account linked to your Synapse
+                account, you may also be able to regain access by signing in
+                with that account instead.
+              </Typography>
+            </>
+          )}
+        </>
       ) : (
         <form
           onSubmit={e => {

--- a/packages/synapse-react-client/src/components/ChangePassword/useChangePasswordFormState.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/useChangePasswordFormState.tsx
@@ -39,7 +39,7 @@ export default function useChangePasswordFormState(
     'twoFAResetToken',
   )
 
-  // Store current and new password in state so that we can re-use it if 2FA is required
+  // Store current and new password in state so that we can re-use the current password if 2FA is required
   const [currentPassword, setCurrentPassword] = useState<string>('')
   const [newPassword, setNewPassword] = useState<string>('')
   const [twoFactorAuthErrorResponse, setTwoFactorAuthErrorResponse] = useState<
@@ -130,7 +130,9 @@ export default function useChangePasswordFormState(
         const request: TwoFactorAuthResetRequest = {
           userId: twoFactorAuthErrorResponse.userId!,
           twoFaResetEndpoint: twoFaResetEndpoint,
-          // When attempting to reset 2FA while resetting a password, the current password must be used to request 2FA reset
+          // The 2fa/reset endpoint only accepts a twoFaToken minted for an AUTHENTICATION (login) challenge;
+          // the token from a change-password 2FA challenge is scoped to PASSWORD_CHANGE and is rejected there.
+          // The current password is therefore the only credential this flow can present.
           password: currentPassword,
         }
         resetTwoFactorAuth(request)

--- a/packages/synapse-react-client/src/components/ChangePassword/useChangePasswordFormState.tsx
+++ b/packages/synapse-react-client/src/components/ChangePassword/useChangePasswordFormState.tsx
@@ -121,6 +121,7 @@ export default function useChangePasswordFormState(
     mutate: resetTwoFactorAuth,
     isSuccess: twoFactorAuthResetIsSuccess,
     isPending: twoFactorAuthResetIsPending,
+    error: twoFactorAuthResetError,
   } = useResetTwoFactorAuth()
 
   const beginTwoFactorAuthReset = useCallback(
@@ -188,6 +189,12 @@ export default function useChangePasswordFormState(
             password after clicking the link sent to your email address.
           </Alert>
         )}
+        {otpStep === 'DISABLE_2FA_PROMPT' && twoFactorAuthResetError && (
+          <Alert severity={'error'} sx={{ my: 2 }}>
+            Failed to reset two-factor authentication:{' '}
+            {twoFactorAuthResetError.reason}
+          </Alert>
+        )}
       </>
     )
   }, [
@@ -198,6 +205,7 @@ export default function useChangePasswordFormState(
     options?.hideReset2FA,
     otpStep,
     promptForTwoFactorAuth,
+    twoFactorAuthResetError,
     twoFactorAuthResetIsPending,
     twoFactorAuthResetIsSuccess,
     twoFactorAuthResetUri,

--- a/packages/synapse-react-client/src/mocks/msw/handlers/resetTwoFactorAuthHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/resetTwoFactorAuthHandlers.ts
@@ -10,3 +10,18 @@ export function getResetTwoFactorAuthHandlers(backendOrigin: string) {
     }),
   ]
 }
+
+export function getResetTwoFactorAuthBadRequestHandler(
+  backendOrigin: string,
+  message: string,
+) {
+  return http.post(`${backendOrigin}/auth/v1/2fa/reset`, () => {
+    return HttpResponse.json(
+      {
+        concreteType: 'org.sagebionetworks.repo.model.ErrorResponse',
+        reason: message,
+      },
+      { status: 400 },
+    )
+  })
+}


### PR DESCRIPTION
## Problem
In `useChangePasswordFormState`, the `resetTwoFactorAuth` mutation (triggered when a user requests a 2FA reset while changing their password) had no `onError` handler and did not expose its `error` state. If the reset request failed (e.g. 400 due to incorrect current password), the failure was silently swallowed — the user saw no feedback at all.

## Fix
- Destructure `error` from `useResetTwoFactorAuth()` and render an error `Alert` with the failure reason when the reset request fails during the 2FA-reset-confirmation step.
- Added `getResetTwoFactorAuthBadRequestHandler` MSW mock handler (mirrors the existing `getBadRequestChangePasswordHandler` pattern).
- Added a regression test (`shows an error message when requesting 2FA reset fails`) that drives the reset flow against the new failure handler and asserts the error message renders. Verified this test fails against the pre-fix code.

## Testing
`pnpm --filter synapse-react-client test ChangePassword.test.tsx` — 10/10 passing.

JIRA: SWC-7964