### PR TITLE
PORTALS-4453: Patch @rjsf/mui@6.0.0-beta.10 array item Grid overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
       "fast-uri": "^3.1.5",
       "shell-quote": "^1.9.0",
       "ip-address": "^10.3.1"
+    },
+    "patchedDependencies": {
+      "@rjsf/mui@6.0.0-beta.10": "patches/@rjsf__mui@6.0.0-beta.10.patch"
     }
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"

--- a/patches/@rjsf__mui@6.0.0-beta.10.patch
+++ b/patches/@rjsf__mui@6.0.0-beta.10.patch
@@ -1,0 +1,52 @@
+diff --git a/dist/index.js b/dist/index.js
+index 36d7ca3b3679b561f77ddc2e6a812a9f7433fc2f..85bc8119573468eab806c5191ca2169b94bef288 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -80,8 +80,12 @@ function ArrayFieldItemTemplate(props) {
+     fontWeight: "bold",
+     minWidth: 0
+   };
++  // PORTALS-4453 patch: upstream `size: "auto"` here produced `flex: 0 0 auto`, letting nested
++  // object/array content overflow this Grid item's container. Fixed upstream in @rjsf/mui@6.1.0
++  // (https://github.com/rjsf-team/react-jsonschema-form/issues/3296) - drop this patch once
++  // @rjsf/mui is upgraded past 6.0.x.
+   return /* @__PURE__ */ (0, import_jsx_runtime2.jsxs)(import_Grid.default, { container: true, alignItems: "center", children: [
+-    /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(import_Grid.default, { size: "auto", style: { overflow: "auto" }, children: /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(import_Box.default, { mb: 2, children: /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(import_Paper.default, { elevation: 2, children: /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(import_Box.default, { p: 2, children }) }) }) }),
++    /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(import_Grid.default, { size: { xs: 8, sm: 9, md: 10, lg: 11, xl: 11.25 }, style: { overflow: "auto" }, children: /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(import_Box.default, { mb: 2, children: /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(import_Paper.default, { elevation: 2, children: /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(import_Box.default, { p: 2, children }) }) }) }),
+     hasToolbar && /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(import_Grid.default, { children: /* @__PURE__ */ (0, import_jsx_runtime2.jsx)(ArrayFieldItemButtonsTemplate, { ...buttonsProps, style: btnStyle }) })
+   ] });
+ }
+diff --git a/lib/ArrayFieldItemTemplate/ArrayFieldItemTemplate.js b/lib/ArrayFieldItemTemplate/ArrayFieldItemTemplate.js
+index 98eaa9dd976faf8bf618071639cea8417a17d2c4..4a990ba372ee1a3304fafb80fecbca0013229e96 100644
+--- a/lib/ArrayFieldItemTemplate/ArrayFieldItemTemplate.js
++++ b/lib/ArrayFieldItemTemplate/ArrayFieldItemTemplate.js
+@@ -18,6 +18,10 @@ export default function ArrayFieldItemTemplate(props) {
+         fontWeight: 'bold',
+         minWidth: 0,
+     };
+-    return (_jsxs(Grid, { container: true, alignItems: 'center', children: [_jsx(Grid, { size: 'auto', style: { overflow: 'auto' }, children: _jsx(Box, { mb: 2, children: _jsx(Paper, { elevation: 2, children: _jsx(Box, { p: 2, children: children }) }) }) }), hasToolbar && (_jsx(Grid, { children: _jsx(ArrayFieldItemButtonsTemplate, { ...buttonsProps, style: btnStyle }) }))] }));
++    // PORTALS-4453 patch: upstream `size: 'auto'` here produced `flex: 0 0 auto`, letting nested
++    // object/array content overflow this Grid item's container. Fixed upstream in @rjsf/mui@6.1.0
++    // (https://github.com/rjsf-team/react-jsonschema-form/issues/3296) - drop this patch once
++    // @rjsf/mui is upgraded past 6.0.x.
++    return (_jsxs(Grid, { container: true, alignItems: 'center', children: [_jsx(Grid, { size: { xs: 8, sm: 9, md: 10, lg: 11, xl: 11.25 }, style: { overflow: 'auto' }, children: _jsx(Box, { mb: 2, children: _jsx(Paper, { elevation: 2, children: _jsx(Box, { p: 2, children: children }) }) }) }), hasToolbar && (_jsx(Grid, { children: _jsx(ArrayFieldItemButtonsTemplate, { ...buttonsProps, style: btnStyle }) }))] }));
+ }
+ //# sourceMappingURL=ArrayFieldItemTemplate.js.map
+\ No newline at end of file
+diff --git a/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx b/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+index 09c1764353a9b3f2d1d91a547a1bdb031443e2bb..7d7e8191f52b3c7232fa8037bd8deac3b4a9b344 100644
+--- a/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
++++ b/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+@@ -36,7 +36,11 @@ export default function ArrayFieldItemTemplate<
+   };
+   return (
+     <Grid container={true} alignItems='center'>
+-      <Grid size='auto' style={{ overflow: 'auto' }}>
++      {/* PORTALS-4453 patch: upstream `size='auto'` here produced `flex: 0 0 auto`, letting nested
++         object/array content overflow this Grid item's container. Fixed upstream in @rjsf/mui@6.1.0
++         (https://github.com/rjsf-team/react-jsonschema-form/issues/3296) - drop this patch once
++         @rjsf/mui is upgraded past 6.0.x. */}
++      <Grid size={{ xs: 8, sm: 9, md: 10, lg: 11, xl: 11.25 }} style={{ overflow: 'auto' }}>
+         <Box mb={2}>
+           <Paper elevation={2}>
+             <Box p={2}>{children}</Box>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,11 @@ overrides:
   shell-quote: ^1.9.0
   ip-address: ^10.3.1
 
+patchedDependencies:
+  '@rjsf/mui@6.0.0-beta.10':
+    hash: 652204a0fed558d14c3bc259de5e2ef3d18a565001b42f32d6bf24b2843fc21f
+    path: patches/@rjsf__mui@6.0.0-beta.10.patch
+
 importers:
 
   .:
@@ -2033,7 +2038,7 @@ importers:
         version: 6.0.0-beta.10(@rjsf/utils@6.0.0-beta.10(react@19.2.7))(react@19.2.7)
       '@rjsf/mui':
         specifier: 6.0.0-beta.10
-        version: 6.0.0-beta.10(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@mui/icons-material@7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@rjsf/core@6.0.0-beta.10(@rjsf/utils@6.0.0-beta.10(react@19.2.7))(react@19.2.7))(@rjsf/utils@6.0.0-beta.10(react@19.2.7))(react@19.2.7)
+        version: 6.0.0-beta.10(patch_hash=652204a0fed558d14c3bc259de5e2ef3d18a565001b42f32d6bf24b2843fc21f)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@mui/icons-material@7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@rjsf/core@6.0.0-beta.10(@rjsf/utils@6.0.0-beta.10(react@19.2.7))(react@19.2.7))(@rjsf/utils@6.0.0-beta.10(react@19.2.7))(react@19.2.7)
       '@rjsf/utils':
         specifier: 6.0.0-beta.10
         version: 6.0.0-beta.10(react@19.2.7)
@@ -13464,8 +13469,8 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.7
 
-  '@rjsf/mui@6.0.0-beta.10(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@mui/icons-material@7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@rjsf/core@6.0.0-beta.10(@rjsf/utils@6.0.0-beta.10(react@19.2.7))(react@19.2.7))(@rjsf/utils@6.0.0-beta.10(react@19.2.7))(react@19.2.7)':
-    dependencies:
+  ? '@rjsf/mui@6.0.0-beta.10(patch_hash=652204a0fed558d14c3bc259de5e2ef3d18a565001b42f32d6bf24b2843fc21f)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@mui/icons-material@7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@rjsf/core@6.0.0-beta.10(@rjsf/utils@6.0.0-beta.10(react@19.2.7))(react@19.2.7))(@rjsf/utils@6.0.0-beta.10(react@19.2.7))(react@19.2.7)'
+  : dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.7)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
       '@mui/icons-material': 7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)


### PR DESCRIPTION
## Problem

On the Submit Observation form (and any other `DynamicForm`-rendered schema with the same shape), an object field nested in an array field nested in another object field overflows its container. Repros with the `NF-Tools-Schemas/observations` schema's `observationsSection` (object) → `observations` (array) → item (object) structure.

## Root cause

`ArrayFieldItemTemplate`'s item-content `Grid` used `size='auto'`, which MUI Grid v2 renders as `flex: 0 0 auto` — content-based sizing, not tied to the parent's width. Nested object/array content deep enough can then exceed the container width with nothing forcing it to constrain.

## Fix

This is already fixed upstream in `@rjsf/mui@6.1.0` ([rjsf-team/react-jsonschema-form#3296](https://github.com/rjsf-team/react-jsonschema-form/issues/3296)), which changed the Grid item to `size={{ xs: 8, sm: 9, md: 10, lg: 11, xl: 11.25 }}`.

Upgrading the full `@rjsf/*` stack to 6.x is not tenable right now — that upgrade surfaced several unrelated upstream defects in RJSF's schema-merge and sanitize behavior. In the meantime, this backports just the one-line Grid sizing fix onto our current `6.0.0-beta.10` pin via `pnpm patch`, with a comment in the patched files noting the upstream fix version so it's easy to drop once we upgrade past `@rjsf/mui@6.0.x`.

## Verification

Manually verified in a worktree against the live `SubmitObservationSchema.json`: added an array item, confirmed the rendered Grid item is `MuiGrid-grid-xs-8` (not `MuiGrid-grid-xs-auto`) and no element in the object-in-array-in-object chain exceeds its parent or the viewport.

## Screenshots

Before:

<img width="950" height="481" alt="image" src="https://github.com/user-attachments/assets/aa7cd4f8-4ae8-45be-a378-886ca3b83d2a" />

After:

<img width="1346" height="678" alt="image" src="https://github.com/user-attachments/assets/b77aef91-d0b4-4e65-a8d1-55cbbce35311" />

