### PR TITLE
SWC-7966 Fix clipped pledge and terms-of-use layout on mobile

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,6 +37,25 @@ jobs:
       - uses: ./.github/actions/pnpm-setup-action
         with:
           STORE_NX_CACHE: 'true'
+      - name: Determine if SageAccountWeb has had any changes
+        id: sage_account_web_changes
+        run: |
+          if pnpm nx show projects --affected --base=remotes/origin/main --json \
+            | jq -e 'index("SageAccountWeb")' > /dev/null; then
+            echo "Project is affected; setting project_affected=true"
+            echo "project_affected=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Project is not affected; setting project_affected=false"
+            echo "project_affected=false" >> "$GITHUB_OUTPUT"
+          fi
+      # SageAccountWeb's browser test project runs real Chromium via Playwright
+      # (jsdom can't evaluate CSS cascade/media queries), so the runner needs
+      # the browser binary installed before `nx affected --target test` runs.
+      - name: Install Playwright Browsers
+        if: ${{ steps.sage_account_web_changes.outputs.project_affected == 'true' }}
+        run: |
+          cd apps/SageAccountWeb
+          pnpm playwright install --with-deps chromium
       - id: test
         # Test runners run in parallel, so we use `--parallel=1` to avoid running them all at once
         run: pnpm nx affected --target test --base=remotes/origin/main --parallel=1

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ node_modules/
 
 # testing
 coverage/
+.vitest-attachments/
+**/__screenshots__/
 
 # incremental builds
 build/

--- a/apps/SageAccountWeb/package.json
+++ b/apps/SageAccountWeb/package.json
@@ -41,6 +41,7 @@
     "@types/react-easy-crop": "^2.0.0",
     "@types/react-plotly.js": "^2.6.4",
     "@types/react-tooltip": "^4.2.4",
+    "@vitest/browser-playwright": "4.1.8",
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/ui": "^4.1.8",
     "@vitest/utils": "^4.1.8",
@@ -52,6 +53,7 @@
     "memfs": "^3.5.3",
     "msw": "^2.14.6",
     "path-browserify": "^1.0.1",
+    "playwright": "^1.62.1",
     "pluralize": "^8.0.0",
     "process": "^0.11.10",
     "source-map-explorer": "^2.5.3",
@@ -66,6 +68,7 @@
     "vite-config": "workspace:*",
     "vite-plugin-node-polyfills": "^0.28.0",
     "vitest": "^4.1.8",
+    "vitest-browser-react": "^2.2.0",
     "vitest-when": "^0.10.0",
     "whatwg-fetch": "^3.6.20"
   },
@@ -91,6 +94,11 @@
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"
+    ]
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
     ]
   },
   "lint-staged": {

--- a/apps/SageAccountWeb/public/mockServiceWorker.js
+++ b/apps/SageAccountWeb/public/mockServiceWorker.js
@@ -1,0 +1,347 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.14.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter(client => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter(client => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find(client => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map(value => value.trim())
+      const filteredValues = values.filter(value => value !== 'msw/passthrough')
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = event => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/apps/SageAccountWeb/src/components/ProfileValidation/ProfileValidation.browser.test.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/ProfileValidation.browser.test.tsx
@@ -1,0 +1,105 @@
+import { DESKTOP_RIGHT_PANEL_TEST_ID } from '@/components/StyledComponents'
+import { mockPledgeTable } from '../../mocks/pledgeTable'
+import { renderInBrowser } from '../../tests/renderInBrowser'
+import {
+  DESKTOP_VIEWPORT,
+  MOBILE_VIEWPORT,
+  VIEWPORTS,
+  Viewport,
+  setViewport,
+} from '../../tests/viewports'
+import ProfileValidation, { ValidationWizardStep } from './ProfileValidation'
+
+const PLEDGE_LABEL = 'I agree to the pledge'
+
+function renderTermsAgreeStep() {
+  // ProfileValidation reads the starting step via `getSearchParam`, which
+  // reads `window.location.search` directly rather than the router's
+  // location -- MemoryRouter's in-memory history doesn't affect that.
+  window.history.pushState({}, '', `/?step=${ValidationWizardStep.TERMS_AGREE}`)
+  return renderInBrowser(<ProfileValidation />)
+}
+
+function setUpTermsAgreeStep(viewport: Viewport) {
+  beforeEach(async () => {
+    await setViewport(viewport)
+    mockPledgeTable([{ label: PLEDGE_LABEL, description: '' }])
+  })
+}
+
+describe('ProfileValidation terms step (SWC-7966)', () => {
+  describe.each(VIEWPORTS)('at $name width', viewport => {
+    setUpTermsAgreeStep(viewport)
+
+    test('the page fits the viewport and the pledge can be agreed to', async () => {
+      const screen = await renderTermsAgreeStep()
+
+      const continueButton = screen.getByRole('button', { name: 'Continue' })
+      await expect.element(continueButton).toBeVisible()
+
+      // The page must fit the viewport width: the container clips with
+      // `overflow: hidden` instead of offering a scrollbar, so anything wider
+      // is unreachable.
+      expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(
+        window.innerWidth,
+      )
+
+      // Agreeing to the pledge is what enables Continue.
+      const checkbox = screen.getByRole('checkbox')
+      await checkbox.click()
+      await expect.element(checkbox).toHaveClass('terms-checked')
+      await expect.element(continueButton).toBeEnabled()
+
+      // Nothing may paint over the Continue button: a click at its own center
+      // must land on the button, not on overlapping text.
+      const buttonElement = continueButton.element()
+      const buttonRect = buttonElement.getBoundingClientRect()
+      const cx = buttonRect.left + buttonRect.width / 2
+      const cy = buttonRect.top + buttonRect.height / 2
+      const elementAtButtonCenter = document.elementFromPoint(cx, cy)
+      expect(
+        buttonElement === elementAtButtonCenter ||
+          buttonElement.contains(elementAtButtonCenter),
+      ).toBe(true)
+    })
+  })
+
+  describe('at mobile width', () => {
+    setUpTermsAgreeStep(MOBILE_VIEWPORT)
+
+    test('moves the pledge explanation into an accordion and hides the right panel', async () => {
+      const screen = await renderTermsAgreeStep()
+
+      const accordionButton = screen.getByRole('button', {
+        name: 'What is the Synapse Pledge?',
+      })
+      await expect.element(accordionButton).toBeVisible()
+
+      const rightPanel = screen.getByTestId(DESKTOP_RIGHT_PANEL_TEST_ID)
+      expect(rightPanel.element()).not.toBeVisible()
+    })
+  })
+
+  describe('at desktop width', () => {
+    setUpTermsAgreeStep(DESKTOP_VIEWPORT)
+
+    test('shows the pledge explanation in the right panel instead of an accordion', async () => {
+      const screen = await renderTermsAgreeStep()
+      await expect
+        .element(screen.getByRole('button', { name: 'Continue' }))
+        .toBeVisible()
+
+      // The right panel is the desktop home of the explanation. Asserted on the
+      // resolved element rather than via `expect.element`, so a regression fails
+      // immediately instead of after the retry timeout.
+      const rightPanel = screen.getByTestId(DESKTOP_RIGHT_PANEL_TEST_ID)
+      expect(rightPanel.element()).toBeVisible()
+      expect(rightPanel.element().textContent).toContain(
+        'What is the Synapse Pledge?',
+      )
+
+      // The accordion is mobile-only, so it must not duplicate the panel here.
+      expect(document.querySelector('.MuiAccordion-root')).not.toBeVisible()
+    })
+  })
+})

--- a/apps/SageAccountWeb/src/components/ProfileValidation/ProfileValidation.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/ProfileValidation.tsx
@@ -1,4 +1,6 @@
 import {
+  DESKTOP_RIGHT_PANEL_TEST_ID,
+  getWideDesktopTwoColumnSx,
   StyledInnerContainer,
   StyledOuterContainer,
 } from '@/components/StyledComponents'
@@ -23,7 +25,7 @@ import { Navigate } from 'react-router'
 import { getSearchParam } from '../../URLUtils'
 import { BackButton } from '../BackButton'
 import { SourceAppLogo } from '../SourceApp'
-import { TermsOfUseRightPanelText } from '../TermsOfUseRightPanelText'
+import { TermsOfUseExplanationSection } from '../TermsOfUseExplanation'
 import { useSourceApp } from '../useSourceApp'
 import Attestation from './Attestation'
 import { ProfileFieldsEditor } from './ProfileFieldsEditor'
@@ -99,7 +101,7 @@ const STEP_CONTENT = [
     title: null,
     body: (
       <>
-        <TermsOfUseRightPanelText />
+        <TermsOfUseExplanationSection />
       </>
     ),
   },
@@ -455,15 +457,8 @@ function ProfileValidation() {
         <StyledInnerContainer
           sx={
             step === ValidationWizardStep.TERMS_AGREE
-              ? theme => ({
-                  width: '1200px',
-                  '& > div:nth-of-type(1)': {
-                    paddingTop: theme.spacing(10),
-                    width: '750px',
-                  },
-                  '& > div:nth-of-type(2)': { paddingTop: theme.spacing(10) },
-                })
-              : null
+              ? getWideDesktopTwoColumnSx
+              : undefined
           }
         >
           {verificationSubmission && (
@@ -485,7 +480,16 @@ function ProfileValidation() {
               />
             </Box>
           )}
-          <RightPanel stepNumber={step} />
+          <Box
+            data-testid={DESKTOP_RIGHT_PANEL_TEST_ID}
+            sx={
+              step === ValidationWizardStep.TERMS_AGREE
+                ? { display: { xs: 'none', md: 'block' } }
+                : undefined
+            }
+          >
+            <RightPanel stepNumber={step} />
+          </Box>
         </StyledInnerContainer>
       ) : (
         <ThankYou>

--- a/apps/SageAccountWeb/src/components/ProfileValidation/TermsAndConditionsItem.browser.test.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/TermsAndConditionsItem.browser.test.tsx
@@ -1,0 +1,100 @@
+import TermsAndConditionsItem from 'synapse-react-client/components/TermsAndConditions/TermsAndConditionsItem'
+import {
+  PLEDGE_ICON_FILE_HANDLE_ID,
+  mockPledgeItemIcon,
+} from '../../mocks/pledgeTable'
+import { renderInBrowser } from '../../tests/renderInBrowser'
+import {
+  DESKTOP_VIEWPORT,
+  MOBILE_VIEWPORT,
+  VIEWPORTS,
+  Viewport,
+  setViewport,
+} from '../../tests/viewports'
+
+function renderPledgeItem() {
+  // `.term-list > li ...` selectors in _terms-and-conditions.scss require
+  // this exact ancestor structure.
+  return renderInBrowser(
+    <div className="terms-conditions">
+      <ul className="term-list">
+        <TermsAndConditionsItem
+          id={0}
+          enabled
+          checked={false}
+          item={{
+            iconFileHandleId: PLEDGE_ICON_FILE_HANDLE_ID,
+            label: 'I agree to the terms',
+            description: '',
+          }}
+          termsAndConditionsTableID="syn1"
+          onChange={() => {}}
+        />
+      </ul>
+    </div>,
+  )
+}
+
+function setUpPledgeItem(viewport: Viewport) {
+  beforeEach(async () => {
+    await setViewport(viewport)
+    mockPledgeItemIcon()
+  })
+}
+
+describe('pledge item (SWC-7966)', () => {
+  describe.each(VIEWPORTS)('at $name width', viewport => {
+    setUpPledgeItem(viewport)
+
+    test('the checkbox is visible and stays within the viewport', async () => {
+      const screen = await renderPledgeItem()
+
+      const checkbox = screen.getByRole('checkbox')
+      await expect.element(checkbox).toBeVisible()
+
+      // The checkbox must stay on-screen: the row's `overflow: hidden` ancestor
+      // clips anything wider than the viewport instead of scrolling to it.
+      const checkboxRect = checkbox.element().getBoundingClientRect()
+      expect(checkboxRect.right).toBeLessThanOrEqual(window.innerWidth)
+      expect(checkboxRect.left).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  describe('at mobile width', () => {
+    setUpPledgeItem(MOBILE_VIEWPORT)
+
+    test('drops the icon column and stacks "I agree" under the checkbox', async () => {
+      const screen = await renderPledgeItem()
+      const checkbox = screen.getByRole('checkbox')
+      await expect.element(checkbox).toBeVisible()
+
+      // The icon column is dropped below `md` to make room for the checkbox.
+      expect(document.querySelector('.terms-icon')).not.toBeVisible()
+
+      // The "I agree" label stacks below and is horizontally centered under the
+      // checkbox circle on narrow viewports.
+      const checkboxColumn = document.querySelector('.terms-checkbox')!
+      expect(getComputedStyle(checkboxColumn).flexDirection).toBe('column')
+      const columnRect = checkboxColumn.getBoundingClientRect()
+      const circleRect = checkbox.element().getBoundingClientRect()
+      const columnCenter = columnRect.left + columnRect.width / 2
+      const circleCenter = circleRect.left + circleRect.width / 2
+      expect(Math.abs(columnCenter - circleCenter)).toBeLessThanOrEqual(1)
+    })
+  })
+
+  describe('at desktop width', () => {
+    setUpPledgeItem(DESKTOP_VIEWPORT)
+
+    test('keeps the icon column and lays "I agree" out beside the checkbox', async () => {
+      const screen = await renderPledgeItem()
+      await expect.element(screen.getByRole('checkbox')).toBeVisible()
+
+      // The icon column and row layout belong to the desktop layout above `md`.
+      expect(document.querySelector('.terms-icon')).toBeVisible()
+
+      const checkboxColumn = document.querySelector('.terms-checkbox')!
+      expect(getComputedStyle(checkboxColumn).flexDirection).toBe('row')
+    })
+  })
+})

--- a/apps/SageAccountWeb/src/components/ProfileValidation/TermsAndConditionsWrapped.tsx
+++ b/apps/SageAccountWeb/src/components/ProfileValidation/TermsAndConditionsWrapped.tsx
@@ -5,6 +5,7 @@ import { VerificationSubmission } from '@sage-bionetworks/synapse-types'
 import { ReturnToAppButton } from './ReturnToAppButton'
 import { TermsAndConditionsLink } from '../TermsAndConditionsLink'
 import TermsAndConditions from 'synapse-react-client/components/TermsAndConditions/TermsAndConditions'
+import { TermsOfUseMobileAccordion } from '../TermsOfUseMobileAccordion'
 // import { TermsAndConditionsSignature } from './TermsAndConditionsSignature'
 
 export type TermsAndConditionsWrappedProps = {
@@ -21,6 +22,7 @@ function TermsAndConditionsWrapped({
 
   return (
     <Box>
+      <TermsOfUseMobileAccordion />
       <TermsAndConditions
         termsAndConditionsTableID={
           import.meta.env.VITE_TERMS_AND_CONDITIONS_TABLE_ID

--- a/apps/SageAccountWeb/src/components/StyledComponents.ts
+++ b/apps/SageAccountWeb/src/components/StyledComponents.ts
@@ -1,37 +1,86 @@
-import { BoxProps, Paper, PaperProps, styled } from '@mui/material'
+import { PaperProps, styled, Theme } from '@mui/material'
+import { SystemStyleObject } from '@mui/system'
 import { StyledComponent } from '@emotion/styled'
-import { StyledOuterContainer as _StyledOuterContainer } from 'synapse-react-client/components/styled/LeftRightPanel'
+import {
+  StyledInnerContainer as BaseStyledInnerContainer,
+  StyledOuterContainer,
+} from 'synapse-react-client/components/styled/LeftRightPanel'
 
-export const StyledOuterContainer: StyledComponent<BoxProps> =
-  _StyledOuterContainer
+export { StyledOuterContainer }
 
-export const StyledInnerContainer: StyledComponent<PaperProps> = styled(Paper, {
-  label: 'StyledInnerContainer',
-})(({ theme }) => ({
-  width: '900px',
-  margin: '0 auto',
-  display: 'flex',
-  overflow: 'hidden',
-  [theme.breakpoints.down('md')]: {
-    flexDirection: 'column',
-    width: '100%',
-    height: '100vh',
-    overflowY: 'scroll',
-  },
-
+/**
+ * SageAccountWeb flavor of the shared `StyledInnerContainer`
+ * (`synapse-react-client/components/styled/LeftRightPanel`). The base supplies
+ * the 900px two-column card, its two-tone panel colors, and the mobile
+ * single-column stacking; this layer adds the app's panel padding and relative
+ * positioning, and lets the single column grow to fill (and scroll past) the
+ * viewport on mobile so tall content is never clipped (SWC-7966).
+ */
+export const StyledInnerContainer: StyledComponent<PaperProps> = styled(
+  BaseStyledInnerContainer,
+)(({ theme }) => ({
   '& > div:nth-of-type(1), & > div:nth-of-type(2)': {
-    width: '450px',
     position: 'relative',
     padding: theme.spacing(8),
     [theme.breakpoints.down('md')]: {
-      height: '100%',
-      width: '100%',
+      minHeight: '100%',
+      height: 'auto',
     },
   },
-  '& > div:nth-of-type(1)': {
-    backgroundColor: '#FFF',
-  },
-  '& > div:nth-of-type(2)': {
-    backgroundColor: '#F1F3F5',
-  },
 }))
+
+/**
+ * Identifies the `StyledInnerContainer` column that only renders above `md`.
+ * The column is a layout wrapper with no accessible role, so tests that assert
+ * it is hidden on mobile have no accessible query to use; reference this
+ * constant from both sides instead of a structural selector.
+ */
+export const DESKTOP_RIGHT_PANEL_TEST_ID = 'desktop-right-panel'
+
+/**
+ * Widens a `StyledInnerContainer` into a 1200px two-column layout (750px
+ * left panel) for content that needs more room than the default 900px/450px
+ * split.
+ *
+ * Scoped to `up('md')` so it never fights `StyledInnerContainer`'s own
+ * mobile-responsive (single-column, full-width) layout below that
+ * breakpoint (SWC-7966)
+ */
+export function getWideDesktopTwoColumnSx(
+  theme: Theme,
+): SystemStyleObject<Theme> {
+  return {
+    [theme.breakpoints.up('md')]: {
+      width: '1200px',
+      '& > div:nth-of-type(1)': {
+        paddingTop: theme.spacing(10),
+        width: '750px',
+      },
+      '& > div:nth-of-type(2)': { paddingTop: theme.spacing(10) },
+    },
+  }
+}
+
+/**
+ * Reverts `StyledInnerContainer`'s mobile inner-scroll model (a fixed `100vh`
+ * card with its own scrollbar) back to document-body scrolling: the container
+ * grows with its content and the page scrolls normally. Used by pages whose
+ * mobile content should flow with the body rather than scroll inside the card
+ * (SWC-7966).
+ */
+export function getMobileBodyScrollSx(theme: Theme): SystemStyleObject<Theme> {
+  return {
+    [theme.breakpoints.down('md')]: {
+      height: 'auto',
+      overflowY: 'visible',
+      '& > div:nth-of-type(1), & > div:nth-of-type(2)': {
+        minHeight: 'unset',
+      },
+    },
+    [theme.breakpoints.down('sm')]: {
+      '& > div:nth-of-type(1), & > div:nth-of-type(2)': {
+        padding: theme.spacing(5),
+      },
+    },
+  }
+}

--- a/apps/SageAccountWeb/src/components/TermsAndConditionsLink.tsx
+++ b/apps/SageAccountWeb/src/components/TermsAndConditionsLink.tsx
@@ -13,7 +13,7 @@ export function TermsAndConditionsLink({ sx }: TermsAndConditionsLinkProps) {
       target="_blank"
       sx={sx}
     >
-      View and Complete Terms and Conditions for Use
+      View Complete Terms and Conditions for Use
     </Button>
   )
 }

--- a/apps/SageAccountWeb/src/components/TermsOfUseExplanation.tsx
+++ b/apps/SageAccountWeb/src/components/TermsOfUseExplanation.tsx
@@ -1,16 +1,14 @@
-import React from 'react'
+import type { ReactNode } from 'react'
 import { Link, Typography } from '@mui/material'
 import { useSourceApp } from './useSourceApp'
 import { STATIC_SOURCE_APP_CONFIG } from 'synapse-react-client/utils/hooks/useSourceAppConfigs'
 
-export const TermsOfUseRightPanelText = (): React.ReactNode => {
+export const TermsOfUseExplanationContent = (): ReactNode => {
   const sourceApp = useSourceApp()
   const sourceAppName = sourceApp?.friendlyName
   const synapseAppName = STATIC_SOURCE_APP_CONFIG.friendlyName
   return (
     <>
-      <Typography variant="headline2">What is the Synapse Pledge?</Typography>
-
       <Typography variant="body1" sx={{ marginBottom: '20px' }}>
         {sourceAppName} is powered by{' '}
         {sourceApp?.friendlyName !== synapseAppName ? (
@@ -34,6 +32,15 @@ export const TermsOfUseRightPanelText = (): React.ReactNode => {
           act@sagebionetworks.org
         </Link>
       </Typography>
+    </>
+  )
+}
+
+export const TermsOfUseExplanationSection = (): ReactNode => {
+  return (
+    <>
+      <Typography variant="headline2">What is the Synapse Pledge?</Typography>
+      <TermsOfUseExplanationContent />
     </>
   )
 }

--- a/apps/SageAccountWeb/src/components/TermsOfUseMobileAccordion.tsx
+++ b/apps/SageAccountWeb/src/components/TermsOfUseMobileAccordion.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Typography,
+} from '@mui/material'
+import { TermsOfUseExplanationContent } from './TermsOfUseExplanation'
+
+/**
+ * Mobile-only collapsible accordion displaying the "What is the Synapse Pledge?"
+ * explanatory content above the pledge items, replacing the desktop right panel
+ * on narrow viewports (SWC-7966).
+ */
+export function TermsOfUseMobileAccordion(): ReactNode {
+  return (
+    <Accordion
+      disableGutters
+      elevation={0}
+      sx={theme => ({
+        display: { xs: 'block', md: 'none' },
+        backgroundColor: 'var(--synapse-gray-200)',
+        borderRadius: '4px',
+        border: '1px solid var(--synapse-border-color-gray)',
+        marginBottom: theme.spacing(2.5),
+        '&:before': { display: 'none' },
+      })}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls="terms-of-use-accordion-content"
+        id="terms-of-use-accordion-header"
+        sx={{
+          minHeight: '44px',
+          px: 2,
+          '& .MuiAccordionSummary-content': { my: 1 },
+        }}
+      >
+        <Typography variant="headline3">What is the Synapse Pledge?</Typography>
+      </AccordionSummary>
+      <AccordionDetails sx={{ px: 2, pt: 0, pb: 2 }}>
+        <TermsOfUseExplanationContent />
+      </AccordionDetails>
+    </Accordion>
+  )
+}

--- a/apps/SageAccountWeb/src/mocks/browser.ts
+++ b/apps/SageAccountWeb/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser'
+import handlers from './handlers/index'
+
+export const worker = setupWorker(...handlers)

--- a/apps/SageAccountWeb/src/mocks/pledgeTable.ts
+++ b/apps/SageAccountWeb/src/mocks/pledgeTable.ts
@@ -1,0 +1,93 @@
+import { QueryResultBundle } from '@sage-bionetworks/synapse-types'
+import { http, HttpResponse } from 'msw'
+import { registerTableQueryResult } from 'synapse-react-client/mocks/msw/handlers/tableQueryService'
+import { FILE_HANDLE_BATCH } from 'synapse-react-client/utils/APIConstants'
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from 'synapse-react-client/utils/functions/getEndpoint'
+import { worker } from './browser'
+
+export const PLEDGE_TABLE_ID = import.meta.env
+  .VITE_TERMS_AND_CONDITIONS_TABLE_ID
+export const PLEDGE_TABLE_VERSION = import.meta.env
+  .VITE_TERMS_AND_CONDITIONS_TABLE_VERSION
+
+export const PLEDGE_ICON_FILE_HANDLE_ID = '9999'
+
+const backendOrigin = getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)
+const iconPresignedUrl = 'https://mock-presigned-url.synapse.org/icon.svg'
+const iconSvg = '<svg width="24" height="24" role="presentation" />'
+
+export type PledgeItem = {
+  label: string
+  description: string
+}
+
+/**
+ * Serves an icon for `PLEDGE_ICON_FILE_HANDLE_ID` so pledge items resolve their
+ * icon through the real presigned-URL query path.
+ */
+export function mockPledgeItemIcon() {
+  worker.use(
+    http.post(`${backendOrigin}${FILE_HANDLE_BATCH}`, () =>
+      HttpResponse.json(
+        {
+          requestedFiles: [
+            {
+              fileHandleId: PLEDGE_ICON_FILE_HANDLE_ID,
+              fileHandle: {
+                concreteType:
+                  'org.sagebionetworks.repo.model.file.S3FileHandle',
+                id: PLEDGE_ICON_FILE_HANDLE_ID,
+                contentType: 'image/svg+xml',
+                fileName: 'icon.svg',
+              },
+              preSignedURL: iconPresignedUrl,
+            },
+          ],
+        },
+        { status: 201 },
+      ),
+    ),
+    http.get(iconPresignedUrl, () => HttpResponse.text(iconSvg)),
+  )
+}
+
+/**
+ * Makes the app's configured pledge table resolve to `items`, so components
+ * under test run the TermsAndConditions success branch (rendered checkboxes)
+ * rather than the "table not found" fallback.
+ */
+export function mockPledgeTable(items: PledgeItem[]) {
+  const bundle: QueryResultBundle = {
+    concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
+    queryResult: {
+      concreteType: 'org.sagebionetworks.repo.model.table.QueryResult',
+      queryResults: {
+        tableId: PLEDGE_TABLE_ID,
+        concreteType: 'org.sagebionetworks.repo.model.table.RowSet',
+        etag: 'etag',
+        headers: [
+          { name: 'icon', columnType: 'STRING' },
+          { name: 'label', columnType: 'STRING' },
+          { name: 'description', columnType: 'STRING' },
+        ],
+        rows: items.map(({ label, description }) => ({
+          values: [PLEDGE_ICON_FILE_HANDLE_ID, label, description],
+        })),
+      },
+    },
+    // `getFullQueryTableResults` pages until a page comes back shorter than
+    // `maxRowsPerPage`; without it the mock table service pages forever.
+    maxRowsPerPage: 100,
+  }
+
+  registerTableQueryResult(
+    {
+      sql: `SELECT * FROM ${PLEDGE_TABLE_ID}.${PLEDGE_TABLE_VERSION} ORDER BY order asc`,
+    },
+    bundle,
+  )
+  mockPledgeItemIcon()
+}

--- a/apps/SageAccountWeb/src/pages/RegisterAccount1.tsx
+++ b/apps/SageAccountWeb/src/pages/RegisterAccount1.tsx
@@ -23,6 +23,7 @@ import { BackButton } from '@/components/BackButton'
 import { EmailConfirmationPage } from '@/components/EmailConfirmationPage'
 import { SourceAppLogo } from '@/components/SourceApp'
 import {
+  getMobileBodyScrollSx,
   StyledInnerContainer,
   StyledOuterContainer,
 } from '@/components/StyledComponents'
@@ -251,7 +252,7 @@ const RegisterAccount1 = (): React.ReactNode => {
   return (
     <>
       <StyledOuterContainer className="RegisterAccount1">
-        <StyledInnerContainer>
+        <StyledInnerContainer sx={getMobileBodyScrollSx}>
           {page !== Pages.EMAIL_REGISTRATION_THANK_YOU && (
             <>
               <Box sx={{ py: 10, px: 8, height: '100%', position: 'relative' }}>

--- a/apps/SageAccountWeb/src/pages/TermsOfUsePage.browser.test.tsx
+++ b/apps/SageAccountWeb/src/pages/TermsOfUsePage.browser.test.tsx
@@ -1,0 +1,100 @@
+import { DESKTOP_RIGHT_PANEL_TEST_ID } from '@/components/StyledComponents'
+import { mockPledgeTable } from '../mocks/pledgeTable'
+import { renderInBrowser } from '../tests/renderInBrowser'
+import {
+  DESKTOP_VIEWPORT,
+  MOBILE_VIEWPORT,
+  VIEWPORTS,
+  Viewport,
+  setViewport,
+} from '../tests/viewports'
+import TermsOfUsePage from './TermsOfUsePage'
+
+// Five pledge items -- enough to reproduce the "right panel covers the 4th
+// item" report on a mobile viewport.
+const PLEDGE_ITEM_COUNT = 5
+
+function setUpTermsOfUsePage(viewport: Viewport) {
+  beforeEach(async () => {
+    await setViewport(viewport)
+    mockPledgeTable(
+      Array.from({ length: PLEDGE_ITEM_COUNT }, (_, i) => ({
+        label: `Pledge item ${i + 1}`,
+        description: `Description ${i + 1}`,
+      })),
+    )
+  })
+}
+
+describe('TermsOfUsePage (SWC-7966)', () => {
+  describe.each(VIEWPORTS)('at $name width', viewport => {
+    setUpTermsOfUsePage(viewport)
+
+    test('every pledge item renders a checkbox inside the viewport', async () => {
+      const screen = await renderInBrowser(<TermsOfUsePage />)
+
+      // Wait for the last pledge item before measuring, so `.elements()` sees
+      // the whole rendered list rather than a partially-resolved query.
+      const checkboxes = screen.getByRole('checkbox')
+      await expect
+        .element(checkboxes.nth(PLEDGE_ITEM_COUNT - 1))
+        .toBeInTheDocument()
+      const checkboxElements = checkboxes.elements()
+      expect(checkboxElements).toHaveLength(PLEDGE_ITEM_COUNT)
+
+      for (const checkbox of checkboxElements) {
+        const checkboxRect = checkbox.getBoundingClientRect()
+        expect(checkboxRect.right).toBeLessThanOrEqual(window.innerWidth)
+        expect(checkboxRect.left).toBeGreaterThanOrEqual(0)
+      }
+
+      const agreeButton = screen.getByRole('button', {
+        name: /Agree and Continue/i,
+      })
+      await expect.element(agreeButton).toBeVisible()
+    })
+  })
+
+  describe('at mobile width', () => {
+    setUpTermsOfUsePage(MOBILE_VIEWPORT)
+
+    test('the accordion expands to reveal the pledge explanation, and the right panel is hidden', async () => {
+      const screen = await renderInBrowser(<TermsOfUsePage />)
+
+      const accordionHeader = screen.getByRole('button', {
+        name: 'What is the Synapse Pledge?',
+      })
+      await expect.element(accordionHeader).toBeVisible()
+
+      await accordionHeader.click()
+      const explanationText = screen
+        .getByRole('region')
+        .getByText(/follows the Synapse Governance/i)
+      await expect.element(explanationText).toBeVisible()
+
+      const rightPanel = screen.getByTestId(DESKTOP_RIGHT_PANEL_TEST_ID)
+      expect(rightPanel.element()).not.toBeVisible()
+    })
+  })
+
+  describe('at desktop width', () => {
+    setUpTermsOfUsePage(DESKTOP_VIEWPORT)
+
+    test('the pledge explanation stays in the right panel and the accordion is hidden', async () => {
+      const screen = await renderInBrowser(<TermsOfUsePage />)
+      await expect
+        .element(screen.getByRole('button', { name: /Agree and Continue/i }))
+        .toBeVisible()
+
+      // Asserted on the resolved element rather than via `expect.element`, so a
+      // regression fails immediately instead of after the retry timeout.
+      const rightPanel = screen.getByTestId(DESKTOP_RIGHT_PANEL_TEST_ID)
+      expect(rightPanel.element()).toBeVisible()
+      expect(rightPanel.element().textContent).toContain(
+        'follows the Synapse Governance',
+      )
+
+      expect(document.querySelector('.MuiAccordion-root')).not.toBeVisible()
+    })
+  })
+})

--- a/apps/SageAccountWeb/src/pages/TermsOfUsePage.tsx
+++ b/apps/SageAccountWeb/src/pages/TermsOfUsePage.tsx
@@ -1,11 +1,14 @@
 import { SyntheticEvent, useState } from 'react'
 import { SourceAppLogo } from '../components/SourceApp'
-import { Box, Button, useTheme } from '@mui/material'
+import { Box, Button } from '@mui/material'
 import {
+  DESKTOP_RIGHT_PANEL_TEST_ID,
+  getWideDesktopTwoColumnSx,
   StyledInnerContainer,
   StyledOuterContainer,
 } from '../components/StyledComponents'
-import { TermsOfUseRightPanelText } from '../components/TermsOfUseRightPanelText'
+import { TermsOfUseExplanationSection } from '../components/TermsOfUseExplanation'
+import { TermsOfUseMobileAccordion } from '../components/TermsOfUseMobileAccordion'
 import { TermsAndConditionsLink } from '../components/TermsAndConditionsLink'
 import { useSourceApp } from '../components/useSourceApp'
 import TermsAndConditions from 'synapse-react-client/components/TermsAndConditions/TermsAndConditions'
@@ -18,7 +21,6 @@ import { displayToast } from 'synapse-react-client/components/ToastMessage/Toast
 import IconSvg from 'synapse-react-client/components/IconSvg/IconSvg'
 
 function TermsOfUsePage() {
-  const theme = useTheme()
   const [isLoading, setIsLoading] = useState(false)
   const [isFormComplete, setIsFormComplete] = useState(false)
   const [isDone, setIsDone] = useState(false)
@@ -74,16 +76,7 @@ function TermsOfUsePage() {
   }
   return (
     <StyledOuterContainer className="TermsOfUsePage">
-      <StyledInnerContainer
-        sx={{
-          width: '1200px',
-          '& > div:nth-of-type(1)': {
-            paddingTop: theme.spacing(10),
-            width: '750px',
-          },
-          '& > div:nth-of-type(2)': { paddingTop: theme.spacing(10) },
-        }}
-      >
+      <StyledInnerContainer sx={getWideDesktopTwoColumnSx}>
         <Box
           sx={{
             height: '100%',
@@ -95,6 +88,7 @@ function TermsOfUsePage() {
               <SourceAppLogo />
             </div>
             <div className={'terms-of-use-panel'}>
+              <TermsOfUseMobileAccordion />
               <TermsAndConditions
                 termsAndConditionsTableID={
                   import.meta.env.VITE_TERMS_AND_CONDITIONS_TABLE_ID
@@ -119,9 +113,12 @@ function TermsOfUsePage() {
             </div>
           </Box>
         </Box>
-        <Box>
+        <Box
+          data-testid={DESKTOP_RIGHT_PANEL_TEST_ID}
+          sx={{ display: { xs: 'none', md: 'block' } }}
+        >
           <Box sx={{ marginTop: '100px' }}>
-            <TermsOfUseRightPanelText />
+            <TermsOfUseExplanationSection />
           </Box>
         </Box>
       </StyledInnerContainer>

--- a/apps/SageAccountWeb/src/tests/renderInBrowser.tsx
+++ b/apps/SageAccountWeb/src/tests/renderInBrowser.tsx
@@ -1,0 +1,40 @@
+import { StyledEngineProvider, ThemeProvider } from '@mui/material/styles'
+import { createTheme } from '@mui/material/styles'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { MemoryRouter, MemoryRouterProps } from 'react-router'
+import { render } from 'vitest-browser-react'
+import { defaultMuiThemeOptions } from 'synapse-react-client/theme/DefaultTheme'
+import { sageAccountWebThemeOverrides } from '../style/theme'
+import '../App.scss'
+
+const theme = createTheme(defaultMuiThemeOptions, sageAccountWebThemeOverrides)
+
+export type RenderInBrowserOptions = {
+  memoryRouterProps?: MemoryRouterProps
+}
+
+/**
+ * Renders `ui` in a real browser with the app's theme, style engine, and
+ * stylesheet, which layout assertions need for the SCSS cascade and MUI
+ * breakpoints to resolve the way they do in the app.
+ */
+export function renderInBrowser(
+  ui: ReactNode,
+  options: RenderInBrowserOptions = {},
+) {
+  // A fresh QueryClient per render keeps `describe.each` viewport runs from
+  // reading another run's cached query data.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter {...options.memoryRouterProps}>
+        <StyledEngineProvider injectFirst>
+          <ThemeProvider theme={theme}>{ui}</ThemeProvider>
+        </StyledEngineProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}

--- a/apps/SageAccountWeb/src/tests/setupTests.browser.ts
+++ b/apps/SageAccountWeb/src/tests/setupTests.browser.ts
@@ -1,0 +1,16 @@
+import 'vitest-browser-react'
+import '@testing-library/jest-dom/vitest'
+import { afterAll, afterEach, beforeAll } from 'vitest'
+import { worker } from '../mocks/browser'
+
+beforeAll(async () => {
+  await worker.start({ quiet: true, onUnhandledRequest: 'error' })
+})
+
+afterEach(() => {
+  worker.resetHandlers()
+})
+
+afterAll(() => {
+  worker.stop()
+})

--- a/apps/SageAccountWeb/src/tests/viewports.ts
+++ b/apps/SageAccountWeb/src/tests/viewports.ts
@@ -1,0 +1,36 @@
+import { page } from 'vitest/browser'
+
+export type Viewport = {
+  name: string
+  width: number
+  height: number
+}
+
+// TODO: Standardize supported viewports with the design team. For now, these are designed around MUI's `md` breakpoint (900px) and iPhone 12/13/14 portrait orientation (390px).
+
+export const MOBILE_VIEWPORT: Viewport = {
+  name: 'mobile',
+  width: 390,
+  height: 844,
+}
+
+export const DESKTOP_VIEWPORT: Viewport = {
+  name: 'desktop',
+  width: 1440,
+  height: 900,
+}
+
+/**
+ * Viewports that every layout invariant must hold at. Use with `describe.each`
+ * for assertions that are true at any width; assert width-specific layout in a
+ * viewport-specific block instead of branching inside a shared test.
+ */
+export const VIEWPORTS: Viewport[] = [MOBILE_VIEWPORT, DESKTOP_VIEWPORT]
+
+/**
+ * Resizes the test iframe. Call before rendering so the breakpoint-dependent
+ * `sx` props and SCSS media queries apply to the first paint.
+ */
+export function setViewport(viewport: Viewport) {
+  return page.viewport(viewport.width, viewport.height)
+}

--- a/apps/SageAccountWeb/vite.config.ts
+++ b/apps/SageAccountWeb/vite.config.ts
@@ -1,4 +1,5 @@
 import { mergeConfig } from 'vite'
+import { playwright } from '@vitest/browser-playwright'
 import {
   baseConfig,
   vitestConfig,
@@ -11,8 +12,47 @@ const config = mergeConfig(
   mergeConfig(vitestConfig, {
     plugins: [nodePolyfillsPlugin(), ...reactPlugins()],
     test: {
-      include: ['src/**/*.test.[jt]s?(x)'],
-      setupFiles: ['src/tests/setupTests.ts'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'jsdom',
+            include: ['src/**/*.test.[jt]s?(x)'],
+            exclude: [
+              '**/node_modules/**',
+              '**/.git/**',
+              '**/dist/**',
+              'src/**/*.browser.test.[jt]s?(x)',
+            ],
+            setupFiles: ['src/tests/setupTests.ts'],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'browser',
+            // Real-browser tests for behavior jsdom cannot observe (actual CSS
+            // layout/cascade, e.g. responsive overflow and overlap bugs).
+            include: ['src/**/*.browser.test.[jt]s?(x)'],
+            // setupTests.ts stubs window.location/matchMedia the jsdom way,
+            // which breaks (or is unnecessary) in a real browser.
+            setupFiles: ['src/tests/setupTests.browser.ts'],
+            // One MSW service worker is registered per browser page and shared
+            // by the per-file iframes, so a parallel file's `resetHandlers()`
+            // can strand another file's in-flight requests.
+            fileParallelism: false,
+            browser: {
+              enabled: true,
+              provider: playwright(),
+              headless: true,
+              // Starting size only; tests that care set their own viewport via
+              // `src/tests/viewports.ts`.
+              viewport: { width: 1440, height: 900 },
+              instances: [{ browser: 'chromium' }],
+            },
+          },
+        },
+      ],
     },
   }),
 )

--- a/packages/synapse-react-client/src/components/styled/LeftRightPanel.tsx
+++ b/packages/synapse-react-client/src/components/styled/LeftRightPanel.tsx
@@ -15,6 +15,12 @@ export const StyledOuterContainer: StyledComponent<BoxProps> = styled(Box, {
   },
 }))
 
+/**
+ * Canonical 900px two-column card that stacks into a single scrollable column
+ * on mobile. Layout-only: consumers supply their own panel padding.
+ * `apps/SageAccountWeb` extends this (adding baked-in panel padding) rather
+ * than redefining it -- see that app's `StyledComponents.ts` (SWC-7966).
+ */
 export const StyledInnerContainer: StyledComponent<PaperProps> = styled(Paper, {
   label: 'StyledInnerContainer',
 })(({ theme }) => ({
@@ -22,9 +28,21 @@ export const StyledInnerContainer: StyledComponent<PaperProps> = styled(Paper, {
   minHeight: '675px',
   margin: '0 auto',
   display: 'flex',
+  overflow: 'hidden',
+  [theme.breakpoints.down('md')]: {
+    flexDirection: 'column',
+    width: '100%',
+    minHeight: 0,
+    height: '100vh',
+    overflowX: 'auto',
+    overflowY: 'scroll',
+  },
   '& > div:nth-of-type(1), & > div:nth-of-type(2)': {
     borderRadius: 'inherit',
     width: '450px',
+    [theme.breakpoints.down('md')]: {
+      width: '100%',
+    },
   },
   '& > div:nth-of-type(1)': {
     backgroundColor: theme.palette.background.paper,

--- a/packages/synapse-react-client/src/mocks/msw/handlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers.ts
@@ -26,6 +26,8 @@ import { getResetTwoFactorAuthHandlers } from './handlers/resetTwoFactorAuthHand
 import { getRealmHandlers } from './handlers/realmHandlers'
 import { getShortIoHandlers } from './handlers/shortIoHandlers'
 import { getSubscriptionHandlers } from './handlers/subscriptionHandlers'
+import { getTermsOfServiceHandlers } from './handlers/termsOfServiceHandlers'
+import { termsOfServiceUpToDateStatus } from '../termsOfService/mockTermsOfService'
 import {
   getAnnotationColumnHandlers,
   getCreateColumnModelBatchHandler,
@@ -91,6 +93,10 @@ export function getHandlersForStorybook(
     resetTwoFactorAuth: getResetTwoFactorAuthHandlers(backendOrigin),
     message: getMessageHandlers(backendOrigin),
     realm: getRealmHandlers(backendOrigin),
+    termsOfService: getTermsOfServiceHandlers(
+      backendOrigin,
+      termsOfServiceUpToDateStatus,
+    ),
     featureFlags: [getFeatureFlagsOverride({ portalOrigin })],
     tableQuery: getHandlersForTableQuery(backendOrigin),
     doi: getDoiHandler(backendOrigin),

--- a/packages/synapse-react-client/src/style/components/_terms-and-conditions.scss
+++ b/packages/synapse-react-client/src/style/components/_terms-and-conditions.scss
@@ -23,10 +23,11 @@
 
     > li {
       display: flex;
-      padding: 20px 0;
+      padding: 20px 16px;
       border: 1px solid var(--terms-accent-gray);
       margin-bottom: var(--terms-margin);
       opacity: 0.3;
+      gap: 8px;
 
       &.terms-enabled {
         opacity: 1;
@@ -42,8 +43,7 @@
       }
       .terms-checkbox {
         align-self: center;
-        text-align: right;
-        padding-right: 30px;
+        text-align: center;
         flex: 0 0 150px;
       }
       .terms-desc-content {
@@ -78,6 +78,28 @@
         background-color: #28a745;
         border: none;
         text-align: center;
+      }
+
+      // The 150px icon and checkbox columns leave too little room for the
+      // description on a narrow viewport, so the row overflows its
+      // `overflow: hidden` ancestor instead of scrolling. Keep this width in
+      // sync with MUI's `theme.breakpoints.down('md')`.
+      // See: SWC-7966
+      @media (max-width: 900px) {
+        .terms-icon {
+          display: none;
+        }
+        .terms-checkbox {
+          flex: 0;
+          white-space: nowrap;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+        }
+        .terms-circle {
+          margin-right: 0;
+        }
       }
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,9 +197,12 @@ importers:
       '@types/react-tooltip':
         specifier: ^4.2.4
         version: 4.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@vitest/browser-playwright':
+        specifier: 4.1.8
+        version: 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/coverage-v8':
         specifier: ^4.1.8
-        version: 4.1.8(vitest@4.1.8)
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -230,6 +233,9 @@ importers:
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
+      playwright:
+        specifier: ^1.62.1
+        version: 1.62.1
       pluralize:
         specifier: ^8.0.0
         version: 8.0.0
@@ -271,7 +277,10 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest-browser-react:
+        specifier: ^2.2.0
+        version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
       vitest-when:
         specifier: ^0.10.0
         version: 0.10.0(@vitest/expect@4.1.8)(vitest@4.1.8)
@@ -353,7 +362,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/ampals:
     dependencies:
@@ -414,7 +423,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/arcusbio:
     dependencies:
@@ -481,7 +490,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/arkportal:
     dependencies:
@@ -557,7 +566,7 @@ importers:
         version: 5.2.0(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/b2ai.standards:
     dependencies:
@@ -624,7 +633,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/bsmn:
     dependencies:
@@ -676,7 +685,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/cancercomplexity:
     dependencies:
@@ -752,7 +761,7 @@ importers:
         version: 5.2.0(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/challenges:
     dependencies:
@@ -810,7 +819,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/classic:
     dependencies:
@@ -880,7 +889,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/demoportal:
     dependencies:
@@ -938,7 +947,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/digitalhealth:
     dependencies:
@@ -993,7 +1002,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/eliteportal:
     dependencies:
@@ -1063,7 +1072,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/genie:
     dependencies:
@@ -1118,7 +1127,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/namhub:
     dependencies:
@@ -1194,7 +1203,7 @@ importers:
         version: 5.2.0(rollup@4.61.1)(typescript@5.8.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/nf:
     dependencies:
@@ -1276,7 +1285,7 @@ importers:
         version: 5.2.0(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/portals/stopadportal:
     dependencies:
@@ -1331,7 +1340,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/synapse-oauth-signin:
     dependencies:
@@ -1416,7 +1425,7 @@ importers:
         version: 4.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@vitest/coverage-v8':
         specifier: ^4.1.8
-        version: 4.1.8(vitest@4.1.8)
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -1497,7 +1506,7 @@ importers:
         version: 0.28.0(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/synapse-portal-framework:
     dependencies:
@@ -1612,7 +1621,7 @@ importers:
         version: 2.6.4
       '@vitest/coverage-v8':
         specifier: ^4.1.8
-        version: 4.1.8(vitest@4.1.8)
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -1693,7 +1702,7 @@ importers:
         version: 4.1.1(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       whatwg-fetch:
         specifier: ^3.6.20
         version: 3.6.20
@@ -1738,7 +1747,7 @@ importers:
         version: link:../vite-config
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/markdown-it-container:
     devDependencies:
@@ -1777,7 +1786,7 @@ importers:
         version: 22.19.20
       '@vitest/coverage-v8':
         specifier: ^4.1.8
-        version: 4.1.8(vitest@4.1.8)
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -1798,7 +1807,7 @@ importers:
         version: link:../vite-config
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/markdown-it-synapse-table:
     devDependencies:
@@ -1810,7 +1819,7 @@ importers:
         version: 22.19.20
       '@vitest/coverage-v8':
         specifier: ^4.1.8
-        version: 4.1.8(vitest@4.1.8)
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -1834,7 +1843,7 @@ importers:
         version: link:../vite-config
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/react-datasheet-grid:
     dependencies:
@@ -1895,7 +1904,7 @@ importers:
         version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.8
-        version: 4.1.8(vitest@4.1.8)
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -1922,7 +1931,7 @@ importers:
         version: link:../vite-config
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/synapse-client:
     devDependencies:
@@ -1970,7 +1979,7 @@ importers:
         version: link:../vite-config
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/synapse-react-client:
     dependencies:
@@ -2400,7 +2409,7 @@ importers:
         version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.8
-        version: 4.1.8(vitest@4.1.8)
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/spy':
         specifier: ^4.1.8
         version: 4.1.8
@@ -2505,7 +2514,7 @@ importers:
         version: 4.1.1(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest-when:
         specifier: ^0.10.0
         version: 0.10.0(@vitest/expect@4.1.8)(vitest@4.1.8)
@@ -2572,7 +2581,7 @@ importers:
         version: 5.2.0(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -2919,6 +2928,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -3429,8 +3441,8 @@ packages:
     resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@3.3.7':
-    resolution: {integrity: sha512-F42g89Qd5oAWtp0k0nnSrjziAKza7w8SVT4mStc18LZMaRb4J1HQAHLCalEtDCxrTuksx7NU9qsmeLwpOfPqWw==}
+  '@eslint/eslintrc@3.3.6':
+    resolution: {integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/js@9.39.4':
@@ -5760,6 +5772,17 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/browser-playwright@4.1.8':
+    resolution: {integrity: sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.8
+
+  '@vitest/browser@4.1.8':
+    resolution: {integrity: sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==}
+    peerDependencies:
+      vitest: 4.1.8
+
   '@vitest/coverage-v8@4.1.8':
     resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
     peerDependencies:
@@ -7343,7 +7366,6 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -9290,9 +9312,19 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   playwright@1.60.0:
     resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   plotly.js-basic-dist@2.35.3:
@@ -9311,6 +9343,10 @@ packages:
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   point-in-polygon@1.1.0:
     resolution: {integrity: sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==}
@@ -9486,8 +9522,8 @@ packages:
   randomfill@1.0.4:
     resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
 
-  react-colorful@5.8.1:
-    resolution: {integrity: sha512-oz68bhsnFWnpDf1ZR8daiQbYpXUnM2h2J6hl9Zg2rTpM/DU6vCqe1E+CpqmqLnJucMZetHZeifSAfJ+geN9lcA==}
+  react-colorful@5.8.0:
+    resolution: {integrity: sha512-Wy9OzPfjSN9bF12OB8N7UQvlsZ0I+7wHxpN+bV5BjNQGxOj6IiwkRjevJK9yOBjJWGQvAaf1OXtn8rUeEatAng==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -10925,6 +10961,20 @@ packages:
       yaml:
         optional: true
 
+  vitest-browser-react@2.2.0:
+    resolution: {integrity: sha512-oY3KM6305kwJMa6nHo92vVtkOsih7mjEf12dLKuphaF+9ywWPEc+qanIBd394SZ6m5LadVEaG6dicvvizOzmjA==}
+    peerDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      vitest: ^4.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   vitest-when@0.10.0:
     resolution: {integrity: sha512-tZiZ3+HR3X+pN1h4484an6/kuPezs/0b7frOikEnHfsPbOLGoiC+8NHRP/CRTAnG9Ccevq5/oGfCNRm/sp2EAw==}
     peerDependencies:
@@ -11758,6 +11808,8 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@blazediff/core@1.9.1': {}
+
   '@borewit/text-codec@0.2.2': {}
 
   '@bramus/specificity@2.4.2':
@@ -12129,7 +12181,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.7':
+  '@eslint/eslintrc@3.3.6':
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3
@@ -14457,7 +14509,69 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       babel-plugin-react-compiler: 1.0.0
 
-  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+  '@vitest/browser-playwright@4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(playwright@1.62.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.8
@@ -14469,7 +14583,9 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+    optionalDependencies:
+      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -14541,7 +14657,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -16192,7 +16308,7 @@ snapshots:
       '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.7
+      '@eslint/eslintrc': 3.3.6
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -18028,7 +18144,7 @@ snapshots:
       papaparse: 5.7.0
       qrcode-generator: 1.5.2
       react: 19.2.7
-      react-colorful: 5.8.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-colorful: 5.8.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-dom: 19.2.7(react@19.2.7)
       react-embed: 3.7.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-router-lite: 1.6.0(react@19.2.7)(tslib@2.8.1)
@@ -18610,9 +18726,17 @@ snapshots:
 
   playwright-core@1.60.0: {}
 
+  playwright-core@1.62.1: {}
+
   playwright@1.60.0:
     dependencies:
       playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -18732,6 +18856,8 @@ snapshots:
   pluralize@8.0.0: {}
 
   pngjs@5.0.0: {}
+
+  pngjs@7.0.0: {}
 
   point-in-polygon@1.1.0: {}
 
@@ -18923,7 +19049,7 @@ snapshots:
       randombytes: 2.1.0
       safe-buffer: 5.2.1
 
-  react-colorful@5.8.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-colorful@5.8.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -20501,14 +20627,23 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
+  vitest-browser-react@2.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      vitest: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   vitest-when@0.10.0(@vitest/expect@4.1.8)(vitest@4.1.8):
     dependencies:
       pretty-format: 30.4.1
-      vitest: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@vitest/expect': 4.1.8
 
-  vitest@4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -20532,13 +20667,14 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.20
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui': 4.1.8(vitest@4.1.8)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -20562,13 +20698,14 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.20
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(playwright@1.62.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui': 4.1.8(vitest@4.1.8)
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -20592,13 +20729,14 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.20
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui': 4.1.8(vitest@4.1.8)
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -20622,13 +20760,14 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.20
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@5.8.3))(playwright@1.62.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui': 4.1.8(vitest@4.1.8)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@22.19.20)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -20652,7 +20791,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.20
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(msw@2.14.6(@types/node@22.19.20)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui': 4.1.8(vitest@4.1.8)
       jsdom: 29.1.1
     transitivePeerDependencies:


### PR DESCRIPTION
Below MUI's `md` breakpoint the pledge card was clipped rather than scrollable: the desktop right panel stacked under the form and covered later pledge items, the fixed 150px icon and checkbox columns pushed the "I agree" control off-screen, and the explanatory copy painted over the Continue button.

Layout
- `LeftRightPanel.StyledInnerContainer` (SRC) now owns the canonical 900px two-column card and its mobile single-column stacking. SageAccountWeb's `StyledInnerContainer` extends it instead of redefining the layout, contributing only panel padding and letting the column grow past the viewport so tall content is never clipped.
- Add `getWideDesktopTwoColumnSx` and `getMobileBodyScrollSx`, replacing the 1200px `sx` block that was duplicated inline in `ProfileValidation` and `TermsOfUsePage`. Scoping the wide layout to `up('md')` keeps it from fighting the mobile single-column rules. `RegisterAccount1` opts into document-body scrolling via the latter.
- Below 900px, `_terms-and-conditions.scss` drops the decorative icon column and stacks/centers the checkbox column so the row fits the viewport.
- Show `TermsOfUseMobileAccordion` in place of the desktop right panel on narrow viewports, and hide the panel itself below `md`.
- Split `TermsOfUseRightPanelText` into `TermsOfUseExplanation`: `...Content` for the accordion and `...Section`, which adds the heading, for the right panel.
- Reword the terms button to "View Complete Terms and Conditions for Use".

Tests
- Split SageAccountWeb's Vitest config into `jsdom` and `browser` projects. The browser project runs Playwright/Chromium, since jsdom cannot evaluate the CSS cascade, media queries, or hit testing that these regressions require. Browser files run serially because the MSW service worker is shared across the per-file iframes.
- Serve MSW through a service worker for browser tests and reject unhandled requests, which had been passed through to the production API.
- Register a `termsOfService` group in SRC's shared MSW handler set, using the neutral UP_TO_DATE status. The handlers previously existed but were reachable only from one story, leaving those endpoints unmocked for every  other consumer.
- Add `renderInBrowser` (app theme, style engine, stylesheet, and a fresh QueryClient per render) plus `viewports.ts`, and assert the pledge layout at both mobile and desktop widths so the mobile fix cannot silently regress the desktop layout.

Screenshots:

<img width="722" height="798" alt="image" src="https://github.com/user-attachments/assets/5250f20e-2fda-47ac-9917-aac4ea00ed61" />

<img width="722" height="798" alt="image" src="https://github.com/user-attachments/assets/87eeed84-a557-4baa-b42b-162cdd532960" />

<img width="2360" height="960" alt="image" src="https://github.com/user-attachments/assets/d0c91ec6-f625-4aa5-9784-46b870b88aed" />

<img width="2362" height="2402" alt="image" src="https://github.com/user-attachments/assets/82ae699f-debe-4f6b-8c2f-e3cd246e390c" />


