### PR TITLE
PORTALS-4475

### DIFF
--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.test.tsx
@@ -14,6 +14,7 @@ import { createWrapper } from '@/testutils/TestingLibraryUtils'
 import {
   DATA_ACCESS_REQUEST,
   DATA_ACCESS_REQUEST_PREVIEW,
+  DATA_ACCESS_REQUEST_SIGNATURE,
   DATA_ACCESS_REQUEST_SUBMISSION,
 } from '@/utils/APIConstants'
 import {
@@ -110,6 +111,7 @@ function renderComponent(props: Partial<ManualUploadDucStepProps> = {}) {
 
 const previewEndpoint = `*${DATA_ACCESS_REQUEST_PREVIEW(MOCK_DATA_ACCESS_REQUEST.id)}`
 const updateEndpoint = `*${DATA_ACCESS_REQUEST}`
+const signatureEndpoint = `*${DATA_ACCESS_REQUEST_SIGNATURE(MOCK_DATA_ACCESS_REQUEST.id)}`
 const submissionEndpoint = `*${DATA_ACCESS_REQUEST_SUBMISSION(
   MOCK_DATA_ACCESS_REQUEST.id,
 )}`
@@ -329,5 +331,48 @@ describe('ManualUploadDucStep', () => {
     await screen.findByText(/couldn't save your change/i)
     expect(screen.getByText('Server error')).toBeInTheDocument()
     expect(mockOnSubmissionCreated).not.toHaveBeenCalled()
+  })
+
+  it('does not re-fetch /preview after voiding the signature envelope', async () => {
+    // Regression: /preview mutates server state (creates a new envelope, resets DAR to draft),
+    // which repopulates `eDucSignatureEnvelopeId` on the DAR and causes the subsequent
+    // updateDar call to be rejected — you can't set `ducFileHandleId` on a DAR that still has
+    // an active signature envelope. The void mutation's onSuccess broadly invalidates the DAR
+    // query tree, which would otherwise auto-refetch the preview observer. See PORTALS-4XXX.
+    mockGetDataRequestForUpdate.mockResolvedValue({
+      ...MOCK_DATA_ACCESS_REQUEST,
+      eDucSignatureEnvelopeId: 'envelope-abc',
+    })
+    let previewCallCount = 0
+    let voidCallCount = 0
+    let updateCallCount = 0
+    server.use(
+      http.get(previewEndpoint, () => {
+        previewCallCount += 1
+        return HttpResponse.json(
+          { fileHandleId: 'preview-file-1' },
+          { status: 200 },
+        )
+      }),
+      http.delete(signatureEndpoint, () => {
+        voidCallCount += 1
+        return new HttpResponse(null, { status: 200 })
+      }),
+      http.post(updateEndpoint, async ({ request }) => {
+        updateCallCount += 1
+        const body = (await request.json()) as { id: string; etag: string }
+        return HttpResponse.json({ ...body, etag: 'new-etag' }, { status: 201 })
+      }),
+    )
+    // Override the downloadHrefOverride so the preview endpoint is actually called.
+    const { user } = renderComponent({ downloadHrefOverride: undefined })
+    await waitFor(() => expect(previewCallCount).toBe(1))
+    await user.click(
+      await screen.findByRole('button', { name: /Upload Signed DUC/i }),
+    )
+    await waitFor(() => expect(voidCallCount).toBe(1))
+    await waitFor(() => expect(updateCallCount).toBe(1))
+    // Preview was fetched once at mount and NOT re-fetched after voiding.
+    expect(previewCallCount).toBe(1)
   })
 })

--- a/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
+++ b/packages/synapse-react-client/src/components/AccessRequirementList/ManagedACTAccessRequirementRequestFlow/ManualUploadDucStep/ManualUploadDucStep.tsx
@@ -71,12 +71,24 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
     throwOnError: true,
   })
 
+  // Once we start the void → refetch → updateDar sequence, the preview query must not run again:
+  // GET /dataAccessRequest/{id}/preview has server-side side effects (creates a new signature
+  // envelope, resets DAR to draft) that repopulate `eDucSignatureEnvelopeId` on the DAR. The
+  // backend then rejects the follow-up updateDar because we're trying to set a manually-uploaded
+  // `ducFileHandleId` on a DAR that still has an active signature envelope. Because
+  // `useVoidDataAccessRequestSignature` invalidates the root DAR query key on success, an active
+  // preview observer would otherwise be auto-refetched.
+  const [isSubmittingSignedDuc, setIsSubmittingSignedDuc] = useState(false)
+
   const {
     data: previewFileHandle,
     isLoading: isLoadingPreview,
     error: previewError,
   } = useGetDataAccessRequestPreview(dataAccessRequest?.id ?? '', {
-    enabled: Boolean(dataAccessRequest?.id) && !downloadHrefOverride,
+    enabled:
+      Boolean(dataAccessRequest?.id) &&
+      !downloadHrefOverride &&
+      !isSubmittingSignedDuc,
   })
 
   const previewFileHandleId = previewFileHandle?.fileHandleId
@@ -157,6 +169,8 @@ export default function ManualUploadDucStep(props: ManualUploadDucStepProps) {
     )
     let latestDar = dataAccessRequest
     if (hasSignatureEnvelope) {
+      // Freeze the preview query before voiding — see the comment above the `isSubmittingSignedDuc` state.
+      setIsSubmittingSignedDuc(true)
       try {
         await voidSignatureAsync(dataAccessRequest.id)
       } catch {


### PR DESCRIPTION
## Fix: don't refetch `/preview` after voiding signature envelope

**File:** `ManualUploadDucStep.tsx`

**Problem**
Uploading a signed DUC on a DAR with an active signature envelope failed the
save step. Sequence:
1. User uploads signed PDF.
2. Client calls DELETE /signature to void the envelope.
3. Void's onSuccess broadly invalidates the DAR query tree.
4. React Query auto-refetches `GET /dataAccessRequest/{id}/preview`, which is
   a stateful endpoint that creates a new envelope and resets the DAR to draft.
5. Client `updateDar(..., ducFileHandleId)` is rejected by the backend because
   the DAR now has both `eDucSignatureEnvelopeId` (re-set by /preview) and a
   pending `ducFileHandleId` update — a state the backend does not allow.

**Change**
Added local state `isSubmittingSignedDuc` that flips to `true` before
`voidSignatureAsync(...)`. It's OR'd into the `enabled` predicate of
`useGetDataAccessRequestPreview` so the observer becomes inactive before the
invalidation fires. Inactive observers are not auto-refetched.

**Test**
Added a regression test in `ManualUploadDucStep.test.tsx` that:
- Mounts with `eDucSignatureEnvelopeId` set
- Counts `/preview`, `DELETE /signature`, and `POST /dataAccessRequest` calls
- Triggers the upload
- Asserts `/preview` was called exactly once (mount only) after the full
  upload → void → refetch → update sequence

All 14 tests in the file pass; adjacent test files (`AccessRequirementList`,
`InFlightEDucSignaturesTable`) also pass unchanged.

Manually verified that with these changes I can now eject out of the eDUC workflow (void signatures) and submit a data access request for review using the manually uploaded document.