### PR TITLE
chore: enable oxlint typescript/prefer-optional-chain rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -142,6 +142,7 @@
     "typescript/no-wrapper-object-types": "error",
     "typescript/only-throw-error": "error",
     "typescript/prefer-as-const": "error",
+    "typescript/prefer-optional-chain": "error",
     "typescript/prefer-namespace-keyword": "error",
     "typescript/prefer-promise-reject-errors": "error",
     "typescript/require-await": "error",

--- a/apps/SageAccountWeb/src/URLUtils.tsx
+++ b/apps/SageAccountWeb/src/URLUtils.tsx
@@ -1,7 +1,7 @@
 export const getSearchParam = (keyName: string): string | undefined => {
   const urlSearchParams = new URLSearchParams(window.location.search)
   let paramValue: string | undefined = undefined
-  if (urlSearchParams && urlSearchParams.get(keyName)) {
+  if (urlSearchParams?.get(keyName)) {
     paramValue = urlSearchParams.get(keyName)!
   }
   return paramValue

--- a/apps/SageAccountWeb/src/pages/JoinTeamPage.tsx
+++ b/apps/SageAccountWeb/src/pages/JoinTeamPage.tsx
@@ -27,7 +27,7 @@ function JoinTeamPage() {
   const [membershipInvitation, setMembershipInvitation] =
     useState<MembershipInvitation>()
   useEffect(() => {
-    if (context && context.signedToken) {
+    if (context?.signedToken) {
       if (isJoinTeamSignedToken(context.signedToken)) {
         setJoinTeamToken(context.signedToken)
       } else if (isMembershipInvtnSignedToken(context.signedToken)) {

--- a/apps/synapse-oauth-signin/src/OAuth2Form.tsx
+++ b/apps/synapse-oauth-signin/src/OAuth2Form.tsx
@@ -196,7 +196,7 @@ export function OAuth2Form() {
   const { mutate: consentToRequest } = SynapseQueries.useConsentToOAuth2Request(
     {
       onSuccess: accessCode => {
-        if (!accessCode || !accessCode.access_code) {
+        if (!accessCode?.access_code) {
           onError(
             new Error(
               'Something went wrong - the access code is missing from the Synapse call.',
@@ -339,8 +339,7 @@ export function OAuth2Form() {
     !isLoading &&
     !error &&
     !isAuthenticated &&
-    oauthClientInfo &&
-    oauthClientInfo.verified &&
+    oauthClientInfo?.verified &&
     pendingRedirectURL === undefined &&
     oidcRequestDescription &&
     hasInitializedSession // wait for session to be initialized (may be anonymous) before jumping to One Sage

--- a/apps/synapse-portal-framework/src/components/AppInitializer.tsx
+++ b/apps/synapse-portal-framework/src/components/AppInitializer.tsx
@@ -41,7 +41,7 @@ function AppInitializer(props: AppInitializerProps) {
       }
 
       const anchorElement = target.closest?.('a')
-      if (anchorElement && anchorElement.href) {
+      if (anchorElement?.href) {
         const { hostname } = new URL(anchorElement.href)
         if (
           KNOWN_SYNAPSE_ORG_URLS.includes(hostname.toLowerCase()) ||

--- a/apps/synapse-portal-framework/src/components/PortalSearch/PortalSearchPage.tsx
+++ b/apps/synapse-portal-framework/src/components/PortalSearch/PortalSearchPage.tsx
@@ -75,11 +75,11 @@ export function PortalSearchPage(props: PortalSearchPageProps) {
       const allCountsSet = searchPageTabs.every(tab => tab.count !== undefined)
       if (selectedTabIndex == undefined && allCountsSet) {
         const roleTab =
-          role &&
-          roleMapping &&
-          searchPageTabs.find(tab => tab.title === roleMapping[role])
+          role && roleMapping
+            ? searchPageTabs.find(tab => tab.title === roleMapping[role])
+            : undefined
         // If a role is selected, navigate to the corresponding tab from the roleMapping unless that corresponding tab has a count of 0.
-        if (roleTab && roleTab.count) {
+        if (roleTab?.count) {
           navigate({
             pathname: `/Search/${roleTab.path}`,
             search: location.search,
@@ -91,7 +91,7 @@ export function PortalSearchPage(props: PortalSearchPageProps) {
             PortalSearchTabConfig | undefined
           >((best, tab) => {
             if (tab.score === undefined) return best
-            if (best === undefined || best.score === undefined) return tab
+            if (best?.score === undefined) return tab
             return tab.score > best.score ? tab : best
           }, undefined)
           navigate({

--- a/apps/synapse-portal-framework/src/components/ProjectDiscussionForum.tsx
+++ b/apps/synapse-portal-framework/src/components/ProjectDiscussionForum.tsx
@@ -48,7 +48,7 @@ const ProjectDiscussionForum = (): React.ReactNode => {
         <DiscussionThread threadId={threadId} limit={20} />
       </Box>
     )
-  } else if (forum && forum.id) {
+  } else if (forum?.id) {
     return (
       <ForumPage
         forumId={forum.id}

--- a/apps/synapse-portal-framework/src/components/challenges/ChallengeParticipantGoogleMap.tsx
+++ b/apps/synapse-portal-framework/src/components/challenges/ChallengeParticipantGoogleMap.tsx
@@ -11,7 +11,7 @@ function ChallengeParticipantGoogleMap(
   const { projectId } = props
 
   const { data: challenge } = SynapseQueries.useGetEntityChallenge(projectId)
-  if (challenge && challenge.participantTeamId) {
+  if (challenge?.participantTeamId) {
     return (
       <Box sx={{ height: '500px' }}>
         <Map teamId={challenge.participantTeamId} />

--- a/apps/synapse-portal-framework/src/shared-config/synapseChatHelpers.ts
+++ b/apps/synapse-portal-framework/src/shared-config/synapseChatHelpers.ts
@@ -21,7 +21,7 @@ export function processResponseDocument(
       const targetElement = redirectElement.querySelector('target')
       const queryElement = redirectElement.querySelector('query')
 
-      if (targetElement && targetElement.textContent) {
+      if (targetElement?.textContent) {
         const target = targetElement.textContent.trim()
 
         // Guard against open redirect: only allow site-relative paths (/foo, not //evil.com or https://...)

--- a/apps/synapse-portal-framework/src/utils/mergeMeta.ts
+++ b/apps/synapse-portal-framework/src/utils/mergeMeta.ts
@@ -27,7 +27,7 @@ export const mergeMeta = <
   descriptors = [...descriptors]
 
   for (const descriptor of args.matches
-    .filter(match => match && match.meta)
+    .filter(match => match?.meta)
     .flatMap(_ => _.meta!)
     .slice()
     .reverse()) {

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+java = "corretto-21"
+node = "22.13.1"
+pnpm = "10.33.0"

--- a/packages/markdown-it-synapse-table/src/index.ts
+++ b/packages/markdown-it-synapse-table/src/index.ts
@@ -201,7 +201,7 @@ export default function synapse_table_plugin(md: MarkdownIt) {
       for (i = 0; i < columns.length; i++) {
         token = state.push('th_open', 'th', 1)
         token.map = [startLine, startLine + 1]
-        if (alignments && alignments[i]) {
+        if (alignments?.[i]) {
           token.attrSet('style', `text-align: ${alignments[i]}`)
         }
 
@@ -253,7 +253,7 @@ export default function synapse_table_plugin(md: MarkdownIt) {
       }
       for (i = 0; i < columnCount; i++) {
         token = state.push('td_open', 'td', 1)
-        if (alignments && alignments[i]) {
+        if (alignments?.[i]) {
           token.attrSet('style', `text-align: ${alignments[i]}`)
         }
         token = state.push('inline', '', 0)

--- a/packages/react-datasheet-grid/src/components/DataSheetGrid.tsx
+++ b/packages/react-datasheet-grid/src/components/DataSheetGrid.tsx
@@ -156,7 +156,7 @@ export const DataSheetGrid = React.memo(
           if (!columns[colIndex]?.stickyLeft) {
             return 0
           }
-          if (!columnWidths || !columnWidths.length) {
+          if (!columnWidths?.length) {
             let offset = 0
             for (let i = 0; i < colIndex; i++) {
               if (columns[i].stickyLeft || i === 0) {
@@ -1007,8 +1007,7 @@ export const DataSheetGrid = React.memo(
           const rightClickOnSelectedHeaders =
             rightClick &&
             selection &&
-            cursorIndex &&
-            cursorIndex.row === -1 &&
+            cursorIndex?.row === -1 &&
             cursorIndex.col >= selection.min.col &&
             cursorIndex.col <= selection.max.col
 

--- a/packages/react-datasheet-grid/src/components/Grid.tsx
+++ b/packages/react-datasheet-grid/src/components/Grid.tsx
@@ -143,7 +143,7 @@ export const Grid = <T,>({
     }
     // If we don't yet have measured column widths, fall back to the virtualizer's
     // estimated offset for this column to avoid overlapping the gutter/first columns.
-    if (!columnWidths || !columnWidths.length) {
+    if (!columnWidths?.length) {
       const estimatedOffset = colVirtualizer.getOffsetForIndex(colIndex)
       return typeof estimatedOffset === 'number' ? estimatedOffset : 0
     }

--- a/packages/react-datasheet-grid/src/components/SelectionRect.tsx
+++ b/packages/react-datasheet-grid/src/components/SelectionRect.tsx
@@ -164,10 +164,8 @@ export const SelectionRect = React.memo<SelectionContextType>(
 
     // Determine if any part of the selection is sticky (for the column marker)
     const selectionHasStickyMinCol =
-      (selection &&
-        stickyLeftColumns &&
-        stickyLeftColumns[selection.min.col]) ||
-      (activeCell && stickyLeftColumns && stickyLeftColumns[activeCell.col])
+      (selection && stickyLeftColumns?.[selection.min.col]) ||
+      (activeCell && stickyLeftColumns?.[activeCell.col])
 
     // Sticky offset for the column marker (using the leftmost selected column)
     const colMarkerStickyLeft =

--- a/packages/synapse-client/src/util/synapseClientFetch.ts
+++ b/packages/synapse-client/src/util/synapseClientFetch.ts
@@ -84,7 +84,7 @@ export const synapseClientFetch = async <TResponse>(
   let responseObject: TResponse | BaseError | string = responseBody
   try {
     // try to parse it as json
-    if (contentType && contentType.includes('application/json')) {
+    if (contentType?.includes('application/json')) {
       responseObject = JSON.parse(responseBody) as TResponse | BaseError
     }
   } catch (error) {

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/DataAccessRequestAccessorsFilesForm/DataAccessRequestAccessorsFilesForm.tsx
@@ -232,8 +232,7 @@ export default function DataAccessRequestAccessorsFilesForm(
         type: isRenewal ? AccessType.RENEW_ACCESS : AccessType.GAIN_ACCESS,
       }
       if (
-        !dataAccessRequest.accessorChanges ||
-        !dataAccessRequest.accessorChanges.find(item =>
+        !dataAccessRequest.accessorChanges?.find(item =>
           deepEquals(item, currentUserWithGainAccess),
         )
       ) {

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/EDucPreviewStep/EDucPreviewStep.tsx
@@ -101,9 +101,7 @@ export default function EDucPreviewStep(props: EDucPreviewStepProps) {
     { enabled: Boolean(dataAccessRequest?.id) },
   )
   const isAtOrOverQuota =
-    signatureQuota != null &&
-    signatureQuota.remaining != null &&
-    signatureQuota.remaining <= 0
+    signatureQuota?.remaining != null && signatureQuota.remaining <= 0
 
   const isLoading =
     isLoadingDar ||

--- a/packages/synapse-react-client/src/components/CannedRejectionDialog/CannedRejectionDialog.tsx
+++ b/packages/synapse-react-client/src/components/CannedRejectionDialog/CannedRejectionDialog.tsx
@@ -141,9 +141,7 @@ function SelectRejectionReasonsForm(props: SelectRejectionReasonsFormProps) {
     )
 
   const rowsGroupedByCategory =
-    tableData &&
-    tableData.queryResult &&
-    tableData.queryResult.queryResults.rows.reduce(
+    tableData?.queryResult?.queryResults.rows.reduce(
       (acc: Record<string, Row[]>, row) => {
         const category: string = row.values[categoryIndex!]!
         acc[category] = [...(acc[category] || []), row]
@@ -286,8 +284,7 @@ export function CannedRejectionDialog(props: CannedRejectionDialogProps) {
 
   // Transform the selected rejection reasons into an object that can be easily transformed into an email
   const defaultEmailMessageObject: RejectionMessageObject | undefined =
-    data &&
-    data.queryResult &&
+    data?.queryResult &&
     selectedRowIds.reduce((messageObject: RejectionMessageObject, rowId) => {
       const row = data.queryResult!.queryResults.rows.find(
         row => row.rowId === rowId,

--- a/packages/synapse-react-client/src/components/CardContainer/CardContainer.tsx
+++ b/packages/synapse-react-client/src/components/CardContainer/CardContainer.tsx
@@ -161,8 +161,7 @@ export function CardContainer(props: CardContainerProps) {
           data: rowData.values,
           selectColumns: rowSet.headers,
           columnModels: queryMetadata!.columnModels,
-          tableEntityConcreteType:
-            tableEntityConcreteType[0] && tableEntityConcreteType[0].type,
+          tableEntityConcreteType: tableEntityConcreteType[0]?.type,
           tableId: rowSet.tableId,
           queryContext: queryContext,
           queryVisualizationContext,

--- a/packages/synapse-react-client/src/components/ChallengeSubmission/ChallengeSubmission.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeSubmission/ChallengeSubmission.tsx
@@ -173,11 +173,7 @@ export function ChallengeSubmission({
   )
 
   useEffect(() => {
-    if (
-      entityPermissions &&
-      entityPermissions.canView &&
-      entityPermissions.canAddChild
-    ) {
+    if (entityPermissions?.canView && entityPermissions.canAddChild) {
       setCanSubmit(true)
     }
     setLoading(false)
@@ -201,7 +197,7 @@ export function ChallengeSubmission({
     async function createChallengeProject() {
       const project: Project = getProject(challenge!, submissionTeam!)
       const challengeProject = await createEntity(project, accessToken)
-      if (challengeProject && challengeProject.id) {
+      if (challengeProject?.id) {
         setChallengeProjectId(challengeProject.id)
         setIsProjectNewlyCreated(true)
       }

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/ChallengeTeamWizard.tsx
@@ -200,37 +200,25 @@ function ChallengeTeamWizard(props: ChallengeTeamWizardProps) {
         let disableJoiningSelectedTeam = false
         let buttonOnClickBehavior: () => void = noop
         let buttonTooltip = ''
-        if (
-          selectedTeamMembershipStatus &&
-          selectedTeamMembershipStatus.hasOpenInvitation
-        ) {
+        if (selectedTeamMembershipStatus?.hasOpenInvitation) {
           // The user has been invited to join the selected team
           buttonText = 'View Invitation to Join Team'
           buttonOnClickBehavior = () => {
             setStep(ChallengeTeamWizardStep.ACCEPT_INVITATION)
           }
-        } else if (
-          selectedTeamMembershipStatus &&
-          selectedTeamMembershipStatus.hasOpenRequest
-        ) {
+        } else if (selectedTeamMembershipStatus?.hasOpenRequest) {
           // User already has an open request to join the selected team, disable button to avoid request spamming
           buttonText = 'Join Request Pending'
           disableJoiningSelectedTeam = true
           buttonTooltip =
             'You have already submitted a request to join this team.'
-        } else if (
-          selectedTeamMembershipStatus &&
-          selectedTeamMembershipStatus.membershipApprovalRequired
-        ) {
+        } else if (selectedTeamMembershipStatus?.membershipApprovalRequired) {
           // The user has to send a request to join the selected team
           buttonText = 'Request to Join Team'
           buttonOnClickBehavior = () => {
             setStep(ChallengeTeamWizardStep.JOIN_REQUEST_FORM)
           }
-        } else if (
-          selectedTeamMembershipStatus &&
-          selectedTeamMembershipStatus.canJoin
-        ) {
+        } else if (selectedTeamMembershipStatus?.canJoin) {
           // The user can freely join the selected team
           buttonText = 'Join Team'
           buttonOnClickBehavior = () => {

--- a/packages/synapse-react-client/src/components/ChallengeTeamWizard/CreateChallengeTeam.tsx
+++ b/packages/synapse-react-client/src/components/ChallengeTeamWizard/CreateChallengeTeam.tsx
@@ -63,7 +63,7 @@ export const CreateChallengeTeam = forwardRef(function CreateChallengeTeam(
   const tooManyInvitees = numberOfInvitees > INVITEE_LIMIT
 
   const formDataIsValid = Boolean(
-    team && team.name && team.name.length > 1 && !tooManyInvitees,
+    team?.name && team.name.length > 1 && !tooManyInvitees,
   )
 
   useEffect(() => {

--- a/packages/synapse-react-client/src/components/CreateTableViewWizard/CreateTableViewWizard.tsx
+++ b/packages/synapse-react-client/src/components/CreateTableViewWizard/CreateTableViewWizard.tsx
@@ -131,7 +131,7 @@ export default function CreateTableViewWizard(
     error: definingSqlValidationError,
   } = useValidateDefiningSql({
     onSuccess: (isSqlValid: ValidateDefiningSqlResponse) => {
-      if (isSqlValid && isSqlValid.isValid) {
+      if (isSqlValid?.isValid) {
         setStep('TABLE_NAME')
       }
     },
@@ -140,7 +140,7 @@ export default function CreateTableViewWizard(
   const sqlValidationError: string | null = useMemo(() => {
     if (definingSqlValidationError) {
       return definingSqlValidationError.reason
-    } else if (isSqlValid && isSqlValid.invalidReason) {
+    } else if (isSqlValid?.invalidReason) {
       return isSqlValid.invalidReason
     } else {
       return null

--- a/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/useDataGridWebsocket.ts
@@ -346,7 +346,7 @@ export function useDataGridWebSocket(options?: UseDataGridWebSocketOptions) {
    * Checks if the model snapshot contains the minimum data required for rendering (columns and rows).
    */
   function isModelRenderable(model: GridModel | null) {
-    if (!model || !model.api.getSnapshot() || !modelSnapshot) {
+    if (!model?.api.getSnapshot() || !modelSnapshot) {
       return false
     }
     const { columnNames, columnOrder, rows } = modelSnapshot

--- a/packages/synapse-react-client/src/components/DownloadCart/DownloadCartPage.tsx
+++ b/packages/synapse-react-client/src/components/DownloadCart/DownloadCartPage.tsx
@@ -84,14 +84,11 @@ export function DownloadCartPage() {
   }
   // SWC-5874: When arriving at the download cart when there are no ARs, the user should start in the Download list
   useEffect(() => {
-    if (data && data.numberOfFilesRequiringAction == 0) {
+    if (data?.numberOfFilesRequiringAction == 0) {
       setSelectedTabIndex(1)
     }
     // also hide the Create Package UI if there are no files available for download
-    if (
-      data &&
-      data.numberOfFilesAvailableForDownloadAndEligibleForPackaging === 0
-    ) {
+    if (data?.numberOfFilesAvailableForDownloadAndEligibleForPackaging === 0) {
       setIsShowingCreatePackageUI(false)
     }
   }, [data])

--- a/packages/synapse-react-client/src/components/DropdownSelect/DropdownSelect.tsx
+++ b/packages/synapse-react-client/src/components/DropdownSelect/DropdownSelect.tsx
@@ -72,10 +72,7 @@ export default function DropdownSelect(props: DropdownSelectProps) {
   }
 
   const handleClose = (event: Event) => {
-    if (
-      anchorRef.current &&
-      anchorRef.current.contains(event.target as HTMLElement)
-    ) {
+    if (anchorRef.current?.contains(event.target as HTMLElement)) {
       return
     }
 

--- a/packages/synapse-react-client/src/components/EntityFinder/tree/EntityTree.tsx
+++ b/packages/synapse-react-client/src/components/EntityFinder/tree/EntityTree.tsx
@@ -194,11 +194,7 @@ export function EntityTree(props: EntityTreeProps) {
   )
 
   const { data: initialContainerPath } = useGetEntityPath(initialContainer!, {
-    enabled: !!(
-      projectId &&
-      initialContainer &&
-      initialContainer.match(SYNAPSE_ENTITY_ID_REGEX)
-    ),
+    enabled: !!(projectId && initialContainer?.match(SYNAPSE_ENTITY_ID_REGEX)),
     refetchInterval: Infinity,
     throwOnError: true,
   })

--- a/packages/synapse-react-client/src/components/EntityFinder/tree/VirtualizedTree.tsx
+++ b/packages/synapse-react-client/src/components/EntityFinder/tree/VirtualizedTree.tsx
@@ -99,7 +99,7 @@ function isLeafNode(node: TreeNode) {
       // Entity is not a container
       !isContainerType(getEntityTypeFromHeader(node)) ||
       // OR Children have been fetched (nonnull) and there are 0 children
-      (node.children != null && node.children.length === 0)
+      node.children?.length === 0
     )
   }
 }

--- a/packages/synapse-react-client/src/components/FeaturedDataTabs/FacetPlotsCard.tsx
+++ b/packages/synapse-react-client/src/components/FeaturedDataTabs/FacetPlotsCard.tsx
@@ -174,7 +174,7 @@ function FacetPlotsCard(props: FacetPlotsCardProps) {
       })
       .filter(x => x !== undefined)[0]
 
-    if (selectedFacet && selectedFacet.value) {
+    if (selectedFacet?.value) {
       return selectedFacet?.value
     }
     return ''

--- a/packages/synapse-react-client/src/components/FullWidthAlert/FullWidthAlert.test.tsx
+++ b/packages/synapse-react-client/src/components/FullWidthAlert/FullWidthAlert.test.tsx
@@ -45,20 +45,17 @@ function setUp(
   const alert = screen.queryByRole('alert')
   const buttons = {
     primary:
-      defaultProps.primaryButtonConfig &&
-      defaultProps.primaryButtonConfig.text &&
+      defaultProps.primaryButtonConfig?.text &&
       screen.queryByRole('button', {
         name: defaultProps.primaryButtonConfig.text,
       }),
     secondary:
-      defaultProps.secondaryButtonConfig &&
-      defaultProps.secondaryButtonConfig.text &&
+      defaultProps.secondaryButtonConfig?.text &&
       screen.queryByRole('button', {
         name: defaultProps.secondaryButtonConfig.text,
       }),
     tertiary:
-      defaultProps.tertiaryButtonConfig &&
-      defaultProps.tertiaryButtonConfig.text &&
+      defaultProps.tertiaryButtonConfig?.text &&
       screen.queryByRole('button', {
         name: defaultProps.tertiaryButtonConfig.text,
       }),
@@ -104,7 +101,7 @@ describe('FullWidthAlert tests', () => {
     await user.click(buttons.secondary as HTMLElement)
     expect(window.open).toHaveBeenCalledTimes(1)
     expect(window.open).toHaveBeenCalledWith(
-      // @ts-ignore - typescript doesn't recognize href within the conditional AlertButtonConfig type
+      // @ts-expect-error - typescript doesn't recognize href within the conditional AlertButtonConfig type
       defaultProps.secondaryButtonConfig!.href,
       '_blank',
       'noopener',

--- a/packages/synapse-react-client/src/components/Markdown/MarkdownEditor.tsx
+++ b/packages/synapse-react-client/src/components/Markdown/MarkdownEditor.tsx
@@ -71,7 +71,7 @@ export function MarkdownEditor({
   }
 
   const handleTagModal = (text: string) => {
-    const start = textAreaRef.current && textAreaRef.current.selectionStart
+    const start = textAreaRef.current?.selectionStart
     if (start && start > 0 && text.charAt(start - 1) === '@') {
       setTagModalWithKeyboard(true)
       setIsShowingTagModal(true)

--- a/packages/synapse-react-client/src/components/OrientationBanner/OrientationBanner.test.tsx
+++ b/packages/synapse-react-client/src/components/OrientationBanner/OrientationBanner.test.tsx
@@ -49,14 +49,12 @@ function setUp(
   const alert = screen.queryByRole('alert')
   const buttons = {
     primary:
-      defaultProps.primaryButtonConfig &&
-      defaultProps.primaryButtonConfig.text &&
+      defaultProps.primaryButtonConfig?.text &&
       screen.queryByRole('button', {
         name: defaultProps.primaryButtonConfig.text,
       }),
     secondary:
-      defaultProps.secondaryButtonConfig &&
-      defaultProps.secondaryButtonConfig.text &&
+      defaultProps.secondaryButtonConfig?.text &&
       screen.queryByRole('button', {
         name: defaultProps.secondaryButtonConfig.text,
       }),

--- a/packages/synapse-react-client/src/components/ProvenanceGraph/ProvenanceGraph.tsx
+++ b/packages/synapse-react-client/src/components/ProvenanceGraph/ProvenanceGraph.tsx
@@ -111,11 +111,7 @@ const ProvenanceReactFlow = (props: ProvenanceProps): React.ReactNode => {
 
   const showNoProvenance = initialBuildComplete && !hasProvenanceNodes
 
-  if (
-    isSuccess &&
-    rootEntityHeadersPage &&
-    rootEntityHeadersPage.totalNumberOfResults == 0
-  ) {
+  if (isSuccess && rootEntityHeadersPage?.totalNumberOfResults == 0) {
     const synapseIds = rootEntityRefs.map(ref => ref.targetId).join(',')
     handleError(
       `Unable to load provenance for the given Synapse IDs: ${synapseIds}`,
@@ -416,8 +412,7 @@ const ProvenanceReactFlow = (props: ProvenanceProps): React.ReactNode => {
     event => {
       // Cannot simply check the truthy value of event.deltaX (or Y) because the value might be 0 (or -0), which is falsy
       if (
-        event &&
-        typeof event.deltaX !== 'undefined' &&
+        typeof event?.deltaX !== 'undefined' &&
         typeof event.deltaY !== 'undefined'
       ) {
         window.scrollTo(

--- a/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
+++ b/packages/synapse-react-client/src/components/QueryBuilder/queryBuilderTranslation.ts
@@ -28,7 +28,7 @@ const COLUMN_MULTI_VALUE_FUNCTION_QUERY_FILTER =
 
 /** A multi-value list column is one whose column type ends in `_LIST`. */
 export function isListColumn(columnType: string | null): boolean {
-  return columnType != null && columnType.endsWith('_LIST')
+  return columnType?.endsWith('_LIST') ?? false
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/LastUpdatedOn.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/LastUpdatedOn.tsx
@@ -9,7 +9,7 @@ function LastUpdatedOn() {
   const { showLastUpdatedOn } = useQueryVisualizationContext()
   const { data: queryMetadata } = useSuspenseGetQueryMetadata()
 
-  return showLastUpdatedOn && queryMetadata && queryMetadata.lastUpdatedOn ? (
+  return showLastUpdatedOn && queryMetadata?.lastUpdatedOn ? (
     <div
       style={{
         display: 'flex',

--- a/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.stories.tsx
+++ b/packages/synapse-react-client/src/components/QueryWrapperPlotNav/QueryWrapperPlotNav.stories.tsx
@@ -274,7 +274,7 @@ const getAllIDs = async (event: CustomControlCallbackData) => {
   event.request!.query.sql = 'select id from syn51186974'
   const results = await SynapseClient.getFullQueryTableResults(event.request!)
   results.queryResult?.queryResults.rows.map(row => {
-    if (row.values && row.values[0]) ids.push(row.values[0])
+    if (row.values?.[0]) ids.push(row.values[0])
   })
   return ids
 }

--- a/packages/synapse-react-client/src/components/StatisticsPlot.tsx
+++ b/packages/synapse-react-client/src/components/StatisticsPlot.tsx
@@ -154,8 +154,7 @@ class StatisticsPlot extends Component<
     const orientation: string = isHorizontal ? 'h' : 'v'
     const traces: any = []
     if (
-      plotData.fileDownloads &&
-      plotData.fileDownloads.months &&
+      plotData.fileDownloads?.months &&
       plotData.fileDownloads.months.length > 0
     ) {
       // add file downloads trace
@@ -169,8 +168,7 @@ class StatisticsPlot extends Component<
       )
     }
     if (
-      plotData.fileUploads &&
-      plotData.fileUploads.months &&
+      plotData.fileUploads?.months &&
       plotData.fileUploads.months.length > 0
     ) {
       // add file uploads trace

--- a/packages/synapse-react-client/src/components/SynapseForm/SynapseFormWrapper.tsx
+++ b/packages/synapse-react-client/src/components/SynapseForm/SynapseFormWrapper.tsx
@@ -125,7 +125,7 @@ class _SynapseFormWrapper extends Component<
           token,
         )
         formData = JSON.parse(fileData)
-        if (submitted && formData && formData['metadata']) {
+        if (submitted && formData?.['metadata']) {
           ;({ formSchemaVersion, uiSchemaVersion, navSchemaVersion } =
             formData['metadata'])
         }

--- a/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseHomepageChatSearch.tsx
+++ b/packages/synapse-react-client/src/components/SynapseHomepageV2/SynapseHomepageChatSearch.tsx
@@ -39,7 +39,7 @@ export function SynapseHomepageChatSearch({
 
       // Check if the input is a valid Synapse ID with version
       const parsedSynId = parseSynId(searchValueCleaned)
-      if (parsedSynId && parsedSynId.targetVersionNumber) {
+      if (parsedSynId?.targetVersionNumber) {
         const synIdWithVersion = `${parsedSynId.targetId}.${parsedSynId.targetVersionNumber}`
         gotoPlace(`/Synapse:${synIdWithVersion}`)
         return

--- a/packages/synapse-react-client/src/components/SynapseSearchPageResults/SynapseSearchPage.tsx
+++ b/packages/synapse-react-client/src/components/SynapseSearchPageResults/SynapseSearchPage.tsx
@@ -47,7 +47,7 @@ function SearchPageInternal() {
   // Store the whole SearchQuery object as JSON in URL
   const handleQueryChange = (newQuery: SearchQuery) => {
     setSearchParams(prev => {
-      if (newQuery && newQuery.queryTerm && newQuery.queryTerm.length > 0) {
+      if (newQuery?.queryTerm && newQuery.queryTerm.length > 0) {
         prev.set(SEARCH_PAGE_QUERY_PARAM, JSON.stringify(newQuery))
       } else {
         prev.delete(SEARCH_PAGE_QUERY_PARAM)

--- a/packages/synapse-react-client/src/components/SynapseTable/SynapseTableRenderers.tsx
+++ b/packages/synapse-react-client/src/components/SynapseTable/SynapseTableRenderers.tsx
@@ -253,8 +253,7 @@ export function TableDataColumnHeader(
     selectColumn &&
     selectColumn.name.toLowerCase() === lockedColumn?.columnName?.toLowerCase() // used in details page to disable filter the column
   const isEntityIDColumn =
-    selectColumn &&
-    selectColumn.name == 'id' &&
+    selectColumn?.name == 'id' &&
     selectColumn.columnType == ColumnTypeEnum.ENTITYID
 
   // TODO: enableFiltering should be specified on the column, but for now it's easier to override `getCanFilter` here where we have the facet information

--- a/packages/synapse-react-client/src/components/SynapseTable/usePrefetchTableData.ts
+++ b/packages/synapse-react-client/src/components/SynapseTable/usePrefetchTableData.ts
@@ -43,7 +43,7 @@ function usePrefetchFileHandleData(rowSet: RowSet) {
   let fileHandlesToPrefetch: FileHandleAssociation[] = []
 
   // Now add all IDs from the entity ID columns
-  if (entity && rowSet && queryMetadata && queryMetadata.selectColumns) {
+  if (entity && rowSet && queryMetadata?.selectColumns) {
     fileHandlesToPrefetch = rowSet.rows.reduce(
       (prev: FileHandleAssociation[], curr) => {
         fileHandleIdColumnIndices.forEach(index => {

--- a/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
+++ b/packages/synapse-react-client/src/components/TableColumnSchemaEditor/TableColumnSchemaFormReducer.ts
@@ -236,7 +236,7 @@ function changeColumnModelType(
   let newColumnModelValue: ColumnModelFormData | JsonSubColumnModelFormData
 
   // Create a copy of the selected column model
-  if (prevState && prevState[columnModelIndex]) {
+  if (prevState?.[columnModelIndex]) {
     if (
       prevState[columnModelIndex].jsonSubColumns &&
       jsonSubColumnModelIndex !== undefined
@@ -293,7 +293,7 @@ function changeColumnModelType(
   }
 
   // Replace the value
-  if (prevState && prevState[columnModelIndex]) {
+  if (prevState?.[columnModelIndex]) {
     if (
       prevState[columnModelIndex].jsonSubColumns &&
       jsonSubColumnModelIndex !== undefined
@@ -339,7 +339,7 @@ function setColumnModelValue(
   prevState: ColumnModelFormData[],
 ) {
   const { columnModelIndex, jsonSubColumnModelIndex, value } = action
-  if (prevState && prevState[columnModelIndex]) {
+  if (prevState?.[columnModelIndex]) {
     if (
       prevState[columnModelIndex].jsonSubColumns &&
       jsonSubColumnModelIndex !== undefined
@@ -361,7 +361,7 @@ function toggleSelect(
   prevState: ColumnModelFormData[],
 ) {
   const { columnModelIndex, jsonSubColumnModelIndex } = action
-  if (prevState && prevState[columnModelIndex]) {
+  if (prevState?.[columnModelIndex]) {
     if (
       prevState[columnModelIndex].jsonSubColumns &&
       jsonSubColumnModelIndex !== undefined

--- a/packages/synapse-react-client/src/components/TanStackTable/TableCellRenderer.tsx
+++ b/packages/synapse-react-client/src/components/TanStackTable/TableCellRenderer.tsx
@@ -9,8 +9,7 @@ import {
 export function TableCellRenderer<T = unknown>(cell: Cell<T, unknown>) {
   const getWrapInExpandableTd =
     cell.getContext().table.options.meta?.getWrapInExpandableTd
-  const wrapInExpandableTd =
-    getWrapInExpandableTd && getWrapInExpandableTd(cell)
+  const wrapInExpandableTd = getWrapInExpandableTd?.(cell)
   const TableDataCellElement = wrapInExpandableTd
     ? ExpandableTableDataCell
     : 'td'

--- a/packages/synapse-react-client/src/components/TermsAndConditions/TermsAndConditions.tsx
+++ b/packages/synapse-react-client/src/components/TermsAndConditions/TermsAndConditions.tsx
@@ -47,7 +47,7 @@ function TermsAndConditions({
 
   // update tcList when data changes (transform)
   useEffect(() => {
-    if (data && data.queryResult && data.queryResult.queryResults) {
+    if (data?.queryResult?.queryResults) {
       const { rows, headers } = data.queryResult.queryResults
       const iconColIndex = headers.findIndex(col => col.name === 'icon')
       const labelColIndex = headers.findIndex(col => col.name === 'label')

--- a/packages/synapse-react-client/src/components/Webhook/CreateWebhookModal.tsx
+++ b/packages/synapse-react-client/src/components/Webhook/CreateWebhookModal.tsx
@@ -162,8 +162,7 @@ export default function CreateWebhookModal(props: CreateWebhookModalProps) {
 
   // If the user attempts to use a domain that has not been added to the allowlist, link to a form to create a request.
   const showRequestDomainForm =
-    error &&
-    error.errorResponse &&
+    error?.errorResponse &&
     'errorCode' in error.errorResponse &&
     error.errorResponse.errorCode ===
       ErrorResponseCode.UNSUPPORTED_WEBHOOK_DOMAIN

--- a/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryTable.tsx
+++ b/packages/synapse-react-client/src/components/dataaccess/UserAccessRequestHistory/UserAccessRequestHistoryTable.tsx
@@ -34,8 +34,7 @@ const columns = [
     enableSorting: false,
     cell: ctx => {
       if (
-        ctx.row.original.userAccessApproval &&
-        ctx.row.original.userAccessApproval.expiredOn &&
+        ctx.row.original.userAccessApproval?.expiredOn &&
         dayjs(ctx.row.original.userAccessApproval.expiredOn).isBefore(dayjs())
       ) {
         return 'Expired'
@@ -57,10 +56,7 @@ const columns = [
     header: props => <ColumnHeader {...props} title={'Expires'} />,
     enableSorting: false,
     cell: ctx => {
-      if (
-        ctx.row.original.userAccessApproval &&
-        ctx.row.original.userAccessApproval.expiredOn
-      ) {
+      if (ctx.row.original.userAccessApproval?.expiredOn) {
         return formatDate(dayjs(ctx.row.original.userAccessApproval.expiredOn))
       }
       return null

--- a/packages/synapse-react-client/src/components/doi/CreateOrUpdateDoiModal.tsx
+++ b/packages/synapse-react-client/src/components/doi/CreateOrUpdateDoiModal.tsx
@@ -293,7 +293,7 @@ export function CreateOrUpdateDoiModal(props: CreateOrUpdateDoiModalProps) {
   }, [currentUser, doi, entityBundle])
 
   function onSave() {
-    if (formRef.current && formRef.current.validateForm()) {
+    if (formRef.current?.validateForm()) {
       const requestDoi: V2Doi = convertFormDataToDoi(formData)
       requestDoi.objectType = objectType
       requestDoi.objectId = objectId

--- a/packages/synapse-react-client/src/components/entity/metadata/EntityModal.tsx
+++ b/packages/synapse-react-client/src/components/entity/metadata/EntityModal.tsx
@@ -77,7 +77,7 @@ export function EntityModal(props: EntityModalProps) {
   }, [isInEditMode, onEditModeChanged])
 
   const { data: entityBundle } = useGetEntityBundle(entityId, versionNumber)
-  const canEdit = entityBundle && entityBundle.permissions.canEdit
+  const canEdit = entityBundle?.permissions?.canEdit
 
   const isVersionable =
     entityBundle && isVersionableEntityType(entityBundle.entityType)

--- a/packages/synapse-react-client/src/components/entity/page/action_menu/EntityActionMenu.tsx
+++ b/packages/synapse-react-client/src/components/entity/page/action_menu/EntityActionMenu.tsx
@@ -104,7 +104,7 @@ function mapAndFilterItemsInMenuGroup(
     (itemAcc: DropdownMenuItem[], actionViewProps: ActionViewProps) => {
       const configForAction = actionConfiguration[actionViewProps.action]
       // Only show the item if it's configured + visible
-      if (configForAction && configForAction.visible) {
+      if (configForAction?.visible) {
         itemAcc.push({
           text: configForAction.text ?? actionViewProps.action,
           onClick: configForAction.onClick,
@@ -178,7 +178,7 @@ export default function EntityActionMenu(props: EntityActionMenuProps) {
     layout.buttonActions.reduce(
       (acc: ComplexMenuButtonProps[], buttonViewProps: ActionViewProps) => {
         const configForAction = actionConfiguration[buttonViewProps.action]
-        if (configForAction && configForAction.visible) {
+        if (configForAction?.visible) {
           let onClick = configForAction.onClick
           if (onClick == null && !configForAction.href) {
             console.warn(`No handler registered for ${buttonViewProps.action}`)

--- a/packages/synapse-react-client/src/components/menu/DropdownMenu.tsx
+++ b/packages/synapse-react-client/src/components/menu/DropdownMenu.tsx
@@ -151,10 +151,7 @@ export function DropdownMenu(props: DropdownMenuProps) {
   }
 
   const handleClose = (event: Event | SyntheticEvent) => {
-    if (
-      anchorRef.current &&
-      anchorRef.current.contains(event.target as HTMLElement)
-    ) {
+    if (anchorRef.current?.contains(event.target as HTMLElement)) {
       return
     }
 

--- a/packages/synapse-react-client/src/components/row_renderers/Dataset.tsx
+++ b/packages/synapse-react-client/src/components/row_renderers/Dataset.tsx
@@ -76,7 +76,7 @@ class Dataset extends Component<DatasetProps, never> {
       { columnDisplayName: 'SIZE', value: fileSize },
       { columnDisplayName: 'FILES', value: fileCount },
     ]
-    if (genericCardSchema && genericCardSchema.secondaryLabels) {
+    if (genericCardSchema?.secondaryLabels) {
       const { secondaryLabels } = genericCardSchema
       for (let i = 0; i < secondaryLabels.length; i++) {
         const columnName = secondaryLabels[i]

--- a/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNavPanel.tsx
+++ b/packages/synapse-react-client/src/components/widgets/facet-nav/FacetNavPanel.tsx
@@ -233,7 +233,7 @@ const applyFacetFilter = (
   allFacetValues: FacetColumnResultValues,
   callbackApplyFn: FacetNavPanelProps['applyChangesToGraphSlice'],
 ) => {
-  if (event.points && event.points[0]) {
+  if (event.points?.[0]) {
     const plotPointData: any = event.points[0]
     const facetValueClickedValue =
       plotPointData.data.facetEnumerationValues[plotPointData.pointNumber]

--- a/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter/EnumFacetFilter.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/EnumFacetFilter/EnumFacetFilter.tsx
@@ -172,8 +172,7 @@ function EnumFacetFilterInternal(props: EnumFacetFilterProps) {
 
     // Apply client-side sorting if no server-side sort is specified
     let sortedValues: RenderedFacetValue[] = restOfFacetValuesArray
-    const isClientSideSort =
-      columnModel == undefined || columnModel.facetSortConfig == undefined
+    const isClientSideSort = columnModel?.facetSortConfig == undefined
     if (isClientSideSort) {
       if (isNumberColumnType) {
         sortedValues = sortBy(restOfFacetValuesArray, fv => Number(fv.value))

--- a/packages/synapse-react-client/src/components/widgets/query-filter/FacetFilterControls.tsx
+++ b/packages/synapse-react-client/src/components/widgets/query-filter/FacetFilterControls.tsx
@@ -52,7 +52,7 @@ const patchRequestFacets = (
   const isEmptyValuesFacet =
     changedFacet.concreteType ===
       'org.sagebionetworks.repo.model.table.FacetColumnValuesRequest' &&
-    (!changedFacet.facetValues || !changedFacet.facetValues.length)
+    !changedFacet.facetValues?.length
   const isEmptyRangesFacet =
     changedFacet.concreteType ===
       'org.sagebionetworks.repo.model.table.FacetColumnRangeRequest' &&

--- a/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
+++ b/packages/synapse-react-client/src/features/entity/metadata-task/components/CreateOrUpdateCurationTaskDialog.tsx
@@ -213,8 +213,7 @@ export default function CreateOrUpdateCurationTaskDialog(
     string[]
   >(() => {
     const ids =
-      task &&
-      task.taskProperties &&
+      task?.taskProperties &&
       instanceOfGridSupportedTaskProperties(task.taskProperties)
         ? task.taskProperties.collaboratorPrincipalIds
         : undefined

--- a/packages/synapse-react-client/src/mocks/msw/handlers/dataAccessRequestHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/dataAccessRequestHandlers.ts
@@ -56,7 +56,7 @@ export function getDataAccessRequestHandlers(backendOrigin: string) {
           'accessRequirementId',
           params.id as string,
         )
-        if (response && response.requestId) {
+        if (response?.requestId) {
           const dataAccessRequest = mockDataAccessRequestService.getOneById(
             response.requestId,
           )

--- a/packages/synapse-react-client/src/mocks/msw/handlers/entityHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/entityHandlers.ts
@@ -114,7 +114,7 @@ export function getVersionedEntityBundleHandler(
         const entityData = getMatchingMockEntity(entityId)
         if (entityData) {
           const bundle = entityData.bundle
-          if (entityData.versions && entityData.versions[versionNumber]) {
+          if (entityData.versions?.[versionNumber]) {
             response = {
               ...bundle,
               entity: entityData.versions[versionNumber],
@@ -189,7 +189,7 @@ export const getEntityHandlers = (backendOrigin: string) => [
       }
 
       const entityData = getMatchingMockEntity(params.entityId as string)
-      if (entityData && entityData.versionInfo) {
+      if (entityData?.versionInfo) {
         response = { results: entityData.versionInfo }
         status = 200
       }
@@ -211,11 +211,7 @@ export const getEntityHandlers = (backendOrigin: string) => [
       }
 
       const entityData = getMatchingMockEntity(params.entityId)
-      if (
-        entityData &&
-        entityData.versions &&
-        entityData.versions[requestedVersionNumber]
-      ) {
+      if (entityData?.versions?.[requestedVersionNumber]) {
         response = entityData.versions[
           requestedVersionNumber
         ] as VersionableEntity
@@ -295,7 +291,7 @@ export const getEntityHandlers = (backendOrigin: string) => [
       }
       const entityData = getMatchingMockEntity(params.entityId as string)
 
-      if (entityData && entityData.path) {
+      if (entityData?.path) {
         response = entityData.path
         status = 200
       }

--- a/packages/synapse-react-client/src/mocks/msw/handlers/userProfileHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/userProfileHandlers.ts
@@ -43,7 +43,7 @@ export const getUserProfileHandlers = (backendOrigin: string) => [
     const match = mockUserData.find(
       userData => userData.id.toString() === params.id,
     )
-    if (match && match.userProfile) {
+    if (match?.userProfile) {
       response = match.userProfile
       status = 200
     }
@@ -80,7 +80,7 @@ export const getUserProfileHandlers = (backendOrigin: string) => [
     const match = mockUserData.find(
       userData => userData.id.toString() === params.id,
     )
-    if (match && match.userBundle) {
+    if (match?.userBundle) {
       response = match.userBundle
       status = 200
     }

--- a/packages/synapse-react-client/src/utils/functions/QueryFilterUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/QueryFilterUtils.ts
@@ -17,7 +17,7 @@ export function getPrimaryKeyINFilter(
   selectedRows: Row[],
   selectColumns: SelectColumn[],
 ): QueryFilter {
-  if (!primaryKeyColumnNames || primaryKeyColumnNames.length !== 1) {
+  if (primaryKeyColumnNames?.length !== 1) {
     // If the key is undefined, then the user should have never been able to apply a filter
     // TODO: Handling a composite key would be tricky since the QueryFilter API currently only allows you to specify one column
     throw new Error('rowSelectionPrimaryKey must be defined and have length 1')

--- a/packages/synapse-react-client/src/utils/functions/SqlFunctions.ts
+++ b/packages/synapse-react-client/src/utils/functions/SqlFunctions.ts
@@ -196,7 +196,7 @@ export const getAdditionalFilters = (
 //look for a pattern of 'from[some number of spaces]syn[somenumbers]` case insensitive
 export const parseEntityIdFromSqlStatement = (sql: string): string => {
   const matches = sql.match(/(from)\s+(syn)\d+/gi)
-  return matches && matches[0] ? matches[0].substr(5).trim() : ''
+  return matches?.[0] ? matches[0].substr(5).trim() : ''
 }
 
 export const parseEntityIdAndVersionFromSqlStatement = (

--- a/packages/synapse-react-client/src/utils/functions/queryUtils.ts
+++ b/packages/synapse-react-client/src/utils/functions/queryUtils.ts
@@ -261,7 +261,7 @@ export function getCorrespondingColumnForFacet(
 ): ColumnModel | JsonSubColumnModel | undefined {
   let columnModel: ColumnModel | JsonSubColumnModel | undefined =
     columnModels.find(model => model.name === facet.columnName)
-  if (facet.jsonPath && columnModel && columnModel.jsonSubColumns) {
+  if (facet.jsonPath && columnModel?.jsonSubColumns) {
     columnModel = columnModel.jsonSubColumns.find(
       cm => cm.jsonPath === facet.jsonPath,
     )

--- a/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useDetectSSOCode.ts
@@ -205,8 +205,7 @@ export default function useDetectSSOCode(
                 }
                 if (
                   // The user logged in with OAuth while attempting to disable 2FA using an emailed signed token
-                  state &&
-                  state.twoFaResetToken &&
+                  state?.twoFaResetToken &&
                   onTwoFactorAuthResetTokenPresent
                 ) {
                   // Let the app handle redirecting to the 2FA reset page

--- a/packages/synapse-react-client/src/utils/hooks/useImmutableTableQuery/useImmutableTableQuery.ts
+++ b/packages/synapse-react-client/src/utils/hooks/useImmutableTableQuery/useImmutableTableQuery.ts
@@ -130,7 +130,7 @@ function useSynchronizeQueryWithUrl(
         componentIndex,
         initQueryRequest.query,
       ).then(queryRequestFromLink => {
-        if (queryRequestFromLink && queryRequestFromLink.query) {
+        if (queryRequestFromLink?.query) {
           setQuery(prevState => ({
             ...prevState,
             ...queryRequestFromLink,

--- a/packages/synapse-react-client/src/utils/jsonschema/SchemaAnnotationUtils.ts
+++ b/packages/synapse-react-client/src/utils/jsonschema/SchemaAnnotationUtils.ts
@@ -91,7 +91,7 @@ export function useRegisterSchema(schema?: JSONSchema7) {
   const [isRegistered, setIsRegistered] = useState(false)
 
   useEffect(() => {
-    if (schema && schema.$id) {
+    if (schema?.$id) {
       // The schema can be registered
       if (!hasSchema(schema.$id)) {
         try {

--- a/packages/synapse-react-client/src/utils/jsonschema/getSchemaPropertyInfo.ts
+++ b/packages/synapse-react-client/src/utils/jsonschema/getSchemaPropertyInfo.ts
@@ -40,11 +40,7 @@ export function getSchemaPropertiesInfo(
       )
 
       // Check for nested enums in array items
-      if (
-        enumeratedValues.length === 0 &&
-        propertySchema &&
-        propertySchema.items
-      ) {
+      if (enumeratedValues.length === 0 && propertySchema?.items) {
         const itemsSchema = Array.isArray(propertySchema.items)
           ? propertySchema.items[0]
           : propertySchema.items


### PR DESCRIPTION
## Summary
- Enable `typescript/prefer-optional-chain` in `.oxlintrc.json` as `error`, matching the existing `prefer-*` rules. Motivation is that Sonarcloud flags these, so if we decide to continue using it, the ruleset should match.
- Fix all 91 pre-existing violations across 65 files via `oxlint --fix` / `--fix-suggestions`, manually correcting two spots where the automated fix changed behavior/types:
  - `queryBuilderTranslation.ts`: `columnType?.endsWith('_LIST')` returned `boolean | undefined` instead of `boolean` — added `?? false`.
  - `PortalSearchPage.tsx`: `roleTab`'s inferred type included `""` (from the original `&&` chain), which `?.` can't guard against like `&&` could — restructured as a ternary so `roleTab` is cleanly `PortalSearchTabConfig | undefined`.
- Add `mise.toml` pinning `node`/`pnpm`/`java` to the versions this repo's `engines` field and OpenAPI codegen step expect, so `pnpm type-check` works without a separately-installed JDK.

## Test plan
- [x] `oxlint --config .oxlintrc.json .` — zero `prefer-optional-chain` violations
- [x] `pnpm type-check` — all 44 tasks pass
- [x] `pnpm lint` — all 26 projects pass