### PR TITLE
PORTALS-4449

### DIFF
--- a/apps/portals/classic/src/config/synapseConfigs/metadata.ts
+++ b/apps/portals/classic/src/config/synapseConfigs/metadata.ts
@@ -8,6 +8,8 @@ const metadataPlotNavProps: QueryWrapperPlotNavProps = {
   shouldDeepLink: true,
   columnAliases: { study: 'On Synapse' },
   defaultShowPlots: false,
+  hideAddToDownloadListMenuItem: true,
+  hideProgrammaticOptionsMenuItem: true,
   tableConfiguration: {
     showAccessColumn: true,
     showDownloadColumn: false,

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.tsx
@@ -125,6 +125,8 @@ export type QueryWrapperPlotNavContentsProps = Pick<
   | 'availableFacets'
   | 'initialExpandedFacetControls'
   | 'hideDownload'
+  | 'hideAddToDownloadListMenuItem'
+  | 'hideProgrammaticOptionsMenuItem'
   | 'hideQueryCount'
   | 'hideSqlEditorControl'
   | 'hideVisualizationsControl'
@@ -155,6 +157,8 @@ export function QueryWrapperPlotNavContents(
     availableFacets,
     initialExpandedFacetControls,
     hideDownload,
+    hideAddToDownloadListMenuItem,
+    hideProgrammaticOptionsMenuItem,
     hideQueryCount,
     hideSqlEditorControl,
     hideVisualizationsControl,
@@ -238,6 +242,12 @@ export function QueryWrapperPlotNavContents(
                     showColumnSelection={tableConfiguration !== undefined}
                     name={name}
                     hideDownload={hideDownload}
+                    hideAddToDownloadListMenuItem={
+                      hideAddToDownloadListMenuItem
+                    }
+                    hideProgrammaticOptionsMenuItem={
+                      hideProgrammaticOptionsMenuItem
+                    }
                     hideQueryCount={hideQueryCount}
                     hideFacetFilterControl={!isFaceted}
                     hideVisualizationsControl={

--- a/packages/synapse-react-client/src/components/SynapseTable/TopLevelControls/TopLevelControls.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/TopLevelControls/TopLevelControls.tsx
@@ -41,6 +41,10 @@ const SEND_TO_ANALYSIS_PLATFORM_BUTTON_ID =
 export type TopLevelControlsProps = {
   name?: string
   hideDownload?: boolean
+  /** If true, the "Add ... files to Download List" option in the Download menu will be hidden */
+  hideAddToDownloadListMenuItem?: boolean
+  /** If true, the "Programmatic Options" option in the Download menu will be hidden */
+  hideProgrammaticOptionsMenuItem?: boolean
   hideVisualizationsControl?: boolean
   hideFacetFilterControl?: boolean
   hideQueryCount?: boolean
@@ -84,6 +88,8 @@ const TopLevelControls = (props: TopLevelControlsProps): React.ReactNode => {
     name,
     showColumnSelection = false,
     hideDownload = false,
+    hideAddToDownloadListMenuItem,
+    hideProgrammaticOptionsMenuItem,
     hideVisualizationsControl = false,
     hideFacetFilterControl = false,
     hideQueryCount = false,
@@ -285,6 +291,8 @@ const TopLevelControls = (props: TopLevelControlsProps): React.ReactNode => {
             <DownloadOptions
               darkTheme={true}
               onDownloadFiles={() => setShowDownloadConfirmation(true)}
+              hideAddToDownloadListMenuItem={hideAddToDownloadListMenuItem}
+              hideProgrammaticOptionsMenuItem={hideProgrammaticOptionsMenuItem}
             />
           )}
 

--- a/packages/synapse-react-client/src/components/SynapseTable/table-top/DownloadOptions.test.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/table-top/DownloadOptions.test.tsx
@@ -269,4 +269,50 @@ describe('Download Options tests', () => {
     expect(downloadFilesMenuItem).toHaveAttribute('aria-disabled', 'true')
     expect(programmaticOptionsMenuItem).toHaveAttribute('aria-disabled', 'true')
   })
+
+  it('Hides the "Add to Download List" menu item when hideAddToDownloadListMenuItem is true', async () => {
+    registerTableQueryResult(fileViewQueryRequest.query, mockQueryResponseData)
+
+    renderComponent(
+      { ...props, hideAddToDownloadListMenuItem: true },
+      fileViewQueryRequest,
+    )
+
+    const downloadOptionsButton = await screen.findByRole('button', {
+      name: 'Download Options',
+    })
+
+    await userEvent.click(downloadOptionsButton)
+
+    await screen.findByRole('menuitem', { name: 'Export Table' })
+    await screen.findByRole('menuitem', { name: 'Programmatic Options' })
+
+    expect(
+      screen.queryByRole('menuitem', { name: ADD_ALL_FILES_TO_DOWNLOAD_CART }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('Hides the "Programmatic Options" menu item when hideProgrammaticOptionsMenuItem is true', async () => {
+    registerTableQueryResult(fileViewQueryRequest.query, mockQueryResponseData)
+
+    renderComponent(
+      { ...props, hideProgrammaticOptionsMenuItem: true },
+      fileViewQueryRequest,
+    )
+
+    const downloadOptionsButton = await screen.findByRole('button', {
+      name: 'Download Options',
+    })
+
+    await userEvent.click(downloadOptionsButton)
+
+    await screen.findByRole('menuitem', { name: 'Export Table' })
+    await screen.findByRole('menuitem', {
+      name: ADD_ALL_FILES_TO_DOWNLOAD_CART,
+    })
+
+    expect(
+      screen.queryByRole('menuitem', { name: 'Programmatic Options' }),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/packages/synapse-react-client/src/components/SynapseTable/table-top/DownloadOptions.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/table-top/DownloadOptions.tsx
@@ -21,6 +21,10 @@ import { DownloadLoginModal } from './DownloadLoginModal'
 export type DownloadOptionsProps = {
   onDownloadFiles: () => void
   darkTheme?: boolean
+  /** If true, the "Add ... files to Download List" menu item will be hidden */
+  hideAddToDownloadListMenuItem?: boolean
+  /** If true, the "Programmatic Options" menu item will be hidden */
+  hideProgrammaticOptionsMenuItem?: boolean
 }
 
 export function DownloadOptions(props: DownloadOptionsProps) {
@@ -45,14 +49,18 @@ export function DownloadOptions(props: DownloadOptionsProps) {
   const [showLoginModal, setShowLoginModal] = useState(false)
   const [showExportMetadata, setShowExportMetadata] = useState(false)
   const [showProgrammaticOptions, setShowProgrammaticOptions] = useState(false)
-  const { onDownloadFiles, darkTheme = true } = props
+  const {
+    onDownloadFiles,
+    darkTheme = true,
+    hideAddToDownloadListMenuItem,
+    hideProgrammaticOptionsMenuItem,
+  } = props
 
   const fileColumnId = getFileColumnModelId(queryMetadata?.columnModels)
 
-  const showAddQueryToDownloadList = canTableQueryBeAddedToDownloadList(
-    entity,
-    fileColumnId,
-  )
+  const showAddQueryToDownloadList =
+    !hideAddToDownloadListMenuItem &&
+    canTableQueryBeAddedToDownloadList(entity, fileColumnId)
 
   // SWC-5878 - Disable downloading a "Draft" dataset
   const disableDownload = entity && isDataset(entity) && entity.isLatestVersion
@@ -102,35 +110,38 @@ export function DownloadOptions(props: DownloadOptionsProps) {
         Export Table
       </MenuItem>,
     )
-    downloadMenuItems.push(
-      <Tooltip
-        key={'programmatic-options'}
-        title={
-          disableDownload
-            ? 'A draft version of a dataset cannot be downloaded programmatically'
-            : null
-        }
-        placement="left"
-        enterNextDelay={300}
-        describeChild={true}
-      >
-        <MenuItem
-          className={disableDownload ? 'ignoreLink' : undefined}
-          disabled={disableDownload}
-          // If disabled, add pointer-events-auto so the tooltip still works
-          style={disableDownload ? { pointerEvents: 'auto' } : {}}
-          onClick={() => setShowProgrammaticOptions(true)}
+    if (!hideProgrammaticOptionsMenuItem) {
+      downloadMenuItems.push(
+        <Tooltip
+          key={'programmatic-options'}
+          title={
+            disableDownload
+              ? 'A draft version of a dataset cannot be downloaded programmatically'
+              : null
+          }
+          placement="left"
+          enterNextDelay={300}
+          describeChild={true}
         >
-          Programmatic Options
-        </MenuItem>
-      </Tooltip>,
-    )
+          <MenuItem
+            className={disableDownload ? 'ignoreLink' : undefined}
+            disabled={disableDownload}
+            // If disabled, add pointer-events-auto so the tooltip still works
+            style={disableDownload ? { pointerEvents: 'auto' } : {}}
+            onClick={() => setShowProgrammaticOptions(true)}
+          >
+            Programmatic Options
+          </MenuItem>
+        </Tooltip>,
+      )
+    }
     return downloadMenuItems
   }, [
     isAuthenticated,
     disableDownload,
     hasResettableFilters,
     hasSelectedRows,
+    hideProgrammaticOptionsMenuItem,
     onDownloadFiles,
     queryMetadata?.queryCount,
     selectedRows,


### PR DESCRIPTION
Added the ability to selectively hide individual menu items in the "Download Options" 
dropdown, without hiding the whole Download button.

### New props

- `hideAddToDownloadListMenuItem?: boolean` — hides the "Add ... files to Download List" menu item
- `hideProgrammaticOptionsMenuItem?: boolean` — hides the "Programmatic Options" menu item

### Changes

- **`DownloadOptions.tsx`** (`synapse-react-client`)
  - Added `hideAddToDownloadListMenuItem` and `hideProgrammaticOptionsMenuItem` to `DownloadOptionsProps`.
  - `showAddQueryToDownloadList` now also requires `!hideAddToDownloadListMenuItem`.
  - The "Programmatic Options" menu item is now only pushed when `!hideProgrammaticOptionsMenuItem`.

- **`DownloadOptions.test.tsx`** (`synapse-react-client`)
  - Added two tests verifying each flag independently hides its corresponding menu item while leaving the other options (`Export Table`, and the non-hidden menu item) visible.

- **`metadata.ts`** (`apps/portals/classic`)
  - Set `hideAddToDownloadListMenuItem: true` and `hideProgrammaticOptionsMenuItem: true` on `metadataPlotNavProps` so the Metadata table's Download menu only shows "Export Table".