### PR TITLE
PORTALS-4444

### DIFF
--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTable.tsx
@@ -318,6 +318,7 @@ export function SynapseTable(props: SynapseTableProps) {
           table={table}
           fullWidth={false}
           autoColumnSizing={true}
+          showTopScrollbar={true}
         />
       </div>
     </SynapseTableContext.Provider>

--- a/packages/synapse-react-client/src/components/TanStackTable/StyledTanStackTable.tsx
+++ b/packages/synapse-react-client/src/components/TanStackTable/StyledTanStackTable.tsx
@@ -9,7 +9,7 @@ import {
   Row,
   Table,
 } from '@tanstack/react-table'
-import { useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { UIEvent, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { MemoizedTableBody, TableBody, TableBodyProps } from './TableBody'
 import {
   getColumnSizeCssVariable,
@@ -183,6 +183,14 @@ export default function StyledTanStackTable<
     ? MemoizedTableBody
     : TableBody
 
+  const callerOnScroll = styledTableContainerProps?.onScroll
+  function handleContainerScroll(e: UIEvent<HTMLDivElement>) {
+    callerOnScroll?.(e)
+    if (showTopScrollbar) {
+      handleBottomScroll(e)
+    }
+  }
+
   return (
     <>
       {showTopScrollbar && (
@@ -197,7 +205,7 @@ export default function StyledTanStackTable<
       <StyledTableContainer
         {...styledTableContainerProps}
         ref={containerRef}
-        onScroll={showTopScrollbar ? handleBottomScroll : undefined}
+        onScroll={handleContainerScroll}
       >
         <Table
           {...tableSlotProps}

--- a/packages/synapse-react-client/src/components/TanStackTable/StyledTanStackTable.tsx
+++ b/packages/synapse-react-client/src/components/TanStackTable/StyledTanStackTable.tsx
@@ -2,6 +2,7 @@ import {
   StyledTableContainer,
   StyledTableContainerProps,
 } from '@/components/styled/StyledTableContainer'
+import { Box } from '@mui/material'
 import {
   ColumnSizingState,
   flexRender,
@@ -16,6 +17,7 @@ import {
   getHeaderSizeCssVariable,
 } from './TanStackTableUtils'
 import { StyledTanStackTableSlotProps, StyledTanStackTableSlots } from './types'
+import { useSyncedTopScrollbar } from './useSyncedTopScrollbar'
 
 export type StyledTanStackTableProps<TData = unknown, TRowType = Row<TData>> = {
   table: Table<TData>
@@ -28,6 +30,13 @@ export type StyledTanStackTableProps<TData = unknown, TRowType = Row<TData>> = {
    * Defaults to false (fixed layout).
    */
   autoColumnSizing?: boolean
+  /**
+   * When true, renders an additional horizontal scrollbar above the table (in addition to the
+   * browser's native scrollbar below it), synced to the same scroll position. Useful for wide
+   * tables where the bottom scrollbar may be far from the viewport's visible area.
+   * @default false
+   */
+  showTopScrollbar?: boolean
   slots?: StyledTanStackTableSlots<TData, TRowType>
   slotProps?: StyledTanStackTableSlotProps<TData, TRowType>
 } & Pick<TableBodyProps<TData, TRowType>, 'rows' | 'rowTransform'>
@@ -45,6 +54,7 @@ export default function StyledTanStackTable<
     styledTableContainerProps,
     fullWidth = true,
     autoColumnSizing = false,
+    showTopScrollbar = false,
     slots = {},
     slotProps = {},
   } = props
@@ -80,6 +90,14 @@ export default function StyledTanStackTable<
    * a column narrower than its content.
    */
   const tableRef = useRef<HTMLTableElement>(null)
+
+  const {
+    containerRef,
+    topScrollRef,
+    targetWidth: tableRenderedWidth,
+    handleTopScroll,
+    handleBottomScroll,
+  } = useSyncedTopScrollbar(tableRef, showTopScrollbar)
 
   // Track what columns+visibility combination was last measured so we know when
   // a re-measurement is needed (e.g. columns change or visibility is toggled).
@@ -166,63 +184,78 @@ export default function StyledTanStackTable<
     : TableBody
 
   return (
-    <StyledTableContainer {...styledTableContainerProps}>
-      <Table
-        {...tableSlotProps}
-        ref={tableRef}
-        style={{
-          ...columnSizeVars,
-          // Pre-measurement: auto layout so the browser can size columns to content.
-          // Post-measurement: fixed layout so the user can resize below content width.
-          tableLayout: hasMeasured ? 'fixed' : 'auto',
-          width: tableWidth,
-          ...tableSlotProps['style'],
-        }}
+    <>
+      {showTopScrollbar && (
+        <Box
+          ref={topScrollRef}
+          onScroll={handleTopScroll}
+          sx={{ overflowX: 'auto', overflowY: 'hidden', height: '16px' }}
+        >
+          <Box sx={{ width: tableRenderedWidth, height: '1px' }} />
+        </Box>
+      )}
+      <StyledTableContainer
+        {...styledTableContainerProps}
+        ref={containerRef}
+        onScroll={showTopScrollbar ? handleBottomScroll : undefined}
       >
-        <Thead {...theadSlotProps}>
-          {table.getHeaderGroups().map(headerGroup => {
-            return (
-              <tr key={headerGroup.id}>
-                {headerGroup.headers.map(header => (
-                  <Th
-                    key={header.id}
-                    colSpan={header.colSpan}
-                    {...thSlotProps}
-                    style={{
-                      // Pre-measurement: no width hint — let the browser size freely.
-                      // Post-measurement: exact width from the measured/resized value.
-                      ...(hasMeasured && {
-                        width: `calc(var(${getHeaderSizeCssVariable(
-                          header.id,
-                        )}) * 1px)`,
-                      }),
-                      ...getCommonPinningStyles(header.column),
-                      ...thSlotProps['style'],
-                    }}
-                  >
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                    {header.column.getCanResize() && (
-                      <div
-                        className={`resizer ${
-                          header.column.getIsResizing() ? 'isResizing' : ''
-                        }`}
-                        onMouseDown={header.getResizeHandler()}
-                        onTouchStart={header.getResizeHandler()}
-                      />
-                    )}
-                  </Th>
-                ))}
-              </tr>
-            )
-          })}
-        </Thead>
-        <TableBodyElement<TData, TRowType> {...tableBodyProps} />
-      </Table>
-    </StyledTableContainer>
+        <Table
+          {...tableSlotProps}
+          ref={tableRef}
+          style={{
+            ...columnSizeVars,
+            // Pre-measurement: auto layout so the browser can size columns to content.
+            // Post-measurement: fixed layout so the user can resize below content width.
+            tableLayout: hasMeasured ? 'fixed' : 'auto',
+            width: tableWidth,
+            ...tableSlotProps['style'],
+          }}
+        >
+          <Thead {...theadSlotProps}>
+            {table.getHeaderGroups().map(headerGroup => {
+              return (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map(header => (
+                    <Th
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      {...thSlotProps}
+                      style={{
+                        // Pre-measurement: no width hint — let the browser size freely.
+                        // Post-measurement: exact width from the measured/resized value.
+                        ...(hasMeasured && {
+                          width: `calc(var(${getHeaderSizeCssVariable(
+                            header.id,
+                          )}) * 1px)`,
+                        }),
+                        ...getCommonPinningStyles(header.column),
+                        ...thSlotProps['style'],
+                      }}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                      {header.column.getCanResize() && (
+                        <div
+                          className={`resizer ${
+                            header.column.getIsResizing() ? 'isResizing' : ''
+                          }`}
+                          onMouseDown={header.getResizeHandler()}
+                          onTouchStart={header.getResizeHandler()}
+                        />
+                      )}
+                    </Th>
+                  ))}
+                </tr>
+              )
+            })}
+          </Thead>
+          <TableBodyElement<TData, TRowType> {...tableBodyProps} />
+        </Table>
+      </StyledTableContainer>
+    </>
   )
 }

--- a/packages/synapse-react-client/src/components/TanStackTable/StyledTanStackTable.tsx
+++ b/packages/synapse-react-client/src/components/TanStackTable/StyledTanStackTable.tsx
@@ -3,6 +3,7 @@ import {
   StyledTableContainerProps,
 } from '@/components/styled/StyledTableContainer'
 import { Box } from '@mui/material'
+import { useForkRef } from '@mui/material/utils'
 import {
   ColumnSizingState,
   flexRender,
@@ -99,6 +100,15 @@ export default function StyledTanStackTable<
     handleBottomScroll,
   } = useSyncedTopScrollbar(tableRef, showTopScrollbar)
 
+  // Merge our own container ref/onScroll with any that the caller passed via
+  // styledTableContainerProps, rather than one clobbering the other.
+  const {
+    ref: callerContainerRef,
+    onScroll: callerOnScroll,
+    ...restContainerProps
+  } = styledTableContainerProps ?? {}
+  const mergedContainerRef = useForkRef(containerRef, callerContainerRef)
+
   // Track what columns+visibility combination was last measured so we know when
   // a re-measurement is needed (e.g. columns change or visibility is toggled).
   const columnVisibility = table.getState().columnVisibility
@@ -183,7 +193,6 @@ export default function StyledTanStackTable<
     ? MemoizedTableBody
     : TableBody
 
-  const callerOnScroll = styledTableContainerProps?.onScroll
   function handleContainerScroll(e: UIEvent<HTMLDivElement>) {
     callerOnScroll?.(e)
     if (showTopScrollbar) {
@@ -203,8 +212,8 @@ export default function StyledTanStackTable<
         </Box>
       )}
       <StyledTableContainer
-        {...styledTableContainerProps}
-        ref={containerRef}
+        {...restContainerProps}
+        ref={mergedContainerRef}
         onScroll={handleContainerScroll}
       >
         <Table

--- a/packages/synapse-react-client/src/components/TanStackTable/useSyncedTopScrollbar.ts
+++ b/packages/synapse-react-client/src/components/TanStackTable/useSyncedTopScrollbar.ts
@@ -1,0 +1,52 @@
+import { useResizeObserver } from '@react-hookz/web'
+import { RefObject, UIEvent, useRef, useState } from 'react'
+
+/**
+ * Keeps an optional top scrollbar in sync with a scrollable container's horizontal scroll
+ * position, sized to match the rendered width of `targetRef`'s element (e.g. a `<table>`).
+ */
+export function useSyncedTopScrollbar(
+  targetRef: RefObject<HTMLElement | null>,
+  enabled: boolean,
+) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const topScrollRef = useRef<HTMLDivElement>(null)
+  const scrollSyncSourceRef = useRef<'top' | 'bottom' | null>(null)
+  const [targetWidth, setTargetWidth] = useState(0)
+
+  useResizeObserver(
+    targetRef,
+    entry => setTargetWidth((entry.target as HTMLElement).offsetWidth),
+    enabled,
+  )
+
+  function handleTopScroll(e: UIEvent<HTMLDivElement>) {
+    if (scrollSyncSourceRef.current === 'bottom') {
+      scrollSyncSourceRef.current = null
+      return
+    }
+    scrollSyncSourceRef.current = 'top'
+    if (containerRef.current) {
+      containerRef.current.scrollLeft = e.currentTarget.scrollLeft
+    }
+  }
+
+  function handleBottomScroll(e: UIEvent<HTMLDivElement>) {
+    if (scrollSyncSourceRef.current === 'top') {
+      scrollSyncSourceRef.current = null
+      return
+    }
+    scrollSyncSourceRef.current = 'bottom'
+    if (topScrollRef.current) {
+      topScrollRef.current.scrollLeft = e.currentTarget.scrollLeft
+    }
+  }
+
+  return {
+    containerRef,
+    topScrollRef,
+    targetWidth,
+    handleTopScroll,
+    handleBottomScroll,
+  }
+}

--- a/packages/synapse-react-client/src/style/base/_core.scss
+++ b/packages/synapse-react-client/src/style/base/_core.scss
@@ -633,15 +633,6 @@ hr ~ .QueryWrapperPlotNav {
   tbody > tr > td {
     vertical-align: top;
   }
-
-  // Flip the scrollable container and its table so the browser renders the
-  // horizontal scrollbar at the top instead of the bottom. This container
-  // never scrolls vertically, so the flip only affects the horizontal scrollbar's position.
-  transform: scaleY(-1);
-
-  table {
-    transform: scaleY(-1);
-  }
 }
 
 .table > tbody > tr > td {

--- a/packages/synapse-react-client/src/style/base/_core.scss
+++ b/packages/synapse-react-client/src/style/base/_core.scss
@@ -633,6 +633,15 @@ hr ~ .QueryWrapperPlotNav {
   tbody > tr > td {
     vertical-align: top;
   }
+
+  // Flip the scrollable container and its table so the browser renders the
+  // horizontal scrollbar at the top instead of the bottom. This container
+  // never scrolls vertically, so the flip only affects the horizontal scrollbar's position.
+  transform: scaleY(-1);
+
+  table {
+    transform: scaleY(-1);
+  }
 }
 
 .table > tbody > tr > td {


### PR DESCRIPTION
## Add synced top horizontal scrollbar to SynapseTable

### Summary
Added a synced horizontal scrollbar above `SynapseTable`, in addition to the
existing one at the bottom, so users don't need to scroll to the bottom of
a long table just to scroll it horizontally.

### Changes

- **`components/TanStackTable/useSyncedTopScrollbar.ts`** *(new)*
  - Custom hook that keeps a top scrollbar element in sync with a table's
    main scroll container.
  - Mirrors `scrollLeft` between the two elements (guarded with a
    `scrollSyncSourceRef` to avoid feedback loops).
  - Uses `@react-hookz/web`'s `useResizeObserver` to track the target
    element's rendered width, so the top scrollbar's thumb size stays
    accurate as columns resize.

- **`components/TanStackTable/StyledTanStackTable.tsx`**
  - Added an opt-in `showTopScrollbar` prop (default `false`).
  - When enabled, renders a lightweight scrollable `Box` above
    `StyledTableContainer`, wired up via `useSyncedTopScrollbar`.
  - No behavior change for existing consumers (prop defaults to off).

- **`components/SynapseTable/SynapseTable.tsx`**
  - Passes `showTopScrollbar={true}` to `StyledTanStackTable`.

### Notes
- Scoped to `SynapseTable` only — other tables built on
  `StyledTanStackTable` (e.g. the virtualized table) are unaffected.
- Tracked in [PORTALS-4444](https://sagebionetworks.jira.com/browse/PORTALS-4444).

[PORTALS-4444]: https://sagebionetworks.jira.com/browse/PORTALS-4444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ