### PR TITLE
PORTALS-4451 fix: correct AMP ALS Sankey plot dataset count

### DIFF
--- a/apps/portals/ampals/src/config/resources.ts
+++ b/apps/portals/ampals/src/config/resources.ts
@@ -6,7 +6,7 @@ export const datasetCollectionsSql =
 export const programsSql = 'SELECT * FROM syn64941043'
 export const filesSql = `SELECT * FROM syn66271104`
 
-export const sankeyPlotSql = `SELECT source, count(source), sum(datasetItemCount) FROM syn66496326 group by source`
+export const sankeyPlotSql = `SELECT COALESCE(source, 'Unknown'), count(*), sum(datasetItemCount) FROM syn66496326 group by source`
 export const partnersSql = `SELECT * FROM syn68804819`
 
 export const datasetsSearchIndexId = 'syn75169900'


### PR DESCRIPTION
## Summary
- The homepage Sankey plot on the AMP ALS portal undercounted total datasets relative to the Datasets explore page.
- Root cause: `sankeyPlotSql` grouped by `source` and selected `COUNT(source)`. SQL `COUNT(column)` ignores NULLs, so the group of datasets with no `source` annotation evaluated to 0 for that group even though rows existed (2 datasets with `source IS NULL` in `syn66496326` at time of writing), silently dropping them from the Sankey total.
- Fix: use `COUNT(*)` instead, and label the null-source group via `COALESCE(source, 'Unknown')` so it renders as a visible flow instead of a blank node.
- Verified live against `syn66496326`: previous query summed to 25 datasets vs. the actual 27 total rows; new query correctly sums to 27.

Jira: [PORTALS-4451](https://sagebionetworks.jira.com/browse/PORTALS-4451)

## Test plan
- [x] `pnpm nx run ampals:lint`
- [x] `pnpm nx run ampals:type-check`
- [x] Verified the corrected SQL against the live `syn66496326` table and confirmed the dataset counts now sum correctly
- [ ] Visual check of the homepage Sankey plot in a running ampals dev server (not done in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PORTALS-4451]: https://sagebionetworks.jira.com/browse/PORTALS-4451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ