### PR TITLE
PORTALS-4470

### DIFF
--- a/packages/synapse-react-client/src/components/DatasetHosting/DatasetDownloadButton.tsx
+++ b/packages/synapse-react-client/src/components/DatasetHosting/DatasetDownloadButton.tsx
@@ -6,13 +6,11 @@ import LayersOutlined from '@mui/icons-material/LayersOutlined'
 import BlockOutlined from '@mui/icons-material/BlockOutlined'
 import AssuredWorkloadOutlined from '@mui/icons-material/AssuredWorkloadOutlined'
 import LoginOutlined from '@mui/icons-material/LoginOutlined'
-import { ReactNode, RefObject, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { ReactNode, useState } from 'react'
 import { TargetEnum } from '@/utils/html/TargetEnum'
 import { SRC_SIGN_IN_CLASS } from '@/utils/SynapseConstants'
 import { useSynapseContext } from '@/utils'
 import GenericCardActionButton from '../GenericCard/GenericCardActionButton'
-import { EntityDownloadConfirmation } from '../EntityDownloadConfirmation'
 import {
   DATASET_HOSTING_CONFIG,
   DatasetHostingConfig,
@@ -35,8 +33,6 @@ export type DatasetDownloadButtonProps = {
   entityId?: string
   /** The dataset name, shown in the download confirmation. */
   name: string
-  /** The dataset version to add to the download list, if any. */
-  version?: number
   /**
    * The dataset's hosting type. Accepts a raw annotation value (possibly blank,
    * null, or unrecognized); anything unrecognized is treated as `synapse`.
@@ -47,8 +43,16 @@ export type DatasetDownloadButtonProps = {
   /** Destination for the action when the dataset is not downloadable (e.g. dbGaP/EGA). */
   externalUrl?: string
   disabled?: boolean
-  /** Portal target for the download-confirmation dialog (see EntityDownloadConfirmation). */
-  downloadConfirmationContainer?: RefObject<HTMLElement | null>
+  /**
+   * Called when an authenticated user clicks a downloadable-hosting button.
+   * Owners of the button render the `EntityDownloadConfirmation` themselves and
+   * toggle it from this callback, so the confirmation banner can be shared with
+   * other download entry points on the same card (e.g. the customSecondaryLabel
+   * "Click here to add to Synapse download list" link).
+   */
+  onDownloadClick?: () => void
+  /** Disables the button while an owner-managed download flow is in progress. */
+  isDownloading?: boolean
 }
 
 function resolveLabel(
@@ -93,12 +97,12 @@ export function DatasetDownloadButton(props: DatasetDownloadButtonProps) {
   const {
     entityId,
     name,
-    version,
     hosting,
     repository,
     externalUrl,
     disabled,
-    downloadConfirmationContainer,
+    onDownloadClick,
+    isDownloading,
   } = props
   const { isAuthenticated } = useSynapseContext()
   const config = DATASET_HOSTING_CONFIG[normalizeHosting(hosting)]
@@ -107,8 +111,6 @@ export function DatasetDownloadButton(props: DatasetDownloadButtonProps) {
   const caveat = fillRepository(config.tooltip, repository)
   const Icon = ICONS[config.icon]
 
-  const [showConfirmation, setShowConfirmation] = useState(false)
-  const [isAdding, setIsAdding] = useState(false)
   const [signInPrompt, setSignInPrompt] = useState(false)
 
   const labelEl = (
@@ -169,35 +171,19 @@ export function DatasetDownloadButton(props: DatasetDownloadButtonProps) {
         variant="outlined"
         aria-label={ariaLabel}
         startIcon={<Icon sx={{ fontSize: '16px' }} />}
-        onClick={() => setShowConfirmation(value => !value)}
-        disabled={disabled || isAdding}
+        onClick={onDownloadClick}
+        disabled={disabled || isDownloading}
         sx={{ maxWidth: MAX_WIDTH, textTransform: 'none' }}
       >
         {labelEl}
       </GenericCardActionButton>
     )
-    const confirmation = showConfirmation ? (
-      <EntityDownloadConfirmation
-        entityId={entityId}
-        versionNumber={version}
-        onIsLoadingChange={setIsAdding}
-        handleClose={() => setShowConfirmation(false)}
-      />
-    ) : null
-    return (
-      <>
-        {caveat ? (
-          <Tooltip title={caveat} arrow placement="top">
-            <span>{button}</span>
-          </Tooltip>
-        ) : (
-          button
-        )}
-        {confirmation &&
-          (downloadConfirmationContainer?.current
-            ? createPortal(confirmation, downloadConfirmationContainer.current)
-            : confirmation)}
-      </>
+    return caveat ? (
+      <Tooltip title={caveat} arrow placement="top">
+        <span>{button}</span>
+      </Tooltip>
+    ) : (
+      button
     )
   }
 

--- a/packages/synapse-react-client/src/components/DatasetHosting/DatasetHosting.stories.tsx
+++ b/packages/synapse-react-client/src/components/DatasetHosting/DatasetHosting.stories.tsx
@@ -9,7 +9,8 @@ import {
   Typography,
 } from '@mui/material'
 import { Meta, StoryObj } from '@storybook/react-vite'
-import { useRef } from 'react'
+import { useState } from 'react'
+import { EntityDownloadConfirmation } from '../EntityDownloadConfirmation'
 import { GenericCard } from '../GenericCard/GenericCard'
 import { GenericCardIcon } from '../GenericCard/GenericCardIcon'
 import {
@@ -50,20 +51,28 @@ type DatasetCardExample = {
   description: string
 }
 
-// Wraps a bare DatasetDownloadButton with a confirmation container, so the
-// download-confirmation dialog (e.g. the unauthenticated "Please Sign In" banner)
-// renders in-flow beneath the button instead of overlapping neighboring content.
+// Wraps a bare DatasetDownloadButton with a confirmation banner that renders
+// in-flow beneath the button, so the unauthenticated "Please Sign In" prompt
+// doesn't overlap neighboring content.
 function DemoDownloadButton(
-  props: Omit<DatasetDownloadButtonProps, 'downloadConfirmationContainer'>,
+  props: Omit<DatasetDownloadButtonProps, 'onDownloadClick' | 'isDownloading'>,
 ) {
-  const confirmationRef = useRef<HTMLDivElement>(null)
+  const [showConfirmation, setShowConfirmation] = useState(false)
+  const [isDownloading, setIsDownloading] = useState(false)
   return (
     <>
       <DatasetDownloadButton
         {...props}
-        downloadConfirmationContainer={confirmationRef}
+        onDownloadClick={() => setShowConfirmation(v => !v)}
+        isDownloading={isDownloading}
       />
-      <div ref={confirmationRef} />
+      {showConfirmation && props.entityId && (
+        <EntityDownloadConfirmation
+          entityId={props.entityId}
+          onIsLoadingChange={setIsDownloading}
+          handleClose={() => setShowConfirmation(false)}
+        />
+      )}
     </>
   )
 }
@@ -73,11 +82,8 @@ function DatasetCardDemo(props: {
   actionButtonStyle?: CardActionButtonStyle
 }) {
   const { example, actionButtonStyle = 'chip' } = props
-  // The card's download-confirmation dialog portals here, mirroring how the real
-  // card (TableRowGenericCard) targets its footer — otherwise the unauthenticated
-  // "Please Sign In" banner renders inline and overlaps the absolutely-positioned
-  // card header.
-  const confirmationRef = useRef<HTMLDivElement>(null)
+  const [showConfirmation, setShowConfirmation] = useState(false)
+  const [isDownloading, setIsDownloading] = useState(false)
   const labels: CardLabel[] = [
     { columnDisplayName: 'Disease Focus', value: 'Neurofibromatosis type 1' },
     { columnDisplayName: 'Assay', value: 'RNA-seq' },
@@ -100,12 +106,19 @@ function DatasetCardDemo(props: {
             hosting={example.hosting}
             repository={example.repository}
             externalUrl={example.externalUrl}
-            downloadConfirmationContainer={confirmationRef}
+            onDownloadClick={() => setShowConfirmation(v => !v)}
+            isDownloading={isDownloading}
           />
         }
         labels={labels}
       />
-      <div ref={confirmationRef} />
+      {showConfirmation && (
+        <EntityDownloadConfirmation
+          entityId={MOCK_DATASET_ID}
+          onIsLoadingChange={setIsDownloading}
+          handleClose={() => setShowConfirmation(false)}
+        />
+      )}
     </CardActionButtonStyleContext.Provider>
   )
 }

--- a/packages/synapse-react-client/src/components/DatasetHosting/DatasetHosting.ts
+++ b/packages/synapse-react-client/src/components/DatasetHosting/DatasetHosting.ts
@@ -64,6 +64,12 @@ export type DatasetHostingConfig = {
   label: string
   /** Fallback label when the template needs a repository but none was provided. */
   labelWithoutRepository?: string
+  /**
+   * Short, scannable label shown as a chip adornment next to the dataset title,
+   * summarizing WHERE the data lives (independent of any repository name). Not
+   * templated — never mentions a specific repository.
+   */
+  chipLabel: string
   /** Tooltip summarizing the hosting/download caveat. `{repository}` is substituted. */
   tooltip?: string
   /** MUI Chip color used for the button. `default` = neutral/non-actionable. */
@@ -87,6 +93,7 @@ export const DATASET_HOSTING_CONFIG: Record<
   synapse: {
     downloadable: true,
     label: 'Download',
+    chipLabel: 'Synapse Hosted',
     color: 'primary',
     icon: 'download',
     // No caveat — the default, expected experience.
@@ -94,6 +101,7 @@ export const DATASET_HOSTING_CONFIG: Record<
   'external-cloud': {
     downloadable: true,
     label: 'Download',
+    chipLabel: 'External Cloud',
     color: 'primary',
     icon: 'cloud',
     tooltip:
@@ -103,6 +111,7 @@ export const DATASET_HOSTING_CONFIG: Record<
     downloadable: true,
     label: 'Download from {repository}',
     labelWithoutRepository: 'Download from external repository',
+    chipLabel: 'Synapse Indexed',
     color: 'primary',
     icon: 'external',
     tooltip:
@@ -113,6 +122,7 @@ export const DATASET_HOSTING_CONFIG: Record<
     isExternalLink: true,
     label: 'Access at {repository}',
     labelWithoutRepository: 'Access externally',
+    chipLabel: 'Externally Hosted',
     color: 'warning',
     icon: 'launch',
     tooltip:
@@ -121,6 +131,7 @@ export const DATASET_HOSTING_CONFIG: Record<
   mixed: {
     downloadable: true,
     label: 'Download available files',
+    chipLabel: 'Mixed Hosting',
     color: 'primary',
     icon: 'mixed',
     tooltip:
@@ -129,6 +140,7 @@ export const DATASET_HOSTING_CONFIG: Record<
   unavailable: {
     downloadable: false,
     label: 'Not available for download',
+    chipLabel: 'Not Available',
     color: 'default',
     icon: 'unavailable',
     tooltip:

--- a/packages/synapse-react-client/src/components/DatasetHosting/DatasetHostingAdornment.test.tsx
+++ b/packages/synapse-react-client/src/components/DatasetHosting/DatasetHostingAdornment.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+import { DatasetHostingAdornment } from './DatasetHostingAdornment'
+
+describe('DatasetHostingAdornment', () => {
+  test.each([
+    ['synapse', 'Synapse Hosted'],
+    ['external-cloud', 'External Cloud'],
+    ['external-download', 'Synapse Indexed'],
+    ['external-access', 'Externally Hosted'],
+    ['mixed', 'Mixed Hosting'],
+    ['unavailable', 'Not Available'],
+  ] as const)(
+    'renders the canonical chip label for hostingType=%s',
+    (hostingType, expectedLabel) => {
+      render(<DatasetHostingAdornment hostingType={hostingType} />)
+      expect(screen.getByText(expectedLabel)).toBeVisible()
+    },
+  )
+
+  test('renders the outlined header variant on dark backgrounds', () => {
+    render(<DatasetHostingAdornment hostingType="synapse" isHeader />)
+    const chip = screen.getByText('Synapse Hosted').closest('.MuiChip-root')
+    expect(chip).toHaveClass('MuiChip-outlined')
+  })
+})

--- a/packages/synapse-react-client/src/components/DatasetHosting/DatasetHostingAdornment.tsx
+++ b/packages/synapse-react-client/src/components/DatasetHosting/DatasetHostingAdornment.tsx
@@ -1,0 +1,32 @@
+import { Chip } from '@mui/material'
+import { DATASET_HOSTING_CONFIG, DatasetHostingType } from './DatasetHosting'
+
+export type DatasetHostingAdornmentProps = {
+  hostingType: DatasetHostingType
+  /** Use the header variant (outlined + white) for dark header backgrounds. */
+  isHeader?: boolean
+}
+
+/**
+ * Small scannable chip that summarizes where a dataset's files live
+ * (e.g. "Synapse Hosted", "Externally Hosted"). Rendered next to the dataset
+ * type on cards and detail-page headers, complementing the hosting-aware action
+ * button, which is a CTA rather than a scan target.
+ */
+export function DatasetHostingAdornment(props: DatasetHostingAdornmentProps) {
+  const { hostingType, isHeader = false } = props
+  const label = DATASET_HOSTING_CONFIG[hostingType].chipLabel
+  if (isHeader) {
+    return (
+      <Chip
+        label={label}
+        size="small"
+        variant="outlined"
+        sx={{ color: 'white', borderColor: 'white' }}
+      />
+    )
+  }
+  return <Chip label={label} size="small" />
+}
+
+export default DatasetHostingAdornment

--- a/packages/synapse-react-client/src/components/DatasetHosting/index.ts
+++ b/packages/synapse-react-client/src/components/DatasetHosting/index.ts
@@ -9,3 +9,8 @@ export {
   default as DatasetDownloadButtonDefault,
 } from './DatasetDownloadButton'
 export type { DatasetDownloadButtonProps } from './DatasetDownloadButton'
+export {
+  DatasetHostingAdornment,
+  default as DatasetHostingAdornmentDefault,
+} from './DatasetHostingAdornment'
+export type { DatasetHostingAdornmentProps } from './DatasetHostingAdornment'

--- a/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.test.tsx
@@ -494,6 +494,101 @@ describe('TableRowGenericCard tests', () => {
     })
   })
 
+  describe('hostingConfig', () => {
+    const hostingSchema = {
+      ...schema,
+      downloadType: 13,
+    }
+    const hostingData = [...data.slice(0, 12), 'syn9999.2', 'Synapse Hosted']
+
+    const propsWithHosting = (
+      hostingValue: string,
+      overrides: Partial<TableToGenericCardMapping> = {},
+    ): TableRowGenericCardProps => {
+      const rowData = [...hostingData]
+      rowData[13] = hostingValue
+      return {
+        ...propsForNonHeaderMode,
+        data: rowData,
+        schema: hostingSchema,
+        genericCardSchema: {
+          ...genericCardSchema,
+          downloadCartSynId: 'datasetAlias',
+          hostingConfig: {
+            hostingColumn: 'downloadType',
+            hostingValueMap: {
+              'Synapse Hosted': 'synapse',
+              'Synapse Indexed': 'external-download',
+              'Externally Hosted': 'external-access',
+              'Not Available for Download': 'unavailable',
+            },
+          },
+          ...overrides,
+        },
+      }
+    }
+
+    it('renders a hosting adornment chip with the canonical label for the row', async () => {
+      renderComponent(propsWithHosting('Synapse Hosted'), 'TableEntity')
+      expect(await screen.findByText('Synapse Hosted')).toBeVisible()
+    })
+
+    it('maps portal-specific values to canonical labels via hostingValueMap', async () => {
+      renderComponent(propsWithHosting('Synapse Indexed'), 'TableEntity')
+      expect(await screen.findByText('Synapse Indexed')).toBeVisible()
+      renderComponent(propsWithHosting('Externally Hosted'), 'TableEntity')
+      expect(await screen.findByText('Externally Hosted')).toBeVisible()
+    })
+
+    it('does not render the hosting adornment when the raw value is blank', async () => {
+      renderComponent(propsWithHosting(''), 'TableEntity')
+      // The card should still render, but no hosting chip should appear.
+      await screen.findByTestId('CardFooter')
+      expect(screen.queryByText('Synapse Hosted')).not.toBeInTheDocument()
+      expect(screen.queryByText('Externally Hosted')).not.toBeInTheDocument()
+      expect(screen.queryByText('Not Available')).not.toBeInTheDocument()
+    })
+
+    it('lets an explicit CardTypeAdornment prop override the auto adornment', async () => {
+      renderComponent(
+        {
+          ...propsWithHosting('Synapse Hosted'),
+          CardTypeAdornment: () => <div>CustomAdornment</div>,
+        },
+        'TableEntity',
+      )
+      expect(await screen.findByText('CustomAdornment')).toBeVisible()
+      expect(screen.queryByText('Synapse Hosted')).not.toBeInTheDocument()
+    })
+
+    it('opens the download confirmation when the HOW TO DOWNLOAD link is clicked for a downloadable hosting type', async () => {
+      // Regression: previously the "Click here to add to Synapse download list"
+      // link toggled state whose EntityDownloadConfirmation render target was
+      // gated behind !hostingConfig, so the link was visible but non-functional.
+      mockEntityDownloadConfirmation.mockImplementation(() => (
+        <div data-testid="EntityDownloadConfirmation" />
+      ))
+      const { container } = renderComponent(
+        propsWithHosting('Synapse Hosted', {
+          customSecondaryLabelConfig: {
+            key: 'How to Download',
+            value: 'placeholder',
+            isVisible: () => true,
+          },
+        }),
+        'TableEntity',
+      )
+      const collapse = container.querySelector('.MuiCollapse-root')
+      expect(collapse).toHaveClass('MuiCollapse-hidden')
+
+      const link = await screen.findByText(
+        /Click here to add to Synapse download list/i,
+      )
+      await userEvent.click(link)
+      expect(collapse).not.toHaveClass('MuiCollapse-hidden')
+    })
+  })
+
   describe('synapseEntityConfig', () => {
     it('derives entity identifiers from column sources', async () => {
       const entityIdColumnName = 'datasetEntityId'

--- a/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.tsx
+++ b/packages/synapse-react-client/src/components/GenericCard/TableRowGenericCard.tsx
@@ -35,7 +35,7 @@ import {
   SelectColumn,
   Table,
 } from '@sage-bionetworks/synapse-types'
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import CitationPopover from '../CitationPopover'
 import {
@@ -44,6 +44,7 @@ import {
   normalizeHosting,
 } from '../DatasetHosting/DatasetHosting'
 import DatasetDownloadButton from '../DatasetHosting/DatasetDownloadButton'
+import DatasetHostingAdornment from '../DatasetHosting/DatasetHostingAdornment'
 import { EntityDownloadConfirmation } from '../EntityDownloadConfirmation'
 import { HeaderCardVariant } from '../HeaderCard'
 import IconList from '../IconList'
@@ -448,9 +449,6 @@ export function TableRowGenericCard(props: TableRowGenericCardProps) {
   const hostingIsDownloadable = hostingType
     ? DATASET_HOSTING_CONFIG[hostingType].downloadable
     : true
-  // Portal target for the DatasetDownloadButton's download-confirmation dialog, so
-  // it renders in the card's top content region rather than inline in the button row.
-  const datasetDownloadConfirmationRef = useRef<HTMLDivElement>(null)
 
   // Transform the row to a record of (columnName, value) pairs for compatibility with getCandidateDoiId
   const dataAsRecord: Record<string, string | null> = useMemo(
@@ -633,9 +631,20 @@ export function TableRowGenericCard(props: TableRowGenericCardProps) {
     )
   }
 
-  const resolvedCardTypeAdornment = CardTypeAdornment ? (
-    <CardTypeAdornment schema={schema} data={data} />
-  ) : null
+  // Auto-render a scannable hosting chip next to the dataset type when the card
+  // opts into hosting-aware behavior and the row has a recognized hosting value,
+  // so the button's icon/tooltip is not the only visual signal of where files
+  // live. An explicit `CardTypeAdornment` prop always wins as an escape hatch.
+  let resolvedCardTypeAdornment: React.ReactNode = null
+  if (CardTypeAdornment) {
+    resolvedCardTypeAdornment = (
+      <CardTypeAdornment schema={schema} data={data} />
+    )
+  } else if (hostingConfig && rawHostingValue?.trim() && hostingType) {
+    resolvedCardTypeAdornment = (
+      <DatasetHostingAdornment hostingType={hostingType} isHeader={isHeader} />
+    )
+  }
 
   let isRenderingIcon = true
   if (isHeader && !imageFileHandleIdValue && !iconValue) {
@@ -691,7 +700,7 @@ export function TableRowGenericCard(props: TableRowGenericCardProps) {
       useStylesForDisplayedImage={Boolean(imageFileHandleIdValue)}
       cardTopContent={
         <>
-          {!hostingConfig && resolvedDownloadCartSynIdValue && (
+          {resolvedDownloadCartSynIdValue && (
             <Collapse in={showDownloadConfirmation}>
               <EntityDownloadConfirmation
                 entityId={resolvedDownloadCartSynIdValue}
@@ -703,8 +712,6 @@ export function TableRowGenericCard(props: TableRowGenericCardProps) {
               />
             </Collapse>
           )}
-          {/* DatasetDownloadButton (hosting path) portals its confirmation here. */}
-          {hostingConfig && <div ref={datasetDownloadConfirmationRef} />}
         </>
       }
       renderedIconList={
@@ -737,11 +744,13 @@ export function TableRowGenericCard(props: TableRowGenericCardProps) {
                 <DatasetDownloadButton
                   entityId={resolvedDownloadCartSynIdValue}
                   name={title}
-                  version={resolvedDownloadCartVersionNumber}
                   hosting={hostingType}
                   repository={hostingRepository}
                   externalUrl={hostingExternalUrl}
-                  downloadConfirmationContainer={datasetDownloadConfirmationRef}
+                  onDownloadClick={() =>
+                    setShowDownloadConfirmation(val => !val)
+                  }
+                  isDownloading={downloadButtonLoading}
                 />
               )}
             {/* PORTALS-3386 Use synapseLink in schema to add entity to download cart */}


### PR DESCRIPTION
# Fix: PR #2973 regression — dead "How to Download" link + missing hosting adornments

## Root cause
- The "Click here to add to Synapse download list" link toggled `showDownloadConfirmation`,
  but its `EntityDownloadConfirmation`/`Collapse` was gated behind `!hostingConfig`, so the
  link was visible but non-functional on any card using the new hosting-aware action.
- The CCKP-specific `DatasetCardTypeAdornment` / `DatasetHeaderCardTypeAdornment` chips
  ("Synapse Hosted", "Synapse Indexed", "Externally Hosted", "Not Available for Download")
  were deleted as part of the hosting-aware button rollout, with no replacement - a real
  regression for scanning a card grid.

## Fix A — restore the download-confirmation link (`hostingConfig` no longer suppresses it)
- **`DatasetDownloadButton.tsx`**: removed the button's own confirmation state
  (`showConfirmation`/`isAdding`), the inline `EntityDownloadConfirmation` render, and
  `createPortal`/`downloadConfirmationContainer`/`version` props. Added
  `onDownloadClick?: () => void` and `isDownloading?: boolean` so the parent card owns the
  single source of truth for the confirmation dialog.
- **`TableRowGenericCard.tsx`**: dropped the `!hostingConfig` guard on the outer
  `Collapse`/`EntityDownloadConfirmation`; removed the now-unused portal ref. The inline
  "How to Download" link and the `DatasetDownloadButton` now share one confirmation instance
  driven by `showDownloadConfirmation`.
- **`DatasetHosting.stories.tsx`**: story wrappers now own their own confirmation state and
  render `EntityDownloadConfirmation` inline via `onDownloadClick`.

## Fix B — auto-render a scannable hosting chip for every `hostingConfig` caller
- **`DatasetHosting.ts`**: added a `chipLabel` to `DatasetHostingConfig` and to each of the
  six hosting entries:
  - `synapse` → "Synapse Hosted"
  - `external-cloud` → "External Cloud"
  - `external-download` → "Synapse Indexed"
  - `external-access` → "Externally Hosted"
  - `mixed` → "Mixed Hosting"
  - `unavailable` → "Not Available"
- **`DatasetHostingAdornment.tsx`** *(new)*: renders a `Chip` with the resolved `chipLabel`;
  `isHeader` variant is outlined + white to match the old CCKP detail-page header chip.
- **`index.ts`**: exports the new component.
- **`TableRowGenericCard.tsx`**: when `hostingConfig` is set, the row's raw hosting value is
  non-blank, and no explicit `CardTypeAdornment` prop is passed, auto-renders
  `<DatasetHostingAdornment hostingType={...} isHeader={isHeader} />`. An explicit
  `CardTypeAdornment` still wins as an escape hatch.

## Effect for callers
- **CCKP** (already sets `hostingConfig` + `hostingValueMap`): automatically regains its
  hosting chips on card grids and the `DatasetsDetailsPage` header, and the inline
  "How to Download" link works again (manually tested and confirmed)
- **NF** (declares `hostingConfig`, but `hosting` annotations aren't populated yet): stays
  inert (blank value → no chip), and will pick up the chip automatically once the
  `nf-metadata-dictionary` annotations land.  (also manually confirmed)

## Tests added/updated
- `TableRowGenericCard.test.tsx` — new `hostingConfig` describe block:
  - Chip renders with the canonical label per hosting type.
  - `hostingValueMap` correctly maps portal-specific values (e.g. CCKP's `downloadType`).
  - No chip when the raw hosting value is blank.
  - Explicit `CardTypeAdornment` overrides the auto adornment.
  - Regression test: clicking "Click here to add to Synapse download list" now expands the
    `EntityDownloadConfirmation` `Collapse` (previously a dead link under `hostingConfig`).
- `DatasetHostingAdornment.test.tsx` *(new)* — verifies each of the six hosting types maps to
  its canonical chip label, and the header variant renders `outlined`.

## Verification
- `synapse-react-client`, `cancercomplexity`, and `nf` all type-check clean.
- 43/43 relevant tests pass (`DatasetDownloadButton`, `DatasetHostingAdornment`,
  `TableRowGenericCard`).
- No new lint warnings introduced.
<img width="1458" height="658" alt="Screenshot 2026-09-09 at 4 17 36 PM" src="https://github.com/user-attachments/assets/20ee7958-4155-499e-b370-146c741d33f4" />
<img width="1446" height="763" alt="Screenshot 2026-09-09 at 4 15 31 PM" src="https://github.com/user-attachments/assets/4854d580-6394-4097-9dbd-df27656c1928" />
<img width="1448" height="759" alt="Screenshot 2026-09-09 at 4 15 00 PM" src="https://github.com/user-attachments/assets/352c2c67-9973-4f90-8ba7-2df2ae216e06" />
<img width="1448" height="763" alt="Screenshot 2026-09-09 at 4 14 37 PM" src="https://github.com/user-attachments/assets/74c9f534-eefc-4ea7-a816-1bfe240f2e9c" />

