### PR TITLE
SWC-7961 fix grid selection scroll

### DIFF
--- a/packages/react-datasheet-grid/e2e/scrolledActiveCell.spec.ts
+++ b/packages/react-datasheet-grid/e2e/scrolledActiveCell.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect, Locator, Page } from '@playwright/test'
+
+// The active cell's value is rendered in a popup portaled outside the
+// scrollable container so it can expand past the grid's edges. Nothing clips
+// that popup, so once the cell it is anchored to scrolls behind the grid's own
+// sticky chrome (header row, pinned columns) or out of the scrollable area, the
+// popup has to stop painting itself — otherwise its text is drawn on top of the
+// column headers and of whatever sits around the grid.
+test.describe('an active cell scrolled out of view', () => {
+  const ROW_COUNT = 40
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`/?rows=${ROW_COUNT}`)
+    await expect(page.locator('.dsg-container')).toBeVisible()
+    await expect(page.locator('.dsg-row').first()).toBeVisible()
+  })
+
+  const dataRows = (page: Page) => page.locator('.dsg-row:not(.dsg-row-header)')
+
+  // Grid columns: gutter | Active (checkbox, pinned) | First name | Last name | Email | Company | Department
+  const getFirstNameCell = (page: Page, rowIndex: number) =>
+    dataRows(page).nth(rowIndex).locator('.dsg-cell').nth(2)
+
+  const cellValue = (cell: Locator) =>
+    cell.locator('textarea.dsg-input').inputValue()
+
+  // Everything the grid renders inside its container is clipped by it and
+  // painted under the sticky header, so only the portaled popup can leak. Its
+  // rect is reported alongside whether it actually paints, since an
+  // out-of-view popup stays mounted to preserve an in-progress edit.
+  const paintedPopups = (page: Page) =>
+    page.evaluate(() =>
+      Array.from(document.querySelectorAll('textarea.dsg-input'))
+        .filter(textarea => !textarea.closest('.dsg-container'))
+        .filter(textarea =>
+          textarea.checkVisibility({
+            opacityProperty: true,
+            visibilityProperty: true,
+          }),
+        )
+        .map(textarea => {
+          const { top, left } = textarea.getBoundingClientRect()
+          return { value: (textarea as HTMLTextAreaElement).value, top, left }
+        }),
+    )
+
+  const valuesRenderedInCells = (page: Page) =>
+    page.evaluate(() =>
+      Array.from(
+        document.querySelectorAll<HTMLTextAreaElement>(
+          '.dsg-container textarea.dsg-input',
+        ),
+      ).map(textarea => textarea.value),
+    )
+
+  // Scroll just far enough to tuck the cell behind the sticky header row (or,
+  // scrolling horizontally, behind the pinned columns) while keeping it within
+  // the rows/columns the grid still renders around the viewport.
+  const scrollCellBehindGridChrome = async (
+    page: Page,
+    cell: Locator,
+    axis: 'vertical' | 'horizontal',
+  ) => {
+    const overlap = 10
+    const cellRect = (await cell.boundingBox())!
+    await page.locator('.dsg-container').evaluate(
+      (container, { cellRect, axis, overlap }) => {
+        if (axis === 'vertical') {
+          const header = container.querySelector('.dsg-row-header')!
+          const headerBottom = header.getBoundingClientRect().bottom
+          container.scrollTop += cellRect.y - headerBottom + overlap
+        } else {
+          const pinnedRight = Math.max(
+            ...Array.from(
+              container.querySelectorAll(
+                '.dsg-row-header .dsg-cell-sticky-left, .dsg-row-header .dsg-cell-gutter',
+              ),
+            ).map(pinned => pinned.getBoundingClientRect().right),
+          )
+          container.scrollLeft += cellRect.x - pinnedRight + overlap
+        }
+      },
+      { cellRect, axis, overlap },
+    )
+    // Position tracking runs on a requestAnimationFrame loop; give it a couple
+    // of frames to catch up.
+    await page.evaluate(
+      () =>
+        new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r))),
+    )
+  }
+
+  test('stops painting its value once it is behind the sticky header row', async ({
+    page,
+  }) => {
+    const cell = getFirstNameCell(page, 1)
+    const value = await cellValue(cell)
+    await cell.click()
+
+    // The popup paints while the cell it belongs to is in view...
+    expect(await paintedPopups(page)).toEqual([
+      expect.objectContaining({ value }),
+    ])
+
+    // ...and stops once that cell has scrolled behind the header row.
+    await scrollCellBehindGridChrome(page, cell, 'vertical')
+
+    expect(await paintedPopups(page)).toEqual([])
+  })
+
+  test('stops painting its value once it is behind the pinned columns', async ({
+    page,
+  }) => {
+    const cell = getFirstNameCell(page, 1)
+    await cell.click()
+    expect(await paintedPopups(page)).toHaveLength(1)
+
+    await scrollCellBehindGridChrome(page, cell, 'horizontal')
+
+    expect(await paintedPopups(page)).toEqual([])
+  })
+
+  test('keeps showing its value in the cell itself, clipped by the grid', async ({
+    page,
+  }) => {
+    // Hiding the popup must not blank out the active cell: the value it was
+    // displaying falls back to rendering inside the cell, where the grid clips
+    // it like any other cell's value.
+    const cell = getFirstNameCell(page, 1)
+    const value = await cellValue(cell)
+    await cell.click()
+    expect(await valuesRenderedInCells(page)).not.toContain(value)
+
+    await scrollCellBehindGridChrome(page, cell, 'vertical')
+
+    expect(await valuesRenderedInCells(page)).toContain(value)
+  })
+
+  test('keeps an in-progress edit focused so scrolling back resumes it', async ({
+    page,
+  }) => {
+    const cell = getFirstNameCell(page, 1)
+    await cell.click()
+    await page.keyboard.type('edited while visible')
+    await expect(page.locator('.dsg-input:focus')).toBeVisible()
+
+    await scrollCellBehindGridChrome(page, cell, 'vertical')
+    expect(await paintedPopups(page)).toEqual([])
+
+    // Still the focused editor, just not painted — so the text survives.
+    await expect(page.locator('.dsg-input:focus')).toHaveValue(
+      'edited while visible',
+    )
+  })
+})

--- a/packages/react-datasheet-grid/example/src/App.tsx
+++ b/packages/react-datasheet-grid/example/src/App.tsx
@@ -17,41 +17,62 @@ type Row = {
   department: string | null
 }
 
+const baseRows: Row[] = [
+  {
+    active: true,
+    firstName: 'Elon',
+    lastName: 'Musk',
+    email: 'elon@tesla.com',
+    company: 'Tesla',
+    department: 'CEO',
+  },
+  {
+    active: false,
+    firstName: 'Jeff',
+    lastName: 'Bezos',
+    email: 'jeff@amazon.com',
+    company: 'Amazon',
+    department: 'Founder',
+  },
+  {
+    active: true,
+    firstName: 'Tim',
+    lastName: 'Cook',
+    email: 'tim@apple.com',
+    company: 'Apple',
+    department: 'CEO',
+  },
+  {
+    active: false,
+    firstName: 'Sundar',
+    lastName: 'Pichai',
+    email: 'sundar@google.com',
+    company: 'Google',
+    department: 'CEO',
+  },
+]
+
+// The grid only grows as tall as its content until it reaches its max height,
+// so the handful of rows shown by default never scrolls vertically. A ?rows=
+// search param repeats the demo data (numbering each row so an individual one
+// can be identified) to get a scrollable grid.
+function getInitialRows(): Row[] {
+  const requested = Number(
+    new URLSearchParams(window.location.search).get('rows'),
+  )
+
+  if (!Number.isFinite(requested) || requested <= baseRows.length) {
+    return baseRows
+  }
+
+  return Array.from({ length: requested }, (_, index) => {
+    const row = baseRows[index % baseRows.length]
+    return { ...row, firstName: `${row.firstName} ${index}` }
+  })
+}
+
 function App() {
-  const [data, setData] = useState<Row[]>([
-    {
-      active: true,
-      firstName: 'Elon',
-      lastName: 'Musk',
-      email: 'elon@tesla.com',
-      company: 'Tesla',
-      department: 'CEO',
-    },
-    {
-      active: false,
-      firstName: 'Jeff',
-      lastName: 'Bezos',
-      email: 'jeff@amazon.com',
-      company: 'Amazon',
-      department: 'Founder',
-    },
-    {
-      active: true,
-      firstName: 'Tim',
-      lastName: 'Cook',
-      email: 'tim@apple.com',
-      company: 'Apple',
-      department: 'CEO',
-    },
-    {
-      active: false,
-      firstName: 'Sundar',
-      lastName: 'Pichai',
-      email: 'sundar@google.com',
-      company: 'Google',
-      department: 'CEO',
-    },
-  ])
+  const [data, setData] = useState<Row[]>(getInitialRows)
 
   const columns: Column<Row>[] = [
     {

--- a/packages/react-datasheet-grid/src/columns/textColumn.tsx
+++ b/packages/react-datasheet-grid/src/columns/textColumn.tsx
@@ -3,6 +3,10 @@ import { createPortal } from 'react-dom'
 import { CellComponent, CellProps, Column } from '../types'
 import cx from 'classnames'
 import { useFirstRender } from '../hooks/useFirstRender'
+import {
+  getVisibleCellBounds,
+  isCellOriginVisible,
+} from '../utils/cellVisibility'
 
 type TextColumnOptions<T> = {
   placeholder?: string
@@ -39,7 +43,21 @@ type Rect = {
   height: number
   maxWidth: number
   maxHeight: number
+  // Whether the cell the popup is anchored to is still visible in the grid, as
+  // opposed to scrolled behind its sticky header/pinned columns or out of its
+  // scrollable area.
+  anchorVisible: boolean
 }
+
+const sameRect = (a: Rect | null, b: Rect): boolean =>
+  a !== null &&
+  a.top === b.top &&
+  a.left === b.left &&
+  a.width === b.width &&
+  a.height === b.height &&
+  a.maxWidth === b.maxWidth &&
+  a.maxHeight === b.maxHeight &&
+  a.anchorVisible === b.anchorVisible
 
 // Mirrors the defaults style.css sets on --dsg-cell-expanded-max-width/
 // height — used as the fallback if that CSS variable can't be read (see
@@ -104,6 +122,9 @@ const TextComponent = React.memo<
       // Small buffer so the popup never touches the very edge of the window.
       const viewportMargin = 8
 
+      const container = anchor.closest<HTMLElement>('.dsg-container')
+      const cell = anchor.closest('.dsg-cell')
+
       let rafId: number
       const update = () => {
         const rect = anchor.getBoundingClientRect()
@@ -121,24 +142,18 @@ const TextComponent = React.memo<
           window.innerHeight,
           viewportMargin,
         )
-        setPopupRect(prev =>
-          prev &&
-          prev.top === rect.top &&
-          prev.left === rect.left &&
-          prev.width === rect.width &&
-          prev.height === rect.height &&
-          prev.maxWidth === maxWidth &&
-          prev.maxHeight === maxHeight
-            ? prev
-            : {
-                top: rect.top,
-                left: rect.left,
-                width: rect.width,
-                height: rect.height,
-                maxWidth,
-                maxHeight,
-              },
-        )
+        const next = {
+          top: rect.top,
+          left: rect.left,
+          width: rect.width,
+          height: rect.height,
+          maxWidth,
+          maxHeight,
+          anchorVisible:
+            !container ||
+            isCellOriginVisible(rect, getVisibleCellBounds(container, cell)),
+        }
+        setPopupRect(prev => (sameRect(prev, next) ? prev : next))
         rafId = requestAnimationFrame(update)
       }
       update()
@@ -228,6 +243,16 @@ const TextComponent = React.memo<
       }
     }, [focus, rowData])
 
+    const anchorVisible = popupRect?.anchorVisible ?? true
+    // Nothing clips the popup, so it must not paint while the cell it is
+    // anchored to is hidden by the grid: an active cell falls back to rendering
+    // its value inside the cell, where the grid clips it like any other value.
+    // An in-progress edit is the exception — its input stays mounted (and
+    // focused) but invisible, so scrolling away doesn't end the edit.
+    const usePopup = active && (anchorVisible || focus)
+    const popupHidden = usePopup && !anchorVisible
+    const interactive = focus && !popupHidden
+
     const floating = Boolean(focus && popupRect)
 
     const textarea = (
@@ -252,7 +277,7 @@ const TextComponent = React.memo<
         style={
           popupRect
             ? {
-                pointerEvents: focus ? 'auto' : 'none',
+                pointerEvents: interactive ? 'auto' : 'none',
                 minWidth: floating
                   ? Math.min(popupRect.width, popupRect.maxWidth)
                   : popupRect.width,
@@ -263,7 +288,7 @@ const TextComponent = React.memo<
                     }
                   : { width: popupRect.width }),
               }
-            : { pointerEvents: focus ? 'auto' : 'none' }
+            : { pointerEvents: interactive ? 'auto' : 'none' }
         }
         onChange={e => {
           asyncRef.current.changedAt = Date.now()
@@ -299,6 +324,9 @@ const TextComponent = React.memo<
           display: 'flex',
           alignItems: 'center',
           pointerEvents: 'none',
+          // Opacity rather than visibility/unmounting: those would blur a
+          // focused input, ending the edit it is meant to preserve.
+          opacity: popupHidden ? 0 : undefined,
         }}
       >
         {textarea}
@@ -310,8 +338,8 @@ const TextComponent = React.memo<
         <div ref={setAnchor} className="dsg-input-anchor" />
         {anchor &&
           createPortal(
-            active ? popup : textarea,
-            active ? document.body : anchor,
+            usePopup ? popup : textarea,
+            usePopup ? document.body : anchor,
           )}
       </>
     )

--- a/packages/react-datasheet-grid/src/utils/cellVisibility.test.ts
+++ b/packages/react-datasheet-grid/src/utils/cellVisibility.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  Bounds,
+  getVisibleCellBounds,
+  isCellOriginVisible,
+} from './cellVisibility'
+
+// JSDOM lays nothing out, so every rect the code under test reads is stubbed.
+const withRect = <T extends HTMLElement>(
+  element: T,
+  rect: Partial<DOMRect>,
+): T => {
+  element.getBoundingClientRect = () =>
+    ({
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      ...rect,
+    }) as DOMRect
+  return element
+}
+
+const appendCell = (
+  parent: HTMLElement,
+  className: string,
+  rect: Partial<DOMRect>,
+) => {
+  const cell = document.createElement('div')
+  cell.className = `dsg-cell ${className}`
+  parent.append(withRect(cell, rect))
+  return cell
+}
+
+type GridOptions = {
+  headerBottom?: number
+  gutterRight?: number
+  pinnedLeftRight?: number
+  pinnedRightLeft?: number
+}
+
+const createGrid = ({
+  headerBottom,
+  gutterRight,
+  pinnedLeftRight,
+  pinnedRightLeft,
+}: GridOptions = {}) => {
+  const container = document.createElement('div')
+  container.className = 'dsg-container'
+  // A wider/taller rect than the client size, as a container with scrollbars
+  // has.
+  withRect(container, { top: 100, left: 200, right: 760, bottom: 560 })
+  Object.defineProperty(container, 'clientWidth', { value: 500 })
+  Object.defineProperty(container, 'clientHeight', { value: 400 })
+
+  if (headerBottom !== undefined) {
+    const headerRow = document.createElement('div')
+    headerRow.className = 'dsg-row dsg-row-header'
+    container.append(withRect(headerRow, { top: 100, bottom: headerBottom }))
+
+    if (gutterRight !== undefined) {
+      appendCell(headerRow, 'dsg-cell-header dsg-cell-gutter', {
+        left: 200,
+        right: gutterRight,
+      })
+    }
+    if (pinnedLeftRight !== undefined) {
+      appendCell(headerRow, 'dsg-cell-header dsg-cell-sticky-left', {
+        left: gutterRight ?? 200,
+        right: pinnedLeftRight,
+      })
+    }
+    if (pinnedRightLeft !== undefined) {
+      appendCell(headerRow, 'dsg-cell-header dsg-cell-sticky-right', {
+        left: pinnedRightLeft,
+        right: 700,
+      })
+    }
+  }
+
+  document.body.append(container)
+  return container
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('getVisibleCellBounds', () => {
+  test('is the scrollable area when the grid has no header row', () => {
+    // clientWidth/clientHeight, not the container's rect: a scrollbar takes up
+    // room inside the container but paints over the cells behind it.
+    expect(getVisibleCellBounds(createGrid(), null)).toEqual<Bounds>({
+      top: 100,
+      left: 200,
+      right: 700,
+      bottom: 500,
+    })
+  })
+
+  test('excludes the sticky header row and the pinned columns', () => {
+    const container = createGrid({
+      headerBottom: 140,
+      gutterRight: 240,
+      pinnedLeftRight: 340,
+      pinnedRightLeft: 650,
+    })
+
+    expect(getVisibleCellBounds(container, null)).toEqual<Bounds>({
+      top: 140,
+      left: 340,
+      right: 650,
+      bottom: 500,
+    })
+  })
+
+  test('excludes the gutter when it is the only sticky column', () => {
+    const container = createGrid({ headerBottom: 140, gutterRight: 240 })
+
+    expect(getVisibleCellBounds(container, null)).toMatchObject({ left: 240 })
+  })
+
+  test('does not exclude the pinned columns for a cell that is itself pinned', () => {
+    const container = createGrid({
+      headerBottom: 140,
+      gutterRight: 240,
+      pinnedLeftRight: 340,
+    })
+    const pinnedCell = appendCell(container, 'dsg-cell-sticky-left', {})
+
+    // A pinned cell scrolls with the columns pinned alongside it, so it can
+    // never end up hidden behind them — only behind the header row.
+    expect(getVisibleCellBounds(container, pinnedCell)).toMatchObject({
+      top: 140,
+      left: 200,
+    })
+  })
+
+  test('does not exclude a right-pinned column for a cell that is itself right-pinned', () => {
+    const container = createGrid({ headerBottom: 140, pinnedRightLeft: 650 })
+    const pinnedCell = appendCell(container, 'dsg-cell-sticky-right', {})
+
+    expect(getVisibleCellBounds(container, pinnedCell)).toMatchObject({
+      right: 700,
+    })
+  })
+})
+
+describe('isCellOriginVisible', () => {
+  const bounds: Bounds = { top: 140, left: 340, right: 650, bottom: 500 }
+
+  test('is true for a cell inside the visible region', () => {
+    expect(isCellOriginVisible({ top: 200, left: 400 }, bounds)).toBe(true)
+  })
+
+  test('is true for a cell whose content overflows the region it starts in', () => {
+    // The popup is allowed to expand past the grid's right and bottom edges,
+    // so only where it is anchored matters.
+    expect(isCellOriginVisible({ top: 499, left: 649 }, bounds)).toBe(true)
+  })
+
+  test('is true within a sub-pixel of an edge', () => {
+    expect(isCellOriginVisible({ top: 139.5, left: 339.5 }, bounds)).toBe(true)
+  })
+
+  test('is false for a cell scrolled behind the header row', () => {
+    expect(isCellOriginVisible({ top: 120, left: 400 }, bounds)).toBe(false)
+  })
+
+  test('is false for a cell scrolled behind the pinned columns', () => {
+    expect(isCellOriginVisible({ top: 200, left: 300 }, bounds)).toBe(false)
+  })
+
+  test('is false for a cell scrolled past the bottom or right edge', () => {
+    expect(isCellOriginVisible({ top: 520, left: 400 }, bounds)).toBe(false)
+    expect(isCellOriginVisible({ top: 200, left: 680 }, bounds)).toBe(false)
+  })
+})

--- a/packages/react-datasheet-grid/src/utils/cellVisibility.ts
+++ b/packages/react-datasheet-grid/src/utils/cellVisibility.ts
@@ -1,0 +1,87 @@
+export type Bounds = {
+  top: number
+  left: number
+  right: number
+  bottom: number
+}
+
+const STICKY_LEFT_CELLS = '.dsg-cell-sticky-left, .dsg-cell-gutter'
+const STICKY_RIGHT_CELLS = '.dsg-cell-sticky-right'
+
+// Sub-pixel rounding between rects measured off different elements should not
+// read as a cell being hidden.
+const TOLERANCE = 1
+
+/**
+ * The region of a grid in which cells are actually visible: the scrollable area
+ * minus the sticky header row and pinned columns, which paint over any cell
+ * scrolled behind them.
+ *
+ * @param container the grid's scrollable container
+ * @param cell the cell whose visibility is being tested — a cell that is itself
+ *   pinned cannot be hidden behind the pinned columns it belongs to
+ */
+export function getVisibleCellBounds(
+  container: HTMLElement,
+  cell: Element | null,
+): Bounds {
+  const { top, left } = container.getBoundingClientRect()
+  // clientWidth/clientHeight rather than the rect's own size: scrollbars sit
+  // inside the container's box but paint over the cells behind them.
+  const bounds = {
+    top,
+    left,
+    right: left + container.clientWidth,
+    bottom: top + container.clientHeight,
+  }
+
+  // Pinned columns are measured on the header row rather than on the cell's own
+  // row: every row pins the same columns, and the header row is always there.
+  const headerRow = container.querySelector('.dsg-row-header')
+
+  if (!headerRow) {
+    return bounds
+  }
+
+  bounds.top = Math.max(bounds.top, headerRow.getBoundingClientRect().bottom)
+
+  if (!cell?.matches(STICKY_LEFT_CELLS)) {
+    Array.from(headerRow.querySelectorAll(STICKY_LEFT_CELLS)).forEach(
+      pinned => {
+        bounds.left = Math.max(
+          bounds.left,
+          pinned.getBoundingClientRect().right,
+        )
+      },
+    )
+  }
+
+  if (!cell?.matches(STICKY_RIGHT_CELLS)) {
+    Array.from(headerRow.querySelectorAll(STICKY_RIGHT_CELLS)).forEach(
+      pinned => {
+        bounds.right = Math.min(
+          bounds.right,
+          pinned.getBoundingClientRect().left,
+        )
+      },
+    )
+  }
+
+  return bounds
+}
+
+/**
+ * Whether the top-left corner of a cell — the point an expanded popup is
+ * anchored to and grows right and down from — is inside the visible region.
+ */
+export function isCellOriginVisible(
+  cellRect: { top: number; left: number },
+  bounds: Bounds,
+): boolean {
+  return (
+    cellRect.top >= bounds.top - TOLERANCE &&
+    cellRect.top <= bounds.bottom + TOLERANCE &&
+    cellRect.left >= bounds.left - TOLERANCE &&
+    cellRect.left <= bounds.right + TOLERANCE
+  )
+}


### PR DESCRIPTION
Fix a regression introduced by the cell expansion feature causing selected data to render outside the grid when scrolling. Calculate the visible area of the grid to hide the expanded cell portal when scrolling.