### PR TITLE
SWC-7959 Display values that violate schema

### DIFF
--- a/packages/synapse-react-client/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/DataGrid.stories.tsx
@@ -397,3 +397,84 @@ export const WithValidationStates: Story = {
     />
   ),
 }
+
+/**
+ * Values that do not match the column's schema type, as written by server-side
+ * CSV import. Numeric and date-time cells display the stored value rather than
+ * appearing empty, so the user can see what made the row invalid.
+ */
+export const WithSchemaMismatchedValues: Story = {
+  render: () => (
+    <DataGridStoryWrapper
+      initialRowData={[
+        {
+          __reactKey: '1',
+          name: 'Matches the schema',
+          age: 28,
+          score: 95.5,
+          created_date: dayjs('2024-01-15').toISOString(),
+          timestamp: dayjs('2024-01-15').valueOf(),
+          __validationStatus: 'valid',
+        },
+        {
+          __reactKey: '2',
+          name: 'Text where a number is expected',
+          age: 'N/A',
+          score: 'unknown',
+          created_date: 'not-a-date',
+          timestamp: 'sometime',
+          __validationStatus: 'invalid',
+        },
+        {
+          __reactKey: '3',
+          name: 'Numbers stored as strings',
+          age: '34',
+          score: '88.25',
+          created_date: '2024-02-20T00:00:00.000Z',
+          timestamp: '1705314600000',
+          __validationStatus: 'invalid',
+        },
+        {
+          __reactKey: '4',
+          name: 'Partially parseable',
+          age: '42 years',
+          score: '1e5',
+          created_date: '2024-13-45',
+          timestamp: -1,
+          __validationStatus: 'invalid',
+        },
+      ]}
+      columnNames={['name', 'age', 'score', 'created_date', 'timestamp']}
+      columnOrder={[0, 1, 2, 3, 4]}
+      schemaPropertiesInfo={{
+        name: {
+          type: { type: 'string', isArray: false },
+          isRequired: true,
+          enumeratedValues: null,
+        },
+        age: {
+          type: { type: 'integer', isArray: false },
+          isRequired: false,
+          enumeratedValues: null,
+        },
+        score: {
+          type: { type: 'number', isArray: false },
+          isRequired: false,
+          enumeratedValues: null,
+        },
+        created_date: {
+          type: { type: 'string', format: 'date-time', isArray: false },
+          isRequired: false,
+          enumeratedValues: null,
+        },
+        // Epoch milliseconds; exercises the numeric date-time storage format.
+        timestamp: {
+          type: { type: 'integer', format: 'date-time', isArray: false },
+          isRequired: false,
+          enumeratedValues: null,
+        },
+      }}
+      jsonSchema={{ type: 'object', properties: {} }}
+    />
+  ),
+}

--- a/packages/synapse-react-client/src/components/DataGrid/columns/DateTimeColumn.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/DateTimeColumn.test.tsx
@@ -1,8 +1,12 @@
 import DateTimePicker from '@/components/DateTimePicker/DateTimePicker'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import dayjs, { Dayjs } from 'dayjs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { DateTimeCell, type DateTimeCellProps } from './DateTimeColumn'
+import {
+  DateTimeCell,
+  interpretDateTimeCellValue,
+  type DateTimeCellProps,
+} from './DateTimeColumn'
 
 vi.mock('@/components/DateTimePicker/DateTimePicker', () => ({
   default: vi.fn(() => null),
@@ -97,6 +101,84 @@ describe('DateTimeCell', () => {
 
       const { value } = mockDateTimePicker.mock.calls[0][0]
       expect(value).toBeNull()
+    })
+
+    it('reads epoch milliseconds stored as a string for a numeric colType', () => {
+      // dayjs would otherwise read "1705314600000" as a year and silently
+      // display a date in 1707.
+      renderCell({ rowData: '1705314600000', colType: 'integer' })
+
+      const { value } = mockDateTimePicker.mock.calls[0][0]
+      expect((value as Dayjs).valueOf()).toBe(1705314600000)
+    })
+  })
+
+  // Regression: an unparseable value rendered the picker's field as blank, so
+  // data written by server-side CSV import was invisible in the grid even though
+  // it was present in the model.
+  describe('a value that is not a valid date', () => {
+    it('renders the raw value as text instead of a blank picker', () => {
+      renderCell({ rowData: 'not-a-date' })
+
+      expect(screen.getByText('not-a-date')).toBeInTheDocument()
+      expect(mockDateTimePicker).not.toHaveBeenCalled()
+    })
+
+    it('renders the picker once the cell is active so the value can be replaced', () => {
+      renderCell({ rowData: 'not-a-date', active: true })
+
+      expect(screen.queryByText('not-a-date')).not.toBeInTheDocument()
+      expect(mockDateTimePicker.mock.calls[0][0].value).toBeNull()
+    })
+
+    it('does not modify the stored value on its own', () => {
+      const setRowData = vi.fn()
+      renderCell({ rowData: 'not-a-date', setRowData })
+
+      expect(setRowData).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('interpretDateTimeCellValue', () => {
+  it.each([
+    ['null', null, undefined],
+    ['undefined', undefined, undefined],
+    ['an empty string', '', undefined],
+    ['a whitespace-only string', '   ', undefined],
+  ])('reports %s as empty', (_label, rowData, colType) => {
+    expect(interpretDateTimeCellValue(rowData, colType)).toEqual({
+      kind: 'empty',
+    })
+  })
+
+  it.each([
+    ['an ISO string', '2024-01-15T10:30:00.000Z', undefined, 1705314600000],
+    ['epoch millis as a number', 1705314600000, 'integer', 1705314600000],
+    ['epoch millis as a string', '1705314600000', 'number', 1705314600000],
+    ['a Date', new Date(1705314600000), undefined, 1705314600000],
+  ])('parses %s', (_label, rowData, colType, expected) => {
+    const result = interpretDateTimeCellValue(rowData, colType)
+    expect(result.kind).toBe('date')
+    expect((result as { date: Dayjs }).date.valueOf()).toBe(expected)
+  })
+
+  it('parses an ISO string even when the schema type is numeric', () => {
+    const result = interpretDateTimeCellValue(
+      '2024-01-15T10:30:00.000Z',
+      'integer',
+    )
+    expect(result.kind).toBe('date')
+  })
+
+  it.each([
+    ['a non-date string', 'not-a-date', 'not-a-date'],
+    ['a partially numeric string', '12abc', '12abc'],
+    ['a boolean', true, 'true'],
+  ])('reports %s as unparseable', (_label, rowData, expectedText) => {
+    expect(interpretDateTimeCellValue(rowData)).toEqual({
+      kind: 'unparseable',
+      text: expectedText,
     })
   })
 })

--- a/packages/synapse-react-client/src/components/DataGrid/columns/DateTimeColumn.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/DateTimeColumn.tsx
@@ -1,14 +1,85 @@
 import DateTimePicker from '@/components/DateTimePicker/DateTimePicker'
+import { Box, SxProps, Theme, Tooltip } from '@mui/material'
 import dayjs, { Dayjs } from 'dayjs'
 import { JSONSchema7Type } from 'json-schema'
+import isNil from 'lodash-es/isNil'
 import {
   CellComponent,
   CellProps,
   Column,
 } from '@sage-bionetworks/react-datasheet-grid'
+import { castCellValueToString } from './AutocompleteColumn'
+
+const UNPARSEABLE_VALUE_SX: SxProps<Theme> = {
+  display: 'flex',
+  alignItems: 'center',
+  width: '100%',
+  height: '100%',
+  px: '14px',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+}
 
 export type DateTimeCellProps = CellProps & {
   colType?: JSONSchema7Type
+}
+
+export type DateTimeCellValue =
+  | { kind: 'empty' }
+  | { kind: 'date'; date: Dayjs }
+  | { kind: 'unparseable'; text: string }
+
+// dayjs coerces values it has no business accepting — dayjs(true) yields epoch
+// 1ms — so restrict parsing to types that can legitimately carry a date.
+function isDateLike(value: unknown): boolean {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    value instanceof Date ||
+    dayjs.isDayjs(value)
+  )
+}
+
+/**
+ * Classify a stored cell value as empty, a usable date, or something the picker
+ * cannot represent.
+ *
+ * Numeric schema types store epoch milliseconds, but an imported value can
+ * arrive as a numeric string, which dayjs would otherwise read as a year
+ * ("1705314600000" parses to 1707). Coercion is attempted only when the string
+ * is fully numeric, so an ISO string in a numeric column still parses as a date.
+ */
+export function interpretDateTimeCellValue(
+  rowData: unknown,
+  colType?: JSONSchema7Type,
+): DateTimeCellValue {
+  if (
+    isNil(rowData) ||
+    (typeof rowData === 'string' && rowData.trim() === '')
+  ) {
+    return { kind: 'empty' }
+  }
+
+  const unparseable = {
+    kind: 'unparseable',
+    text: castCellValueToString(rowData),
+  } as const
+
+  if (!isDateLike(rowData)) {
+    return unparseable
+  }
+
+  const expectsEpochMillis = colType === 'number' || colType === 'integer'
+  const epochMillis =
+    expectsEpochMillis &&
+    typeof rowData === 'string' &&
+    Number.isFinite(Number(rowData))
+      ? Number(rowData)
+      : null
+
+  const date = dayjs((epochMillis ?? rowData) as dayjs.ConfigType)
+  return date.isValid() ? { kind: 'date', date } : unparseable
 }
 
 export function DateTimeCell({
@@ -16,11 +87,26 @@ export function DateTimeCell({
   setRowData,
   disabled,
   colType,
+  active,
 }: DateTimeCellProps) {
+  const cellValue = interpretDateTimeCellValue(rowData, colType)
+
+  // The picker renders a value it can't parse as an empty field, which hides
+  // imported data that fails schema validation. Show the raw value instead until
+  // the user activates the cell, at which point the picker is the only way to
+  // replace it. The value is left untouched unless the user commits a change.
+  if (cellValue.kind === 'unparseable' && !active) {
+    return (
+      <Tooltip title={cellValue.text} placement="top-start" arrow>
+        <Box sx={UNPARSEABLE_VALUE_SX}>{cellValue.text}</Box>
+      </Tooltip>
+    )
+  }
+
   return (
     <DateTimePicker
       disabled={disabled}
-      value={rowData ? dayjs(rowData) : null}
+      value={cellValue.kind === 'date' ? cellValue.date : null}
       onChange={(newValue: string | Dayjs | null) => {
         if (newValue == null) {
           setRowData(null)

--- a/packages/synapse-react-client/src/components/DataGrid/columns/NumberColumn.test.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/NumberColumn.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { formatNumberCellValue, numberColumn } from './NumberColumn'
+
+/**
+ * Renders the column's cell component and returns the underlying input, whose
+ * value reflects `formatBlurredInput` while idle and `formatInputOnFocus` while
+ * focused.
+ */
+function renderCell(
+  value: unknown,
+  { isRequired = false, colType = 'number' } = {},
+) {
+  const column = numberColumn({ colType, isRequired })
+  const Component = column.component!
+  render(
+    <Component
+      rowData={value}
+      setRowData={() => {}}
+      focus={false}
+      active={false}
+      rowIndex={0}
+      columnIndex={0}
+      columnData={column.columnData!}
+      disabled={false}
+      stopEditing={() => {}}
+      insertRowBelow={() => {}}
+      duplicateRow={() => {}}
+      deleteRow={() => {}}
+      getContextMenuItems={() => []}
+    />,
+  )
+  return screen.getByRole<HTMLInputElement>('textbox')
+}
+
+describe('numberColumn', () => {
+  describe('displays the stored value regardless of whether it is a number', () => {
+    // Regression: the stock floatColumn formatted only `typeof value ===
+    // 'number'` and returned '' for everything else, so values written by
+    // server-side CSV import were invisible until the cell was focused.
+    it.each([
+      ['an integer', 0, '0'],
+      ['a float', 1.5, '1.5'],
+      ['a large number with grouping separators', 1234567, '1,234,567'],
+      ['a negative number', -42, '-42'],
+      ['a numeric string', '42', '42'],
+      ['a non-numeric string', 'N/A', 'N/A'],
+      ['a partially numeric string', '12abc', '12abc'],
+      ['a boolean', true, 'true'],
+      ['an object', { a: 1 }, '{"a":1}'],
+    ])('renders %s', (_label, value, expected) => {
+      expect(renderCell(value).value).toBe(expected)
+    })
+
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['NaN', NaN],
+    ])('renders %s as an empty cell', (_label, value) => {
+      expect(renderCell(value).value).toBe('')
+    })
+  })
+
+  describe('formatInputOnFocus', () => {
+    function formatInputOnFocus(value: unknown) {
+      return numberColumn({ colType: 'number' }).columnData!.formatInputOnFocus(
+        value,
+      )
+    }
+
+    it('edits against the raw value rather than the grouped display value', () => {
+      expect(formatInputOnFocus(1234567)).toBe('1234567')
+    })
+
+    it('shows an unparseable value so it can be corrected', () => {
+      expect(formatInputOnFocus('N/A')).toBe('N/A')
+    })
+
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+    ])('shows an empty input for %s', (_label, value) => {
+      expect(formatInputOnFocus(value)).toBe('')
+    })
+  })
+
+  describe('parseUserInput', () => {
+    function parse(
+      value: string,
+      opts?: { isRequired?: boolean; colType?: string },
+    ) {
+      return numberColumn({
+        colType: 'number',
+        ...opts,
+      }).columnData!.parseUserInput(value)
+    }
+
+    it('parses a valid number', () => {
+      expect(parse('42.5')).toBe(42.5)
+    })
+
+    it('preserves text that is not a number so the validator can report it', () => {
+      expect(parse('N/A')).toBe('N/A')
+    })
+
+    it('coerces empty input to undefined for an optional column', () => {
+      expect(parse('   ')).toBeUndefined()
+    })
+
+    it('coerces empty input to null for a required column', () => {
+      expect(parse('   ', { isRequired: true })).toBeNull()
+    })
+  })
+
+  describe('parsePastedValue', () => {
+    function paste(value: string) {
+      return numberColumn({ colType: 'number' }).pasteValue!({
+        rowData: undefined,
+        value,
+        rowIndex: 0,
+      })
+    }
+
+    it('parses a valid number', () => {
+      expect(paste('42')).toBe(42)
+    })
+
+    it('preserves text that is not a number', () => {
+      expect(paste('N/A')).toBe('N/A')
+    })
+
+    it('collapses newlines before parsing', () => {
+      expect(paste('42\n')).toBe(42)
+    })
+  })
+
+  describe('isCellEmpty', () => {
+    function isEmpty(rowData: unknown) {
+      return numberColumn({ colType: 'number' }).isCellEmpty!({
+        rowData,
+        rowIndex: 0,
+      })
+    }
+
+    it.each([
+      ['null', null, true],
+      ['undefined', undefined, true],
+      ['a number', 0, false],
+      ['an unparseable string', 'N/A', false],
+    ])('reports %s', (_label, rowData, expected) => {
+      expect(isEmpty(rowData)).toBe(expected)
+    })
+  })
+})
+
+describe('formatNumberCellValue', () => {
+  it('formats integers without a decimal', () => {
+    expect(formatNumberCellValue(1000)).toBe('1,000')
+  })
+
+  it('returns an empty string for NaN', () => {
+    expect(formatNumberCellValue(NaN)).toBe('')
+  })
+
+  it('stringifies arrays', () => {
+    expect(formatNumberCellValue([1, 2])).toBe('[1,2]')
+  })
+})

--- a/packages/synapse-react-client/src/components/DataGrid/columns/NumberColumn.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/columns/NumberColumn.ts
@@ -1,0 +1,69 @@
+import { getEmptyValue } from '@/components/DataGrid/utils/getEmptyValue'
+import parseFreeTextGivenJsonSchemaType from '@/components/DataGrid/utils/parseFreeTextUsingJsonSchemaType'
+import {
+  Column,
+  createTextColumn,
+} from '@sage-bionetworks/react-datasheet-grid'
+import { JSONSchema7Type } from 'json-schema'
+import { castCellValueToString } from './AutocompleteColumn'
+
+const NUMBER_FORMAT = new Intl.NumberFormat()
+
+/**
+ * Render a numeric cell value for display while the cell is not being edited.
+ *
+ * Real numbers are locale-formatted; anything else is stringified verbatim.
+ * Numeric columns legitimately hold non-numeric values — CSV import writes
+ * cells server-side without passing through any client-side parsing, and
+ * parseFreeTextGivenJsonSchemaType deliberately preserves unparseable text so
+ * the validator can report it. Rendering those as blank leaves the user with an
+ * apparently empty cell on a row flagged invalid.
+ */
+export function formatNumberCellValue(value: unknown): string {
+  if (typeof value === 'number') {
+    return Number.isNaN(value) ? '' : NUMBER_FORMAT.format(value)
+  }
+  return castCellValueToString(value)
+}
+
+export type NumberColumnProps = {
+  colType?: JSONSchema7Type
+  isRequired?: boolean
+}
+
+/**
+ * Mirrors the (unexported) columnData that createTextColumn builds, so callers
+ * and tests can reach the format/parse functions it derives.
+ */
+export type NumberColumnData = {
+  placeholder?: string
+  alignRight: boolean
+  continuousUpdates: boolean
+  parseUserInput: (value: string) => unknown
+  formatBlurredInput: (value: unknown) => string
+  formatInputOnFocus: (value: unknown) => string
+}
+
+export function numberColumn({
+  colType = 'number',
+  isRequired,
+}: NumberColumnProps): Partial<Column<unknown, NumberColumnData, string>> {
+  function parse(value: string): unknown {
+    if (value.trim() === '') {
+      return getEmptyValue(isRequired)
+    }
+    return parseFreeTextGivenJsonSchemaType(value, colType)
+  }
+
+  return createTextColumn<unknown>({
+    alignRight: true,
+    continuousUpdates: false,
+    deletedValue: getEmptyValue(isRequired),
+    formatBlurredInput: formatNumberCellValue,
+    // Edit against the stored value rather than the locale-formatted one so
+    // grouping separators never reach the parser.
+    formatInputOnFocus: castCellValueToString,
+    parseUserInput: parse,
+    parsePastedValue: value => parse(value.replace(/[\n\r]+/g, ' ')),
+  })
+}

--- a/packages/synapse-react-client/src/components/DataGrid/utils/columnFactory.test.ts
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/columnFactory.test.ts
@@ -1,6 +1,5 @@
 import {
   createTextColumn,
-  floatColumn,
   keyColumn,
 } from '@sage-bionetworks/react-datasheet-grid'
 import { autocompleteColumn } from '../columns/AutocompleteColumn'
@@ -8,6 +7,7 @@ import { mocked } from 'storybook/test'
 import { describe, expect, it } from 'vitest'
 import { autocompleteMultipleEnumColumn } from '../columns/AutocompleteMultipleEnumColumn'
 import { dateTimeColumn } from '../columns/DateTimeColumn'
+import { numberColumn } from '../columns/NumberColumn'
 import { createColumn } from './columnFactory'
 import React, { isValidElement, ReactElement } from 'react'
 
@@ -37,6 +37,10 @@ vi.mock('../columns/DateTimeColumn', () => ({
 
 vi.mock('../columns/AutocompleteMultipleEnumColumn', () => ({
   autocompleteMultipleEnumColumn: vi.fn(),
+}))
+
+vi.mock('../columns/NumberColumn', () => ({
+  numberColumn: vi.fn(),
 }))
 
 /** Helper to extract props from ColumnHeaderWithTooltip React element */
@@ -86,6 +90,7 @@ const mockAutocompleteMultipleEnumColumn = mocked(
   autocompleteMultipleEnumColumn,
 ).mockReturnValue(fakeColumn)
 const mockDateTimeColumn = mocked(dateTimeColumn).mockReturnValue(fakeColumn)
+const mockNumberColumn = mocked(numberColumn).mockReturnValue(fakeColumn)
 
 describe('columnFactory', () => {
   beforeEach(() => {
@@ -153,7 +158,11 @@ describe('columnFactory', () => {
       }
 
       const column = createColumn(config)
-      expect(keyColumnSpy).toHaveBeenCalledWith('count', floatColumn)
+      expect(mockNumberColumn).toHaveBeenCalledWith({
+        colType: 'number',
+        isRequired: true,
+      })
+      expect(keyColumnSpy).toHaveBeenCalledWith('count', fakeColumn)
 
       const headerProps = getHeaderProps(column.title)
       expect(headerProps.name).toBe('count')
@@ -169,6 +178,10 @@ describe('columnFactory', () => {
       }
 
       const column = createColumn(config)
+      expect(mockNumberColumn).toHaveBeenCalledWith({
+        colType: 'integer',
+        isRequired: false,
+      })
 
       const headerProps = getHeaderProps(column.title)
       expect(headerProps.name).toBe('age')

--- a/packages/synapse-react-client/src/components/DataGrid/utils/columnFactory.tsx
+++ b/packages/synapse-react-client/src/components/DataGrid/utils/columnFactory.tsx
@@ -7,11 +7,11 @@ import {
   CellProps,
   Column,
   createTextColumn,
-  floatColumn,
   keyColumn,
 } from '@sage-bionetworks/react-datasheet-grid'
 import { autocompleteColumn } from '../columns/AutocompleteColumn'
 import { autocompleteMultipleEnumColumn } from '../columns/AutocompleteMultipleEnumColumn'
+import { numberColumn } from '../columns/NumberColumn'
 import {
   calculateDefaultColumnWidth,
   HeaderOptions,
@@ -187,7 +187,13 @@ const COLUMN_FACTORIES = {
   },
 
   number: (config: ColumnConfig) => {
-    return createBaseColumn(config, floatColumn)
+    return createBaseColumn(
+      config,
+      numberColumn({
+        colType: config.typeInfo?.type,
+        isRequired: config.isRequired,
+      }),
+    )
   },
 
   enumerated: (config: ColumnConfig) => {


### PR DESCRIPTION
This PR improves the grid's display of values that violate the schema. This is particularly an issue after uploading a CSV containing invalid values. Date and numeric columns will not display string data, leading to a confusing UX after upload. The data is retained in the CRDT model but not displayed.