### PR TITLE
PORTALS-4447 Gate RDCA-DAP DAR wizard on account eligibility

### DIFF
--- a/apps/portals/ampals/src/components/AmpAlsAccessColumn.tsx
+++ b/apps/portals/ampals/src/components/AmpAlsAccessColumn.tsx
@@ -11,22 +11,25 @@ type SourceValue = 'Synapse' | 'GEO' | 'Critical Path Institute' | null
 
 const ID_COLUMN_NAME = 'id'
 const SOURCE_COLUMN_NAME = 'source'
-const URL_COLUMN_NAME = 'url'
 const DATASET_CODE_COLUMN_NAME = 'dataset_code'
 
 function AccessBySource(props: {
   source: SourceValue
   id: string
   datasetCode: string
-  url?: string
 }) {
-  const { source, id, url, datasetCode } = props
+  const { source, id, datasetCode } = props
 
   switch (source) {
     case 'GEO':
       return <AccessIcon restrictionUiType={RestrictionUiType.Accessible} />
     case 'Critical Path Institute':
-      return <AridhiaAccessStatus url={url} datasetCode={datasetCode} />
+      return (
+        <AridhiaAccessStatus
+          fairPortalUrl={import.meta.env.VITE_ARIDHIA_FAIR_PORTAL_URL}
+          datasetCode={datasetCode}
+        />
+      )
     case 'Synapse':
     default:
       return <HasAccessV2 entityId={id} showButtonText={false} />
@@ -45,7 +48,6 @@ function AmpAlsAccessColumnCell<TValue = unknown>(
 
   const idColumnIndex = getColumnIndex(ID_COLUMN_NAME, selectColumns)
   const sourceColumnIndex = getColumnIndex(SOURCE_COLUMN_NAME, selectColumns)
-  const urlColumnIndex = getColumnIndex(URL_COLUMN_NAME, selectColumns)
   const datasetCodeColumnIndex = getColumnIndex(
     DATASET_CODE_COLUMN_NAME,
     selectColumns,
@@ -53,27 +55,20 @@ function AmpAlsAccessColumnCell<TValue = unknown>(
   if (
     idColumnIndex == null ||
     sourceColumnIndex == null ||
-    urlColumnIndex == null ||
     datasetCodeColumnIndex == null
   ) {
     console.warn(
-      "AmpAlsAccessColumn: 'id', 'source', 'url' or 'dataset_code' column not found",
+      "AmpAlsAccessColumn: 'id', 'source' or 'dataset_code' column not found",
     )
     return null
   }
 
   const id = row.original.values[idColumnIndex]!
   const sourceValue = row.original.values[sourceColumnIndex] as SourceValue
-  const url = row.original.values[urlColumnIndex] ?? undefined
   const datasetCode = row.original.values[datasetCodeColumnIndex]!
 
   return (
-    <AccessBySource
-      source={sourceValue}
-      id={id}
-      url={url}
-      datasetCode={datasetCode}
-    />
+    <AccessBySource source={sourceValue} id={id} datasetCode={datasetCode} />
   )
 }
 

--- a/packages/aridhia-client/src/codegen/filterSpec.ts
+++ b/packages/aridhia-client/src/codegen/filterSpec.ts
@@ -349,6 +349,31 @@ function applyUpstreamDefectPatches(spec: OpenAPISpec): OpenAPISpec {
     fieldItemSchema.properties.default_options = { type: 'string' }
   }
 
+  // 7. `RequestListItem` and `RequestFull` both declare `datasets` as a single `RequestDataset`
+  //    object, but the live `GET /fair/requests` and `GET /fair/requests/{code}` responses
+  //    return `datasets` as an array of `RequestDataset` (a request can span multiple
+  //    datasets). Confirmed against live gateway responses.
+  {
+    for (const schemaName of ['RequestListItem', 'RequestFull']) {
+      const pointer = `#/components/schemas/${schemaName}`
+      const schema = getByPointer(spec, pointer)
+      const objectPart = schema?.allOf?.find(
+        part => part?.properties && 'datasets' in part.properties,
+      )
+      const datasetsSchema = objectPart?.properties?.datasets
+      const isDefect =
+        datasetsSchema?.$ref === '#/components/schemas/RequestDataset'
+      if (!isDefect) {
+        throw new Error(
+          `Upstream spec defect patch failed: ${pointer}.datasets is no longer a single RequestDataset $ref. Re-check whether this patch is still needed.`,
+        )
+      }
+      objectPart.properties.datasets = {
+        type: 'array',
+        items: { $ref: '#/components/schemas/RequestDataset' },
+      }
+    }
+  }
   return spec
 }
 

--- a/packages/synapse-react-client/src/aridhia-queries/useAridhiaQuery.test.tsx
+++ b/packages/synapse-react-client/src/aridhia-queries/useAridhiaQuery.test.tsx
@@ -255,6 +255,33 @@ describe('useAridhiaMutation', () => {
     },
   )
 
+  it('normalizes a FAIR-side 403 "not authorised" response into an eligibility-failure AridhiaError', async () => {
+    const mutationFn = vi.fn().mockRejectedValue(
+      responseError(
+        {
+          error: {
+            status: 403,
+            message: 'Not authorised for this operation',
+          },
+        },
+        403,
+      ),
+    )
+    server.use(getAridhiaAuthenticateHandler())
+
+    const { result } = renderAridhiaHook(() => useAridhiaMutation(mutationFn))
+
+    act(() => {
+      result.current.mutate(undefined)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    const error = result.current.error as AridhiaError
+    expect(error.code).toBe('not_authorized')
+    expect(error.isEligibilityFailure).toBe(true)
+    expect(error.httpStatus).toBe(403)
+  })
+
   it('surfaces the server text verbatim for an unrecognized error body, still coded unknown', async () => {
     server.use(getAridhiaAuthenticateHandler())
     const mutationFn = vi

--- a/packages/synapse-react-client/src/aridhia-queries/useAridhiaQuery.ts
+++ b/packages/synapse-react-client/src/aridhia-queries/useAridhiaQuery.ts
@@ -17,7 +17,11 @@ import { createAridhiaApiConfiguration } from './aridhiaTokenExchange'
 
 /**
  * - `invalid_token` / `invalid_issuer` — the gateway's `/authenticate` rejected the Synapse
- *   token outright (e.g. no linked RDCA-DAP account yet).
+ *   token outright. The gateway currently mints a token whether or not the account is linked
+ *   to RDCA-DAP, but kept as a recognized shape in case that changes.
+ * - `not_authorized` — a FAIR API call (e.g. `GET /fair/requests`) rejected an otherwise-valid
+ *   Aridhia token with 403 `{ error: { message: 'Not authorised for this operation' } }`. This
+ *   is the actual eligibility signal in practice: it means no linked RDCA-DAP account yet.
  * - `Invalid parameter` — the token-exchange request body was malformed. This is our bug, not
  *   the user's eligibility, so it is never treated as an eligibility failure.
  * - `not_configured` — called without an `AridhiaContextProvider` or a Synapse access token;
@@ -27,6 +31,7 @@ import { createAridhiaApiConfiguration } from './aridhiaTokenExchange'
 export type AridhiaErrorCode =
   | 'invalid_token'
   | 'invalid_issuer'
+  | 'not_authorized'
   | 'Invalid parameter'
   | 'not_configured'
   | 'unknown'
@@ -113,6 +118,18 @@ export async function toAridhiaError(error: unknown): Promise<AridhiaError> {
         httpStatus,
         // A malformed request body is our bug, not the user's account state.
         isEligibilityFailure: bodyErrorText !== 'Invalid parameter',
+      })
+    }
+    // The gateway's `/authenticate` always mints a token regardless of RDCA-DAP linkage; a FAIR
+    // resource call (e.g. `/fair/requests`) is what actually rejects an unlinked account, as a
+    // 403 with this message in its own `{ error: { message } }` envelope.
+    if (
+      httpStatus === 403 &&
+      bodyErrorText === 'Not authorised for this operation'
+    ) {
+      return new AridhiaError('not_authorized', bodyErrorText, {
+        httpStatus,
+        isEligibilityFailure: true,
       })
     }
     // An unrecognized error shape (e.g. a FAIR-side validation error on `/requests/`, which

--- a/packages/synapse-react-client/src/components/Aridhia/AridhiaAccessStatus.test.tsx
+++ b/packages/synapse-react-client/src/components/Aridhia/AridhiaAccessStatus.test.tsx
@@ -14,9 +14,10 @@ import {
   getAridhiaWorkspacesHandler,
   MOCK_ARIDHIA_AUTHENTICATION_REQUEST,
   MOCK_ARIDHIA_DATASET_CODE,
+  MOCK_ARIDHIA_FAIR_PORTAL_URL,
   MOCK_ARIDHIA_GATEWAY,
+  MOCK_ARIDHIA_NOT_AUTHORIZED_ERROR,
 } from '@/mocks/msw/handlers/aridhiaHandlers'
-import { getFeatureFlagsOverride } from '@/mocks/msw/handlers/featureFlagHandlers'
 import { server } from '@/mocks/msw/server'
 import {
   fillRjsfTextField,
@@ -24,23 +25,20 @@ import {
 } from '@/testutils/RjsfFormTestUtils'
 import { createWrapper } from '@/testutils/TestingLibraryUtils'
 import { AridhiaContextProvider } from '@/utils/context/AridhiaContext'
-import { FeatureFlagEnum } from '@/utils/featureflag/FeatureFlags'
-import { BackendDestinationEnum, getEndpoint } from '@/utils/functions'
 import { HttpResponse } from 'msw'
 import AridhiaAccessStatus from './AridhiaAccessStatus'
-
-function darFormFeatureFlagOverride(enabled: boolean) {
-  return getFeatureFlagsOverride({
-    portalOrigin: getEndpoint(BackendDestinationEnum.PORTAL_ENDPOINT),
-    overrides: { [FeatureFlagEnum.AMPALS_RDCA_DAP_FORM_ENABLED]: enabled },
-  })
-}
+import {
+  getAridhiaFairPortalDatasetUrl,
+  getAridhiaFairPortalRequestUrl,
+} from './aridhiaFairPortalUrls'
 
 // The tooltip text `AccessIcon` gives each state, which is also the icon's accessible name.
 const NO_ACCESS_ICON_NAME = 'You must request access to this restricted item.'
+const PENDING_ACCESS_ICON_NAME =
+  'Your access request is pending approval by RDCA-DAP.'
 const HAS_ACCESS_ICON_NAME = 'You have access to this item.'
 
-function renderStatus(url?: string) {
+function renderStatus(fairPortalUrl?: string) {
   const Wrapper = createWrapper()
   return render(
     <MemoryRouter>
@@ -51,7 +49,7 @@ function renderStatus(url?: string) {
         >
           <AridhiaAccessStatus
             datasetCode={MOCK_ARIDHIA_DATASET_CODE}
-            url={url}
+            fairPortalUrl={fairPortalUrl}
           />
         </AridhiaContextProvider>
       </Wrapper>
@@ -61,7 +59,6 @@ function renderStatus(url?: string) {
 
 function wizardHandlers() {
   return [
-    darFormFeatureFlagOverride(true),
     getAridhiaAuthenticateHandler(),
     getAridhiaRequestsHandler(),
     getAridhiaDatasetSettingsHandler(),
@@ -82,6 +79,28 @@ async function openWizard(user: UserEvent) {
   await user.click(screen.getByRole('button', { name: 'Request data access' }))
 }
 
+async function fillAndSubmitWizard(user: UserEvent) {
+  await user.click(await screen.findByLabelText('Location'))
+  await user.click(await screen.findByRole('option', { name: 'UK South' }))
+  await user.click(await screen.findByLabelText('Workspace'))
+  await user.click(await screen.findByRole('option', { name: 'My Workspace' }))
+  await user.click(screen.getByRole('button', { name: 'Next' }))
+
+  await waitFor(() =>
+    expect(getRjsfTextField('project name')).toBeInTheDocument(),
+  )
+  await fillRjsfTextField(user, 'project name', 'My Research Project')
+  await user.click(screen.getByRole('button', { name: 'Next' }))
+  await waitFor(() => expect(getRjsfTextField('your name')).toBeInTheDocument())
+
+  await fillRjsfTextField(user, 'your name', 'Jane Doe')
+  await fillRjsfTextField(user, 'email address', 'jane@example.edu')
+  await user.click(screen.getByRole('button', { name: 'Next' }))
+
+  await user.click(await screen.findByRole('checkbox'))
+  await user.click(screen.getByRole('button', { name: 'Submit request' }))
+}
+
 /**
  * Which dialog slot holds an action is a layout concern with no accessible expression: the
  * footer must stay pinned while the form content scrolls. Assert on MUI's slot class.
@@ -95,13 +114,9 @@ describe('AridhiaAccessStatus', () => {
   afterEach(() => server.resetHandlers())
   afterAll(() => server.close())
 
-  it('opens the request wizard in a dialog when no request exists for this dataset and the feature flag is enabled', async () => {
+  it('opens the request wizard in a dialog when no request exists for this dataset', async () => {
     const user = userEvent.setup()
-    server.use(
-      darFormFeatureFlagOverride(true),
-      getAridhiaAuthenticateHandler(),
-      getAridhiaRequestsHandler(),
-    )
+    server.use(getAridhiaAuthenticateHandler(), getAridhiaRequestsHandler())
     renderStatus()
 
     await findNoAccessIcon()
@@ -116,48 +131,96 @@ describe('AridhiaAccessStatus', () => {
     ).toBeInTheDocument()
   })
 
-  it('links out to RDCA-DAP when the request is approved', async () => {
+  it('opens the status popover showing the request code when a request is pending, linking to the specific request on the FAIR portal', async () => {
+    const user = userEvent.setup()
+    server.use(
+      getAridhiaAuthenticateHandler(),
+      getAridhiaRequestsHandler([
+        {
+          code: 'ampals-sdtm_als1003-abc12345',
+          name: 'My Request',
+          status: 'pending',
+          datasets: [{ code: MOCK_ARIDHIA_DATASET_CODE }],
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ]),
+    )
+    renderStatus(MOCK_ARIDHIA_FAIR_PORTAL_URL)
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('img', { name: PENDING_ACCESS_ICON_NAME }),
+      ).toBeInTheDocument(),
+    )
+    await user.click(screen.getByRole('button'))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('ampals-sdtm_als1003-abc12345', { exact: false }),
+      ).toBeInTheDocument(),
+    )
+    expect(
+      screen.getByRole('link', { name: 'View on RDCA-DAP' }),
+    ).toHaveAttribute(
+      'href',
+      getAridhiaFairPortalRequestUrl(
+        MOCK_ARIDHIA_FAIR_PORTAL_URL,
+        'ampals-sdtm_als1003-abc12345',
+      ),
+    )
+  })
+
+  it('links out to the dataset on the FAIR portal when the request is approved', async () => {
     server.use(
       getAridhiaAuthenticateHandler(),
       getAridhiaRequestsHandler([
         {
           code: 'ampals-sdtm_als1003-abc12345',
           status: 'approved',
-          datasets: { code: MOCK_ARIDHIA_DATASET_CODE },
+          datasets: [{ code: MOCK_ARIDHIA_DATASET_CODE }],
         },
       ]),
     )
-    renderStatus('https://portal.rdca.c-path.org/datasets/sdtm_als1003')
+    renderStatus(MOCK_ARIDHIA_FAIR_PORTAL_URL)
 
     expect(
       await screen.findByRole('img', { name: HAS_ACCESS_ICON_NAME }),
     ).toBeInTheDocument()
     expect(screen.getByRole('link')).toHaveAttribute(
       'href',
-      'https://portal.rdca.c-path.org/datasets/sdtm_als1003',
+      getAridhiaFairPortalDatasetUrl(
+        MOCK_ARIDHIA_FAIR_PORTAL_URL,
+        MOCK_ARIDHIA_DATASET_CODE,
+      ),
     )
   })
 
-  it('does not open the request wizard when the feature flag is disabled, and instead links out to the provided URL', async () => {
-    const user = userEvent.setup()
+  it('shows the account-not-linked icon when the token exchange fails eligibility', async () => {
     server.use(
-      darFormFeatureFlagOverride(false),
-      getAridhiaAuthenticateHandler(),
+      getAridhiaAuthenticateHandler({ error: 'invalid_token' }, 400),
       getAridhiaRequestsHandler(),
     )
-    renderStatus('https://portal.rdca.c-path.org/datasets/sdtm_als1003')
+    renderStatus()
 
-    await findNoAccessIcon()
     expect(
-      screen.queryByRole('button', { name: 'Request data access' }),
-    ).not.toBeInTheDocument()
-    expect(screen.getByRole('link')).toHaveAttribute(
-      'href',
-      'https://portal.rdca.c-path.org/datasets/sdtm_als1003',
-    )
+      await screen.findByRole('img', {
+        name: 'Link your RDCA-DAP account to request access to this item.',
+      }),
+    ).toBeInTheDocument()
+  })
 
-    await user.click(screen.getByRole('link'))
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  it('shows the account-not-linked icon when the token exchange succeeds but the FAIR API rejects it with a 403', async () => {
+    server.use(
+      getAridhiaAuthenticateHandler(),
+      getAridhiaRequestsHandler([], MOCK_ARIDHIA_NOT_AUTHORIZED_ERROR),
+    )
+    renderStatus()
+
+    expect(
+      await screen.findByRole('img', {
+        name: 'Link your RDCA-DAP account to request access to this item.',
+      }),
+    ).toBeInTheDocument()
   })
 
   it('renders the wizard navigation buttons in a DialogActions footer, not inside the scrollable content', async () => {
@@ -194,30 +257,7 @@ describe('AridhiaAccessStatus', () => {
     )
     renderStatus()
     await openWizard(user)
-
-    await user.click(await screen.findByLabelText('Location'))
-    await user.click(await screen.findByRole('option', { name: 'UK South' }))
-    await user.click(await screen.findByLabelText('Workspace'))
-    await user.click(
-      await screen.findByRole('option', { name: 'My Workspace' }),
-    )
-    await user.click(screen.getByRole('button', { name: 'Next' }))
-
-    await waitFor(() =>
-      expect(getRjsfTextField('project name')).toBeInTheDocument(),
-    )
-    await fillRjsfTextField(user, 'project name', 'My Research Project')
-    await user.click(screen.getByRole('button', { name: 'Next' }))
-    await waitFor(() =>
-      expect(getRjsfTextField('your name')).toBeInTheDocument(),
-    )
-
-    await fillRjsfTextField(user, 'your name', 'Jane Doe')
-    await fillRjsfTextField(user, 'email address', 'jane@example.edu')
-    await user.click(screen.getByRole('button', { name: 'Next' }))
-
-    await user.click(await screen.findByRole('checkbox'))
-    await user.click(screen.getByRole('button', { name: 'Submit request' }))
+    await fillAndSubmitWizard(user)
 
     const closeButton = await screen.findByRole('button', { name: 'Close' })
     expect(getDialogActions()).toContainElement(closeButton)
@@ -226,5 +266,53 @@ describe('AridhiaAccessStatus', () => {
     await waitFor(() =>
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
     )
+  })
+
+  it('keeps the submitted confirmation screen open when the post-submission requests refetch changes the background access icon', async () => {
+    const user = userEvent.setup()
+    server.use(
+      ...wizardHandlers(),
+      getAridhiaSubmitRequestHandler(body => {
+        // Regression test: submitting invalidates the requests list. If the dialog is only mounted
+        // when no requests are pending, the confirmation screen unexpectedly disappears after the
+        // requests query is invalidated to find the request that was just created.
+        server.use(
+          getAridhiaRequestsHandler([
+            {
+              code: 'ampals-sdtm_als1003-abc12345',
+              name: 'My Research Project',
+              status: 'pending',
+              datasets: [{ code: MOCK_ARIDHIA_DATASET_CODE }],
+              updated_at: '2024-01-01T00:00:00Z',
+            },
+          ]),
+        )
+        return HttpResponse.json(
+          { ...(body as object), status: 'pending' },
+          { status: 201 },
+        )
+      }),
+    )
+    renderStatus()
+    await openWizard(user)
+    await fillAndSubmitWizard(user)
+    expect(
+      await screen.findByRole('button', { name: 'Close' }),
+    ).toBeInTheDocument()
+
+    // Wait for the invalidated requests query to refetch and flip the access icon to "pending".
+    await waitFor(() =>
+      expect(
+        screen.getByRole('img', {
+          name: PENDING_ACCESS_ICON_NAME,
+          // The icon is behind the open dialog, so it's excluded from the accessibility tree by default —
+          // `hidden: true` can find it.
+          hidden: true,
+        }),
+      ).toBeInTheDocument(),
+    )
+    // The confirmation screen must still be showing afterward since it wasn't closed by the user.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
   })
 })

--- a/packages/synapse-react-client/src/components/Aridhia/AridhiaAccessStatus.tsx
+++ b/packages/synapse-react-client/src/components/Aridhia/AridhiaAccessStatus.tsx
@@ -1,17 +1,18 @@
-import { Button } from '@mui/material'
+import { ReactNode, useState } from 'react'
 import { useGetAridhiaRequests } from '@/aridhia-queries'
-import AccessIcon, { RestrictionUiType } from '../HasAccess/AccessIcon'
-import { SRC_SIGN_IN_CLASS } from '@/utils/SynapseConstants'
 import { useSynapseContext } from '@/utils'
-import {
-  getRestrictionUiTypeFromAridhiaRequest,
-  findRequestForDataset,
-} from './aridhiaAccessStatusUtils'
-import { useState } from 'react'
+import { SRC_SIGN_IN_CLASS } from '@/utils/SynapseConstants'
+import { Button } from '@mui/material'
 import { DialogBase } from '../DialogBase'
+import AccessIcon, { RestrictionUiType } from '../HasAccess/AccessIcon'
+import {
+  findRequestForDataset,
+  getRestrictionUiTypeFromAridhiaRequest,
+} from './aridhiaAccessStatusUtils'
+import { getAridhiaFairPortalDatasetUrl } from './aridhiaFairPortalUrls'
+import AridhiaDarStatusPopover from './AridhiaDarStatusPopover'
 import { useAridhiaDarWizardParts } from './DarWizard/AridhiaDarWizard'
-import { useGetFeatureFlag } from '@/synapse-queries'
-import { FeatureFlagEnum } from '@/utils/featureflag/FeatureFlags'
+import RdcaDapEligibilityDialog from './RdcaDapEligibilityDialog'
 
 const buttonSx = { p: '0px', minWidth: 'unset' }
 
@@ -20,7 +21,8 @@ export type AridhiaAccessStatusProps = {
    * dataset code
    */
   datasetCode: string
-  url?: string
+  /** Base URL of the RDCA-DAP FAIR portal's browsable UI, e.g. `https://fair.dap.c-path.org`. */
+  fairPortalUrl?: string
 }
 
 /**
@@ -29,13 +31,19 @@ export type AridhiaAccessStatusProps = {
  * Otherwise, shows the access status based on the data access requests.
  */
 export default function AridhiaAccessStatus(props: AridhiaAccessStatusProps) {
-  const { datasetCode, url } = props
+  const { datasetCode, fairPortalUrl } = props
   const { isAuthenticated } = useSynapseContext()
-  const isDarFormEnabled = useGetFeatureFlag(
-    FeatureFlagEnum.AMPALS_RDCA_DAP_FORM_ENABLED,
-  )
-  const { data: requestsResponse, isLoading } = useGetAridhiaRequests()
 
+  const {
+    data: requestsResponse,
+    isLoading,
+    isError,
+    error,
+  } = useGetAridhiaRequests()
+  const [popoverAnchorEl, setPopoverAnchorEl] = useState<HTMLElement | null>(
+    null,
+  )
+  const [eligibilityDialogOpen, setEligibilityDialogOpen] = useState(false)
   const [requestDialogOpen, setRequestDialogOpen] = useState(false)
   const { content: wizardContent, actions: wizardActions } =
     useAridhiaDarWizardParts(
@@ -79,43 +87,95 @@ export default function AridhiaAccessStatus(props: AridhiaAccessStatusProps) {
     )
   }
 
-  // Show loading state
+  let content: ReactNode = null
   if (isLoading) {
-    return <></>
-  }
-
-  // Check if there's a request for this dataset
-  const entityRequest = findRequestForDataset(
-    requestsResponse?.items ?? [],
-    datasetCode,
-  )
-
-  const restrictionUiType =
-    getRestrictionUiTypeFromAridhiaRequest(entityRequest)
-
-  const icon = <AccessIcon restrictionUiType={restrictionUiType} />
-
-  if (restrictionUiType === RestrictionUiType.Accessible || !isDarFormEnabled) {
-    // Approved, or the RDCA-DAP request form is not yet enabled — keep the existing
-    // link-out to RDCA-DAP to access or request the data.
-    return url ? (
-      <a href={url} target="_blank" rel="noopener noreferrer">
-        {icon}
-      </a>
-    ) : (
-      icon
+    // Show loading state — nothing to render yet.
+  } else if (isError && error.isEligibilityFailure) {
+    // The token exchange (or any other request) failed because this user has no linked
+    // RDCA-DAP account yet — the DAR wizard is unreachable until that's resolved.
+    content = (
+      <>
+        <Button
+          sx={buttonSx}
+          onClick={() => setEligibilityDialogOpen(true)}
+          aria-label="Link your RDCA-DAP account"
+        >
+          <AccessIcon
+            restrictionUiType={
+              RestrictionUiType.AccessBlockedByRDCADAPAccountNotLinked
+            }
+          />
+        </Button>
+        <RdcaDapEligibilityDialog
+          open={eligibilityDialogOpen}
+          onClose={() => setEligibilityDialogOpen(false)}
+        />
+      </>
     )
+  } else {
+    // Check if there's a request for this dataset
+    const entityRequest = findRequestForDataset(
+      requestsResponse?.items ?? [],
+      datasetCode,
+    )
+    const restrictionUiType =
+      getRestrictionUiTypeFromAridhiaRequest(entityRequest)
+    const icon = <AccessIcon restrictionUiType={restrictionUiType} />
+
+    if (restrictionUiType === RestrictionUiType.Accessible) {
+      // Approved, or the RDCA-DAP request form is not yet enabled — keep the existing
+      // link-out to RDCA-DAP to access or request the data.
+      content = fairPortalUrl ? (
+        <a
+          href={getAridhiaFairPortalDatasetUrl(fairPortalUrl, datasetCode)}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {icon}
+        </a>
+      ) : (
+        icon
+      )
+    } else if (entityRequest) {
+      // Pending or denied — click opens the status popover.
+      content = (
+        <>
+          <Button
+            sx={buttonSx}
+            onClick={ev => setPopoverAnchorEl(ev.currentTarget)}
+            aria-label="View data access request status"
+          >
+            {icon}
+          </Button>
+          <AridhiaDarStatusPopover
+            open={!!popoverAnchorEl}
+            anchorEl={popoverAnchorEl}
+            onClose={() => setPopoverAnchorEl(null)}
+            request={entityRequest}
+            fairPortalUrl={fairPortalUrl}
+          />
+        </>
+      )
+    } else {
+      // No request yet — the icon opens the request wizard in a dialog. The same wizard also
+      // renders at the route-based, non-modal `AridhiaDarWizard` page for a full-page entry
+      // point.
+      content = (
+        <Button
+          sx={buttonSx}
+          onClick={() => setRequestDialogOpen(true)}
+          aria-label="Request data access"
+        >
+          {icon}
+        </Button>
+      )
+    }
   }
 
   return (
     <>
-      <Button
-        sx={buttonSx}
-        onClick={() => setRequestDialogOpen(true)}
-        aria-label="Request data access"
-      >
-        {icon}
-      </Button>
+      {content}
+      {/*  Ensure all authenticated return paths render the wizard dialog to prevent flicker as the DAR state changes (e.g. on the confirmation screen). */}
       <DialogBase
         open={requestDialogOpen}
         onCancel={() => setRequestDialogOpen(false)}

--- a/packages/synapse-react-client/src/components/Aridhia/AridhiaDarStatusPopover.tsx
+++ b/packages/synapse-react-client/src/components/Aridhia/AridhiaDarStatusPopover.tsx
@@ -1,0 +1,65 @@
+import {
+  Popover,
+  PopoverProps,
+  Stack,
+  Typography,
+  Link as MuiLink,
+} from '@mui/material'
+import { RequestListItem } from '@sage-bionetworks/aridhia-client/generated/models'
+import { getAridhiaFairPortalRequestUrl } from './aridhiaFairPortalUrls'
+
+export type AridhiaDarStatusPopoverProps = Pick<
+  PopoverProps,
+  'anchorEl' | 'open' | 'id' | 'onClose'
+> & {
+  request: RequestListItem
+  /** Base URL of the RDCA-DAP FAIR portal's browsable UI, e.g. `https://fair.dap.c-path.org`. */
+  fairPortalUrl?: string
+}
+
+/**
+ * Detail popover for a pending or denied DAR.
+ */
+export default function AridhiaDarStatusPopover(
+  props: AridhiaDarStatusPopoverProps,
+) {
+  const { anchorEl, open, id, onClose, request, fairPortalUrl } = props
+
+  return (
+    <Popover
+      id={id}
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+    >
+      <Stack spacing={1} sx={{ p: 2, maxWidth: 320 }}>
+        <Typography variant="subtitle2">
+          {request.name ?? request.code}
+        </Typography>
+        <Typography variant="body2">Code: {request.code}</Typography>
+        <Typography variant="body2">Status: {request.status}</Typography>
+        {request.created_at && (
+          <Typography variant="body2">
+            Created: {new Date(request.created_at).toLocaleDateString()}
+          </Typography>
+        )}
+        {request.updated_at && (
+          <Typography variant="body2">
+            Updated: {new Date(request.updated_at).toLocaleDateString()}
+          </Typography>
+        )}
+        {fairPortalUrl && request.code && (
+          <MuiLink
+            href={getAridhiaFairPortalRequestUrl(fairPortalUrl, request.code)}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View on RDCA-DAP
+          </MuiLink>
+        )}
+      </Stack>
+    </Popover>
+  )
+}

--- a/packages/synapse-react-client/src/components/Aridhia/DarWizard/AridhiaDarWizard.test.tsx
+++ b/packages/synapse-react-client/src/components/Aridhia/DarWizard/AridhiaDarWizard.test.tsx
@@ -4,6 +4,7 @@ import type { UserEvent } from '@testing-library/user-event'
 import { HttpHandler, HttpResponse } from 'msw'
 import { RequestPost } from '@sage-bionetworks/aridhia-client/generated/models'
 import {
+  getAridhiaAuthenticateHandler,
   getAridhiaDatasetSettingsHandler,
   getAridhiaDarWizardHandlers,
   getAridhiaSubmitRequestHandler,
@@ -714,6 +715,19 @@ describe('AridhiaDarWizard', () => {
     await waitFor(() => expect(capturedRequestBodies).toHaveLength(2))
 
     expect(capturedRequestBodies[0].code).toBe(capturedRequestBodies[1].code)
+  })
+
+  it('renders the ineligibility explainer when the token exchange is rejected', async () => {
+    server.use(
+      getAridhiaAuthenticateHandler({ error: 'invalid_token' }, 400),
+      getAridhiaDatasetSettingsHandler(),
+    )
+    renderWizard()
+
+    await waitFor(() =>
+      expect(screen.getByText(/linked rdca-dap account/i)).toBeInTheDocument(),
+    )
+    expect(screen.queryByLabelText('Tables')).not.toBeInTheDocument()
   })
 
   it('blocks submission and names an unsupported field type', async () => {

--- a/packages/synapse-react-client/src/components/Aridhia/DarWizard/AridhiaDarWizard.tsx
+++ b/packages/synapse-react-client/src/components/Aridhia/DarWizard/AridhiaDarWizard.tsx
@@ -16,6 +16,7 @@ import {
   parseFairFormSections,
   summarizeFormAnswers,
 } from '@/components/Aridhia/fairFormToRjsf'
+import { RdcaDapEligibilityExplainer } from '@/components/Aridhia/RdcaDapEligibilityDialog'
 import { useDarDraft } from './useDarDraft'
 import { DarDestinationStep } from './DarDestinationStep'
 import { DarWorkspaceStep } from './DarWorkspaceStep'
@@ -159,6 +160,17 @@ function useAridhiaDarWizardParts(
       onSubmitted?.(code)
     },
   })
+
+  const eligibilityError = [
+    settingsQuery.error,
+    workflowQuery.error,
+    dictionariesQuery.error,
+    submitMutation.error,
+  ].find(error => error?.isEligibilityFailure)
+
+  if (eligibilityError) {
+    return { content: <RdcaDapEligibilityExplainer /> }
+  }
 
   if (settingsQuery.isLoading) {
     return { content: <Skeleton height={400} /> }
@@ -463,11 +475,8 @@ function useAridhiaDarWizardParts(
       {currentStepKey === 'complete' ? (
         <Button
           variant="contained"
-          disabled={
-            !canAdvance ||
-            unsupportedFields.length > 0 ||
-            submitMutation.isPending
-          }
+          disabled={!canAdvance || unsupportedFields.length > 0}
+          loading={submitMutation.isPending}
           onClick={handleSubmit}
         >
           Submit request

--- a/packages/synapse-react-client/src/components/Aridhia/DarWizard/DarSubmittedPanel.tsx
+++ b/packages/synapse-react-client/src/components/Aridhia/DarWizard/DarSubmittedPanel.tsx
@@ -1,6 +1,6 @@
 import { Alert, Link as MuiLink, Stack, Typography } from '@mui/material'
+import { RDCA_DAP_URL } from '@/components/Aridhia/rdcaDapConstants'
 
-const RDCA_DAP_URL = 'https://portal.rdca.c-path.org/'
 const C_PATH_ADMIN_EMAIL = 'vtheurercrider@c-path.org'
 
 export type DarSubmittedPanelProps = {

--- a/packages/synapse-react-client/src/components/Aridhia/RdcaDapEligibilityDialog.tsx
+++ b/packages/synapse-react-client/src/components/Aridhia/RdcaDapEligibilityDialog.tsx
@@ -1,0 +1,62 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { RDCA_DAP_URL } from './rdcaDapConstants'
+
+/**
+ * Explains why the user can't use the RDCA-DAP API yet. A one-time RDCA-DAP sign-in links
+ * the Synapse account.
+ */
+export function RdcaDapEligibilityExplainer() {
+  return (
+    <Stack spacing={2}>
+      <Typography>
+        You need a linked RDCA-DAP account before you can request access to this
+        dataset.
+      </Typography>
+      <Typography>
+        If you already have an account, sign in to RDCA-DAP once to link it to
+        your ALS Knowledge Portal (Synapse) account.
+      </Typography>
+      <Typography>
+        If you don&apos;t have one yet, create an RDCA-DAP account.
+      </Typography>
+    </Stack>
+  )
+}
+
+export type RdcaDapEligibilityDialogProps = {
+  open: boolean
+  onClose: () => void
+}
+
+export default function RdcaDapEligibilityDialog(
+  props: RdcaDapEligibilityDialogProps,
+) {
+  const { open, onClose } = props
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Link your RDCA-DAP account</DialogTitle>
+      <DialogContent>
+        <RdcaDapEligibilityExplainer />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+        <Button
+          variant="contained"
+          href={RDCA_DAP_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Go to RDCA-DAP
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/packages/synapse-react-client/src/components/Aridhia/RdcaDapEligibilityDialog.tsx
+++ b/packages/synapse-react-client/src/components/Aridhia/RdcaDapEligibilityDialog.tsx
@@ -21,11 +21,8 @@ export function RdcaDapEligibilityExplainer() {
         dataset.
       </Typography>
       <Typography>
-        If you already have an account, sign in to RDCA-DAP once to link it to
-        your ALS Knowledge Portal (Synapse) account.
-      </Typography>
-      <Typography>
-        If you don&apos;t have one yet, create an RDCA-DAP account.
+        To create a new account or link an existing account, open RDCA-DAP and
+        sign in with your ALS Knowledge Portal (Synapse) account.
       </Typography>
     </Stack>
   )

--- a/packages/synapse-react-client/src/components/Aridhia/aridhiaAccessStatusUtils.test.ts
+++ b/packages/synapse-react-client/src/components/Aridhia/aridhiaAccessStatusUtils.test.ts
@@ -78,12 +78,12 @@ describe('aridhiaAccessStatusUtils', () => {
         {
           code: 'REQ001',
           status: 'approved',
-          datasets: { code: 'DATASET_A' },
+          datasets: [{ code: 'DATASET_A' }],
         },
         {
           code: 'REQ002',
           status: 'pending',
-          datasets: { code: 'DATASET_C' },
+          datasets: [{ code: 'DATASET_C' }],
         },
       ]
 
@@ -97,7 +97,7 @@ describe('aridhiaAccessStatusUtils', () => {
         {
           code: 'REQ001',
           status: 'approved',
-          datasets: { code: 'DATASET_A' },
+          datasets: [{ code: 'DATASET_A' }],
         },
       ]
 
@@ -127,13 +127,13 @@ describe('aridhiaAccessStatusUtils', () => {
         {
           code: 'REQ001',
           status: 'approved',
-          datasets: { code: 'DATASET_A' },
+          datasets: [{ code: 'DATASET_A' }],
           updated_at: '2024-01-01T10:00:00Z',
         },
         {
           code: 'REQ002',
           status: 'pending',
-          datasets: { code: 'DATASET_A' },
+          datasets: [{ code: 'DATASET_A' }],
           updated_at: '2024-01-02T10:00:00Z',
         },
       ]
@@ -148,19 +148,19 @@ describe('aridhiaAccessStatusUtils', () => {
         {
           code: 'REQ001',
           status: 'approved',
-          datasets: { code: 'DATASET_A' },
+          datasets: [{ code: 'DATASET_A' }],
           updated_at: '2024-01-03T10:00:00Z', // Most recent
         },
         {
           code: 'REQ002',
           status: 'pending',
-          datasets: { code: 'DATASET_A' },
+          datasets: [{ code: 'DATASET_A' }],
           updated_at: '2024-01-01T10:00:00Z', // Oldest
         },
         {
           code: 'REQ003',
           status: 'denied',
-          datasets: { code: 'DATASET_A' },
+          datasets: [{ code: 'DATASET_A' }],
           updated_at: '2024-01-02T10:00:00Z', // Middle
         },
       ]
@@ -175,13 +175,13 @@ describe('aridhiaAccessStatusUtils', () => {
         {
           code: 'REQ001',
           status: 'approved',
-          datasets: { code: 'DATASET_A' },
+          datasets: [{ code: 'DATASET_A' }],
           // No updated_at
         },
         {
           code: 'REQ002',
           status: 'pending',
-          datasets: { code: 'DATASET_A' },
+          datasets: [{ code: 'DATASET_A' }],
           updated_at: '2024-01-01T10:00:00Z',
         },
       ]
@@ -197,12 +197,12 @@ describe('aridhiaAccessStatusUtils', () => {
         {
           code: 'REQ001',
           status: 'approved',
-          datasets: { code: 'DATASET_A' },
+          datasets: [{ code: 'DATASET_A' }],
         },
         {
           code: 'REQ002',
           status: 'pending',
-          datasets: { code: 'DATASET_A' },
+          datasets: [{ code: 'DATASET_A' }],
         },
       ]
 
@@ -217,7 +217,7 @@ describe('aridhiaAccessStatusUtils', () => {
         {
           code: 'REQ001',
           status: 'approved',
-          datasets: { code: 'dataset_a' },
+          datasets: [{ code: 'dataset_a' }],
         },
       ]
 

--- a/packages/synapse-react-client/src/components/Aridhia/aridhiaAccessStatusUtils.ts
+++ b/packages/synapse-react-client/src/components/Aridhia/aridhiaAccessStatusUtils.ts
@@ -41,8 +41,8 @@ export function findRequestForDataset(
   requests: RequestListItem[],
   datasetCode: string,
 ): RequestListItem | undefined {
-  const matchingRequests = requests.filter(
-    request => request.datasets?.code === datasetCode,
+  const matchingRequests = requests.filter(request =>
+    request.datasets?.some(dataset => dataset.code === datasetCode),
   )
 
   if (matchingRequests.length === 0) {

--- a/packages/synapse-react-client/src/components/Aridhia/aridhiaFairPortalUrls.ts
+++ b/packages/synapse-react-client/src/components/Aridhia/aridhiaFairPortalUrls.ts
@@ -1,0 +1,20 @@
+/**
+ * Builds a link to a dataset's page on the RDCA-DAP FAIR portal's browsable UI.
+ */
+export function getAridhiaFairPortalDatasetUrl(
+  fairPortalUrl: string,
+  datasetCode: string,
+): string {
+  return `${fairPortalUrl}/#/data/datasets/${datasetCode}`
+}
+
+/**
+ * Builds a link to a specific data access request's page on the RDCA-DAP FAIR portal's
+ * browsable UI.
+ */
+export function getAridhiaFairPortalRequestUrl(
+  fairPortalUrl: string,
+  requestCode: string,
+): string {
+  return `${fairPortalUrl}/#/data/requests/${requestCode}`
+}

--- a/packages/synapse-react-client/src/components/Aridhia/rdcaDapConstants.ts
+++ b/packages/synapse-react-client/src/components/Aridhia/rdcaDapConstants.ts
@@ -1,0 +1,2 @@
+/** Base URL of RDCA-DAP's own sign-in/browsable UI (not the FAIR portal — see `aridhiaFairPortalUrls.ts`). */
+export const RDCA_DAP_URL = 'https://portal.rdca.c-path.org/'

--- a/packages/synapse-react-client/src/components/HasAccess/AccessIcon.tsx
+++ b/packages/synapse-react-client/src/components/HasAccess/AccessIcon.tsx
@@ -12,6 +12,8 @@ export enum RestrictionUiType {
   AccessBlockedByACL = 'AccessBlockedByACL',
   AccessBlockedToAnonymous = 'AccessBlockedToAnonymous',
   AccessibleExternalFileHandle = 'AccessibleExternalFileHandle',
+  /** The user has no RDCA-DAP account linked yet, so the DAR wizard is unreachable. */
+  AccessBlockedByRDCADAPAccountNotLinked = 'AccessBlockedByRDCADAPAccountNotLinked',
 }
 
 const iconConfiguration: Record<
@@ -48,6 +50,11 @@ const iconConfiguration: Record<
     icon: 'accessClosed',
     color: theme => theme.palette.warning.main,
     tooltipText: 'Your access request has been denied by RDCA-DAP.',
+  },
+  [RestrictionUiType.AccessBlockedByRDCADAPAccountNotLinked]: {
+    icon: 'linkOff',
+    color: theme => theme.palette.warning.main,
+    tooltipText: 'Link your RDCA-DAP account to request access to this item.',
   },
   [RestrictionUiType.AccessBlockedByACL]: {
     icon: 'accessClosed',

--- a/packages/synapse-react-client/src/mocks/msw/handlers/aridhiaHandlers.ts
+++ b/packages/synapse-react-client/src/mocks/msw/handlers/aridhiaHandlers.ts
@@ -2,7 +2,19 @@ import { FairField } from '@/aridhia-queries/FairFormPayload'
 import { http, HttpHandler, HttpResponse, JsonBodyType } from 'msw'
 
 export const MOCK_ARIDHIA_GATEWAY = 'https://mock-gateway.test'
+export const MOCK_ARIDHIA_FAIR_PORTAL_URL = 'https://mock-fair-portal.test'
 export const MOCK_ARIDHIA_DATASET_CODE = 'sdtm_als1003'
+
+/**
+ * The FAIR API's 403 response for a Synapse-authenticated user with no linked RDCA-DAP
+ * account. Distinct from the gateway's own `/authenticate` OAuth-error envelope.
+ */
+export const MOCK_ARIDHIA_NOT_AUTHORIZED_ERROR = {
+  status: 403,
+  body: {
+    error: { status: 403, message: 'Not authorised for this operation' },
+  },
+}
 
 export const MOCK_ARIDHIA_AUTHENTICATION_REQUEST = {
   subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
@@ -84,12 +96,17 @@ export function getAridhiaAuthenticateHandler(
   )
 }
 
-export function getAridhiaRequestsHandler(items: unknown[] = []): HttpHandler {
+export function getAridhiaRequestsHandler(
+  items: unknown[] = [],
+  errorResponse?: { status: number; body: object },
+): HttpHandler {
   return http.get(`${MOCK_ARIDHIA_GATEWAY}/fair/requests/`, () =>
-    HttpResponse.json({
-      items,
-      paging: { page: 1, pageSize: 100, total: items.length },
-    }),
+    errorResponse
+      ? HttpResponse.json(errorResponse.body, { status: errorResponse.status })
+      : HttpResponse.json({
+          items,
+          paging: { page: 1, pageSize: 100, total: items.length },
+        }),
   )
 }
 

--- a/packages/synapse-react-client/src/utils/featureflag/FeatureFlags.ts
+++ b/packages/synapse-react-client/src/utils/featureflag/FeatureFlags.ts
@@ -25,9 +25,6 @@ export enum FeatureFlagEnum {
   // If enabled, show the Models section in the ELITE portal (nav item, Explore tab, and Search tab)
   ELITE_PORTAL_MODELS = 'ELITE_PORTAL_MODELS',
 
-  // If enabled, opens the RDCA-DAP data access request form when requesting access to an Aridhia dataset
-  AMPALS_RDCA_DAP_FORM_ENABLED = 'AMPALS_RDCA_DAP_FORM_ENABLED',
-
   // Reserved for unit tests. Not configured in Stack Builder; do not use in production code.
   TEST_ONLY = 'TEST_ONLY',
 }


### PR DESCRIPTION
 - Detect isEligibilityFailure from wizard queries/mutation and surface a shared RdcaDapEligibilityExplainer before and during the wizard
 - Block AridhiaAccessStatus from offering the wizard when ineligible; add AccessBlockedByRDCADAPAccountNotLinked icon state
 - Add not_authorized error code for FAIR 403 "not authorised" responses
 - Fix datasets to be an array (matches live API) in the OpenAPI patch, request-matching util, and mocks
 - Add DAR status popover and FAIR portal URL helpers for pending/approved requests
 - Remove unused AMPALS_RDCA_DAP_FORM_ENABLED feature flag
 - Dedupe RDCA_DAP_URL into a shared constant


Screenshots:

<img width="441" height="207" alt="image" src="https://github.com/user-attachments/assets/c52dc244-634f-42ef-a11e-a72a0c116cdf" />

<img width="441" height="367" alt="image" src="https://github.com/user-attachments/assets/5ab3303a-8894-4ec4-a3d9-0256355b735e" />

<img width="441" height="367" alt="image" src="https://github.com/user-attachments/assets/f6d9d13a-91a6-4d37-95c7-de3d3ab056f2" />

<img width="441" height="367" alt="image" src="https://github.com/user-attachments/assets/10a5f740-395e-4f0c-8d13-ddd465d831be" />

Account is not linked with RDCA-DAP:

<img width="573" height="526" alt="image" src="https://github.com/user-attachments/assets/1b14884e-858f-4308-aa74-fc633dca0714" />

After clicking the 'unlinked' icon':

<img width="590" height="390" alt="image" src="https://github.com/user-attachments/assets/405d8eda-9745-4381-86d2-e56e390d83e4" />

