### PR TITLE
Update flow when sending eDUC (pop up info message on send), and update style of user access request histo…

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.test.tsx
@@ -9,11 +9,26 @@ import { server } from '@/mocks/msw/server'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
 import { AccessRequirement } from '@sage-bionetworks/synapse-types'
 import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { displayToast } from '../ToastMessage/ToastMessage'
 import AccessRequirementList, {
   AccessRequirementListProps,
   RequestDataStep,
 } from './AccessRequirementList'
 import * as AccessRequirementListUtils from './AccessRequirementListUtils'
+import EDucPreviewStep from './ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep'
+
+vi.mock('../ToastMessage/ToastMessage')
+const mockedDisplayToast = vi.mocked(displayToast)
+
+vi.mock(
+  './ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep',
+  () => ({
+    __esModule: true,
+    default: vi.fn(),
+  }),
+)
+const MockEDucPreviewStep = vi.mocked(EDucPreviewStep)
 
 const MOCK_FILE_ENTITY_ID = mockFileEntityData.id
 
@@ -95,5 +110,34 @@ describe('AccessRequirementList tests', () => {
     expect(
       screen.queryByRole('button', { name: 'Back' }),
     ).not.toBeInTheDocument()
+  })
+
+  it('shows an info toast and closes the wizard when send-for-signature succeeds', async () => {
+    const onHide = vi.fn()
+    MockEDucPreviewStep.mockImplementation(({ onSendForSignature }) => (
+      <button onClick={onSendForSignature}>Mock send</button>
+    ))
+
+    await init({
+      ...props,
+      onHide,
+      initialWizardEntry: {
+        step: RequestDataStep.EDUC_PREVIEW,
+        managedACTAccessRequirement: {
+          ...mockManagedACTAccessRequirement,
+          eDucTemplateId: 'template-abc-123',
+        },
+      },
+    })
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Mock send' }),
+    )
+
+    expect(mockedDisplayToast).toHaveBeenCalledWith(
+      expect.stringContaining('emailed to your collaborators'),
+      'info',
+    )
+    expect(onHide).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/AccessRequirementList.tsx
@@ -35,6 +35,7 @@ import { ReactNode, useMemo, useState } from 'react'
 import { DialogBaseTitle } from '../DialogBase'
 import { EntityLink } from '../EntityLink'
 import IconSvg from '../IconSvg/IconSvg'
+import { displayToast } from '../ToastMessage/ToastMessage'
 import UserOrTeamBadge from '../UserOrTeamBadge'
 import { AccessRequirementListItem } from './AccessRequirementListItem'
 import { useCanShowManagedACTWikiInWizard } from './AccessRequirementListUtils'
@@ -454,7 +455,14 @@ export default function AccessRequirementList(
             requestDataStepCallback({ step: RequestDataStep.REVIEW_DUC })
           }}
           onSendForSignature={() => {
-            requestDataStepCallback({ step: RequestDataStep.SIGNATURE_STATUS })
+            // The signature-status step isn't useful right after routing (0 signatures collected,
+            // Submit necessarily disabled), so surface a toast and close the wizard. The user can
+            // resume from their in-flight requests table when signatures are ready.
+            displayToast(
+              'Your DUC has been emailed to your collaborators. You can check signature progress in your access request history.',
+              'info',
+            )
+            onHide()
           }}
           onManualUpload={() => {
             requestDataStepCallback({

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.test.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.test.tsx
@@ -78,7 +78,7 @@ describe('InFlightEDucSignaturesTable', () => {
       ])
     })
 
-    screen.getByRole('heading', { name: /In-flight eDUC signatures/i })
+    screen.getByText(/In-flight eDUC signatures/i)
     const table = screen.getByRole('table')
     const columnHeaders = within(table).getAllByRole('columnheader')
     expect(columnHeaders).toHaveLength(3)
@@ -108,7 +108,7 @@ describe('InFlightEDucSignaturesTable', () => {
     })
     expect(screen.queryByRole('table')).not.toBeInTheDocument()
     expect(
-      screen.queryByRole('heading', { name: /In-flight eDUC signatures/i }),
+      screen.queryByText(/In-flight eDUC signatures/i),
     ).not.toBeInTheDocument()
   })
 

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/InFlightEDucSignaturesTable.tsx
@@ -2,7 +2,7 @@ import { SkeletonTable } from '@/components/Skeleton'
 import ColumnHeader from '@/components/TanStackTable/ColumnHeader'
 import StyledTanStackTable from '@/components/TanStackTable/StyledTanStackTable'
 import { useListAllUserDataAccessRequests } from '@/synapse-queries'
-import { Alert, Box, Typography } from '@mui/material'
+import { Alert, Box, Typography, Stack } from '@mui/material'
 import {
   AccessRequestSummary,
   AccessRequestSummaryStatusEnum,
@@ -114,10 +114,16 @@ export function InFlightEDucSignaturesTable() {
 
   return (
     <Box>
-      <Typography variant={'headline2'} component={'h2'} gutterBottom>
-        In-flight eDUC signatures
-      </Typography>
-      <StyledTanStackTable table={table} fullWidth={true} />
+      <Stack
+        sx={{
+          gap: 2,
+        }}
+      >
+        <Typography variant="headline1" gutterBottom>
+          In-flight eDUC signatures
+        </Typography>
+        <StyledTanStackTable table={table} fullWidth={true} />
+      </Stack>
     </Box>
   )
 }

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryPage.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryPage.tsx
@@ -34,6 +34,7 @@ export function UserAccessRequestHistoryPage() {
         gap: 2,
       }}
     >
+      <InFlightEDucSignaturesTable />
       <Typography variant="headline1" gutterBottom>
         History of your access requests
       </Typography>
@@ -63,7 +64,6 @@ export function UserAccessRequestHistoryPage() {
           </div>
         </>
       )}
-      <InFlightEDucSignaturesTable />
       <UserAccessRequestHistoryTable />
     </Stack>
   )

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryPlace.stories.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryPlace.stories.tsx
@@ -1,4 +1,18 @@
+import { getUserProfileHandlers } from '@/mocks/msw/handlers/userProfileHandlers'
+import {
+  MOCK_USER_ID,
+  MOCK_USER_ID_2,
+  MOCK_USER_ID_3,
+} from '@/mocks/user/mock_user_profile'
+import { DATA_ACCESS_REQUEST_LIST } from '@/utils/APIConstants'
+import { MOCK_REPO_ORIGIN } from '@/utils/functions/getEndpoint'
+import {
+  AccessRequestList,
+  UserSubmissionSearchResponse,
+} from '@sage-bionetworks/synapse-client'
+import { SubmissionState } from '@sage-bionetworks/synapse-types'
 import { Meta, StoryObj } from '@storybook/react-vite'
+import { http, HttpResponse } from 'msw'
 import { UserAccessRequestHistoryPlace } from './UserAccessRequestHistoryPlace'
 
 const meta = {
@@ -8,9 +22,117 @@ const meta = {
     useMemoryRouter: true,
     routerBaseName: '/',
   },
+  parameters: {
+    stack: 'mock',
+    msw: {
+      handlers: [
+        // In-flight eDUC signatures — powers the top table via useListAllUserDataAccessRequests.
+        // Response is paginated by nextPageToken; the queryFn walks every page before rendering.
+        http.post<never, { nextPageToken?: string }>(
+          `${MOCK_REPO_ORIGIN}${DATA_ACCESS_REQUEST_LIST}`,
+          async ({ request }) => {
+            const body = await request.json()
+            const isSecondPage = body?.nextPageToken === 'page-2'
+            const page: AccessRequestList = isSecondPage
+              ? { results: page2 }
+              : { results: page1, nextPageToken: 'page-2' }
+            return HttpResponse.json(page, { status: 200 })
+          },
+        ),
+        // Submission history — powers the bottom table via useSearchAccessSubmissionUserRequestsInfinite.
+        http.post(
+          `${MOCK_REPO_ORIGIN}/repo/v1/dataAccessSubmission/userRequests`,
+          () =>
+            HttpResponse.json<UserSubmissionSearchResponse>(
+              { results: submissionHistory },
+              { status: 200 },
+            ),
+        ),
+        ...getUserProfileHandlers(MOCK_REPO_ORIGIN),
+      ],
+    },
+  },
 } satisfies Meta
 export default meta
 type Story = StoryObj<typeof meta>
+
+const page1: AccessRequestList['results'] = [
+  {
+    requestId: '100',
+    accessRequirementName: 'ROSMAP eDUC',
+    isEDuc: true,
+    status: 'sent',
+    signaturesAcquired: 2,
+    signaturesRequested: 5,
+    modifiedOn: '2026-08-20T10:00:00Z',
+  },
+  {
+    requestId: '101',
+    accessRequirementName: 'MSSM Study Data',
+    isEDuc: true,
+    status: 'delivered',
+    signaturesAcquired: 4,
+    signaturesRequested: 5,
+    modifiedOn: '2026-08-19T10:00:00Z',
+  },
+  {
+    requestId: '199',
+    accessRequirementName: 'Legacy TOU (non-eDUC)',
+    isEDuc: false,
+    status: 'submitted',
+    modifiedOn: '2026-06-05T10:00:00Z',
+  },
+]
+
+const page2: AccessRequestList['results'] = [
+  {
+    requestId: '102',
+    accessRequirementName: 'AMP-PD Data',
+    isEDuc: true,
+    status: 'completed',
+    signaturesAcquired: 3,
+    signaturesRequested: 3,
+    modifiedOn: '2026-08-21T10:00:00Z',
+  },
+]
+
+const futureDate = new Date()
+futureDate.setFullYear(futureDate.getFullYear() + 5)
+const pastDate = new Date()
+pastDate.setFullYear(pastDate.getFullYear() - 5)
+
+const submissionHistory: UserSubmissionSearchResponse['results'] = [
+  {
+    id: '1',
+    accessRequirementName: 'ROSMAP eDUC',
+    state: SubmissionState.APPROVED,
+    createdOn: pastDate.toISOString(),
+    submitterId: MOCK_USER_ID.toString(),
+    userAccessApproval: { expiredOn: futureDate.toISOString() },
+  },
+  {
+    id: '2',
+    accessRequirementName: 'ADNI Study Data',
+    state: SubmissionState.APPROVED,
+    createdOn: pastDate.toISOString(),
+    submitterId: MOCK_USER_ID_2.toString(),
+    userAccessApproval: { expiredOn: pastDate.toISOString() },
+  },
+  {
+    id: '3',
+    accessRequirementName: 'MSSM Study Data',
+    state: SubmissionState.REJECTED,
+    createdOn: '2025-03-15T12:00:00Z',
+    submitterId: MOCK_USER_ID_3.toString(),
+  },
+  {
+    id: '4',
+    accessRequirementName: 'AMP-PD Data',
+    state: SubmissionState.SUBMITTED,
+    createdOn: '2025-04-05T12:00:00Z',
+    submitterId: MOCK_USER_ID_3.toString(),
+  },
+]
 
 export const Demo: Story = {
   name: 'UserAccessRequestHistoryPlace',


### PR DESCRIPTION
…ry page

Instead of taking the user to the signature status page of the wizard after sending the document out for signatures (which will always have 0 signatures, and no ability to submit), let's pop up an info message.  We'll have other commands that take the user to the signature status page

history page before:
<img width="1315" height="683" alt="Screenshot 2026-09-02 at 2 43 14 PM" src="https://github.com/user-attachments/assets/1c2b94ad-37da-406c-9075-642cc27e2d69" />


history page content after:
<img width="1391" height="645" alt="Screenshot 2026-09-02 at 2 42 08 PM" src="https://github.com/user-attachments/assets/819bd191-a612-47e1-85f1-6497bd1fc646" />

