### PR TITLE
SWC-7873: Nit: On Project/Tables tab, 'Table/View' button does not reset to white text after cancel

### DIFF
--- a/packages/synapse-react-client/src/components/menu/DropdownMenu.tsx
+++ b/packages/synapse-react-client/src/components/menu/DropdownMenu.tsx
@@ -132,12 +132,12 @@ export function DropdownMenu(props: DropdownMenuProps) {
     const menuItem = items.flat()[0]
     return (
       <Button
-        component={'href' in menuItem ? 'a' : 'button'}
+        component={menuItem.href ? 'a' : 'button'}
         title={menuItem.tooltipText}
         variant={variant}
-        href={'href' in menuItem ? menuItem.href : undefined}
-        rel={'href' in menuItem ? 'noopener noreferrer' : undefined}
-        onClick={'onClick' in menuItem ? menuItem.onClick : undefined}
+        href={menuItem.href}
+        rel={menuItem.href ? 'noopener noreferrer' : undefined}
+        onClick={menuItem.onClick}
         disabled={menuItem.disabled}
         endIcon={menuItem.icon && <IconSvg icon={menuItem.icon} wrap={false} />}
       >
@@ -242,11 +242,9 @@ export function DropdownMenu(props: DropdownMenuProps) {
                                   },
                                 }}
                                 disabled={item.disabled}
-                                href={'href' in item ? item.href : undefined}
+                                href={item.href}
                                 rel={
-                                  'href' in item
-                                    ? 'noopener noreferrer'
-                                    : undefined
+                                  item.href ? 'noopener noreferrer' : undefined
                                 }
                                 // Allow pointer events on disabled item so tooltip works.
                                 style={{ pointerEvents: 'auto' }}


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/jira/software/c/projects/PLFM/boards/238?assignee=712020%3Aa7fbbeb0-d7a6-443a-9dd4-246363ff09dd&selectedIssue=SWC-7873

Looks like the intent was to render an <a> only for links and a <button> otherwise but we were doing a key check rather than a value check so the href key exist with no actual link (we always push href key for EntityActionMenu):
<img width="1512" height="982" alt="Screenshot 2026-09-02 at 1 44 40 PM" src="https://github.com/user-attachments/assets/f4da7f70-30db-421a-8caf-20dfd3c59a0d" />

Table/View just opens a modal so it should be rendered as <button>.
<img width="1512" height="982" alt="Screenshot 2026-09-02 at 1 53 13 PM" src="https://github.com/user-attachments/assets/234ce029-e285-4cc0-8b65-86993bc2aeab" />
