### PR TITLE
PORTALS-4476: Update NF portal search configs from (re)tuned results

### DIFF
--- a/apps/portals/nf/src/config/resources.ts
+++ b/apps/portals/nf/src/config/resources.ts
@@ -110,8 +110,9 @@ export const publicationsSearchQueryConfig: SearchQueryConfig = {
 }
 export const studiesSearchIndexId = 'syn75081633'
 // Tuned in nf-osi/opensearch-ops (benchmark/studies/fields.yaml).
-// includeUnlistedFields:true is load-bearing, not just the default -- the `*` it appends is
-// what keeps the keyword-mapped ENTITYID columns searchable.
+// includeUnlistedFields:true because the `*` enables search for keyword-mapped ENTITYID 
+// cols not explicitly here; accessRequirements or others at 1 despite `*` to convey
+// they were measured-and-unboosted, and weights may still change as content evolves.
 export const studiesSearchQueryConfig: SearchQueryConfig = {
   queryStrategy: 'MULTI_MATCH_CROSS_FIELDS',
   includeUnlistedFields: true,

--- a/apps/portals/nf/src/config/resources.ts
+++ b/apps/portals/nf/src/config/resources.ts
@@ -42,21 +42,121 @@ export const enabledAnalysisPlatforms: ExternalAnalysisPlatform[] = [
   'terra',
 ]
 export const datasetsSearchIndexId = 'syn75081630'
+// Tuned in nf-osi/opensearch-ops (benchmark/datasets/fields.yaml), which has the rationale.
+// Equal weights and includeUnlistedFields:false are both measured, not defaults -- boosting
+// costs recall here, and appending `*` undoes the whole gain.
+export const datasetsSearchQueryConfig: SearchQueryConfig = {
+  queryStrategy: 'BOOSTED_FUZZY',
+  includeUnlistedFields: false,
+  fieldBoosts: {
+    title: 1,
+    name: 1,
+    alternateName: 1,
+    series: 1,
+    keywords: 1,
+    measurementTechnique: 1,
+    assay: 1,
+    dataType: 1,
+    subject: 1,
+    description: 1,
+    manifestation: 1,
+    diseaseFocus: 1,
+    species: 1,
+    modelSystemName: 1,
+    ageGroup: 1,
+    creator: 1,
+    contributor: 1,
+    funder: 1,
+    fundingAgency: 1,
+    citation: 1,
+    countryOfOrigin: 1,
+    accessType: 1,
+    license: 1,
+    conditionsOfAccess: 1,
+    dataUseModifiers: 1,
+    includedInDataCatalog: 1,
+    hosting: 1,
+    repository: 1,
+    externalUrl: 1,
+    externalRepositoryUri: 1,
+    visualizeDataOn: 1,
+    path: 1,
+    doi: 1,
+    etag: 1,
+    datasetMD5Hex: 1,
+    croissant_file_s3_object: 1,
+    versionLabel: 1,
+    versionComment: 1,
+  },
+}
 export const publicationsSearchIndexId = 'syn75081631'
+// Tuned in nf-osi/opensearch-ops (benchmark/publications/fields.yaml).
+export const publicationsSearchQueryConfig: SearchQueryConfig = {
+  queryStrategy: 'BOOSTED_FUZZY',
+  includeUnlistedFields: false,
+  fieldBoosts: {
+    title: 5,
+    author: 3,
+    manifestation: 3,
+    diseaseFocus: 2,
+    studyName: 2,
+    journal: 2,
+    studyId: 1,
+    doi: 1,
+    pmid: 1,
+    fundingAgency: 1,
+    publicationType: 1,
+  },
+}
 export const studiesSearchIndexId = 'syn75081633'
+// Tuned in nf-osi/opensearch-ops (benchmark/studies/fields.yaml).
+// includeUnlistedFields:true is load-bearing, not just the default -- the `*` it appends is
+// what keeps the keyword-mapped ENTITYID columns searchable.
+export const studiesSearchQueryConfig: SearchQueryConfig = {
+  queryStrategy: 'MULTI_MATCH_CROSS_FIELDS',
+  includeUnlistedFields: true,
+  fieldBoosts: {
+    manifestation: 10,
+    name: 5,
+    studyName: 5,
+    studyLeads: 3,
+    institutions: 3,
+    initiative: 3,
+    summary: 3,
+    dataType: 3,
+    diseaseFocus: 2,
+    fundingAgency: 2,
+    grantDOI: 2,
+    studyStatus: 2,
+    dataStatus: 2,
+    clinicalTrialID: 2,
+    alternateDataRepository: 2,
+    accessRequirements: 1,
+    acknowledgementStatements: 1,
+  },
+}
 export const initiativesSearchIndexId = 'syn75081635'
 export const toolsSearchIndexId = 'syn75081636'
+// Tuned in nf-osi/opensearch-ops (benchmark/tools/fields.yaml), which has the sweep record.
+// Weights were swept for cross_fields specifically; they are not best_fields weights.
 export const toolsSearchQueryConfig: SearchQueryConfig = {
-  queryStrategy: 'MULTI_MATCH_BEST_FIELDS',
+  queryStrategy: 'MULTI_MATCH_CROSS_FIELDS',
+  includeUnlistedFields: false,
   fieldBoosts: {
-    resourceName: 5,
-    synonyms: 4,
-    rrid: 4,
-    targetAntigen: 2,
-    // Was diseaseType (Biobank's pre-migration field name, dropped when it was unified
-    // into the shared geneticDisorder column across resource types) -- this boost was a
-    // silent no-op against a nonexistent field until fixed.
-    geneticDisorder: 1,
+    resourceName: 2.5,
+    synonyms: 2,
+    rrid: 2,
+    targetAntigen: 1.75,
+    manifestation: 1.75,
+    geneticDisorder: 1.5,
+    tumorType: 1.5,
+    species: 1.5,
+    cellLineCategory: 1.5,
+    resourceType: 1.5,
+    vectorType: 1.5,
+    investigatorName: 2.25,
+    race: 1,
+    sex: 1,
     description: 1,
   },
 }

--- a/apps/portals/nf/src/config/synapseConfigs/datasets.ts
+++ b/apps/portals/nf/src/config/synapseConfigs/datasets.ts
@@ -1,7 +1,11 @@
 import type { CardConfiguration } from 'synapse-react-client/components/CardContainer/CardConfiguration'
 import type { QueryWrapperPlotNavProps } from 'synapse-react-client/components/QueryWrapperPlotNav/QueryWrapperPlotNav'
 import * as SynapseConstants from 'synapse-react-client/utils/SynapseConstants'
-import { datasetsSearchIndexId, datasetsSql } from '../resources'
+import {
+  datasetsSearchIndexId,
+  datasetsSearchQueryConfig,
+  datasetsSql,
+} from '../resources'
 import { columnAliases as sharedColumnAliases } from './commonProps'
 import { studyColumnIconConfigs } from './studies'
 import { SearchQueryWrapperPlotNavProps } from 'synapse-react-client/components/SearchQueryWrapperPlotNav/SearchQueryWrapperPlotNav'
@@ -116,6 +120,7 @@ export const datasetsSearch: SearchQueryWrapperPlotNavProps = {
   cardConfiguration: datasetCardConfiguration,
   columnAliases,
   searchIndexId: datasetsSearchIndexId,
+  searchQueryConfig: datasetsSearchQueryConfig,
   autocompleteFieldName: 'title',
   hideTopLevelControls: false,
   hideQueryCount: false,

--- a/apps/portals/nf/src/config/synapseConfigs/publications.ts
+++ b/apps/portals/nf/src/config/synapseConfigs/publications.ts
@@ -2,7 +2,11 @@ import type { CardConfiguration } from 'synapse-react-client/components/CardCont
 import type { QueryWrapperPlotNavProps } from 'synapse-react-client/components/QueryWrapperPlotNav/QueryWrapperPlotNav'
 import * as SynapseConstants from 'synapse-react-client/utils/SynapseConstants'
 import { columnAliases } from './commonProps'
-import { publicationsSearchIndexId, publicationsSql } from '../resources'
+import {
+  publicationsSearchIndexId,
+  publicationsSearchQueryConfig,
+  publicationsSql,
+} from '../resources'
 import { SearchQueryWrapperPlotNavProps } from 'synapse-react-client/components/SearchQueryWrapperPlotNav/SearchQueryWrapperPlotNav'
 
 export const newPublicationsSql = `${publicationsSql} order by ROW_ID desc limit 3`
@@ -73,6 +77,7 @@ export const publicationsSearch: SearchQueryWrapperPlotNavProps = {
   cardConfiguration: publicationsCardConfiguration,
   columnAliases,
   searchIndexId: publicationsSearchIndexId,
+  searchQueryConfig: publicationsSearchQueryConfig,
   autocompleteFieldName: 'title',
   hideTopLevelControls: false,
   hideQueryCount: false,

--- a/apps/portals/nf/src/config/synapseConfigs/studies.ts
+++ b/apps/portals/nf/src/config/synapseConfigs/studies.ts
@@ -14,6 +14,7 @@ import {
 } from '../doiRedirector'
 import {
   studiesSearchIndexId,
+  studiesSearchQueryConfig,
   studiesSql,
   SYNAPSE_PORTAL_ID,
 } from '../resources'
@@ -188,6 +189,7 @@ export const studiesSearch: SearchQueryWrapperPlotNavProps = {
   cardConfiguration: studyCardConfiguration,
   columnAliases,
   searchIndexId: studiesSearchIndexId,
+  searchQueryConfig: studiesSearchQueryConfig,
   autocompleteFieldName: 'studyName',
   hideTopLevelControls: false,
   hideQueryCount: false,

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.test.ts
@@ -1689,6 +1689,37 @@ describe('toSearchIndexQuery – searchQueryConfig', () => {
     })
   })
 
+  it.each(['schwann', '"schwann cell"', 'syn12345'])(
+    'searches only the listed fields for %s',
+    searchExpression => {
+      const result = toSearchIndexQuery(
+        makeQueryBundleRequest({
+          additionalFilters: [
+            {
+              concreteType: TEXT_MATCHES_QUERY_FILTER_CONCRETE_TYPE_VALUE,
+              searchExpression,
+            },
+          ],
+        }),
+        SEARCH_INDEX_ID,
+        undefined,
+        {
+          queryStrategy: 'MULTI_MATCH_BEST_FIELDS',
+          includeUnlistedFields: false,
+          fieldBoosts: { resourceName: 5, description: 1 },
+        },
+      )
+      const clauseType =
+        searchExpression !== 'schwann' ? 'simple_query_string' : 'multi_match'
+      expect(result.searchQuery?.query).toMatchObject({
+        [clauseType]: {
+          query: searchExpression,
+          fields: ['resourceName^5', 'description'],
+        },
+      })
+    },
+  )
+
   it('an explicit "*" boost is respected and not overridden', () => {
     const result = toSearchIndexQuery(
       queryBundleWithText,

--- a/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
+++ b/packages/synapse-react-client/src/components/SearchQueryWrapper/SearchQueryUseQueryOptions.ts
@@ -66,6 +66,8 @@ export type SearchQueryConfig = {
    * queried at equal weight.
    */
   fieldBoosts?: Record<string, number>
+  /** Whether to append `*` to fieldBoosts at neutral weight. Defaults to true. */
+  includeUnlistedFields?: boolean
   /**
    * Fuzziness override. Overrides the per-strategy default. Leave undefined to
    * use each strategy's natural default (AUTO for MULTI_MATCH/BOOSTED_FUZZY,
@@ -114,11 +116,13 @@ type SearchQueryDSL =
 
 function resolveFields(
   fieldBoosts: Record<string, number> | undefined,
+  includeUnlistedFields: boolean,
 ): string[] | undefined {
   if (!fieldBoosts) return undefined
-  // Ensure fields not explicitly boosted are still searched (at neutral weight)
-  // rather than being excluded entirely.
-  const boosts = '*' in fieldBoosts ? fieldBoosts : { ...fieldBoosts, '*': 1 }
+  const boosts =
+    includeUnlistedFields && !('*' in fieldBoosts)
+      ? { ...fieldBoosts, '*': 1 }
+      : fieldBoosts
   return Object.entries(boosts).map(([field, boost]) =>
     boost === 1 ? field : `${field}^${boost}`,
   )
@@ -150,8 +154,13 @@ function buildQueryClause(
   queryText: string,
   config: SearchQueryConfig = {},
 ): MultiMatchClause | SimpleQueryStringClause {
-  const { queryStrategy = 'MULTI_MATCH', fieldBoosts, fuzziness } = config
-  const fields = resolveFields(fieldBoosts)
+  const {
+    queryStrategy = 'MULTI_MATCH',
+    fieldBoosts,
+    includeUnlistedFields = true,
+    fuzziness,
+  } = config
+  const fields = resolveFields(fieldBoosts, includeUnlistedFields)
 
   // Route to simple_query_string when the query needs exact-token treatment:
   //  - a double-quoted phrase (multi_match can't honour the phrase operator), or


### PR DESCRIPTION
Updates existing tools config and adds a `SearchQueryConfig` to the NF datasets, publications and studies searches. Also have to make one small synapse-react-client API change this config update depends on.  Added `includeUnlistedFields` for more control, defaulting to `true` **so existing configs are unaffected**, because it turns out that we do want the ability to exclude fields in some cases where `*` pulls back in columns that add too much noise.

All new weights/shapes are transcribed from recently updated benchmarks, scored against each of their golden set on the live indexes. Each index wanted a different shape, which is the main reason these are per-index configs rather than one shared default, e.g.

- **Cross-fields** wins where queries spread terms across several columns, e.g. a real query seen in GA4 for "human+nerve+plexiform+neurofibroma+bulk+RNA-seq" that essentially needs info from 4 different columns.
- **Fuzziness** wins on some others where search may be more complicated so there needs to be more typo tolerance.
- Datasets is deliberately unboosted, just how the scores turned out.
