### PR TITLE
PORTALS-4440: Take the Curie launcher out of Experimental Mode in the B2AI Standards Explorer

### DIFF
--- a/apps/portals/b2ai.standards/src/index.tsx
+++ b/apps/portals/b2ai.standards/src/index.tsx
@@ -33,6 +33,7 @@ root.render(
       logoFooterConfig={logoFooterConfig}
       navbarConfig={navbarConfig}
       synapseChatProps={synapseChatConfig}
+      isCurieLauncherEnabled
     />
   </StrictMode>,
 )


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/jira/software/c/projects/PLFM/boards/238?assignee=712020%3Aa7fbbeb0-d7a6-443a-9dd4-246363ff09dd&selectedIssue=PORTALS-4440

<img width="1512" height="982" alt="Standards Explorer" src="https://github.com/user-attachments/assets/106c31b7-2860-42bb-85e9-a489af34f9ad" />
<img width="1512" height="982" alt="Screenshot 2026-09-02 at 11 52 10 AM" src="https://github.com/user-attachments/assets/caddff9a-404a-4516-99c9-202317488bf0" />
<img width="1512" height="982" alt="Screenshot 2026-09-02 at 11 52 25 AM" src="https://github.com/user-attachments/assets/e05f56da-9ced-40cf-9cfb-588a613894bf" />
