### PR TITLE
PORTALS-4441

### DIFF
--- a/packages/synapse-react-client/src/components/QueryBuilder/QueryBuilderTypes.ts
+++ b/packages/synapse-react-client/src/components/QueryBuilder/QueryBuilderTypes.ts
@@ -1,0 +1,69 @@
+/**
+ * QB internal UI types. These carry column-model metadata and per-input state
+ * (values / range / text) that the QueryFilter API objects don't. They are
+ * never serialized directly to the API — {@link qbNodeToApiFilter} converts
+ * them to {@link QueryFilter} first.
+ */
+
+export type QBCombinator = 'AND' | 'OR'
+
+export type QBConditionOp =
+  // enum / multi-value list columns
+  | 'is_any_of'
+  | 'is_all_of'
+  // range (numeric / date) columns
+  | 'between'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  // single-value equality (string / numeric / date / boolean)
+  | 'equal'
+  | 'not_equal'
+  // presence (any column)
+  | 'has_value'
+  | 'no_value'
+  // text columns
+  | 'contains'
+  | 'starts_with'
+  | 'ends_with'
+  | 'is_exactly'
+
+export type QBCondition = {
+  kind: 'condition'
+  id: string
+  columnName: string | null
+  /** `ColumnTypeEnum` string from the query metadata (STRING, INTEGER, …). */
+  columnType: string | null
+  op: QBConditionOp
+  /**
+   * - `is_any_of` / `is_all_of`: one or more selected values.
+   * - `equal` / `not_equal` (any single-value column, including booleans stored
+   *   as `'true'` / `'false'`): single-element array.
+   */
+  values: string[]
+  /** Lower bound for `between` / `gt` / `gte`. */
+  rangeMin: string | null
+  /** Upper bound for `between` / `lt` / `lte`. */
+  rangeMax: string | null
+  /** Free-text input for `contains` / `starts_with` / `ends_with` / `is_exactly`. */
+  text: string | null
+}
+
+export type QBGroup = {
+  kind: 'group'
+  id: string
+  combinator: QBCombinator
+  not: boolean
+  children: QBNode[]
+}
+
+export type QBNode = QBCondition | QBGroup
+
+export function isQBCondition(node: QBNode): node is QBCondition {
+  return node.kind === 'condition'
+}
+
+export function isQBGroup(node: QBNode): node is QBGroup {
+  return node.kind === 'group'
+}

--- a/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.test.ts
+++ b/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.test.ts
@@ -1,0 +1,643 @@
+import {
+  COLUMN_MULTI_VALUE_FUNCTION_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+  COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+  ColumnMultiValueFunction,
+  ColumnMultiValueFunctionQueryFilter,
+  ColumnSingleValueFilterOperator,
+  ColumnSingleValueQueryFilter,
+  FacetColumnRangeRequest,
+  FacetColumnValuesRequest,
+  FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+  FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE_VALUE,
+  FILTER_GROUP_CONCRETE_TYPE_VALUE,
+  FilterGroup,
+} from '@sage-bionetworks/synapse-types'
+import {
+  apiFilterToQBNode,
+  classifyLikePattern,
+  escapeLike,
+  isListColumn,
+  qbNodeToApiFilter,
+  selectedFacetsToQBGroup,
+  unescapeLike,
+} from './queryBuilderTranslation'
+import { QBCondition, QBGroup } from './QueryBuilderTypes'
+
+function condition(patch: Partial<QBCondition>): QBCondition {
+  return {
+    kind: 'condition',
+    id: 'test-id',
+    columnName: 'col',
+    columnType: 'STRING',
+    op: 'equal',
+    values: [],
+    rangeMin: null,
+    rangeMax: null,
+    text: null,
+    ...patch,
+  }
+}
+
+function group(patch: Partial<QBGroup>): QBGroup {
+  return {
+    kind: 'group',
+    id: 'test-group',
+    combinator: 'AND',
+    not: false,
+    children: [],
+    ...patch,
+  }
+}
+
+describe('isListColumn', () => {
+  it.each([
+    ['STRING_LIST', true],
+    ['INTEGER_LIST', true],
+    ['STRING', false],
+    ['INTEGER', false],
+    [null, false],
+  ])('classifies %s as list=%s', (input, expected) => {
+    expect(isListColumn(input)).toBe(expected)
+  })
+})
+
+describe('escapeLike / unescapeLike', () => {
+  it('round-trips text with %, _, and \\', () => {
+    const originals = ['50%', 'a_b', 'raw text', '100% pure_junk\\', '%%__\\\\']
+    for (const original of originals) {
+      expect(unescapeLike(escapeLike(original))).toBe(original)
+    }
+  })
+
+  it('escapes the wildcards so they are not interpreted', () => {
+    expect(escapeLike('50%')).toBe('50\\%')
+    expect(escapeLike('a_b')).toBe('a\\_b')
+  })
+})
+
+describe('classifyLikePattern', () => {
+  it('recognizes contains', () => {
+    expect(classifyLikePattern('%foo%')).toEqual({
+      op: 'contains',
+      text: 'foo',
+    })
+  })
+  it('recognizes starts_with', () => {
+    expect(classifyLikePattern('foo%')).toEqual({
+      op: 'starts_with',
+      text: 'foo',
+    })
+  })
+  it('recognizes ends_with', () => {
+    expect(classifyLikePattern('%foo')).toEqual({
+      op: 'ends_with',
+      text: 'foo',
+    })
+  })
+  it('recognizes is_exactly when no wildcards are present', () => {
+    expect(classifyLikePattern('foo')).toEqual({
+      op: 'is_exactly',
+      text: 'foo',
+    })
+  })
+  it('un-escapes literal wildcards inside the text', () => {
+    expect(classifyLikePattern('%50\\%%')).toEqual({
+      op: 'contains',
+      text: '50%',
+    })
+  })
+})
+
+describe('qbNodeToApiFilter — conditions', () => {
+  it('returns null for a condition with no columnName', () => {
+    expect(qbNodeToApiFilter(condition({ columnName: null }))).toBeNull()
+  })
+
+  describe('is_any_of', () => {
+    it('emits IN on ColumnSingleValueQueryFilter for non-list columns', () => {
+      const result = qbNodeToApiFilter(
+        condition({
+          op: 'is_any_of',
+          columnType: 'STRING',
+          values: ['a', 'b'],
+        }),
+      )
+      expect(result).toEqual<ColumnSingleValueQueryFilter>({
+        concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        operator: ColumnSingleValueFilterOperator.IN,
+        values: ['a', 'b'],
+      })
+    })
+
+    it('emits HAS on ColumnMultiValueFunctionQueryFilter for _LIST columns', () => {
+      const result = qbNodeToApiFilter(
+        condition({
+          op: 'is_any_of',
+          columnType: 'STRING_LIST',
+          values: ['a', 'b'],
+        }),
+      )
+      expect(result).toEqual<ColumnMultiValueFunctionQueryFilter>({
+        concreteType:
+          COLUMN_MULTI_VALUE_FUNCTION_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        function: ColumnMultiValueFunction.HAS,
+        _function: ColumnMultiValueFunction.HAS,
+        values: ['a', 'b'],
+      })
+    })
+
+    it('returns null when values is empty', () => {
+      expect(
+        qbNodeToApiFilter(condition({ op: 'is_any_of', values: [] })),
+      ).toBeNull()
+    })
+  })
+
+  describe('is_all_of', () => {
+    it('emits HAS on ColumnMultiValueFunctionQueryFilter', () => {
+      const result = qbNodeToApiFilter(
+        condition({
+          op: 'is_all_of',
+          columnType: 'STRING_LIST',
+          values: ['a', 'b'],
+        }),
+      )
+      expect(result).toEqual<ColumnMultiValueFunctionQueryFilter>({
+        concreteType:
+          COLUMN_MULTI_VALUE_FUNCTION_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        function: ColumnMultiValueFunction.HAS,
+        _function: ColumnMultiValueFunction.HAS,
+        values: ['a', 'b'],
+      })
+    })
+
+    it('returns null when values is empty', () => {
+      expect(
+        qbNodeToApiFilter(condition({ op: 'is_all_of', values: [] })),
+      ).toBeNull()
+    })
+  })
+
+  describe('range operators', () => {
+    it('between emits BETWEEN with [min, max]', () => {
+      expect(
+        qbNodeToApiFilter(
+          condition({
+            op: 'between',
+            rangeMin: '1',
+            rangeMax: '10',
+          }),
+        ),
+      ).toEqual<ColumnSingleValueQueryFilter>({
+        concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        operator: ColumnSingleValueFilterOperator.BETWEEN,
+        values: ['1', '10'],
+      })
+    })
+
+    it.each([
+      ['between', { rangeMin: null, rangeMax: '10' }],
+      ['between', { rangeMin: '1', rangeMax: null }],
+      ['between', { rangeMin: '', rangeMax: '10' }],
+      ['gt', { rangeMin: null }],
+      ['gte', { rangeMin: '' }],
+      ['lt', { rangeMax: null }],
+      ['lte', { rangeMax: '' }],
+    ])('%s returns null when bounds are missing (%o)', (op, bounds) => {
+      expect(
+        qbNodeToApiFilter(
+          condition({
+            op: op as 'between' | 'gt' | 'gte' | 'lt' | 'lte',
+            ...bounds,
+          }),
+        ),
+      ).toBeNull()
+    })
+
+    it.each([
+      ['gt', ColumnSingleValueFilterOperator.GREATER_THAN, 'rangeMin'],
+      [
+        'gte',
+        ColumnSingleValueFilterOperator.GREATER_THAN_OR_EQUAL,
+        'rangeMin',
+      ],
+      ['lt', ColumnSingleValueFilterOperator.LESS_THAN, 'rangeMax'],
+      ['lte', ColumnSingleValueFilterOperator.LESS_THAN_OR_EQUAL, 'rangeMax'],
+    ])('%s emits %s with the bound value', (op, expectedOp, boundField) => {
+      const result = qbNodeToApiFilter(
+        condition({
+          op: op as 'gt' | 'gte' | 'lt' | 'lte',
+          [boundField]: '5',
+        } as Partial<QBCondition>),
+      )
+      expect(result).toEqual<ColumnSingleValueQueryFilter>({
+        concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        operator: expectedOp,
+        values: ['5'],
+      })
+    })
+  })
+
+  describe('equal / not_equal', () => {
+    it('equal uses values[0]', () => {
+      expect(
+        qbNodeToApiFilter(
+          condition({ op: 'equal', values: ['yes', 'ignored'] }),
+        ),
+      ).toEqual<ColumnSingleValueQueryFilter>({
+        concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        operator: ColumnSingleValueFilterOperator.EQUAL,
+        values: ['yes'],
+      })
+    })
+
+    it('equal returns null with empty values', () => {
+      expect(
+        qbNodeToApiFilter(condition({ op: 'equal', values: [] })),
+      ).toBeNull()
+    })
+
+    it('not_equal returns null with empty values', () => {
+      expect(
+        qbNodeToApiFilter(condition({ op: 'not_equal', values: [] })),
+      ).toBeNull()
+    })
+
+    it('equal supports boolean stored as "true" / "false" in values[0]', () => {
+      expect(
+        qbNodeToApiFilter(
+          condition({
+            op: 'equal',
+            columnType: 'BOOLEAN',
+            values: ['true'],
+          }),
+        ),
+      ).toEqual<ColumnSingleValueQueryFilter>({
+        concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        operator: ColumnSingleValueFilterOperator.EQUAL,
+        values: ['true'],
+      })
+    })
+  })
+
+  describe('presence operators', () => {
+    it('has_value emits IS_NOT_NULL with empty values', () => {
+      expect(
+        qbNodeToApiFilter(condition({ op: 'has_value' })),
+      ).toEqual<ColumnSingleValueQueryFilter>({
+        concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        operator: ColumnSingleValueFilterOperator.IS_NOT_NULL,
+        values: [],
+      })
+    })
+
+    it('no_value emits IS_NULL with empty values', () => {
+      expect(
+        qbNodeToApiFilter(condition({ op: 'no_value' })),
+      ).toEqual<ColumnSingleValueQueryFilter>({
+        concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        operator: ColumnSingleValueFilterOperator.IS_NULL,
+        values: [],
+      })
+    })
+  })
+
+  describe('text operators', () => {
+    it.each([
+      ['contains', 'foo', '%foo%'],
+      ['starts_with', 'foo', 'foo%'],
+      ['ends_with', 'foo', '%foo'],
+    ])('%s emits LIKE with %j → %j', (op, text, expectedValue) => {
+      expect(
+        qbNodeToApiFilter(
+          condition({
+            op: op as 'contains' | 'starts_with' | 'ends_with',
+            text,
+          }),
+        ),
+      ).toEqual<ColumnSingleValueQueryFilter>({
+        concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        operator: ColumnSingleValueFilterOperator.LIKE,
+        values: [expectedValue],
+      })
+    })
+
+    it('is_exactly emits EQUAL with the raw text', () => {
+      expect(
+        qbNodeToApiFilter(condition({ op: 'is_exactly', text: 'foo' })),
+      ).toEqual<ColumnSingleValueQueryFilter>({
+        concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        operator: ColumnSingleValueFilterOperator.EQUAL,
+        values: ['foo'],
+      })
+    })
+
+    it('contains escapes % and _ in user input', () => {
+      const result = qbNodeToApiFilter(
+        condition({ op: 'contains', text: '50%' }),
+      ) as ColumnSingleValueQueryFilter
+      expect(result.values).toEqual(['%50\\%%'])
+    })
+
+    it.each(['contains', 'starts_with', 'ends_with', 'is_exactly'])(
+      '%s returns null when text is empty',
+      op => {
+        expect(
+          qbNodeToApiFilter(
+            condition({
+              op: op as 'contains' | 'starts_with' | 'ends_with' | 'is_exactly',
+              text: '',
+            }),
+          ),
+        ).toBeNull()
+        expect(
+          qbNodeToApiFilter(
+            condition({
+              op: op as 'contains' | 'starts_with' | 'ends_with' | 'is_exactly',
+              text: null,
+            }),
+          ),
+        ).toBeNull()
+      },
+    )
+  })
+})
+
+describe('qbNodeToApiFilter — groups', () => {
+  it('returns null for an empty group', () => {
+    expect(qbNodeToApiFilter(group({}))).toBeNull()
+  })
+
+  it('returns null for a group whose children are all incomplete', () => {
+    expect(
+      qbNodeToApiFilter(
+        group({
+          children: [
+            condition({ op: 'equal', values: [] }),
+            condition({ op: 'contains', text: '' }),
+          ],
+        }),
+      ),
+    ).toBeNull()
+  })
+
+  it('emits a FilterGroup with only the complete children', () => {
+    const result = qbNodeToApiFilter(
+      group({
+        combinator: 'OR',
+        children: [
+          condition({ op: 'equal', values: ['a'] }),
+          condition({ op: 'equal', values: [], columnName: 'skipped' }),
+          condition({ op: 'is_any_of', values: ['x', 'y'] }),
+        ],
+      }),
+    ) as FilterGroup
+    expect(result.concreteType).toBe(FILTER_GROUP_CONCRETE_TYPE_VALUE)
+    expect(result.operator).toBe('OR')
+    expect(result.not).toBeUndefined()
+    expect(result.children).toHaveLength(2)
+  })
+
+  it('includes not:true when the group is negated', () => {
+    const result = qbNodeToApiFilter(
+      group({
+        not: true,
+        children: [condition({ op: 'equal', values: ['a'] })],
+      }),
+    ) as FilterGroup
+    expect(result.not).toBe(true)
+  })
+
+  it('recurses into nested groups', () => {
+    const result = qbNodeToApiFilter(
+      group({
+        children: [
+          group({
+            combinator: 'OR',
+            children: [
+              condition({ op: 'equal', values: ['a'] }),
+              condition({ op: 'equal', values: ['b'] }),
+            ],
+          }),
+          condition({ op: 'has_value' }),
+        ],
+      }),
+    ) as FilterGroup
+    expect(result.children).toHaveLength(2)
+    const [nested] = result.children!
+    expect(nested).toMatchObject({
+      concreteType: FILTER_GROUP_CONCRETE_TYPE_VALUE,
+      operator: 'OR',
+    })
+  })
+})
+
+describe('apiFilterToQBNode', () => {
+  it('round-trips a FilterGroup back through qbNodeToApiFilter', () => {
+    const apiTree: FilterGroup = {
+      concreteType: FILTER_GROUP_CONCRETE_TYPE_VALUE,
+      operator: 'AND',
+      children: [
+        {
+          concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+          columnName: 'age',
+          operator: ColumnSingleValueFilterOperator.GREATER_THAN,
+          values: ['65'],
+        },
+        {
+          concreteType: FILTER_GROUP_CONCRETE_TYPE_VALUE,
+          operator: 'OR',
+          not: true,
+          children: [
+            {
+              concreteType:
+                COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+              columnName: 'diagnosis',
+              operator: ColumnSingleValueFilterOperator.IN,
+              values: ["Alzheimer's Disease"],
+            },
+          ],
+        },
+      ],
+    }
+    const qb = apiFilterToQBNode(apiTree)!
+    const back = qbNodeToApiFilter(qb) as FilterGroup
+    expect(back).toMatchObject({
+      concreteType: FILTER_GROUP_CONCRETE_TYPE_VALUE,
+      operator: 'AND',
+    })
+    expect(back.children).toHaveLength(2)
+    expect(back.children![1]).toMatchObject({
+      concreteType: FILTER_GROUP_CONCRETE_TYPE_VALUE,
+      operator: 'OR',
+      not: true,
+    })
+  })
+
+  it.each([
+    [
+      ColumnSingleValueFilterOperator.EQUAL,
+      ['x'],
+      { op: 'equal', values: ['x'] },
+    ],
+    [
+      ColumnSingleValueFilterOperator.NOT_EQUAL,
+      ['x'],
+      { op: 'not_equal', values: ['x'] },
+    ],
+    [
+      ColumnSingleValueFilterOperator.IN,
+      ['x', 'y'],
+      { op: 'is_any_of', values: ['x', 'y'] },
+    ],
+    [
+      ColumnSingleValueFilterOperator.GREATER_THAN,
+      ['1'],
+      { op: 'gt', rangeMin: '1' },
+    ],
+    [
+      ColumnSingleValueFilterOperator.LESS_THAN_OR_EQUAL,
+      ['9'],
+      { op: 'lte', rangeMax: '9' },
+    ],
+    [
+      ColumnSingleValueFilterOperator.BETWEEN,
+      ['1', '9'],
+      { op: 'between', rangeMin: '1', rangeMax: '9' },
+    ],
+    [ColumnSingleValueFilterOperator.IS_NULL, [], { op: 'no_value' }],
+    [ColumnSingleValueFilterOperator.IS_NOT_NULL, [], { op: 'has_value' }],
+  ])(
+    'maps single-value operator %s back to the expected QBCondition',
+    (operator, values, expectedPatch) => {
+      const result = apiFilterToQBNode({
+        concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+        columnName: 'col',
+        operator,
+        values,
+      }) as QBCondition
+      expect(result).toMatchObject({
+        kind: 'condition',
+        columnName: 'col',
+        ...expectedPatch,
+      })
+    },
+  )
+
+  it('classifies LIKE patterns back into contains/starts_with/ends_with', () => {
+    const contains = apiFilterToQBNode({
+      concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+      columnName: 'col',
+      operator: ColumnSingleValueFilterOperator.LIKE,
+      values: ['%50\\%%'],
+    }) as QBCondition
+    expect(contains).toMatchObject({ op: 'contains', text: '50%' })
+  })
+
+  it('maps HAS multi-value filter back to is_any_of (lossy)', () => {
+    const result = apiFilterToQBNode({
+      concreteType:
+        COLUMN_MULTI_VALUE_FUNCTION_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+      columnName: 'col',
+      function: ColumnMultiValueFunction.HAS,
+      _function: ColumnMultiValueFunction.HAS,
+      values: ['a', 'b'],
+    }) as QBCondition
+    expect(result).toMatchObject({
+      op: 'is_any_of',
+      values: ['a', 'b'],
+    })
+  })
+})
+
+describe('selectedFacetsToQBGroup', () => {
+  it('produces an empty AND group when no facets are selected', () => {
+    expect(selectedFacetsToQBGroup([])).toMatchObject({
+      combinator: 'AND',
+      not: false,
+      children: [],
+    })
+  })
+
+  it('translates value facets into is_any_of conditions', () => {
+    const facet: FacetColumnValuesRequest = {
+      concreteType: FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE_VALUE,
+      columnName: 'sex',
+      facetValues: ['Female', 'Male'],
+    }
+    const result = selectedFacetsToQBGroup([facet])
+    expect(result.children).toHaveLength(1)
+    expect(result.children[0]).toMatchObject({
+      kind: 'condition',
+      columnName: 'sex',
+      op: 'is_any_of',
+      values: ['Female', 'Male'],
+    })
+  })
+
+  it('skips value facets with no selected values', () => {
+    const facet: FacetColumnValuesRequest = {
+      concreteType: FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE_VALUE,
+      columnName: 'sex',
+      facetValues: [],
+    }
+    expect(selectedFacetsToQBGroup([facet]).children).toHaveLength(0)
+  })
+
+  it('translates range facets with both bounds into between', () => {
+    const facet: FacetColumnRangeRequest = {
+      concreteType: FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+      columnName: 'age',
+      min: '18',
+      max: '65',
+    }
+    expect(selectedFacetsToQBGroup([facet]).children[0]).toMatchObject({
+      op: 'between',
+      rangeMin: '18',
+      rangeMax: '65',
+    })
+  })
+
+  it('translates range facets with only min into gte', () => {
+    const facet: FacetColumnRangeRequest = {
+      concreteType: FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+      columnName: 'age',
+      min: '18',
+    }
+    expect(selectedFacetsToQBGroup([facet]).children[0]).toMatchObject({
+      op: 'gte',
+      rangeMin: '18',
+    })
+  })
+
+  it('translates range facets with only max into lte', () => {
+    const facet: FacetColumnRangeRequest = {
+      concreteType: FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+      columnName: 'age',
+      max: '65',
+    }
+    expect(selectedFacetsToQBGroup([facet]).children[0]).toMatchObject({
+      op: 'lte',
+      rangeMax: '65',
+    })
+  })
+
+  it('skips range facets with no bounds', () => {
+    const facet: FacetColumnRangeRequest = {
+      concreteType: FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+      columnName: 'age',
+    }
+    expect(selectedFacetsToQBGroup([facet]).children).toHaveLength(0)
+  })
+})

--- a/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
+++ b/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
@@ -446,7 +446,7 @@ function newId(): string {
   ) {
     return crypto.randomUUID()
   }
-  // Fallback for environments without crypto.randomUUID (older jsdom, etc.).
+  // Monotonic counter is sufficient — QB ids are client-only React keys, not secrets.
   idCounter += 1
-  return `qb-${idCounter}-${Math.random().toString(36).slice(2, 10)}`
+  return `qb-${idCounter}`
 }

--- a/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
+++ b/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
@@ -176,7 +176,13 @@ function conditionToApiFilter(
             [text!],
           )
     default: {
+      // Compile-time exhaustiveness guard; the log fires only if a new op is
+      // added to QBConditionOp without a case here.
       op satisfies never
+      console.warn(
+        `conditionToApiFilter: unrecognized QB op, skipping condition for column "${columnName}"`,
+        { op },
+      )
       return null
     }
   }

--- a/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
+++ b/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
@@ -105,32 +105,14 @@ function conditionToApiFilter(
   if (columnName === null) return null
 
   switch (op) {
-    case 'is_any_of': {
-      if (values.length === 0) return null
-      // Multi-value list columns use HAS on ColumnMultiValueFunctionQueryFilter;
-      // single-value columns use IN on ColumnSingleValueQueryFilter.
-      if (isListColumn(columnType)) {
-        return makeMultiValueFilter(columnName, values)
-      }
-      return makeSingleValueFilter(
-        columnName,
-        ColumnSingleValueFilterOperator.IN,
-        values,
-      )
-    }
-    case 'is_all_of': {
-      if (values.length === 0) return null
-      return makeMultiValueFilter(columnName, values)
-    }
-    case 'between': {
-      if (rangeMin == null || rangeMin === '') return null
-      if (rangeMax == null || rangeMax === '') return null
-      return makeSingleValueFilter(
-        columnName,
-        ColumnSingleValueFilterOperator.BETWEEN,
-        [rangeMin, rangeMax],
-      )
-    }
+    case 'is_any_of':
+      return anyOfFilter(columnName, columnType, values)
+    case 'is_all_of':
+      return values.length === 0
+        ? null
+        : makeMultiValueFilter(columnName, values)
+    case 'between':
+      return betweenFilter(columnName, rangeMin, rangeMax)
     case 'gt':
       return rangeBoundFilter(
         columnName,
@@ -156,18 +138,16 @@ function conditionToApiFilter(
         ColumnSingleValueFilterOperator.LESS_THAN_OR_EQUAL,
       )
     case 'equal':
-      if (values.length === 0) return null
-      return makeSingleValueFilter(
+      return equalityFilter(
         columnName,
+        values,
         ColumnSingleValueFilterOperator.EQUAL,
-        [values[0]],
       )
     case 'not_equal':
-      if (values.length === 0) return null
-      return makeSingleValueFilter(
+      return equalityFilter(
         columnName,
+        values,
         ColumnSingleValueFilterOperator.NOT_EQUAL,
-        [values[0]],
       )
     case 'has_value':
       return makeSingleValueFilter(
@@ -182,38 +162,77 @@ function conditionToApiFilter(
         [],
       )
     case 'contains':
-      if (text == null || text === '') return null
-      return makeSingleValueFilter(
-        columnName,
-        ColumnSingleValueFilterOperator.LIKE,
-        [`%${escapeLike(text)}%`],
-      )
+      return likeFilter(columnName, text, escaped => `%${escaped}%`)
     case 'starts_with':
-      if (text == null || text === '') return null
-      return makeSingleValueFilter(
-        columnName,
-        ColumnSingleValueFilterOperator.LIKE,
-        [`${escapeLike(text)}%`],
-      )
+      return likeFilter(columnName, text, escaped => `${escaped}%`)
     case 'ends_with':
-      if (text == null || text === '') return null
-      return makeSingleValueFilter(
-        columnName,
-        ColumnSingleValueFilterOperator.LIKE,
-        [`%${escapeLike(text)}`],
-      )
+      return likeFilter(columnName, text, escaped => `%${escaped}`)
     case 'is_exactly':
-      if (text == null || text === '') return null
-      return makeSingleValueFilter(
-        columnName,
-        ColumnSingleValueFilterOperator.EQUAL,
-        [text],
-      )
+      return isBlank(text)
+        ? null
+        : makeSingleValueFilter(
+            columnName,
+            ColumnSingleValueFilterOperator.EQUAL,
+            [text!],
+          )
     default: {
       op satisfies never
       return null
     }
   }
+}
+
+function isBlank(value: string | null | undefined): boolean {
+  return value == null || value === ''
+}
+
+function anyOfFilter(
+  columnName: string,
+  columnType: string | null,
+  values: string[],
+): ColumnSingleValueQueryFilter | ColumnMultiValueFunctionQueryFilter | null {
+  if (values.length === 0) return null
+  if (isListColumn(columnType)) return makeMultiValueFilter(columnName, values)
+  return makeSingleValueFilter(
+    columnName,
+    ColumnSingleValueFilterOperator.IN,
+    values,
+  )
+}
+
+function betweenFilter(
+  columnName: string,
+  rangeMin: string | null,
+  rangeMax: string | null,
+): ColumnSingleValueQueryFilter | null {
+  if (isBlank(rangeMin) || isBlank(rangeMax)) return null
+  return makeSingleValueFilter(
+    columnName,
+    ColumnSingleValueFilterOperator.BETWEEN,
+    [rangeMin!, rangeMax!],
+  )
+}
+
+function equalityFilter(
+  columnName: string,
+  values: string[],
+  operator: ColumnSingleValueFilterOperator,
+): ColumnSingleValueQueryFilter | null {
+  if (values.length === 0) return null
+  return makeSingleValueFilter(columnName, operator, [values[0]])
+}
+
+function likeFilter(
+  columnName: string,
+  text: string | null,
+  wrap: (escapedText: string) => string,
+): ColumnSingleValueQueryFilter | null {
+  if (isBlank(text)) return null
+  return makeSingleValueFilter(
+    columnName,
+    ColumnSingleValueFilterOperator.LIKE,
+    [wrap(escapeLike(text!))],
+  )
 }
 
 function makeSingleValueFilter(

--- a/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
+++ b/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
@@ -369,7 +369,13 @@ function singleValueToCondition(
       return { ...base, op: classified.op, text: classified.text }
     }
     default:
+      // Compile-time exhaustiveness guard; the log fires only if a new operator
+      // is added to ColumnSingleValueFilterOperator without a case here.
       filter.operator satisfies never
+      console.warn(
+        `singleValueToCondition: unrecognized filter operator, falling back to 'equal' for column "${filter.columnName}"`,
+        { operator: filter.operator },
+      )
       return { ...base, op: 'equal' }
   }
 }

--- a/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
+++ b/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
@@ -1,0 +1,433 @@
+import {
+  ColumnMultiValueFunction,
+  ColumnMultiValueFunctionQueryFilter,
+  ColumnSingleValueFilterOperator,
+  ColumnSingleValueQueryFilter,
+  FacetColumnRequest,
+  FILTER_GROUP_CONCRETE_TYPE_VALUE,
+  FilterGroup,
+  QueryFilter,
+} from '@sage-bionetworks/synapse-types'
+import {
+  isColumnMultiValueFunctionQueryFilter,
+  isColumnSingleValueQueryFilter,
+  isFacetColumnRangeRequest,
+  isFacetColumnValuesRequest,
+  isFilterGroup,
+} from '../../utils/types/IsType'
+import { isQBGroup, QBCondition, QBGroup, QBNode } from './QueryBuilderTypes'
+
+const COLUMN_SINGLE_VALUE_QUERY_FILTER =
+  'org.sagebionetworks.repo.model.table.ColumnSingleValueQueryFilter' as const
+const COLUMN_MULTI_VALUE_FUNCTION_QUERY_FILTER =
+  'org.sagebionetworks.repo.model.table.ColumnMultiValueFunctionQueryFilter' as const
+
+// -----------------------------------------------------------------------------
+// Column-kind classification
+// -----------------------------------------------------------------------------
+
+/** A multi-value list column is one whose column type ends in `_LIST`. */
+export function isListColumn(columnType: string | null): boolean {
+  return columnType != null && columnType.endsWith('_LIST')
+}
+
+// -----------------------------------------------------------------------------
+// LIKE escaping / classification
+// -----------------------------------------------------------------------------
+
+/**
+ * Escape SQL LIKE metacharacters (`%` and `_`) plus the escape character itself
+ * (`\`) so a user's literal `50%` isn't treated as a wildcard match.
+ */
+export function escapeLike(input: string): string {
+  return input.replace(/[\\%_]/g, ch => '\\' + ch)
+}
+
+/**
+ * Inverse of {@link escapeLike}: strip the backslash escapes that
+ * {@link escapeLike} added.
+ */
+export function unescapeLike(input: string): string {
+  return input.replace(/\\([\\%_])/g, '$1')
+}
+
+/**
+ * Classify a LIKE pattern string produced by {@link qbNodeToApiFilter} back
+ * into a QB op + un-escaped text. Handles the four wildcard shapes
+ * produced by that function (`%val%`, `val%`, `%val`, `val`).
+ */
+export function classifyLikePattern(pattern: string): {
+  op: 'contains' | 'starts_with' | 'ends_with' | 'is_exactly'
+  text: string
+} {
+  const startsPct = pattern.startsWith('%')
+  // Only treat a trailing '%' as a wildcard if it isn't itself escaped
+  const endsPct = /(?<!\\)%$/.test(pattern)
+  const core = pattern.slice(startsPct ? 1 : 0, endsPct ? -1 : undefined)
+  const text = unescapeLike(core)
+  if (startsPct && endsPct) return { op: 'contains', text }
+  if (endsPct) return { op: 'starts_with', text }
+  if (startsPct) return { op: 'ends_with', text }
+  return { op: 'is_exactly', text }
+}
+
+// -----------------------------------------------------------------------------
+// QB → API
+// -----------------------------------------------------------------------------
+
+/**
+ * Convert a QB tree node into a `QueryFilter`. Returns `null` when the node
+ * (or an entire subtree) has no complete conditions — an incomplete leaf and
+ * an empty group are both treated as "no constraint" so partial user input
+ * never contributes to the outgoing query.
+ */
+export function qbNodeToApiFilter(node: QBNode): QueryFilter | null {
+  if (isQBGroup(node)) {
+    const children = node.children
+      .map(qbNodeToApiFilter)
+      .filter((f): f is QueryFilter => f !== null)
+    if (children.length === 0) return null
+    const filter: FilterGroup = {
+      concreteType: FILTER_GROUP_CONCRETE_TYPE_VALUE,
+      operator: node.combinator,
+      not: node.not || undefined,
+      children,
+    }
+    return filter
+  }
+  return conditionToApiFilter(node)
+}
+
+function conditionToApiFilter(
+  node: QBCondition,
+): ColumnSingleValueQueryFilter | ColumnMultiValueFunctionQueryFilter | null {
+  const { columnName, columnType, op, values, rangeMin, rangeMax, text } = node
+  if (columnName === null) return null
+
+  switch (op) {
+    case 'is_any_of': {
+      if (values.length === 0) return null
+      // Multi-value list columns use HAS on ColumnMultiValueFunctionQueryFilter;
+      // single-value columns use IN on ColumnSingleValueQueryFilter.
+      if (isListColumn(columnType)) {
+        return makeMultiValueFilter(columnName, values)
+      }
+      return makeSingleValueFilter(
+        columnName,
+        ColumnSingleValueFilterOperator.IN,
+        values,
+      )
+    }
+    case 'is_all_of': {
+      if (values.length === 0) return null
+      return makeMultiValueFilter(columnName, values)
+    }
+    case 'between': {
+      if (rangeMin == null || rangeMin === '') return null
+      if (rangeMax == null || rangeMax === '') return null
+      return makeSingleValueFilter(
+        columnName,
+        ColumnSingleValueFilterOperator.BETWEEN,
+        [rangeMin, rangeMax],
+      )
+    }
+    case 'gt':
+      return rangeBoundFilter(
+        columnName,
+        rangeMin,
+        ColumnSingleValueFilterOperator.GREATER_THAN,
+      )
+    case 'gte':
+      return rangeBoundFilter(
+        columnName,
+        rangeMin,
+        ColumnSingleValueFilterOperator.GREATER_THAN_OR_EQUAL,
+      )
+    case 'lt':
+      return rangeBoundFilter(
+        columnName,
+        rangeMax,
+        ColumnSingleValueFilterOperator.LESS_THAN,
+      )
+    case 'lte':
+      return rangeBoundFilter(
+        columnName,
+        rangeMax,
+        ColumnSingleValueFilterOperator.LESS_THAN_OR_EQUAL,
+      )
+    case 'equal':
+      if (values.length === 0) return null
+      return makeSingleValueFilter(
+        columnName,
+        ColumnSingleValueFilterOperator.EQUAL,
+        [values[0]],
+      )
+    case 'not_equal':
+      if (values.length === 0) return null
+      return makeSingleValueFilter(
+        columnName,
+        ColumnSingleValueFilterOperator.NOT_EQUAL,
+        [values[0]],
+      )
+    case 'has_value':
+      return makeSingleValueFilter(
+        columnName,
+        ColumnSingleValueFilterOperator.IS_NOT_NULL,
+        [],
+      )
+    case 'no_value':
+      return makeSingleValueFilter(
+        columnName,
+        ColumnSingleValueFilterOperator.IS_NULL,
+        [],
+      )
+    case 'contains':
+      if (text == null || text === '') return null
+      return makeSingleValueFilter(
+        columnName,
+        ColumnSingleValueFilterOperator.LIKE,
+        [`%${escapeLike(text)}%`],
+      )
+    case 'starts_with':
+      if (text == null || text === '') return null
+      return makeSingleValueFilter(
+        columnName,
+        ColumnSingleValueFilterOperator.LIKE,
+        [`${escapeLike(text)}%`],
+      )
+    case 'ends_with':
+      if (text == null || text === '') return null
+      return makeSingleValueFilter(
+        columnName,
+        ColumnSingleValueFilterOperator.LIKE,
+        [`%${escapeLike(text)}`],
+      )
+    case 'is_exactly':
+      if (text == null || text === '') return null
+      return makeSingleValueFilter(
+        columnName,
+        ColumnSingleValueFilterOperator.EQUAL,
+        [text],
+      )
+    default: {
+      op satisfies never
+      return null
+    }
+  }
+}
+
+function makeSingleValueFilter(
+  columnName: string,
+  operator: ColumnSingleValueFilterOperator,
+  values: string[],
+): ColumnSingleValueQueryFilter {
+  return {
+    concreteType: COLUMN_SINGLE_VALUE_QUERY_FILTER,
+    columnName,
+    operator,
+    values,
+  }
+}
+
+function makeMultiValueFilter(
+  columnName: string,
+  values: string[],
+): ColumnMultiValueFunctionQueryFilter {
+  return {
+    concreteType: COLUMN_MULTI_VALUE_FUNCTION_QUERY_FILTER,
+    columnName,
+    function: ColumnMultiValueFunction.HAS,
+    _function: ColumnMultiValueFunction.HAS,
+    values,
+  }
+}
+
+function rangeBoundFilter(
+  columnName: string,
+  bound: string | null,
+  operator: ColumnSingleValueFilterOperator,
+): ColumnSingleValueQueryFilter | null {
+  if (bound == null || bound === '') return null
+  return makeSingleValueFilter(columnName, operator, [bound])
+}
+
+// -----------------------------------------------------------------------------
+// API → QB (initial hydration)
+// -----------------------------------------------------------------------------
+
+/**
+ * Convert an API `QueryFilter` back into a QB node. Used when the initial
+ * query already contains a `FilterGroup` (see filterMode auto-detect) so the
+ * QB tree can be reconstructed on mount.
+ *
+ * Some conversions are lossy — `HAS` always deserializes as `is_any_of` (we
+ * can't distinguish it from an `is_all_of` at the API layer), and `EQUAL` on
+ * text columns deserializes as `equal` (not `is_exactly`) because they share
+ * the same wire representation. Users can adjust the operator picker.
+ */
+export function apiFilterToQBNode(filter: QueryFilter): QBNode | null {
+  if (isFilterGroup(filter)) {
+    const children = (filter.children ?? [])
+      .map(apiFilterToQBNode)
+      .filter((n): n is QBNode => n !== null)
+    return {
+      kind: 'group',
+      id: newId(),
+      combinator: filter.operator ?? 'AND',
+      not: filter.not ?? false,
+      children,
+    }
+  }
+  if (isColumnSingleValueQueryFilter(filter)) {
+    return singleValueToCondition(filter)
+  }
+  if (isColumnMultiValueFunctionQueryFilter(filter)) {
+    return {
+      kind: 'condition',
+      id: newId(),
+      columnName: filter.columnName,
+      columnType: null,
+      op: 'is_any_of',
+      values: [...filter.values],
+      rangeMin: null,
+      rangeMax: null,
+      text: null,
+    }
+  }
+  // TextMatchesQueryFilter and other non-QB filter types are not part of the
+  // QB tree — they belong in the non-QB baseline.
+  return null
+}
+
+function singleValueToCondition(
+  filter: ColumnSingleValueQueryFilter,
+): QBCondition {
+  const base = {
+    kind: 'condition' as const,
+    id: newId(),
+    columnName: filter.columnName,
+    columnType: null,
+    values: [] as string[],
+    rangeMin: null as string | null,
+    rangeMax: null as string | null,
+    text: null as string | null,
+  }
+  const [firstValue] = filter.values
+  switch (filter.operator) {
+    case ColumnSingleValueFilterOperator.IN:
+      return { ...base, op: 'is_any_of', values: [...filter.values] }
+    case ColumnSingleValueFilterOperator.EQUAL:
+      return { ...base, op: 'equal', values: [...filter.values] }
+    case ColumnSingleValueFilterOperator.NOT_EQUAL:
+      return { ...base, op: 'not_equal', values: [...filter.values] }
+    case ColumnSingleValueFilterOperator.GREATER_THAN:
+      return { ...base, op: 'gt', rangeMin: firstValue ?? null }
+    case ColumnSingleValueFilterOperator.GREATER_THAN_OR_EQUAL:
+      return { ...base, op: 'gte', rangeMin: firstValue ?? null }
+    case ColumnSingleValueFilterOperator.LESS_THAN:
+      return { ...base, op: 'lt', rangeMax: firstValue ?? null }
+    case ColumnSingleValueFilterOperator.LESS_THAN_OR_EQUAL:
+      return { ...base, op: 'lte', rangeMax: firstValue ?? null }
+    case ColumnSingleValueFilterOperator.BETWEEN:
+      return {
+        ...base,
+        op: 'between',
+        rangeMin: filter.values[0] ?? null,
+        rangeMax: filter.values[1] ?? null,
+      }
+    case ColumnSingleValueFilterOperator.IS_NULL:
+      return { ...base, op: 'no_value' }
+    case ColumnSingleValueFilterOperator.IS_NOT_NULL:
+      return { ...base, op: 'has_value' }
+    case ColumnSingleValueFilterOperator.LIKE: {
+      const classified = classifyLikePattern(firstValue ?? '')
+      return { ...base, op: classified.op, text: classified.text }
+    }
+    default:
+      filter.operator satisfies never
+      return { ...base, op: 'equal' }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Facets → QB (mode switch)
+// -----------------------------------------------------------------------------
+
+/**
+ * Translate `selectedFacets` into a QB group whose children mirror each facet
+ * (as an AND-combined, non-negated group). The reverse direction is not
+ * generally possible; a QB → facets switch clears the tree.
+ */
+export function selectedFacetsToQBGroup(
+  selectedFacets: FacetColumnRequest[],
+): QBGroup {
+  return {
+    kind: 'group',
+    id: newId(),
+    combinator: 'AND',
+    not: false,
+    children: selectedFacets
+      .map(facetToQBCondition)
+      .filter((c): c is QBCondition => c !== null),
+  }
+}
+
+function facetToQBCondition(facet: FacetColumnRequest): QBCondition | null {
+  if (isFacetColumnValuesRequest(facet)) {
+    if (!facet.facetValues || facet.facetValues.length === 0) return null
+    return {
+      kind: 'condition',
+      id: newId(),
+      columnName: facet.columnName,
+      columnType: null,
+      op: 'is_any_of',
+      values: [...facet.facetValues],
+      rangeMin: null,
+      rangeMax: null,
+      text: null,
+    }
+  }
+  if (isFacetColumnRangeRequest(facet)) {
+    const hasMin = facet.min != null && facet.min !== ''
+    const hasMax = facet.max != null && facet.max !== ''
+    if (!hasMin && !hasMax) return null
+    const base = {
+      kind: 'condition' as const,
+      id: newId(),
+      columnName: facet.columnName,
+      columnType: null,
+      values: [],
+      text: null,
+    }
+    if (hasMin && hasMax) {
+      return {
+        ...base,
+        op: 'between',
+        rangeMin: facet.min!,
+        rangeMax: facet.max!,
+      }
+    }
+    if (hasMin) {
+      return { ...base, op: 'gte', rangeMin: facet.min!, rangeMax: null }
+    }
+    return { ...base, op: 'lte', rangeMin: null, rangeMax: facet.max! }
+  }
+  return null
+}
+
+// -----------------------------------------------------------------------------
+// Utilities
+// -----------------------------------------------------------------------------
+
+let idCounter = 0
+function newId(): string {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID()
+  }
+  // Fallback for environments without crypto.randomUUID (older jsdom, etc.).
+  idCounter += 1
+  return `qb-${idCounter}-${Math.random().toString(36).slice(2, 10)}`
+}

--- a/packages/synapse-react-client/src/utils/functions/SqlFunctions.ts
+++ b/packages/synapse-react-client/src/utils/functions/SqlFunctions.ts
@@ -90,7 +90,12 @@ export const getAdditionalFilters = (
             return filter
           }
           switch (operator) {
-            case ColumnSingleValueFilterOperator.EQUAL: {
+            case ColumnSingleValueFilterOperator.EQUAL:
+            case ColumnSingleValueFilterOperator.NOT_EQUAL:
+            case ColumnSingleValueFilterOperator.GREATER_THAN:
+            case ColumnSingleValueFilterOperator.LESS_THAN:
+            case ColumnSingleValueFilterOperator.GREATER_THAN_OR_EQUAL:
+            case ColumnSingleValueFilterOperator.LESS_THAN_OR_EQUAL: {
               const filter: ColumnSingleValueQueryFilter = {
                 concreteType:
                   'org.sagebionetworks.repo.model.table.ColumnSingleValueQueryFilter',
@@ -100,13 +105,25 @@ export const getAdditionalFilters = (
               }
               return filter
             }
-            case ColumnSingleValueFilterOperator.IN: {
+            case ColumnSingleValueFilterOperator.IN:
+            case ColumnSingleValueFilterOperator.BETWEEN: {
               const filter: ColumnSingleValueQueryFilter = {
                 concreteType:
                   'org.sagebionetworks.repo.model.table.ColumnSingleValueQueryFilter',
                 columnName: key,
                 operator: operator,
                 values: splitAndTrim(searchParams[key]),
+              }
+              return filter
+            }
+            case ColumnSingleValueFilterOperator.IS_NULL:
+            case ColumnSingleValueFilterOperator.IS_NOT_NULL: {
+              const filter: ColumnSingleValueQueryFilter = {
+                concreteType:
+                  'org.sagebionetworks.repo.model.table.ColumnSingleValueQueryFilter',
+                columnName: key,
+                operator: operator,
+                values: [],
               }
               return filter
             }
@@ -150,8 +167,20 @@ export const getAdditionalFilters = (
               }
               return filter
             }
+            default:
+              // exhaustive
+              operator satisfies never
+              return undefined
           }
-        }),
+        })
+        .filter(
+          (
+            f,
+          ): f is
+            | TextMatchesQueryFilter
+            | ColumnSingleValueQueryFilter
+            | ColumnMultiValueFunctionQueryFilter => f !== undefined,
+        ),
     )
   }
 

--- a/packages/synapse-react-client/src/utils/functions/SqlFunctions.ts
+++ b/packages/synapse-react-client/src/utils/functions/SqlFunctions.ts
@@ -168,8 +168,13 @@ export const getAdditionalFilters = (
               return filter
             }
             default:
-              // exhaustive
+              // Compile-time exhaustiveness guard; the log fires only if a new
+              // operator is added to the union without a case here.
               operator satisfies never
+              console.warn(
+                `getAdditionalFilters: unrecognized SQL operator, skipping filter for key "${key}"`,
+                { operator },
+              )
               return undefined
           }
         })

--- a/packages/synapse-react-client/src/utils/types/IsType.ts
+++ b/packages/synapse-react-client/src/utils/types/IsType.ts
@@ -15,7 +15,9 @@ import {
   FacetColumnRangeRequest,
   FacetColumnValuesRequest,
   FILE_ENTITY_CONCRETE_TYPE_VALUE,
+  FILTER_GROUP_CONCRETE_TYPE_VALUE,
   FileEntity,
+  FilterGroup,
   GOOGLE_CLOUD_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   INVITEE_VERIFICATION_CONCRETE_TYPE_VALUE,
   InviteeVerificationSignedToken,
@@ -99,6 +101,9 @@ export const isColumnMultiValueFunctionQueryFilter =
   isTypeViaConcreteTypeFactory<ColumnMultiValueFunctionQueryFilter>(
     COLUMN_MULTI_VALUE_FUNCTION_QUERY_FILTER_CONCRETE_TYPE_VALUE,
   )
+export const isFilterGroup = isTypeViaConcreteTypeFactory<FilterGroup>(
+  FILTER_GROUP_CONCRETE_TYPE_VALUE,
+)
 export const isS3FileHandle = isTypeViaConcreteTypeFactory<S3FileHandle>(
   S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
 )

--- a/packages/synapse-types/src/Table/QueryFilter.ts
+++ b/packages/synapse-types/src/Table/QueryFilter.ts
@@ -5,6 +5,22 @@ export enum ColumnSingleValueFilterOperator {
   EQUAL = 'EQUAL',
   /* The IN operation */
   IN = 'IN',
+  /* '>' */
+  GREATER_THAN = 'GREATER_THAN',
+  /* '<' */
+  LESS_THAN = 'LESS_THAN',
+  /* '>=' */
+  GREATER_THAN_OR_EQUAL = 'GREATER_THAN_OR_EQUAL',
+  /* '<=' */
+  LESS_THAN_OR_EQUAL = 'LESS_THAN_OR_EQUAL',
+  /* '<>' */
+  NOT_EQUAL = 'NOT_EQUAL',
+  /* IS NULL */
+  IS_NULL = 'IS_NULL',
+  /* IS NOT NULL */
+  IS_NOT_NULL = 'IS_NOT_NULL',
+  /* BETWEEN: values[0] is the lower bound, values[1] is the upper bound (inclusive). */
+  BETWEEN = 'BETWEEN',
 }
 export enum ColumnMultiValueFunction {
   /* HAS function on multi-value columns, same as the predicate: 'columnName HAS ()' */
@@ -56,7 +72,24 @@ export interface TextMatchesQueryFilter {
   searchMode?: TextMatchesMode
 }
 
+/* Boolean combinator for a FilterGroup's children. */
+export type BooleanOperator = 'AND' | 'OR'
+
+export const FILTER_GROUP_CONCRETE_TYPE_VALUE =
+  'org.sagebionetworks.repo.model.table.FilterGroup'
+export type FILTER_GROUP_CONCRETE_TYPE = typeof FILTER_GROUP_CONCRETE_TYPE_VALUE
+
+// A group of filter conditions combined with a boolean operator. Groups can be nested to form arbitrary boolean expression trees (AND/OR/NOT).
+export interface FilterGroup {
+  concreteType: FILTER_GROUP_CONCRETE_TYPE
+  isDefiningCondition?: boolean //When null (default) or false, this condition will be applied to WHERE clause of table/view query.  When set to true, for a query against a VirtualTable, this condition will be applied to the WHERE clause of the VirtualTable's definingSQL
+  operator?: BooleanOperator
+  not?: boolean
+  children?: QueryFilter[]
+}
+
 export type QueryFilter =
   | TextMatchesQueryFilter
   | ColumnSingleValueQueryFilter
   | ColumnMultiValueFunctionQueryFilter
+  | FilterGroup


### PR DESCRIPTION
## PORTALS-4441 — Change Summary

### `@sage-bionetworks/synapse-types`

**`packages/synapse-types/src/Table/QueryFilter.ts`**

- Extended `ColumnSingleValueFilterOperator` enum with the 8 new operators shipped by the backend:
  `GREATER_THAN`, `LESS_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN_OR_EQUAL`,
  `NOT_EQUAL`, `IS_NULL`, `IS_NOT_NULL`, `BETWEEN`.
- Added `BooleanOperator = 'AND' | 'OR'`.
- Added `FILTER_GROUP_CONCRETE_TYPE_VALUE` constant + `FILTER_GROUP_CONCRETE_TYPE`
  type alias (`'org.sagebionetworks.repo.model.table.FilterGroup'`).
- Added `FilterGroup` interface (`operator`, `not`, `children`, `isDefiningCondition`),
  mirroring the shape from `@sage-bionetworks/synapse-client`.
- Extended the `QueryFilter` union to include `FilterGroup`.

### `synapse-react-client`

**`src/utils/types/IsType.ts`**

- New `isFilterGroup` type guard, following the existing hand-written
  `isTypeViaConcreteTypeFactory` pattern in that file.

**`src/utils/functions/SqlFunctions.ts`**

- Extended the `getAdditionalFilters` switch so URL-search-params → additional-filters
  handles every new operator:
  - `EQUAL` / `NOT_EQUAL` / `GREATER_THAN` / `LESS_THAN` / `GREATER_THAN_OR_EQUAL`
    / `LESS_THAN_OR_EQUAL` — single-value pattern with `[searchParams[key]]`.
  - `IN` / `BETWEEN` — multi-value via `splitAndTrim`.
  - `IS_NULL` / `IS_NOT_NULL` — `values: []`.
  - `LIKE` (unchanged), `HAS` / `HAS_LIKE` (unchanged).
- Added `operator satisfies never` exhaustiveness guard so future enum additions
  break the type-check at this exact site.
- Preserved the existing test contract — `getAdditionalFilters` now returns a
  valid filter for every operator (verified by the pre-existing
  "handles every filter type" test).

**`src/components/QueryBuilder/QueryBuilderTypes.ts`** (new)

- Internal QB UI types: `QBNode`, `QBGroup`, `QBCondition`, `QBConditionOp`,
  `QBCombinator`.
- `QBConditionOp` covers 15 ops: `is_any_of`, `is_all_of`, `between`, `gt`,
  `gte`, `lt`, `lte`, `equal`, `not_equal`, `has_value`, `no_value`, `contains`,
  `starts_with`, `ends_with`, `is_exactly`. Negation is expressed via a
  `QBGroup { not: true }` — there is no `is_none_of` leaf op.
- Type narrows: `isQBGroup`, `isQBCondition`.

**`src/components/QueryBuilder/queryBuilderTranslation.ts`** (new)

- `qbNodeToApiFilter(node)` — QB tree → `QueryFilter | null`.
  - Empty groups and incomplete conditions return `null` (partial input never
    reaches the outgoing query).
  - `is_any_of` on `*_LIST` columns emits `ColumnMultiValueFunctionQueryFilter { HAS }`;
    on single-value columns emits `ColumnSingleValueQueryFilter { IN }`.
  - `is_all_of` emits `HAS` (multi-value list columns only).
  - Range ops emit their matching `ColumnSingleValueFilterOperator`; `BETWEEN`
    packs `[rangeMin, rangeMax]`.
  - Text ops escape `%` / `_` / `\` in user text so a literal `50%` isn't
    treated as a wildcard.
  - Groups emit `FilterGroup { concreteType, operator, not, children }`,
    omitting `not` when false.
- `apiFilterToQBNode(filter)` — `QueryFilter` → QB tree for initial hydration
  (used when the initial query already carries a `FilterGroup`).
  - Documented lossy inversions: `HAS` → `is_any_of` (can't distinguish from
    `is_all_of` at the API layer); `EQUAL` on text → `equal` (not `is_exactly`);
    `TextMatchesQueryFilter` and other non-QB filters are left in the baseline.
- `selectedFacetsToQBGroup(facets)` — mode-switch translation from
  `selectedFacets` into a QB tree.
- Pure helpers: `isListColumn`, `escapeLike`, `unescapeLike`,
  `classifyLikePattern`.

**`src/components/QueryBuilder/queryBuilderTranslation.test.ts`** (new)

- 68 unit tests covering:
  - Column-kind classification (`isListColumn`).
  - LIKE escape / unescape round-trip on `%`, `_`, `\`.
  - `classifyLikePattern` mapping (`%foo%`, `foo%`, `%foo`, `foo`, plus
    escaped-wildcard cases).
  - Every `QBConditionOp` → API translation, including incomplete-input null
    guards, boolean values in `values[0]`, and multi-value `HAS` vs
    single-value `IN`.
  - Group serialization: empty group / all-incomplete children → `null`;
    partial children pruned; `not: true` preserved; nested groups recurse.
  - `apiFilterToQBNode` for every `ColumnSingleValueFilterOperator` plus the
    LIKE-pattern classification path and the HAS → `is_any_of` lossy path.
  - Full round-trip through a nested `FilterGroup`.
  - `selectedFacetsToQBGroup` for both value and range facet shapes.

### Verification

- `pnpm nx run @sage-bionetworks/synapse-types:type-check` ✓
- `pnpm nx run synapse-react-client:type-check` ✓
- 68 translation tests ✓
- All 20 pre-existing `sqlFunctions.test.ts` tests ✓ (including the
  "handles every filter type" case)

### Out of scope for this ticket

- No component / UI changes (tracked in PORTALS-4442).
- `ColumnSubQueryFilter` / `SubQueryFilter` (tracked with the Cohort Builder
  page work).
- No context wiring, `hasResettableFilters` update, or mode-transition logic
  in `QueryVisualizationWrapper` (part of PORTALS-4442).